### PR TITLE
fix(cerebrum): status pill dispatches on embedding.provider

### DIFF
--- a/internal/embedding/ollama.go
+++ b/internal/embedding/ollama.go
@@ -134,6 +134,12 @@ func (c *Client) Name() string {
 	return "ollama"
 }
 
+// Model implements embedding.Modeler so the CEREBRUM status pill can show
+// which Ollama model is currently bound (e.g. "nomic-embed-text").
+func (c *Client) Model() string {
+	return c.model
+}
+
 // Ping checks if Ollama is reachable.
 func (c *Client) Ping(ctx context.Context) error {
 	httpReq, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/api/tags", nil)

--- a/internal/embedding/openai_compatible.go
+++ b/internal/embedding/openai_compatible.go
@@ -160,6 +160,13 @@ func (c *OpenAICompatibleClient) Name() string {
 	return "openai-compatible"
 }
 
+// Model implements embedding.Modeler so the CEREBRUM status pill can show
+// which upstream model identifier this client sends in its embed requests
+// (e.g. "Alibaba-NLP/gte-Qwen2-1.5B-instruct").
+func (c *OpenAICompatibleClient) Model() string {
+	return c.model
+}
+
 // Ping checks whether the configured endpoint is reachable. The OpenAI
 // embeddings spec doesn't define a dedicated health endpoint, so we issue
 // a minimal embed request — most servers will return a fast response or a

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -22,3 +22,22 @@ type Provider interface {
 type Named interface {
 	Name() string
 }
+
+// Modeler is an optional interface a Provider can implement to expose the
+// model identifier it serves. The CEREBRUM dashboard surfaces this in the
+// embedder status pill so operators running multi-model stacks (vLLM /
+// LiteLLM / Ollama with several embedding models loaded) can confirm at a
+// glance which one SAGE actually talks to. Providers that don't implement
+// this simply don't get a model label in the UI.
+type Modeler interface {
+	Model() string
+}
+
+// Pinger is an optional interface a Provider can implement to expose a
+// cheap liveness check. The dashboard health endpoint prefers Ping over
+// Ready when present, because Ready is a sticky "has-ever-succeeded" flag
+// — useful for /v1/embed/info but unhelpful for a real-time operator pill
+// where the upstream embed server may have gone away after boot.
+type Pinger interface {
+	Ping(ctx context.Context) error
+}

--- a/web/handler.go
+++ b/web/handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/l33tdawg/sage/internal/auth"
+	"github.com/l33tdawg/sage/internal/embedding"
 	"github.com/l33tdawg/sage/internal/memory"
 	"github.com/l33tdawg/sage/internal/store"
 	"github.com/l33tdawg/sage/internal/tx"
@@ -41,9 +42,24 @@ type PreferencesStore interface {
 	DeprecateMemories(ctx context.Context, memoryIDs []string) (int, error)
 }
 
-// Embedder generates vector embeddings for text content.
+// Embedder generates vector embeddings for text content. The dashboard
+// imports + task-planning paths only need Embed; the optional methods below
+// let /v1/dashboard/health report which provider is configured and whether
+// it is reachable. Any value satisfying embedding.Provider (Ollama, OpenAI-
+// compatible, Hash) plugs in unchanged via SetEmbedder.
 type Embedder interface {
 	Embed(ctx context.Context, text string) ([]float32, error)
+}
+
+// embedderProvider is the dashboard-side view of the optional methods an
+// embedding.Provider exposes. handleHealth type-asserts h.embedder to this
+// interface so the status pill can dispatch on the actual configured
+// provider (Ollama vs openai-compatible vs hash) instead of hard-coding an
+// Ollama probe at localhost:11434 — the bug this exists to fix.
+type embedderProvider interface {
+	Dimension() int
+	Ready() bool
+	Semantic() bool
 }
 
 // DashboardHandler serves the CEREBRUM dashboard UI and its API endpoints.
@@ -1324,16 +1340,110 @@ func (h *DashboardHandler) handleHealth(w http.ResponseWriter, r *http.Request) 
 		"uptime":       time.Since(startTime).String(),
 	}
 
-	// Check Ollama
-	client := &http.Client{Timeout: 2 * time.Second}
-	ollamaReq, _ := http.NewRequestWithContext(r.Context(), "GET", "http://localhost:11434/api/tags", nil)
-	resp, err := client.Do(ollamaReq)
-	if err != nil {
-		health["ollama"] = "offline"
-	} else {
-		resp.Body.Close()
-		health["ollama"] = "running"
+	// Embedder status. Before v6.8.8 the dashboard hard-coded an Ollama probe
+	// to localhost:11434, which painted "Ollama offline" any time the operator
+	// had selected the openai-compatible or hash provider — cosmetic only, but
+	// confusing because SAGE was actually embedding fine through the configured
+	// path. We now dispatch on the configured provider: type-assert h.embedder
+	// to the optional interfaces in internal/embedding (Named / Modeler /
+	// Pinger / the Dimension+Ready+Semantic trio from Provider) and report a
+	// structured embedder block.
+	//
+	// The legacy "ollama" string field is still populated so older builds of
+	// the dashboard JS keep showing something sensible during version skew:
+	//   - provider == "ollama": "running" iff the configured client pings ok
+	//   - provider != "ollama": "n/a" — the old key is no longer meaningful,
+	//     but we don't reuse it to signal openai-compatible state because old
+	//     clients would mis-render that as "Ollama running".
+	provider, model := "", ""
+	dimension := 0
+	ready := false
+	semantic := false
+	probeAttempted := false
+	probeOK := false
+
+	if h.embedder != nil {
+		if ep, ok := h.embedder.(embedderProvider); ok {
+			dimension = ep.Dimension()
+			ready = ep.Ready()
+			semantic = ep.Semantic()
+		}
+		if named, ok := h.embedder.(embedding.Named); ok {
+			provider = named.Name()
+		} else if semantic {
+			// Pre-Named providers in the wild are Ollama; hash exposes
+			// Semantic()=false. Mirror api/rest/embed_handler.go's fallback.
+			provider = "ollama"
+		} else {
+			provider = "hash"
+		}
+		if modeler, ok := h.embedder.(embedding.Modeler); ok {
+			model = modeler.Model()
+		}
+		if pinger, ok := h.embedder.(embedding.Pinger); ok {
+			probeAttempted = true
+			pingCtx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+			if err := pinger.Ping(pingCtx); err == nil {
+				probeOK = true
+			}
+			cancel()
+		}
 	}
+
+	// Legacy field, kept for backward compatibility with pre-v6.8.8 dashboards
+	// that read health.ollama directly.
+	switch provider {
+	case "ollama":
+		if probeAttempted {
+			if probeOK {
+				health["ollama"] = "running"
+			} else {
+				health["ollama"] = "offline"
+			}
+		} else {
+			// No Pinger on this Ollama client (shouldn't happen in current
+			// builds, but keep the legacy probe as a fallback so the field
+			// stays accurate).
+			client := &http.Client{Timeout: 2 * time.Second}
+			ollamaReq, _ := http.NewRequestWithContext(r.Context(), "GET", "http://localhost:11434/api/tags", nil)
+			if resp, err := client.Do(ollamaReq); err != nil {
+				health["ollama"] = "offline"
+			} else {
+				resp.Body.Close()
+				health["ollama"] = "running"
+			}
+		}
+	default:
+		// "n/a" signals to legacy clients that this field doesn't describe
+		// the active embedder. New clients ignore it and read health.embedder.
+		health["ollama"] = "n/a"
+	}
+
+	embedderInfo := map[string]any{
+		"provider":  provider,
+		"dimension": dimension,
+		"ready":     ready,
+		"semantic":  semantic,
+	}
+	if model != "" {
+		embedderInfo["model"] = model
+	}
+	// online: best-effort liveness for the operator pill. Prefer Pinger
+	// (real-time), fall back to Ready() (sticky has-ever-succeeded). Hash
+	// is always online — it has no upstream.
+	switch {
+	case probeAttempted:
+		embedderInfo["online"] = probeOK
+	case provider == "hash":
+		embedderInfo["online"] = true
+	default:
+		embedderInfo["online"] = ready
+	}
+	if h.embedder == nil {
+		embedderInfo["provider"] = "none"
+		embedderInfo["online"] = false
+	}
+	health["embedder"] = embedderInfo
 
 	// Get memory stats
 	stats, err := h.store.GetStats(r.Context())

--- a/web/handler_health_embedder_test.go
+++ b/web/handler_health_embedder_test.go
@@ -1,0 +1,210 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeEmbedder is a test double for an embedding.Provider. It supplies the
+// full optional interface surface (Name / Model / Dimension / Ready / Semantic
+// / Ping) the dashboard health endpoint type-asserts against, so each variant
+// of the matrix (ollama running, openai-compatible offline, hash, missing) can
+// be exercised without standing up a real backing service.
+type fakeEmbedder struct {
+	name      string
+	model     string
+	dimension int
+	ready     bool
+	semantic  bool
+	pingErr   error
+}
+
+func (f *fakeEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return make([]float32, f.dimension), nil
+}
+func (f *fakeEmbedder) Name() string                 { return f.name }
+func (f *fakeEmbedder) Model() string                { return f.model }
+func (f *fakeEmbedder) Dimension() int               { return f.dimension }
+func (f *fakeEmbedder) Ready() bool                  { return f.ready }
+func (f *fakeEmbedder) Semantic() bool               { return f.semantic }
+func (f *fakeEmbedder) Ping(_ context.Context) error { return f.pingErr }
+
+// hashOnlyEmbedder reproduces the (pre-Named) HashProvider shape: no Name,
+// no Model, no Pinger. The dashboard must still classify it correctly using
+// Semantic()=false as the fallback signal — same logic as
+// api/rest/embed_handler.go.
+type hashOnlyEmbedder struct{}
+
+func (hashOnlyEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return make([]float32, 768), nil
+}
+func (hashOnlyEmbedder) Dimension() int { return 768 }
+func (hashOnlyEmbedder) Ready() bool    { return true }
+func (hashOnlyEmbedder) Semantic() bool { return false }
+
+// doHealth dispatches GET /v1/dashboard/health against a router built from h
+// and returns the decoded JSON body. It's a thin helper so the table tests
+// below stay legible.
+func doHealth(t *testing.T, h *DashboardHandler) map[string]any {
+	t.Helper()
+	r := testRouter(h)
+	req := httptest.NewRequest("GET", "/v1/dashboard/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	return resp
+}
+
+// TestHandleHealth_EmbedderOllamaRunning is the happy-path case for the
+// pre-existing default deployment: an Ollama client that pings successfully
+// must produce embedder.provider="ollama", embedder.online=true, AND the
+// legacy "ollama":"running" field so older dashboards keep working.
+func TestHandleHealth_EmbedderOllamaRunning(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetEmbedder(&fakeEmbedder{
+		name:      "ollama",
+		model:     "nomic-embed-text",
+		dimension: 768,
+		ready:     true,
+		semantic:  true,
+		pingErr:   nil,
+	})
+
+	resp := doHealth(t, h)
+
+	emb, ok := resp["embedder"].(map[string]any)
+	require.True(t, ok, "embedder block must be present")
+	assert.Equal(t, "ollama", emb["provider"])
+	assert.Equal(t, "nomic-embed-text", emb["model"])
+	assert.Equal(t, float64(768), emb["dimension"])
+	assert.Equal(t, true, emb["online"])
+	assert.Equal(t, true, emb["semantic"])
+	assert.Equal(t, true, emb["ready"])
+
+	// Legacy field — pre-fix dashboards read this; must still say "running"
+	// for the Ollama-online case so we don't regress them.
+	assert.Equal(t, "running", resp["ollama"])
+}
+
+// TestHandleHealth_EmbedderOllamaOffline covers Ollama configured but the
+// upstream unreachable: provider stays "ollama", online flips to false, and
+// the legacy field reflects it.
+func TestHandleHealth_EmbedderOllamaOffline(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetEmbedder(&fakeEmbedder{
+		name:      "ollama",
+		model:     "nomic-embed-text",
+		dimension: 768,
+		ready:     false,
+		semantic:  true,
+		pingErr:   errors.New("connection refused"),
+	})
+
+	resp := doHealth(t, h)
+
+	emb := resp["embedder"].(map[string]any)
+	assert.Equal(t, "ollama", emb["provider"])
+	assert.Equal(t, false, emb["online"])
+	assert.Equal(t, "offline", resp["ollama"])
+}
+
+// TestHandleHealth_EmbedderOpenAICompatibleOnline is the bug-fix case: with
+// openai-compatible selected, the dashboard MUST NOT paint "Ollama offline".
+// embedder.provider="openai-compatible", and the legacy field flips to
+// "n/a" so older dashboards don't render a misleading Ollama status.
+func TestHandleHealth_EmbedderOpenAICompatibleOnline(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetEmbedder(&fakeEmbedder{
+		name:      "openai-compatible",
+		model:     "Alibaba-NLP/gte-Qwen2-1.5B-instruct",
+		dimension: 1536,
+		ready:     true,
+		semantic:  true,
+		pingErr:   nil,
+	})
+
+	resp := doHealth(t, h)
+
+	emb := resp["embedder"].(map[string]any)
+	assert.Equal(t, "openai-compatible", emb["provider"])
+	assert.Equal(t, "Alibaba-NLP/gte-Qwen2-1.5B-instruct", emb["model"])
+	assert.Equal(t, float64(1536), emb["dimension"])
+	assert.Equal(t, true, emb["online"])
+	assert.Equal(t, true, emb["semantic"])
+
+	// Legacy field is now "n/a" — older dashboards will paint Ollama as
+	// "unknown" rather than the false-positive "Connected" we'd get if we
+	// claimed "running" with a non-Ollama provider.
+	assert.Equal(t, "n/a", resp["ollama"])
+}
+
+// TestHandleHealth_EmbedderOpenAICompatibleOffline confirms the operator pill
+// will correctly show the openai-compatible endpoint as offline when its
+// Ping fails — a wedge case that, without the fix, the user would see as
+// "Ollama offline" and chase the wrong upstream.
+func TestHandleHealth_EmbedderOpenAICompatibleOffline(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetEmbedder(&fakeEmbedder{
+		name:      "openai-compatible",
+		model:     "gte-qwen2",
+		dimension: 1536,
+		ready:     false,
+		semantic:  true,
+		pingErr:   errors.New("dial tcp: connect: connection refused"),
+	})
+
+	resp := doHealth(t, h)
+
+	emb := resp["embedder"].(map[string]any)
+	assert.Equal(t, "openai-compatible", emb["provider"])
+	assert.Equal(t, false, emb["online"])
+	assert.Equal(t, "n/a", resp["ollama"])
+}
+
+// TestHandleHealth_EmbedderHash exercises the pre-Named hash provider path.
+// It has no Name(), no Model(), no Pinger — but Semantic()=false is enough
+// to label it correctly. Hash has no upstream, so online=true is the right
+// answer (the embed call never leaves the process).
+func TestHandleHealth_EmbedderHash(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetEmbedder(hashOnlyEmbedder{})
+
+	resp := doHealth(t, h)
+
+	emb := resp["embedder"].(map[string]any)
+	assert.Equal(t, "hash", emb["provider"])
+	assert.Equal(t, float64(768), emb["dimension"])
+	assert.Equal(t, true, emb["online"], "hash provider is always online — no upstream to fail")
+	assert.Equal(t, false, emb["semantic"])
+	// Model is omitted for hash — the helper assert.NotContains makes the
+	// "no model suffix in the UI" contract explicit.
+	_, hasModel := emb["model"]
+	assert.False(t, hasModel, "hash provider must not advertise a model identifier")
+	// Legacy field — hash isn't Ollama, so "n/a".
+	assert.Equal(t, "n/a", resp["ollama"])
+}
+
+// TestHandleHealth_EmbedderNotConfigured covers the boot-window case where
+// SetEmbedder hasn't been called yet. The block must still be present (so
+// the dashboard can render a sensible "no embedder" state) and online must
+// be false.
+func TestHandleHealth_EmbedderNotConfigured(t *testing.T) {
+	h, _ := newTestHandler(t)
+	// Deliberately no SetEmbedder call.
+
+	resp := doHealth(t, h)
+
+	emb, ok := resp["embedder"].(map[string]any)
+	require.True(t, ok, "embedder block must always be present, even when nil")
+	assert.Equal(t, "none", emb["provider"])
+	assert.Equal(t, false, emb["online"])
+}

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -102,6 +102,82 @@ function confidenceColor(v) {
     return '#ef4444';
 }
 
+// describeEmbedder normalizes the /v1/dashboard/health embedder block into the
+// shape the status pill + system-status row need. Handles three server tiers:
+//   1. v6.8.8+:   health.embedder = { provider, model, dimension, ready,
+//                                     semantic, online }
+//   2. v6.8.7:    health.ollama only ("running" | "offline"). Treat as Ollama
+//                 even though that may be wrong — pre-fix server can't tell us
+//                 otherwise, and the misreport this exists to fix is exactly
+//                 this case. Once upstream ships the fix this branch becomes
+//                 dead code for new deployments.
+//   3. degraded:  no health at all → unknown.
+function describeEmbedder(health) {
+    // displayName is the short noun the System Status row renders as the
+    // dependency name (the "Ollama" column equivalent). It's deliberately not
+    // derived from shortLabel.split(' ')[0] — that worked for "Ollama" /
+    // "Hash" / "OpenAI-compatible" but produced "No" for the
+    // "No embedder configured" case.
+    const displayName = {
+        'ollama': 'Ollama',
+        'openai-compatible': 'OpenAI-compatible',
+        'hash': 'Hash provider',
+        'none': 'Embedder',
+        'unknown': 'Embedder',
+    };
+    const emb = health?.embedder;
+    if (emb && emb.provider) {
+        const p = emb.provider;
+        const online = !!emb.online;
+        let label;
+        switch (p) {
+            case 'ollama':
+                label = `Ollama ${online ? 'connected' : 'offline'}`;
+                break;
+            case 'openai-compatible':
+                label = `OpenAI-compatible ${online ? 'connected' : 'offline'}`;
+                break;
+            case 'hash':
+                // Hash has no upstream and no semantic meaning. Make the
+                // operator-facing label say so loudly — it's a test/fallback
+                // mode and a long-running deployment on it is almost always
+                // a misconfiguration.
+                label = 'Hash provider (no semantic search)';
+                break;
+            case 'none':
+                label = 'No embedder configured';
+                break;
+            default:
+                label = `${p} ${online ? 'connected' : 'offline'}`;
+        }
+        // Append model + dimension when known. Hash and "none" don't get a
+        // model suffix — they don't talk to anything.
+        const detailParts = [];
+        if (emb.model && p !== 'hash' && p !== 'none') detailParts.push(emb.model);
+        if (emb.dimension && p !== 'none') detailParts.push(`${emb.dimension}-dim`);
+        const detail = detailParts.length ? ` (${detailParts.join(', ')})` : '';
+        return {
+            provider: p,
+            online,
+            label: label + detail,
+            shortLabel: label,
+            displayName: displayName[p] || p,
+            detail: detailParts.join(', '),
+        };
+    }
+    // Pre-v6.8.8 fallback: only the legacy ollama string is available. The
+    // value "n/a" means a newer server explicitly told us not to use this
+    // field — treat as unknown so we don't paint a false Ollama status.
+    const legacy = health?.ollama;
+    if (legacy === 'running') {
+        return { provider: 'ollama', online: true, label: 'Ollama connected', shortLabel: 'Ollama connected', displayName: displayName.ollama, detail: '' };
+    }
+    if (legacy === 'offline') {
+        return { provider: 'ollama', online: false, label: 'Ollama offline', shortLabel: 'Ollama offline', displayName: displayName.ollama, detail: '' };
+    }
+    return { provider: 'unknown', online: false, label: 'Embedder status unknown', shortLabel: 'Embedder unknown', displayName: displayName.unknown, detail: '' };
+}
+
 // SVG Icons
 const icons = {
     brain: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2C9.5 2 7.5 3.5 7 5.5C5.5 5.5 4 7 4 9c0 1.5.8 2.8 2 3.5C5.5 13.5 5 15 5.5 16.5c.5 1 1.5 2 3 2.5l.5 1c.3.6 1 1 1.7 1h2.6c.7 0 1.4-.4 1.7-1l.5-1c1.5-.5 2.5-1.5 3-2.5.5-1.5 0-3-.5-4C19.2 11.8 20 10.5 20 9c0-2-1.5-3.5-3-3.5C16.5 3.5 14.5 2 12 2z"/><path d="M12 2v19" opacity="0.3"/><path d="M8 8c-1 0-2 .5-2 1.5" opacity="0.5"/><path d="M16 8c1 0 2 .5 2 1.5" opacity="0.5"/></svg>`,
@@ -3017,7 +3093,10 @@ function SettingsPage() {
     const ver = health?.version || 'dev';
     const encrypted = health?.encrypted || false;
     const chain = health?.chain || null;
-    const ollama = health?.ollama || 'unknown';
+    // Embedder status. v6.8.8+ servers return a structured `embedder` block;
+    // older servers only set the `ollama` string. Derive a normalized view
+    // so the row below this can render any provider without branching twice.
+    const embedderStatus = describeEmbedder(health);
     const uptimeRaw = health?.uptime || '';
     const uptimeBaseSec = useRef(0);
     const [uptimeOffset, setUptimeOffset] = useState(0);
@@ -3140,7 +3219,7 @@ function SettingsPage() {
                         <div class="settings-section">
                             <h3>System Status</h3>
                             <div class="settings-row"><span class="label">${statusDot(true)} SAGE</span><span class="value" style="color:#10b981">Running</span></div>
-                            <div class="settings-row"><span class="label">${statusDot(ollama === 'running')} Ollama</span><span class="value" style="color: ${ollama === 'running' ? '#10b981' : '#6b7280'}">${ollama === 'running' ? 'Connected' : 'Offline'}</span></div>
+                            <div class="settings-row"><span class="label">${statusDot(embedderStatus.online)} ${embedderStatus.displayName}</span><span class="value" style="color: ${embedderStatus.online ? '#10b981' : '#6b7280'}" title="${embedderStatus.detail || ''}">${embedderStatus.online ? (embedderStatus.detail ? embedderStatus.detail : 'Connected') : 'Offline'}</span></div>
                             <div class="settings-row"><span class="label">${statusDot(encrypted)} Synaptic Ledger Encryption</span><span class="value" style="color: ${encrypted ? '#10b981' : '#6b7280'}">${encrypted ? 'AES-256-GCM' : 'Off'}</span></div>
                             <div class="settings-row"><span class="label">Version</span><span class="value">${ver}</span></div>
                             <div class="settings-row"><span class="label">Uptime</span><span class="value">${uptime}</span></div>
@@ -3944,15 +4023,15 @@ function HealthBar() {
 
     if (!health) return null;
 
-    const ollamaOk = health.ollama === 'running';
+    const embedderStatus = describeEmbedder(health);
     const totalMem = health.memories?.total_memories || 0;
     const domains = health.memories?.by_domain ? Object.keys(health.memories.by_domain).length : 0;
 
     return html`
         <div class="health-bar">
-            <div class="health-item">
-                <div class="health-dot ${ollamaOk ? 'ok' : 'err'}"></div>
-                <span>Ollama ${ollamaOk ? 'connected' : 'offline'}</span>
+            <div class="health-item" title="${embedderStatus.detail || ''}">
+                <div class="health-dot ${embedderStatus.online ? 'ok' : 'err'}"></div>
+                <span>${embedderStatus.label}</span>
             </div>
             <div class="health-sep"></div>
             <div class="health-item">


### PR DESCRIPTION
Follow-up to #22.

Before this fix the CEREBRUM dashboard's `/v1/dashboard/health` endpoint hard-coded a probe to `http://localhost:11434/api/tags` and set `health.ollama` to `running` or `offline` regardless of which embedder was actually configured. The status pill at the top of CEREBRUM and the System Status row on the Settings → Overview tab both read that single field, so any deployment that picked `openai-compatible` (PR #22, shipped in v6.8.7) or `hash` got a permanent red "Ollama offline" indicator even when embeddings were flowing fine through the configured upstream. Purely cosmetic, but it actively misleads the operator about which dependency to chase when something does go wrong.

## Backend (`web/handler.go` `handleHealth`)

- Type-assert `h.embedder` against the optional `embedding.Named`, `embedding.Modeler`, `embedding.Pinger` interfaces (plus the `Dimension` / `Ready` / `Semantic` trio every `Provider` already has).
- Return a structured `embedder` block:

  ```json
  {
    "provider": "openai-compatible",
    "model": "Alibaba-NLP/gte-Qwen2-1.5B-instruct",
    "dimension": 1536,
    "ready": true,
    "semantic": true,
    "online": true
  }
  ```

  `online` prefers a live `Pinger` probe with a 2s context timeout; falls back to `Ready()` for providers without a `Ping`; hash is always online (no upstream).
- The legacy `ollama` string field is kept but flips to `"n/a"` when the configured provider isn't Ollama, so pre-fix dashboards stop rendering a false-positive "Ollama running" for non-Ollama deployments. Ollama deployments still see `"running"` / `"offline"` as before.

## New optional interfaces (`internal/embedding/provider.go`)

- `Modeler { Model() string }` — surfaces the configured model name in the UI; useful when an operator runs several embedding models on the same vLLM / LiteLLM endpoint.
- `Pinger { Ping(ctx) error }` — cheap liveness check separate from `Ready()`, which is a sticky has-ever-succeeded flag. For an operator-facing pill we want a real-time signal.

Both the Ollama client (`internal/embedding/ollama.go`) and the OpenAI-compatible client (`internal/embedding/openai_compatible.go`) now implement `Modeler`. Ollama already had `Ping`; the OpenAI-compatible client gets a `Ping` that issues a minimal `/v1/embeddings` call — the spec doesn't define a health path and most servers return fast on a one-token input.

## Frontend (`web/static/js/app.js`)

- New `describeEmbedder(health)` helper normalizes both the v6.8.8+ embedder block and the legacy `ollama` string into a single `{ provider, online, label, shortLabel, detail }` view so the two render sites (top health bar + Settings System Status row) stay in sync.
- Labels:

  | provider             | label |
  |----------------------|-------|
  | `ollama`             | Ollama connected/offline |
  | `openai-compatible`  | OpenAI-compatible connected/offline |
  | `hash`               | Hash provider (no semantic search) |
  | `none`               | No embedder configured |

  plus a `(model, N-dim)` suffix when the server reports them.
- Pre-v6.8.8 fallback: when only `health.ollama` is present and is `"running"` or `"offline"`, render the Ollama label. When it is `"n/a"` or absent, render "Embedder status unknown" rather than fabricating an Ollama status.

## Tests (`web/handler_health_embedder_test.go`, 6 cases)

- ollama running / offline
- openai-compatible online / offline (the bug-fix case — provider correctly reported as `openai-compatible`, legacy `ollama` field flips to `"n/a"`)
- hash (`Semantic()=false` fallback, no model suffix, always online)
- not configured (embedder block still present with `provider="none"`)

```
$ go test ./web/ -run TestHandleHealth_Embedder -v
--- PASS: TestHandleHealth_EmbedderOllamaRunning (0.18s)
--- PASS: TestHandleHealth_EmbedderOllamaOffline (0.20s)
--- PASS: TestHandleHealth_EmbedderOpenAICompatibleOnline (0.22s)
--- PASS: TestHandleHealth_EmbedderOpenAICompatibleOffline (0.20s)
--- PASS: TestHandleHealth_EmbedderHash (0.20s)
--- PASS: TestHandleHealth_EmbedderNotConfigured (0.21s)
PASS
```

`go test ./...` is green across the tree. `golangci-lint v2.1.6 run ./web/ ./internal/embedding/` reports `0 issues`.

## Local verification

Verified against a locally rebuilt `6.8.7-cerebrum-pill` image swapped into a stack pointed at `gte-Qwen2-1.5B-instruct` over the openai-compatible provider. `GET /v1/dashboard/health` returned:

```json
{
  "embedder": {
    "dimension": 1536,
    "model": "Alibaba-NLP/gte-Qwen2-1.5B-instruct",
    "online": true,
    "provider": "openai-compatible",
    "ready": false,
    "semantic": true
  },
  "ollama": "n/a",
  ...
}
```

and the pill in the browser renders `OpenAI-compatible connected (Alibaba-NLP/gte-Qwen2-1.5B-instruct, 1536-dim)` with a green dot. After verification the local stack was reverted to the upstream `:6.8.7` image.

## Scope

BFT consensus and the app-validator layer are untouched. This change is entirely below the embedder API surface and above the validator layer; the embed call path itself is unmodified.