### PR TITLE
ci(workflow): Include and build for `linux/arm64` container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,10 +244,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build and push Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             VERSION=${{ steps.version.outputs.version }}


### PR DESCRIPTION
- Include `setup-buildx-actions` as this enables multi-platform images.
- Include `linux/arm64` as additional platform during `build-push-action`.
- Fixes #12 