### PR TITLE
Add OpenAI-compatible embedder provider

### DIFF
--- a/api/rest/embed_handler.go
+++ b/api/rest/embed_handler.go
@@ -2,6 +2,8 @@ package rest
 
 import (
 	"net/http"
+
+	"github.com/l33tdawg/sage/internal/embedding"
 )
 
 // EmbedRequest is the request body for POST /v1/embed.
@@ -46,7 +48,15 @@ func (s *Server) handleEmbedInfo(w http.ResponseWriter, r *http.Request) {
 	semantic := s.embedder.Semantic()
 	provider := "hash"
 	if semantic {
+		// Default semantic name is "ollama" for backward compat with clients
+		// that pre-date the multi-provider patch. Providers may override by
+		// implementing the optional Named interface (e.g. openai-compatible).
 		provider = "ollama"
+		if named, ok := s.embedder.(embedding.Named); ok {
+			if n := named.Name(); n != "" {
+				provider = n
+			}
+		}
 	}
 
 	// Vault-active forces semantic-only mode. Even if no embedder is

--- a/api/rest/embed_handler_test.go
+++ b/api/rest/embed_handler_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -111,4 +112,48 @@ func TestHandleEmbedInfo_NoVaultAPIPreservesLegacyBehavior(t *testing.T) {
 	// so the response should reflect the embedder unchanged: semantic=false.
 	assert.False(t, resp.Semantic)
 	assert.Equal(t, "hash", resp.Provider)
+}
+
+// namedSemanticEmbedder is a minimal Provider that implements the optional
+// embedding.Named interface so we can assert /v1/embed/info uses the embedder's
+// own name rather than always reporting "ollama" for any semantic provider.
+type namedSemanticEmbedder struct {
+	name string
+	dim  int
+}
+
+func (n *namedSemanticEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return make([]float32, n.dim), nil
+}
+func (n *namedSemanticEmbedder) Dimension() int { return n.dim }
+func (n *namedSemanticEmbedder) Ready() bool    { return true }
+func (n *namedSemanticEmbedder) Semantic() bool { return true }
+func (n *namedSemanticEmbedder) Name() string   { return n.name }
+
+// TestHandleEmbedInfo_NamedProviderOverridesOllama confirms that semantic
+// providers other than the legacy Ollama client (e.g. the openai-compatible
+// provider) report their own name through /v1/embed/info instead of being
+// silently labeled "ollama".
+func TestHandleEmbedInfo_NamedProviderOverridesOllama(t *testing.T) {
+	emb := &namedSemanticEmbedder{name: "openai-compatible", dim: 1536}
+
+	memStore := newMockMemoryStore()
+	scoreStore := newMockScoreStore()
+	health := metrics.NewHealthChecker()
+	health.SetPostgresHealth(true)
+	health.SetCometBFTHealth(true)
+
+	srv := NewServer("", memStore, scoreStore, nil, health, zerolog.Nop(), emb)
+
+	req, _ := signedRequest(t, http.MethodGet, "/v1/embed/info", nil)
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp EmbedInfoResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	assert.True(t, resp.Semantic)
+	assert.Equal(t, "openai-compatible", resp.Provider)
+	assert.Equal(t, 1536, resp.Dimension)
 }

--- a/cmd/sage-gui/config.go
+++ b/cmd/sage-gui/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -45,12 +46,17 @@ type EncryptionConfig struct {
 }
 
 // EmbeddingConfig configures the embedding provider.
+//
+// Provider values:
+//   - "hash"              — built-in deterministic non-semantic embeddings
+//   - "ollama"            — local Ollama (POST /api/embed)
+//   - "openai-compatible" — OpenAI / vLLM / LiteLLM / TEI (POST /v1/embeddings)
 type EmbeddingConfig struct {
-	Provider  string `yaml:"provider"` // "ollama" or "hash"
+	Provider  string `yaml:"provider"` // "hash", "ollama", or "openai-compatible"
 	APIKey    string `yaml:"api_key,omitempty"`
 	Model     string `yaml:"model,omitempty"`
 	Dimension int    `yaml:"dimension,omitempty"`
-	BaseURL   string `yaml:"base_url,omitempty"` // For Ollama
+	BaseURL   string `yaml:"base_url,omitempty"` // Ollama or OpenAI-compatible base
 }
 
 // DefaultConfig returns the default configuration.
@@ -89,22 +95,7 @@ func LoadConfig() (*Config, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// REST_ADDR env var override (for Docker: REST_ADDR=0.0.0.0:8080)
-			if envAddr := os.Getenv("REST_ADDR"); envAddr != "" {
-				cfg.RESTAddr = envAddr
-			}
-			// SAGE_EMBEDDING_PROVIDER env var override (for Docker: SAGE_EMBEDDING_PROVIDER=ollama)
-			if envProvider := os.Getenv("SAGE_EMBEDDING_PROVIDER"); envProvider != "" {
-				cfg.Embedding.Provider = envProvider
-			}
-			// OLLAMA_URL env var override (for Docker: OLLAMA_URL=http://ollama:11434)
-			if envURL := os.Getenv("OLLAMA_URL"); envURL != "" {
-				cfg.Embedding.BaseURL = envURL
-			}
-			// OLLAMA_MODEL env var override (for Docker: OLLAMA_MODEL=nomic-embed-text)
-			if envModel := os.Getenv("OLLAMA_MODEL"); envModel != "" {
-				cfg.Embedding.Model = envModel
-			}
+			applyEnvOverrides(cfg)
 			return cfg, nil
 		}
 		return nil, fmt.Errorf("read config: %w", err)
@@ -114,23 +105,7 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
-	// REST_ADDR env var override (for Docker: REST_ADDR=0.0.0.0:8080)
-	if envAddr := os.Getenv("REST_ADDR"); envAddr != "" {
-		cfg.RESTAddr = envAddr
-	}
-
-	// SAGE_EMBEDDING_PROVIDER env var override (for Docker: SAGE_EMBEDDING_PROVIDER=ollama)
-	if envProvider := os.Getenv("SAGE_EMBEDDING_PROVIDER"); envProvider != "" {
-		cfg.Embedding.Provider = envProvider
-	}
-	// OLLAMA_URL env var override (for Docker: OLLAMA_URL=http://ollama:11434)
-	if envURL := os.Getenv("OLLAMA_URL"); envURL != "" {
-		cfg.Embedding.BaseURL = envURL
-	}
-	// OLLAMA_MODEL env var override (for Docker: OLLAMA_MODEL=nomic-embed-text)
-	if envModel := os.Getenv("OLLAMA_MODEL"); envModel != "" {
-		cfg.Embedding.Model = envModel
-	}
+	applyEnvOverrides(cfg)
 
 	// Expand ~ and ensure absolute paths
 	cfg.DataDir = expandHome(cfg.DataDir)
@@ -143,6 +118,47 @@ func LoadConfig() (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// applyEnvOverrides applies environment-variable overrides to cfg in place.
+//
+// Backward-compat: REST_ADDR, SAGE_EMBEDDING_PROVIDER, OLLAMA_URL, OLLAMA_MODEL
+// keep their original meanings.
+//
+// New (for the openai-compatible provider): SAGE_EMBEDDING_BASE_URL,
+// SAGE_EMBEDDING_MODEL, SAGE_EMBEDDING_API_KEY, SAGE_EMBEDDING_DIMENSION.
+// The SAGE_EMBEDDING_* names take precedence over OLLAMA_* when both are set,
+// because the OLLAMA_* names are misleading once a non-Ollama backend is in
+// use (e.g. vLLM at /v1/embeddings).
+func applyEnvOverrides(cfg *Config) {
+	if envAddr := os.Getenv("REST_ADDR"); envAddr != "" {
+		cfg.RESTAddr = envAddr
+	}
+	if envProvider := os.Getenv("SAGE_EMBEDDING_PROVIDER"); envProvider != "" {
+		cfg.Embedding.Provider = envProvider
+	}
+	// Ollama-named overrides (legacy).
+	if envURL := os.Getenv("OLLAMA_URL"); envURL != "" {
+		cfg.Embedding.BaseURL = envURL
+	}
+	if envModel := os.Getenv("OLLAMA_MODEL"); envModel != "" {
+		cfg.Embedding.Model = envModel
+	}
+	// Provider-agnostic overrides — preferred for openai-compatible deployments.
+	if envURL := os.Getenv("SAGE_EMBEDDING_BASE_URL"); envURL != "" {
+		cfg.Embedding.BaseURL = envURL
+	}
+	if envModel := os.Getenv("SAGE_EMBEDDING_MODEL"); envModel != "" {
+		cfg.Embedding.Model = envModel
+	}
+	if envKey := os.Getenv("SAGE_EMBEDDING_API_KEY"); envKey != "" {
+		cfg.Embedding.APIKey = envKey
+	}
+	if envDim := os.Getenv("SAGE_EMBEDDING_DIMENSION"); envDim != "" {
+		if n, err := strconv.Atoi(envDim); err == nil && n > 0 {
+			cfg.Embedding.Dimension = n
+		}
+	}
 }
 
 // expandHome replaces a leading ~ with the user's home directory.

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -724,6 +724,23 @@ func createEmbeddingProvider(cfg *Config, logger zerolog.Logger) embedding.Provi
 	case "ollama":
 		logger.Info().Str("url", cfg.Embedding.BaseURL).Msg("using Ollama embeddings")
 		return embedding.NewClient(cfg.Embedding.BaseURL, cfg.Embedding.Model)
+	case "openai-compatible":
+		dim := cfg.Embedding.Dimension
+		if dim <= 0 {
+			dim = 1536 // OpenAI text-embedding-3-small default
+		}
+		logger.Info().
+			Str("url", cfg.Embedding.BaseURL).
+			Str("model", cfg.Embedding.Model).
+			Int("dimension", dim).
+			Bool("authenticated", cfg.Embedding.APIKey != "").
+			Msg("using OpenAI-compatible embeddings")
+		return embedding.NewOpenAICompatibleClient(
+			cfg.Embedding.BaseURL,
+			cfg.Embedding.Model,
+			cfg.Embedding.APIKey,
+			dim,
+		)
 	default:
 		dim := cfg.Embedding.Dimension
 		if dim <= 0 {

--- a/cmd/sage-gui/wizard.go
+++ b/cmd/sage-gui/wizard.go
@@ -102,9 +102,11 @@ func handleWizardPage(w http.ResponseWriter, r *http.Request) {
 func handleTestProvider(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB max
 	var req struct {
-		Provider string `json:"provider"`
-		APIKey   string `json:"api_key"`
-		BaseURL  string `json:"base_url"`
+		Provider  string `json:"provider"`
+		APIKey    string `json:"api_key"`
+		BaseURL   string `json:"base_url"`
+		Model     string `json:"model"`
+		Dimension int    `json:"dimension"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, `{"ok":false,"error":"invalid request"}`, http.StatusBadRequest)
@@ -117,6 +119,12 @@ func handleTestProvider(w http.ResponseWriter, r *http.Request) {
 		provider = embedding.NewClient(req.BaseURL, "")
 	case "hash":
 		provider = embedding.NewHashProvider(768)
+	case "openai-compatible":
+		dim := req.Dimension
+		if dim <= 0 {
+			dim = 1536
+		}
+		provider = embedding.NewOpenAICompatibleClient(req.BaseURL, req.Model, req.APIKey, dim)
 	default:
 		_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "unknown provider"})
 		return

--- a/internal/embedding/openai_compatible.go
+++ b/internal/embedding/openai_compatible.go
@@ -1,0 +1,170 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// OpenAICompatibleClient generates embeddings via any server that speaks the
+// OpenAI /v1/embeddings request/response shape (OpenAI itself, vLLM, LiteLLM,
+// Text Embeddings Inference, llama.cpp's server, etc.).
+//
+// Why this exists alongside the Ollama client:
+//   - SAGE deployments often share an embeddings stack with other services
+//     (e.g. a multilingual vLLM serving gte-Qwen2 or BAAI bge-m3).
+//   - The hash provider isn't semantic; the Ollama provider is locked to the
+//     /api/embed shape. This third option lets operators reuse whatever
+//     OpenAI-compatible endpoint they already run.
+//
+// BFT app-validator semantics are unaffected — embedder swap is below the
+// validator layer; this only changes how text turns into a float32 vector.
+type OpenAICompatibleClient struct {
+	baseURL    string
+	model      string
+	apiKey     string
+	dimension  int
+	httpClient *http.Client
+	mu         sync.RWMutex
+	ready      bool
+}
+
+// NewOpenAICompatibleClient creates a client for an OpenAI-compatible
+// /v1/embeddings endpoint.
+//
+//   - baseURL:    e.g. "https://api.openai.com" or "http://my-vllm:9501".
+//     The "/v1/embeddings" path is appended automatically.
+//   - model:      model identifier the upstream expects (e.g.
+//     "text-embedding-3-small", "Alibaba-NLP/gte-Qwen2-1.5B-instruct").
+//   - apiKey:     bearer token. If empty, no Authorization header is sent —
+//     useful for self-hosted endpoints on a trusted network.
+//   - dimension:  expected output dimension. The response is validated to
+//     match this; mismatches are surfaced as errors to make
+//     misconfiguration loud rather than silently corrupt the
+//     vector store. Must be > 0.
+func NewOpenAICompatibleClient(baseURL, model, apiKey string, dimension int) *OpenAICompatibleClient {
+	return &OpenAICompatibleClient{
+		baseURL:   baseURL,
+		model:     model,
+		apiKey:    apiKey,
+		dimension: dimension,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// openAIEmbedRequest mirrors the OpenAI POST /v1/embeddings request body.
+// "input" can be a string or an array of strings; we send a single string
+// per call to keep parity with the Ollama and Hash providers.
+type openAIEmbedRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+}
+
+// openAIEmbedResponse mirrors the OpenAI POST /v1/embeddings response. We
+// only need the first item's "embedding" field; everything else (usage,
+// model echo, object type) is ignored.
+type openAIEmbedResponse struct {
+	Data []struct {
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
+}
+
+// Embed generates an embedding vector for the given text via the configured
+// OpenAI-compatible endpoint and validates the response dimension.
+func (c *OpenAICompatibleClient) Embed(ctx context.Context, text string) ([]float32, error) {
+	body, err := json.Marshal(openAIEmbedRequest{
+		Model: c.model,
+		Input: text,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal embed request: %w", err)
+	}
+
+	url := c.baseURL + "/v1/embeddings"
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create embed request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("openai-compatible embed request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MB max
+		return nil, fmt.Errorf("openai-compatible embed error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var embedResp openAIEmbedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&embedResp); err != nil {
+		return nil, fmt.Errorf("decode embed response: %w", err)
+	}
+
+	if len(embedResp.Data) == 0 || len(embedResp.Data[0].Embedding) == 0 {
+		return nil, fmt.Errorf("openai-compatible endpoint returned no embeddings")
+	}
+
+	f64 := embedResp.Data[0].Embedding
+	if c.dimension > 0 && len(f64) != c.dimension {
+		return nil, fmt.Errorf("openai-compatible embed dimension mismatch: configured %d, got %d", c.dimension, len(f64))
+	}
+
+	// Convert float64 to float32 for pgvector parity with the Ollama provider.
+	result := make([]float32, len(f64))
+	for i, v := range f64 {
+		result[i] = float32(v)
+	}
+
+	c.mu.Lock()
+	c.ready = true
+	c.mu.Unlock()
+
+	return result, nil
+}
+
+// Dimension returns the configured output dimension.
+func (c *OpenAICompatibleClient) Dimension() int {
+	return c.dimension
+}
+
+// Ready returns true once at least one successful embedding has been generated.
+func (c *OpenAICompatibleClient) Ready() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.ready
+}
+
+// Semantic returns true — OpenAI-compatible endpoints are expected to serve
+// real embedding models (text-embedding-3-*, gte-Qwen2, bge-m3, etc.).
+func (c *OpenAICompatibleClient) Semantic() bool {
+	return true
+}
+
+// Name returns the canonical provider name. The REST /v1/embed/info handler
+// uses this when present so semantic providers other than Ollama don't get
+// mislabeled in operator-facing health output.
+func (c *OpenAICompatibleClient) Name() string {
+	return "openai-compatible"
+}
+
+// Ping checks whether the configured endpoint is reachable. The OpenAI
+// embeddings spec doesn't define a dedicated health endpoint, so we issue
+// a minimal embed request — most servers will return a fast response or a
+// recognizable 4xx that still proves the endpoint is alive.
+func (c *OpenAICompatibleClient) Ping(ctx context.Context) error {
+	_, err := c.Embed(ctx, "ping")
+	return err
+}

--- a/internal/embedding/openai_compatible_test.go
+++ b/internal/embedding/openai_compatible_test.go
@@ -1,0 +1,189 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeOAIServer constructs an httptest.Server that mimics the OpenAI
+// /v1/embeddings shape. It returns the server, a pointer to the most-recent
+// inbound Authorization header (so tests can assert auth behavior), and a
+// pointer to the most-recent JSON body (so tests can assert the request shape).
+func fakeOAIServer(t *testing.T, embedding []float64, status int, lastAuth *string, lastBody *map[string]any) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/embeddings", func(w http.ResponseWriter, r *http.Request) {
+		if lastAuth != nil {
+			*lastAuth = r.Header.Get("Authorization")
+		}
+		if lastBody != nil {
+			*lastBody = map[string]any{}
+			_ = json.NewDecoder(r.Body).Decode(lastBody)
+		}
+		if status != http.StatusOK {
+			http.Error(w, `{"error":"forced"}`, status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"embedding": embedding, "index": 0, "object": "embedding"},
+			},
+			"model":  "test-model",
+			"object": "list",
+		})
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestOpenAICompatible_ImplementsProvider(t *testing.T) {
+	var _ Provider = (*OpenAICompatibleClient)(nil)
+}
+
+func TestOpenAICompatible_ImplementsNamed(t *testing.T) {
+	var _ Named = (*OpenAICompatibleClient)(nil)
+}
+
+func TestOpenAICompatible_HappyPath(t *testing.T) {
+	emb := make([]float64, 1536)
+	for i := range emb {
+		emb[i] = float64(i) / 1536.0
+	}
+
+	var lastAuth string
+	var lastBody map[string]any
+	srv := fakeOAIServer(t, emb, http.StatusOK, &lastAuth, &lastBody)
+	defer srv.Close()
+
+	c := NewOpenAICompatibleClient(srv.URL, "gte-Qwen2-1.5B-instruct", "", 1536)
+	require.False(t, c.Ready(), "should not be Ready before first successful call")
+
+	out, err := c.Embed(context.Background(), "hello world")
+	require.NoError(t, err)
+	assert.Len(t, out, 1536)
+	assert.Equal(t, 1536, c.Dimension())
+	assert.True(t, c.Semantic())
+	assert.Equal(t, "openai-compatible", c.Name())
+	assert.True(t, c.Ready(), "should flip Ready true after a success")
+
+	// Request shape: model + input fields populated correctly.
+	assert.Equal(t, "gte-Qwen2-1.5B-instruct", lastBody["model"])
+	assert.Equal(t, "hello world", lastBody["input"])
+}
+
+func TestOpenAICompatible_AuthHeaderSentWhenAPIKeySet(t *testing.T) {
+	var lastAuth string
+	srv := fakeOAIServer(t, []float64{0.1, 0.2, 0.3}, http.StatusOK, &lastAuth, nil)
+	defer srv.Close()
+
+	c := NewOpenAICompatibleClient(srv.URL, "m", "sk-test-12345", 3)
+	_, err := c.Embed(context.Background(), "x")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer sk-test-12345", lastAuth)
+}
+
+func TestOpenAICompatible_AuthHeaderOmittedWhenAPIKeyEmpty(t *testing.T) {
+	var lastAuth string
+	srv := fakeOAIServer(t, []float64{0.1, 0.2, 0.3}, http.StatusOK, &lastAuth, nil)
+	defer srv.Close()
+
+	c := NewOpenAICompatibleClient(srv.URL, "m", "", 3)
+	_, err := c.Embed(context.Background(), "x")
+	require.NoError(t, err)
+	assert.Empty(t, lastAuth, "no Authorization header should be sent when api_key is empty")
+}
+
+func TestOpenAICompatible_DimensionMismatch(t *testing.T) {
+	srv := fakeOAIServer(t, []float64{0.1, 0.2, 0.3}, http.StatusOK, nil, nil)
+	defer srv.Close()
+
+	c := NewOpenAICompatibleClient(srv.URL, "m", "", 1536)
+	_, err := c.Embed(context.Background(), "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dimension mismatch")
+	assert.False(t, c.Ready(), "Ready must stay false on mismatch — vector store would have been corrupted")
+}
+
+func TestOpenAICompatible_NoData(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/embeddings", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"model":"m","object":"list"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewOpenAICompatibleClient(srv.URL, "m", "", 1536)
+	_, err := c.Embed(context.Background(), "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no embeddings")
+}
+
+func TestOpenAICompatible_ServerError(t *testing.T) {
+	srv := fakeOAIServer(t, nil, http.StatusInternalServerError, nil, nil)
+	defer srv.Close()
+
+	c := NewOpenAICompatibleClient(srv.URL, "m", "", 1536)
+	_, err := c.Embed(context.Background(), "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 500")
+}
+
+func TestOpenAICompatible_BadRequest(t *testing.T) {
+	srv := fakeOAIServer(t, nil, http.StatusBadRequest, nil, nil)
+	defer srv.Close()
+
+	c := NewOpenAICompatibleClient(srv.URL, "m", "", 1536)
+	_, err := c.Embed(context.Background(), "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 400")
+}
+
+func TestOpenAICompatible_NetworkFailure(t *testing.T) {
+	// Bind a server, get its URL, then close it so the next dial fails.
+	srv := fakeOAIServer(t, []float64{0.1}, http.StatusOK, nil, nil)
+	url := srv.URL
+	srv.Close()
+
+	c := NewOpenAICompatibleClient(url, "m", "", 1)
+	_, err := c.Embed(context.Background(), "x")
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "embed request")
+}
+
+func TestOpenAICompatible_DimensionGetter(t *testing.T) {
+	c := NewOpenAICompatibleClient("http://x", "m", "", 1024)
+	assert.Equal(t, 1024, c.Dimension())
+	assert.True(t, c.Semantic())
+}
+
+func TestOpenAICompatible_DimensionZeroSkipsValidation(t *testing.T) {
+	// dimension=0 means "trust whatever the server returns" — useful when the
+	// operator hasn't pinned a dimension. Keep behavior permissive.
+	srv := fakeOAIServer(t, []float64{0.1, 0.2, 0.3, 0.4}, http.StatusOK, nil, nil)
+	defer srv.Close()
+
+	c := NewOpenAICompatibleClient(srv.URL, "m", "", 0)
+	out, err := c.Embed(context.Background(), "x")
+	require.NoError(t, err)
+	assert.Len(t, out, 4)
+}
+
+func TestOpenAICompatible_RespectsContextCancellation(t *testing.T) {
+	srv := fakeOAIServer(t, []float64{0.1}, http.StatusOK, nil, nil)
+	defer srv.Close()
+
+	c := NewOpenAICompatibleClient(srv.URL, "m", "", 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled
+
+	_, err := c.Embed(ctx, "x")
+	require.Error(t, err)
+}

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -14,3 +14,11 @@ type Provider interface {
 	// Hash-based providers return false — cosine similarity is meaningless.
 	Semantic() bool
 }
+
+// Named is an optional interface a Provider can implement to expose its
+// canonical name. Operator-facing surfaces (e.g. /v1/embed/info) prefer this
+// over inferring "ollama" vs "hash" from Semantic() alone, so providers other
+// than the original two don't get mislabeled.
+type Named interface {
+	Name() string
+}


### PR DESCRIPTION
## Motivation

Enables SAGE deployments to share an existing OpenAI-compatible embeddings stack (vLLM, OpenAI, LiteLLM, etc.) instead of running Ollama or relying on the hash-based default. Particularly valuable for multilingual content where stronger embedders (e.g. gte-Qwen2-1.5B-instruct, BAAI bge-m3) outperform the hash default by a wide margin.

## What changes

- New `embedding.provider` value: `openai-compatible`
- Adds `OpenAICompatibleClient` alongside the existing hash and ollama providers
- Calls `POST {base_url}/v1/embeddings` with the standard OpenAI embeddings request shape
- Configurable dimension (validated against response), optional bearer auth via `embedding.api_key`
- Optional `Named` interface so the REST `/v1/embed` info handler reports the correct provider name
- Unit tests for the new provider (httptest.NewServer mock; happy path, auth header, error cases)

## Compatibility

- Existing `hash` and `ollama` providers unaffected — additive only.
- BFT app-validator semantics unchanged. Embedder swap is below the validator layer.
- License: Apache 2.0 (matches SAGE).

## Tested

- `go test ./...` clean
- Smoke-tested in a SAGE Personal-mode container against vLLM running gte-Qwen2-1.5B-instruct (1536-dim, multilingual). Prose-only recall queries that returned 0 hits on the hash embedder return the expected fact on the new provider.

## Configuration example

```yaml
embedding:
  provider: openai-compatible
  base_url: https://api.openai.com  # or vLLM, LiteLLM, your own gateway
  model: text-embedding-3-small
  api_key: sk-...
  dimension: 1536
```