### PR TITLE
fix(abci): Info — report current app version from activated forks, not hardcoded 1

### DIFF
--- a/internal/abci/app.go
+++ b/internal/abci/app.go
@@ -746,6 +746,33 @@ func NewSageAppWithStores(bs *store.BadgerStore, offchain store.OffchainStore, l
 	return app, nil
 }
 
+// currentAppVersion reports the consensus app version this node announces to
+// CometBFT in Info(): the highest activated PoE fork's target version, or 1 if
+// none has activated. FinalizeBlock bumps consensus_params.version.app to
+// plan.TargetAppVersion when a fork activates, so a node restarting on a
+// post-fork chain MUST report the same version here or the CometBFT handshake
+// sees an app-version regression against the committed consensus params.
+//
+// The fork gates activate in order (reconcilePoEForkMonotonicity guarantees a
+// higher fork implies every lower one is applied too), so a top-down check
+// returns the current version. The fields are populated by the refreshV8*Fork
+// calls in NewSageApp before CometBFT ever calls Info(). A new fork must add
+// its case here, mirroring the v8*UpgradeName constants (app-vN → version N).
+func (app *SageApp) currentAppVersion() uint64 {
+	switch {
+	case app.v8_4AppliedHeight > 0:
+		return 5 // app-v5 (v8.4 domain-factor)
+	case app.v8_3AppliedHeight > 0:
+		return 4 // app-v4 (v8.3 PoE signals)
+	case app.v8_2AppliedHeight > 0:
+		return 3 // app-v3 (v8.2 PoE-weighted quorum)
+	case app.v8AppliedHeight > 0:
+		return 2 // app-v2 (v8.0 access-control)
+	default:
+		return 1
+	}
+}
+
 // Info returns application info for CometBFT handshake.
 func (app *SageApp) Info(_ context.Context, req *abcitypes.RequestInfo) (*abcitypes.ResponseInfo, error) {
 	ver := app.Version
@@ -755,7 +782,7 @@ func (app *SageApp) Info(_ context.Context, req *abcitypes.RequestInfo) (*abcity
 	return &abcitypes.ResponseInfo{
 		Data:             "sage",
 		Version:          ver,
-		AppVersion:       1,
+		AppVersion:       app.currentAppVersion(),
 		LastBlockHeight:  app.state.Height,
 		LastBlockAppHash: app.state.AppHash,
 	}, nil

--- a/internal/abci/v8_fork_test.go
+++ b/internal/abci/v8_fork_test.go
@@ -1,8 +1,10 @@
 package abci
 
 import (
+	"context"
 	"testing"
 
+	abcitypes "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +34,37 @@ func TestV8Fork_PredicateBoundary(t *testing.T) {
 	assert.False(t, app.postV8Fork(100), "at activation block: still pre-fork (H+1 semantic)")
 	assert.True(t, app.postV8Fork(101), "first post-activation block: post-fork")
 	assert.True(t, app.postV8Fork(1_000_000), "far future: post-fork")
+}
+
+// TestInfo_AppVersionReflectsActivatedFork asserts Info() reports the consensus
+// app version matching the highest activated PoE fork, instead of a hardcoded
+// 1. FinalizeBlock bumps consensus_params.version.app to plan.TargetAppVersion
+// on activation (app-vN → N); a node restarting on a post-fork chain that still
+// reported AppVersion=1 here would hand CometBFT an app-version regression
+// against the committed consensus params. The activations are cumulative,
+// mirroring a real chain progressing app-v2 → app-v5 in order.
+func TestInfo_AppVersionReflectsActivatedFork(t *testing.T) {
+	app := setupTestApp(t)
+
+	info := func() uint64 {
+		resp, err := app.Info(context.TODO(), &abcitypes.RequestInfo{})
+		require.NoError(t, err)
+		return resp.AppVersion
+	}
+
+	assert.Equal(t, uint64(1), info(), "fresh chain (no fork) reports app version 1")
+
+	app.v8AppliedHeight = 10
+	assert.Equal(t, uint64(2), info(), "app-v2 (v8.0 access-control) → version 2")
+
+	app.v8_2AppliedHeight = 20
+	assert.Equal(t, uint64(3), info(), "app-v3 (v8.2 PoE-weighted quorum) → version 3")
+
+	app.v8_3AppliedHeight = 30
+	assert.Equal(t, uint64(4), info(), "app-v4 (v8.3 PoE signals) → version 4")
+
+	app.v8_4AppliedHeight = 40
+	assert.Equal(t, uint64(5), info(), "app-v5 (v8.4 domain-factor) → version 5")
 }
 
 // TestV8Fork_RefreshFromPersisted asserts refreshV8Fork pulls the height


### PR DESCRIPTION
## What

`Info()` reports the consensus app version matching the highest activated PoE fork instead of a hardcoded `1`. A new `currentAppVersion()` helper derives it from the existing `v8*AppliedHeight` fields; `Info()` calls it in place of the literal at `internal/abci/app.go:785`.

## Why

`FinalizeBlock` bumps `consensus_params.version.app` to `plan.TargetAppVersion` every time a PoE fork activates. The repo now has four activated fork gates:

- app-v2 (v8.0 access-control) → version 2
- app-v3 (v8.2 PoE-weighted quorum) → version 3
- app-v4 (v8.3 PoE signals) → version 4
- app-v5 (v8.4 domain-factor) → version 5

But `Info()` (`internal/abci/app.go:777`) still announced `AppVersion: 1` to CometBFT on every (re)connect. So a node restarting on any current chain reports `app=1` while the committed consensus params say `app=5` — an app-version regression at the handshake. The exposure is aggravated by v8.2.1 bumping CometBFT v0.38.15 → v0.38.23 (commit `0eb7bda`); handshake strictness can vary across that gap.

This surfaced during the v8.0 review and was deferred while the mismatch was only 1→2. The v8.2/v8.3/v8.4 fork stack widened it to 1→5, which makes it worth shipping now.

## How

- `currentAppVersion()` does a top-down check of `v8_4AppliedHeight` / `v8_3AppliedHeight` / `v8_2AppliedHeight` / `v8AppliedHeight`, returning the highest activated fork's target version (app-vN → N), else 1.
- The check is correct because `reconcilePoEForkMonotonicity` guarantees a higher fork implies every lower one is applied, and the fields are populated by the `refreshV8*Fork` calls in `NewSageApp` before CometBFT ever calls `Info()`.
- A new fork adds one case to the helper, mirroring the `v8*UpgradeName` constants — documented inline so the next bump isn't missed.

## ABCI determinism

Consensus path untouched. `Info()` is the handshake-reporting path only — it does not touch `FinalizeBlock`, `AppHash`, or any committed state, so there is no replay divergence and no fork gate is needed. The fix brings what the node *reports* into agreement with the version `FinalizeBlock` already commits. The `FinalizeBlock` side (`ConsensusParamUpdates.Version.App = plan.TargetAppVersion`) is unchanged and stays pinned by `upgrade_drift_test.go`.

## Tests

- `TestInfo_AppVersionReflectsActivatedFork` in `internal/abci/v8_fork_test.go` — cumulatively activates app-v2 → app-v5 and asserts `Info()` reports 1→2→3→4→5. Companion to `upgrade_drift_test.go`, which pins the `FinalizeBlock`-emitted version across replicas.
- `go build ./...`, `go vet ./...` clean.
- `go test -race -count=1 ./internal/abci/...` clean (full package).
- `golangci-lint v2.12.2` (current CI pin) — 0 issues.
