### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The architecture is described in [Paper 1: Agent Memory Infrastructure](papers/P
 
 > **Just want to install it?** [Download here](https://l33tdawg.github.io/sage/) — double-click, done. Works with any AI.
 
+<a href="https://glama.ai/mcp/servers/l33tdawg/s-age">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/l33tdawg/s-age/badge" alt="(S)AGE MCP server" />
+</a>
+
 ---
 
 ## Architecture


### PR DESCRIPTION
This PR adds a badge for the [(S)AGE](https://glama.ai/mcp/servers/l33tdawg/s-age) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/l33tdawg/s-age">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/l33tdawg/s-age/badge" alt="(S)AGE MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.