### PR TITLE
fix(rest): handleEmbed — report the actual embedding model, not a hardcoded literal

### DIFF
--- a/api/rest/embed_handler.go
+++ b/api/rest/embed_handler.go
@@ -103,9 +103,22 @@ func (s *Server) handleEmbed(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Report the model the embedding was actually produced with. Providers
+	// expose it via the optional embedding.Modeler interface (openai-compatible
+	// returns its configured model, Ollama returns its bound model). Mirrors
+	// handleEmbedInfo's feature-detect of the Named interface for `provider`.
+	// Falls back to the legacy default for providers that don't implement
+	// Modeler (e.g. the hash provider), preserving prior behavior there.
+	model := "nomic-embed-text"
+	if m, ok := s.embedder.(embedding.Modeler); ok {
+		if name := m.Model(); name != "" {
+			model = name
+		}
+	}
+
 	writeJSON(w, http.StatusOK, EmbedResponse{
 		Embedding: emb,
-		Model:     "nomic-embed-text",
+		Model:     model,
 		Dimension: len(emb),
 	})
 }

--- a/api/rest/embed_handler_test.go
+++ b/api/rest/embed_handler_test.go
@@ -157,3 +157,75 @@ func TestHandleEmbedInfo_NamedProviderOverridesOllama(t *testing.T) {
 	assert.Equal(t, "openai-compatible", resp.Provider)
 	assert.Equal(t, 1536, resp.Dimension)
 }
+
+// modeledEmbedder implements the optional embedding.Modeler interface so we
+// can assert /v1/embed reports the model the embedding was actually produced
+// with, rather than the hardcoded "nomic-embed-text" literal.
+type modeledEmbedder struct {
+	model string
+	dim   int
+}
+
+func (m *modeledEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return make([]float32, m.dim), nil
+}
+func (m *modeledEmbedder) Dimension() int { return m.dim }
+func (m *modeledEmbedder) Ready() bool    { return true }
+func (m *modeledEmbedder) Semantic() bool { return true }
+func (m *modeledEmbedder) Model() string  { return m.model }
+
+// TestHandleEmbed_ModelerReportsActualModel confirms POST /v1/embed reports the
+// provider's actual model (via the optional Modeler interface) instead of the
+// hardcoded "nomic-embed-text". An openai-compatible node must not claim its
+// gte-Qwen2 embeddings came from nomic-embed-text.
+func TestHandleEmbed_ModelerReportsActualModel(t *testing.T) {
+	emb := &modeledEmbedder{model: "Alibaba-NLP/gte-Qwen2-1.5B-instruct", dim: 1536}
+
+	memStore := newMockMemoryStore()
+	scoreStore := newMockScoreStore()
+	health := metrics.NewHealthChecker()
+	health.SetPostgresHealth(true)
+	health.SetCometBFTHealth(true)
+
+	srv := NewServer("", memStore, scoreStore, nil, health, zerolog.Nop(), emb)
+
+	body := []byte(`{"text":"hello"}`)
+	req, _ := signedRequest(t, http.MethodPost, "/v1/embed", body)
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp EmbedResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	assert.Equal(t, "Alibaba-NLP/gte-Qwen2-1.5B-instruct", resp.Model,
+		"/v1/embed must report the provider's actual model, not the hardcoded default")
+	assert.Equal(t, 1536, resp.Dimension)
+}
+
+// TestHandleEmbed_FallsBackForNonModeler confirms a provider that does NOT
+// implement Modeler (e.g. the hash provider) preserves the legacy default
+// model string — the fix is additive and must not regress that path.
+func TestHandleEmbed_FallsBackForNonModeler(t *testing.T) {
+	hashEmbedder := embedding.NewHashProvider(768)
+
+	memStore := newMockMemoryStore()
+	scoreStore := newMockScoreStore()
+	health := metrics.NewHealthChecker()
+	health.SetPostgresHealth(true)
+	health.SetCometBFTHealth(true)
+
+	srv := NewServer("", memStore, scoreStore, nil, health, zerolog.Nop(), hashEmbedder)
+
+	body := []byte(`{"text":"hello"}`)
+	req, _ := signedRequest(t, http.MethodPost, "/v1/embed", body)
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp EmbedResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	assert.Equal(t, "nomic-embed-text", resp.Model,
+		"non-Modeler provider must preserve the legacy default model string")
+}


### PR DESCRIPTION
## What

`POST /v1/embed` now reports the model that actually produced the embedding instead of a hardcoded `"nomic-embed-text"`. A node running the `openai-compatible` embedder previously returned `model: "nomic-embed-text"` for vectors produced by a different model (e.g. `Alibaba-NLP/gte-Qwen2-1.5B-instruct`).

## Why

`handleEmbed` (`api/rest/embed_handler.go`) wrote `Model: "nomic-embed-text"` literally into every `EmbedResponse`, regardless of the configured provider. `api/openapi.yaml:1234` documents `EmbedResponse.model` as the model name with no caveat, so a stale literal contradicts the spec.

The `embedding.Modeler` optional interface (`internal/embedding/provider.go:32`, `Model() string`) already exists for exactly this. Both real providers implement it — `OpenAICompatibleClient.Model()` (`internal/embedding/openai_compatible.go:166`) returns its configured model, Ollama `Client.Model()` (`internal/embedding/ollama.go:139`) returns its bound model. The sibling `handleEmbedInfo` in the same file already feature-detects the optional `Named` interface to report the real `provider` (`api/rest/embed_handler.go:55`); `handleEmbed` was never given the parallel treatment for `model`.

This completes wiring that landed in PR #22 (`feat(embedding): add OpenAI-compatible embedder provider`) — that PR added the provider and the `Modeler` interface, but `/v1/embed`'s response stayed hardcoded. It's the same misreport class as PR #24 (`fix(cerebrum): status pill dispatches on embedding.provider`): a surface lying about the active provider/model, in a handler #24 didn't touch.

## How

- after computing the embedding, feature-detect `embedding.Modeler` and use `Model()` when present and non-empty
- fall back to the legacy `"nomic-embed-text"` literal only for providers that don't implement `Modeler` (the hash provider), preserving prior behavior on that path
- mirrors `handleEmbedInfo`'s `Named` feature-detect pattern exactly

## ABCI determinism

No consensus-path code touched. This is a read/util REST handler that formats a response; no tx, no `internal/abci`, no store write, no AppHash contribution.

## Tests

- `TestHandleEmbed_ModelerReportsActualModel` — a `Modeler`-implementing embedder makes `/v1/embed` report its actual model (`Alibaba-NLP/gte-Qwen2-1.5B-instruct`), not the default; mirrors `TestHandleEmbedInfo_NamedProviderOverridesOllama`
- `TestHandleEmbed_FallsBackForNonModeler` — the hash provider (no `Modeler`) still returns the legacy `nomic-embed-text` default; pins no-regression on that path
- `go build ./...` clean
- `go test -race -count=1 ./api/rest/...` clean
- `golangci-lint v2.12.2` (current CI pin) clean
