### PR TITLE
v9.2.3: operator `sage-gui upgrade` surface for app-v7…app-v10 forks (closes #32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,20 @@ Add agents, configure domain-level read/write permissions, manage clearance leve
 
 ---
 
-## What's New in v9.2.2
+## What's New in v9.2.3
+
+**Operator path to activate the app-v7…app-v10 forks.** v9.2.3 is a non-fork patch: the committed app version stays 10 and nothing here touches consensus, the AppHash, or block replay. It closes a gap reported in [#32](https://github.com/l33tdawg/sage/issues/32) by [@ihubanov](https://github.com/ihubanov). The upgrade machinery's voting and processing halves were complete — `processUpgradePropose` activates a plan deterministically and validators auto-vote ACCEPT — but nothing in the tree could *submit* a plan for the governance-gated forks. The only `UpgradePropose` constructor was the boot watchdog, frozen at the deployment-safe default, so on a long-lived chain app-v7 (content-validation), app-v8 (quorum-gated upgrades), app-v9 (nonce/replay) and app-v10 (corroboration integrity) were unreachable past app-v6.
+
+- **New `sage-gui upgrade` command.** `upgrade status` shows the chain's app version and the next fork; `upgrade propose --target N` submits a signed, admin-gated `UpgradePropose` that routes through the existing 2/3 governance quorum. Off-consensus: the tx is built and signed client-side, and `processUpgradePropose` is unchanged.
+- **Strictly sequential activation, by design.** Targets must be `current + 1`. The app-v7…app-v10 fork gates are independent, but `currentAppVersion()` reports the highest active one and the on-chain regression guard rejects anything at or below current — so a jump (e.g. app-v6 → app-v10) would activate only the top fork and permanently strand the ones it skipped. The command refuses jumps and points you at the correct next step.
+- **Honest result reporting.** The proposal is committed and the block-execution result is read back, so an already-pending plan or a non-admin proposer key surfaces as a failure rather than a false success.
+
+SDK 9.2.3.
+
+## Older releases
+
+<details>
+<summary>v9.2.2 — snapshot retention/pruning (KeepLast wired + boot staging sweep + snapshot CLI)</summary>
 
 **Snapshot retention — the node now bounds its own disk.** v9.2.2 is a non-fork patch: the committed app version stays 10 and nothing here touches consensus or the AppHash. SAGE has taken periodic chain snapshots since v7.5 (every 10k blocks / 6h, plus before every upgrade), but it never reaped them — the `KeepLast` retention policy and the crash-staging sweep both existed yet were wired into nothing, so on a long-lived node snapshots accumulated without bound.
 
@@ -67,7 +80,7 @@ Add agents, configure domain-level read/write permissions, manage clearance leve
 
 SDK 9.2.2.
 
-## Older releases
+</details>
 
 <details>
 <summary>v9.2.1 — FTS5 backfill startup hotfix + two-sided fork-branch metrics + on-chain nonce seed</summary>

--- a/cmd/sage-gui/main.go
+++ b/cmd/sage-gui/main.go
@@ -51,6 +51,8 @@ func main() {
 		err = runBackup()
 	case "snapshot":
 		err = runSnapshot(os.Args[2:])
+	case "upgrade":
+		err = runUpgrade(os.Args[2:])
 	case "recover":
 		err = runRecover()
 	case "quorum-init":
@@ -91,6 +93,7 @@ Commands:
   import    Import memories from a .vault file
   backup    Create a timestamped backup of the memory database
   snapshot  List or prune on-disk chain snapshots (list | prune [--keep N])
+  upgrade   Activate app-version consensus forks (status | propose --target N)
   recover   Reset vault passphrase using your recovery key
   quorum-init   Initialize a quorum network (generates shared genesis)
   quorum-join   Join a quorum network (imports genesis from another node)

--- a/cmd/sage-gui/upgrade.go
+++ b/cmd/sage-gui/upgrade.go
@@ -1,0 +1,258 @@
+// Package main — `sage-gui upgrade` operator surface.
+//
+// This is the missing operator-submit half of the app-version upgrade
+// machinery (issue #32). The voting and processing halves already exist:
+// processUpgradePropose (internal/abci/app.go) persists and deterministically
+// activates a plan, and the validator auto-voter (node.go) re-votes ACCEPT on
+// any active upgrade proposal whose target this binary supports. But nothing in
+// the tree could *submit* a plan for app-v7…app-v10: the watchdog
+// (upgrade_watchdog.go) is frozen at the deployment-safe default and is the only
+// other TxTypeUpgradePropose constructor. Without this surface the
+// governance-gated forks — app-v7 (content-validation), app-v8 (quorum-gated
+// upgrades), app-v9 (nonce/replay), app-v10 (corroboration integrity, #31) —
+// are unreachable on a deployed chain.
+//
+// The command reuses the watchdog's exact signing/broadcast path
+// (buildUpgradeProposeTx → EncodeTx → broadcastTxSync, signed with the
+// operator's ~/.sage/agent.key) and adds the guards an operator action needs:
+// strictly-sequential targets (current+1 only) and a canonical plan name.
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	sageabci "github.com/l33tdawg/sage/internal/abci"
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+// defaultCometRPC is the local node's CometBFT RPC endpoint — the same address
+// runServe binds (node.go) and the watchdog talks to. Overridable per-invocation
+// via --rpc or the SAGE_COMET_RPC env var for non-default deployments.
+func defaultCometRPC() string {
+	if v := os.Getenv("SAGE_COMET_RPC"); v != "" {
+		return v
+	}
+	return "http://127.0.0.1:26657"
+}
+
+// runUpgrade dispatches `sage-gui upgrade <subcommand>`.
+func runUpgrade(args []string) error {
+	if len(args) == 0 {
+		printUpgradeUsage()
+		return nil
+	}
+	switch args[0] {
+	case "propose":
+		return runUpgradePropose(args[1:])
+	case "status":
+		return runUpgradeStatus(args[1:])
+	case "help", "--help", "-h":
+		printUpgradeUsage()
+		return nil
+	default:
+		printUpgradeUsage()
+		return fmt.Errorf("unknown upgrade subcommand %q", args[0])
+	}
+}
+
+func printUpgradeUsage() {
+	fmt.Println(`Usage: sage-gui upgrade <subcommand>
+
+Activate the governance-gated app-version consensus forks (app-v7…app-v10).
+The voting/processing already exists; this submits the plan an operator needs.
+
+Subcommands:
+  status                       Show the chain's app version and the next fork
+  propose --target <N>         Propose activation of app-v<N> (must be current+1)
+
+propose flags:
+  --target <N>   App version to activate. MUST be the chain's current version + 1.
+                 Forks activate one at a time; jumping (e.g. 6 -> 10) would turn on
+                 only app-v10 and permanently strand the skipped forks.
+  --name <s>     Optional. Defaults to the canonical "app-v<target>" (which is
+                 required); a non-canonical name is rejected.
+  --rpc <url>    CometBFT RPC endpoint (default: $SAGE_COMET_RPC or
+                 http://127.0.0.1:26657).
+  --yes          Skip the confirmation prompt.
+
+The proposal is signed with the operator agent key at $SAGE_HOME/agent.key and
+routed through the 2/3 governance quorum; validators auto-vote ACCEPT if they
+support the target. Run this on the node host where the key lives.`)
+}
+
+// runUpgradeStatus prints the chain's current app version and the next fork an
+// operator would activate. Read-only.
+func runUpgradeStatus(args []string) error {
+	fs := flag.NewFlagSet("upgrade status", flag.ContinueOnError)
+	rpc := fs.String("rpc", defaultCometRPC(), "CometBFT RPC endpoint")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	current, err := readChainAppVersion(ctx, *rpc)
+	if err != nil {
+		return fmt.Errorf("read chain app_version (is the node running? try --rpc): %w", err)
+	}
+	maxV := sageabci.MaxSupportedAppVersion()
+
+	fmt.Printf("Chain app version : %d (app-v%d)\n", current, current)
+	fmt.Printf("Binary supports   : up to app-v%d\n", maxV)
+	if current >= maxV {
+		fmt.Println("Next fork         : none — chain is at the highest version this binary supports")
+		return nil
+	}
+	fmt.Printf("Next fork         : app-v%d — activate with:\n", current+1)
+	fmt.Printf("    sage-gui upgrade propose --target %d\n", current+1)
+	return nil
+}
+
+// runUpgradePropose submits a signed UpgradePropose for the given target.
+func runUpgradePropose(args []string) error {
+	fs := flag.NewFlagSet("upgrade propose", flag.ContinueOnError)
+	target := fs.Uint64("target", 0, "target app version to activate (must be the chain's current version + 1)")
+	name := fs.String("name", "", "plan name (optional; defaults to the canonical app-v<target>)")
+	rpc := fs.String("rpc", defaultCometRPC(), "CometBFT RPC endpoint")
+	yes := fs.Bool("yes", false, "skip the confirmation prompt")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *target == 0 {
+		return fmt.Errorf("--target is required (the app version to activate, e.g. --target 7)")
+	}
+
+	// Warnings to stderr; the command's own output goes to stdout via fmt.Print.
+	logger := zerolog.New(os.Stderr).Level(zerolog.WarnLevel).With().Timestamp().Logger()
+
+	// Operator key — the same key/path the watchdog and REST server use for RBAC.
+	key := loadOperatorAgentKey(logger)
+	if key == nil {
+		return fmt.Errorf("no operator agent key at %s/agent.key — run this on the node host where the key lives", SageHome())
+	}
+
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 15*time.Second)
+	current, err := readChainAppVersion(readCtx, *rpc)
+	cancelRead()
+	if err != nil {
+		return fmt.Errorf("read chain app_version (is the node running? try --rpc): %w", err)
+	}
+
+	canonical, err := validateUpgradeTarget(current, *target, sageabci.MaxSupportedAppVersion(), *name)
+	if err != nil {
+		return err
+	}
+
+	// Confirm — this is a consensus action routed through the 2/3 quorum.
+	if !*yes {
+		fmt.Printf("Propose activation of %s (app version %d) on the chain at app-v%d?\n", canonical, *target, current)
+		fmt.Println("  • Routed through the 2/3 governance quorum; validators auto-vote ACCEPT if they support the target.")
+		fmt.Printf("  • Signed with the operator agent key at %s/agent.key.\n", SageHome())
+		fmt.Print("Proceed? [y/N]: ")
+		line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+		if s := strings.ToLower(strings.TrimSpace(line)); s != "y" && s != "yes" {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	// Build + broadcast, reusing the watchdog's signing path.
+	cfg := upgradeWatchdogConfig{
+		BinaryVersion: version,
+		AgentKey:      key,
+		CometRPC:      *rpc,
+		Logger:        logger,
+	}
+	ptx, err := buildUpgradeProposeTx(cfg, *target)
+	if err != nil {
+		return fmt.Errorf("build upgrade propose tx: %w", err)
+	}
+	encoded, err := tx.EncodeTx(ptx)
+	if err != nil {
+		return fmt.Errorf("encode upgrade propose tx: %w", err)
+	}
+	// Commit, not the watchdog's fire-and-forget sync: the meaningful
+	// UpgradePropose rejections — a non-admin proposer key, an already-pending
+	// plan — are produced in processUpgradePropose under FinalizeBlock, so they
+	// surface ONLY in the block-execution result, never in CheckTx. Reporting
+	// success off a CheckTx code alone would print a checkmark for a proposal the
+	// chain silently rejected. A fresh context (not the pre-check read's) means a
+	// slow operator at the prompt above can't eat the broadcast's deadline.
+	bcastCtx, cancelBcast := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancelBcast()
+	res, err := broadcastTxCommit(bcastCtx, *rpc, encoded)
+	if err != nil {
+		return fmt.Errorf("broadcast: %w\n(if the commit timed out the proposal may still land — re-check with: sage-gui upgrade status)", err)
+	}
+	if res.CheckTxCode != 0 {
+		return fmt.Errorf("rejected at CheckTx (code %d): %s", res.CheckTxCode, res.CheckTxLog)
+	}
+	if res.TxResultCode != 0 {
+		if strings.Contains(res.TxResultLog, "already pending") {
+			return fmt.Errorf("an upgrade plan is already pending (at-most-one-pending invariant); wait for it to activate or expire before proposing %s", canonical)
+		}
+		return fmt.Errorf("rejected at block execution (code %d): %s\n(a common cause is the operator key lacking the chain-admin role required to propose upgrades)", res.TxResultCode, res.TxResultLog)
+	}
+
+	fmt.Printf("✓ Proposed %s (target app version %d) — accepted at height %d.\n", canonical, *target, res.Height)
+	fmt.Printf("  tx hash: %s\n", res.Hash)
+	fmt.Println("  Routed to the governance quorum — validators will auto-vote ACCEPT. Track activation with:")
+	fmt.Println("    sage-gui upgrade status")
+	if *target < sageabci.MaxSupportedAppVersion() {
+		fmt.Printf("  After it activates, propose the next fork: sage-gui upgrade propose --target %d\n", *target+1)
+	}
+	return nil
+}
+
+// validateUpgradeTarget enforces the operator-submit invariants for an
+// app-version upgrade and returns the canonical plan name to use. Pure (no I/O)
+// so the guard logic is unit-tested directly.
+//
+// Invariants:
+//   - within binary support (target <= maxSupported), else activation commits a
+//     consensus version this binary can't run and halts the chain on the next
+//     handshake (the maxSupportedAppVersion footgun);
+//   - strictly sequential (target == current+1). The app-v7…app-v10 fork gates
+//     are INDEPENDENT per-applied-height booleans, but currentAppVersion() is a
+//     priority cascade returning the highest set gate and the on-chain
+//     regression guard rejects target <= current. So a jump (e.g. app-v6 →
+//     app-v10) activates ONLY the top fork, leaving the skipped ones dormant
+//     forever with no way to ever activate them. One step at a time is the only
+//     path that reaches every fork;
+//   - canonical name. plan.Name is the fork-gate activation KEY (matched against
+//     "app-v<N>"), not a label — a free-form name bumps the version but leaves
+//     the gate false forever (the bug class app-v6's canonical-name guard
+//     defends against), so a supplied --name must equal the canonical key.
+func validateUpgradeTarget(current, target, maxSupported uint64, name string) (string, error) {
+	if target == 0 {
+		return "", fmt.Errorf("--target is required (the app version to activate, e.g. --target 7)")
+	}
+	if target > maxSupported {
+		return "", fmt.Errorf("--target %d exceeds the max app version this binary supports (app-v%d); upgrade the binary first", target, maxSupported)
+	}
+	if target <= current {
+		return "", fmt.Errorf("chain is already at app-v%d; --target %d would regress or no-op (the on-chain version-regression guard rejects target <= current)", current, target)
+	}
+	if target != current+1 {
+		strand := fmt.Sprintf("app-v%d", current+1)
+		if target-1 > current+1 {
+			strand = fmt.Sprintf("app-v%d…app-v%d", current+1, target-1)
+		}
+		return "", fmt.Errorf("chain is at app-v%d; activate forks one at a time — use --target %d next. "+
+			"Jumping to app-v%d would activate ONLY that fork and permanently strand %s (the gates are independent; once the chain reports a higher version the skipped forks can never be activated)",
+			current, current+1, target, strand)
+	}
+	canonical := tx.CanonicalUpgradeName(target)
+	if name != "" && name != canonical {
+		return "", fmt.Errorf("--name %q is not the canonical activation key for target %d; it must be %q (omit --name to derive it)", name, target, canonical)
+	}
+	return canonical, nil
+}

--- a/cmd/sage-gui/upgrade_test.go
+++ b/cmd/sage-gui/upgrade_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sageabci "github.com/l33tdawg/sage/internal/abci"
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+// TestValidateUpgradeTarget exercises the operator-submit guard in isolation —
+// the heart of the issue #32 fix: sequential-only targets and canonical names.
+func TestValidateUpgradeTarget(t *testing.T) {
+	const maxV = 10
+
+	tests := []struct {
+		name     string
+		current  uint64
+		target   uint64
+		planName string
+		wantName string
+		wantErr  string // substring; "" means no error
+	}{
+		{
+			name:     "sequential next, derived name",
+			current:  6,
+			target:   7,
+			wantName: "app-v7",
+		},
+		{
+			name:     "sequential next with matching canonical name",
+			current:  6,
+			target:   7,
+			planName: "app-v7",
+			wantName: "app-v7",
+		},
+		{
+			name:     "top supported fork sequential",
+			current:  9,
+			target:   10,
+			wantName: "app-v10",
+		},
+		{
+			name:    "missing target",
+			current: 6,
+			target:  0,
+			wantErr: "--target is required",
+		},
+		{
+			name:    "exceeds max supported",
+			current: 9,
+			target:  11,
+			wantErr: "exceeds the max app version",
+		},
+		{
+			name:    "no-op (target == current)",
+			current: 6,
+			target:  6,
+			wantErr: "would regress or no-op",
+		},
+		{
+			name:    "regression (target < current)",
+			current: 7,
+			target:  6,
+			wantErr: "would regress or no-op",
+		},
+		{
+			name:    "skip-ahead strands single fork",
+			current: 8,
+			target:  10,
+			wantErr: "permanently strand app-v9",
+		},
+		{
+			name:    "skip-ahead strands a range",
+			current: 6,
+			target:  10,
+			wantErr: "permanently strand app-v7…app-v9",
+		},
+		{
+			name:     "non-canonical name rejected",
+			current:  6,
+			target:   7,
+			planName: "v9.2.2",
+			wantErr:  "not the canonical activation key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateUpgradeTarget(tc.current, tc.target, maxV, tc.planName)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (name=%q)", tc.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantName {
+				t.Fatalf("canonical name = %q, want %q", got, tc.wantName)
+			}
+		})
+	}
+}
+
+// TestValidateUpgradeTarget_SkipAheadMessageActionable verifies the skip-ahead
+// error tells the operator the correct next step (current+1), not the rejected
+// jump — the whole point of the guard is to steer them onto the safe path.
+func TestValidateUpgradeTarget_SkipAheadMessageActionable(t *testing.T) {
+	_, err := validateUpgradeTarget(6, 10, 10, "")
+	if err == nil {
+		t.Fatal("expected skip-ahead error")
+	}
+	if !strings.Contains(err.Error(), "--target 7 next") {
+		t.Fatalf("skip-ahead error should steer to --target 7; got: %v", err)
+	}
+}
+
+// TestBuildUpgradeProposeTx_Parameterized proves the builder now honors an
+// arbitrary (validated) target — the capability the operator surface needs.
+// Before the fix it was hardwired to upgradeTargetAppVersion (6).
+func TestBuildUpgradeProposeTx_Parameterized(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	cfg := upgradeWatchdogConfig{
+		BinaryVersion: "v9.2.2-test",
+		AgentKey:      priv,
+	}
+
+	for _, target := range []uint64{7, 8, 9, 10} {
+		ptx, err := buildUpgradeProposeTx(cfg, target)
+		if err != nil {
+			t.Fatalf("target %d: build: %v", target, err)
+		}
+		if ptx.Type != tx.TxTypeUpgradePropose {
+			t.Fatalf("target %d: tx type = %v, want UpgradePropose", target, ptx.Type)
+		}
+		if ptx.UpgradePropose == nil {
+			t.Fatalf("target %d: nil UpgradePropose payload", target)
+		}
+		if ptx.UpgradePropose.TargetAppVersion != target {
+			t.Errorf("target %d: TargetAppVersion = %d", target, ptx.UpgradePropose.TargetAppVersion)
+		}
+		want := tx.CanonicalUpgradeName(target)
+		if ptx.UpgradePropose.Name != want {
+			t.Errorf("target %d: Name = %q, want canonical %q", target, ptx.UpgradePropose.Name, want)
+		}
+		// The plan name must never be the human binary version — that bug bumps
+		// the app version while leaving every fork gate false.
+		if ptx.UpgradePropose.Name == cfg.BinaryVersion {
+			t.Errorf("target %d: plan named after binary version, not canonical key", target)
+		}
+	}
+}
+
+// TestValidateUpgradeTarget_RespectsBinaryCeiling guards the readiness ceiling
+// against the actual exported max, so the test tracks the binary's real support
+// window rather than a hardcoded 10.
+func TestValidateUpgradeTarget_RespectsBinaryCeiling(t *testing.T) {
+	maxV := sageabci.MaxSupportedAppVersion()
+	// One past the ceiling, proposed sequentially from the top, must be refused.
+	if _, err := validateUpgradeTarget(maxV, maxV+1, maxV, ""); err == nil {
+		t.Fatalf("expected refusal for target %d > max %d", maxV+1, maxV)
+	}
+}
+
+// TestBroadcastTxCommit_SurfacesBlockExecutionResult is the regression guard for
+// the false-success bug: /broadcast_tx_commit admits a well-formed tx at CheckTx
+// (Code 0) but the real UpgradePropose rejection (e.g. an already-pending plan,
+// or a non-admin proposer) is a Code-47 result produced under FinalizeBlock. The
+// fire-and-forget /broadcast_tx_sync the watchdog uses would hide that and the
+// command would print a false ✓; commit must expose tx_result so it's reported
+// as a failure.
+func TestBroadcastTxCommit_SurfacesBlockExecutionResult(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/broadcast_tx_commit", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{
+				"hash":      "ABC123",
+				"height":    "4242",
+				"check_tx":  map[string]any{"code": 0, "log": ""},
+				"tx_result": map[string]any{"code": 47, "log": "upgrade plan already pending"},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	res, err := broadcastTxCommit(context.Background(), srv.URL, []byte{0x01, 0x02})
+	if err != nil {
+		t.Fatalf("broadcastTxCommit: %v", err)
+	}
+	if res.CheckTxCode != 0 {
+		t.Errorf("CheckTxCode = %d, want 0 (admitted to mempool)", res.CheckTxCode)
+	}
+	if res.TxResultCode != 47 {
+		t.Errorf("TxResultCode = %d, want 47 (the block-execution rejection sync would hide)", res.TxResultCode)
+	}
+	if !strings.Contains(res.TxResultLog, "already pending") {
+		t.Errorf("TxResultLog = %q, want it to carry the rejection reason", res.TxResultLog)
+	}
+	if res.Height != 4242 {
+		t.Errorf("Height = %d, want 4242", res.Height)
+	}
+	if res.Hash != "ABC123" {
+		t.Errorf("Hash = %q, want ABC123", res.Hash)
+	}
+}
+
+// TestBroadcastTxCommit_Success confirms the happy path: both CheckTx and the
+// block-execution result are Code 0.
+func TestBroadcastTxCommit_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/broadcast_tx_commit", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{
+				"hash":      "FEED",
+				"height":    "100",
+				"check_tx":  map[string]any{"code": 0},
+				"tx_result": map[string]any{"code": 0},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	res, err := broadcastTxCommit(context.Background(), srv.URL, []byte{0xaa})
+	if err != nil {
+		t.Fatalf("broadcastTxCommit: %v", err)
+	}
+	if res.CheckTxCode != 0 || res.TxResultCode != 0 {
+		t.Fatalf("expected success codes, got check=%d tx_result=%d", res.CheckTxCode, res.TxResultCode)
+	}
+	if res.Height != 100 {
+		t.Errorf("Height = %d, want 100", res.Height)
+	}
+}
+
+// TestBroadcastTxCommit_RPCError surfaces a CometBFT RPC error (e.g. the
+// broadcast-commit timeout) as a Go error rather than a nil-result success.
+func TestBroadcastTxCommit_RPCError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/broadcast_tx_commit", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"message": "timed out waiting for tx to be included in a block",
+				"data":    "",
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if _, err := broadcastTxCommit(context.Background(), srv.URL, []byte{0x01}); err == nil {
+		t.Fatal("expected an error for an RPC-error response, got nil")
+	}
+}

--- a/cmd/sage-gui/upgrade_watchdog.go
+++ b/cmd/sage-gui/upgrade_watchdog.go
@@ -150,7 +150,7 @@ func maybeProposeUpgrade(ctx context.Context, cfg upgradeWatchdogConfig) bool {
 		return true
 	}
 
-	parsedTx, err := buildUpgradeProposeTx(cfg)
+	parsedTx, err := buildUpgradeProposeTx(cfg, upgradeTargetAppVersion)
 	if err != nil {
 		cfg.Logger.Error().Err(err).Msg("upgrade watchdog: build propose tx failed")
 		return false
@@ -187,10 +187,15 @@ func maybeProposeUpgrade(ctx context.Context, cfg upgradeWatchdogConfig) bool {
 	return false
 }
 
-// buildUpgradeProposeTx constructs and signs an UpgradePropose tx
-// using the operator's agent key. Mirrors signAgentProof's canonical
-// message format so verifyAgentIdentity accepts the embedded proof.
-func buildUpgradeProposeTx(cfg upgradeWatchdogConfig) (*tx.ParsedTx, error) {
+// buildUpgradeProposeTx constructs and signs an UpgradePropose tx for the given
+// target app version using the operator's agent key. Mirrors signAgentProof's
+// canonical message format so verifyAgentIdentity accepts the embedded proof.
+//
+// target is a parameter (not the upgradeTargetAppVersion const) so two callers
+// share one signing path: the watchdog passes the frozen const, while the
+// operator `upgrade propose` subcommand passes a validated, strictly-sequential
+// target to reach the governance-gated app-v7…app-v10 forks. See issue #32.
+func buildUpgradeProposeTx(cfg upgradeWatchdogConfig, target uint64) (*tx.ParsedTx, error) {
 	pub, ok := cfg.AgentKey.Public().(ed25519.PublicKey)
 	if !ok {
 		return nil, fmt.Errorf("agent key public type assertion failed")
@@ -204,8 +209,8 @@ func buildUpgradeProposeTx(cfg upgradeWatchdogConfig) (*tx.ParsedTx, error) {
 	// after cfg.BinaryVersion (e.g. "v8.4.0", or "dev" — main.version is
 	// never empty, so the old canonical fallback was dead code) bumped the
 	// app version while leaving every postV8_*Fork gate false forever. Always
-	// derive the name from the single source of truth.
-	name := tx.CanonicalUpgradeName(upgradeTargetAppVersion)
+	// derive the name from the target version, the single source of truth.
+	name := tx.CanonicalUpgradeName(target)
 	body := []byte(name)
 	bodyHash := sha256.Sum256(body)
 
@@ -227,7 +232,7 @@ func buildUpgradeProposeTx(cfg upgradeWatchdogConfig) (*tx.ParsedTx, error) {
 		AgentTimestamp: ts,
 		UpgradePropose: &tx.UpgradePropose{
 			Name:               name,
-			TargetAppVersion:   upgradeTargetAppVersion,
+			TargetAppVersion:   target,
 			BinarySHA256:       binarySHA,
 			ProposerID:         agentID,
 			UpgradeDelayBlocks: 0, // chain applies floor (200 blocks)
@@ -381,5 +386,86 @@ func broadcastTxSync(ctx context.Context, cometRPC string, txBytes []byte) (*bro
 		Hash:        out.Result.Hash,
 		CheckTxCode: uint32(out.Result.Code), // #nosec G115 -- CheckTx code fits uint32
 		CheckTxLog:  out.Result.Log,
+	}, nil
+}
+
+// broadcastCommitResp is the result of /broadcast_tx_commit: it carries BOTH the
+// CheckTx (mempool admission) and the TxResult (block-execution / FinalizeBlock)
+// outcomes. The interactive `upgrade propose` command needs the latter because
+// the meaningful UpgradePropose rejections — a non-admin proposer key, an
+// already-pending plan — are produced in processUpgradePropose under
+// FinalizeBlock and so never appear in the CheckTx-only result that the
+// fire-and-forget /broadcast_tx_sync (used by the watchdog) returns.
+type broadcastCommitResp struct {
+	Hash         string
+	Height       int64
+	CheckTxCode  uint32
+	CheckTxLog   string
+	TxResultCode uint32
+	TxResultLog  string
+}
+
+// broadcastTxCommit POSTs to /broadcast_tx_commit and blocks until the tx is
+// committed in a block (or CometBFT's broadcast-commit timeout fires), returning
+// both the CheckTx and the block-execution results so a silently-rejected
+// proposal is reported as a failure instead of a false success. The watchdog
+// deliberately uses the non-blocking sync variant; this is for the one-shot
+// operator command where the real outcome matters.
+func broadcastTxCommit(ctx context.Context, cometRPC string, txBytes []byte) (*broadcastCommitResp, error) {
+	url := fmt.Sprintf("%s/broadcast_tx_commit?tx=0x%s", strings.TrimRight(cometRPC, "/"), hex.EncodeToString(txBytes))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("broadcast_tx_commit: HTTP %d", resp.StatusCode)
+	}
+	var out struct {
+		Result struct {
+			Hash    string `json:"hash"`
+			Height  string `json:"height"` // CometBFT serializes int64 as a string
+			CheckTx struct {
+				Code uint32 `json:"code"`
+				Log  string `json:"log"`
+			} `json:"check_tx"`
+			TxResult struct {
+				Code uint32 `json:"code"`
+				Log  string `json:"log"`
+			} `json:"tx_result"`
+		} `json:"result"`
+		Error *struct {
+			Message string `json:"message"`
+			Data    string `json:"data"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode broadcast_tx_commit: %w", err)
+	}
+	if out.Error != nil {
+		// CometBFT returns an RPC error if the tx isn't committed within its
+		// broadcast-commit timeout; the tx may still land in a later block.
+		if out.Error.Data != "" {
+			return nil, fmt.Errorf("rpc error: %s (%s)", out.Error.Message, out.Error.Data)
+		}
+		return nil, fmt.Errorf("rpc error: %s", out.Error.Message)
+	}
+	var height int64
+	if out.Result.Height != "" {
+		if _, err := fmt.Sscanf(out.Result.Height, "%d", &height); err != nil {
+			height = 0
+		}
+	}
+	return &broadcastCommitResp{
+		Hash:         out.Result.Hash,
+		Height:       height,
+		CheckTxCode:  out.Result.CheckTx.Code,
+		CheckTxLog:   out.Result.CheckTx.Log,
+		TxResultCode: out.Result.TxResult.Code,
+		TxResultLog:  out.Result.TxResult.Log,
 	}, nil
 }

--- a/internal/abci/app.go
+++ b/internal/abci/app.go
@@ -1146,13 +1146,21 @@ func (app *SageApp) currentAppVersion() uint64 {
 }
 
 // maxSupportedAppVersion is the highest app version this binary has a compiled
-// fork gate for (currently app-v9). It is the readiness ceiling for upgrade
+// fork gate for (currently app-v10). It is the readiness ceiling for upgrade
 // auto-voting: a validator must never vote to activate an upgrade it cannot
 // execute — doing so would commit consensus version.app=N while the binary
 // still runs at N-1, halting the chain on the next CometBFT handshake (the
 // maxSupportedAppVersion footgun). Bump this in lockstep with every new
 // appV<N>UpgradeName fork gate added above.
 const maxSupportedAppVersion uint64 = 10
+
+// MaxSupportedAppVersion returns the highest app version this binary has a
+// compiled fork gate for. Operator tooling (cmd/sage-gui `upgrade propose`)
+// reads it to refuse proposing a target this binary cannot execute — the same
+// readiness ceiling the auto-voter enforces via ActiveUpgradeVote. Exported
+// because cmd/sage-gui lives outside this package; see maxSupportedAppVersion
+// for the footgun this guards against.
+func MaxSupportedAppVersion() uint64 { return maxSupportedAppVersion }
 
 // ActiveUpgradeVote reports the currently active OpUpgrade governance proposal,
 // if any, for the in-process app-validators' auto-vote. It returns the proposal

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "9.2.2"
+version = "9.2.3"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "9.2.2"
+__version__ = "9.2.3"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "9.2.2",
+  "version": "9.2.3",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:9.2.2",
+      "identifier": "ghcr.io/l33tdawg/sage:9.2.3",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Closes #32.

## What this is

@ihubanov correctly identified that SAGE's app-version upgrade machinery had its **voting and processing halves** but **no operator-submit half**: `processUpgradePropose` activates plans deterministically and validators auto-vote ACCEPT, but the only `TxTypeUpgradePropose` constructor in the tree was the boot watchdog — frozen at the deployment-safe `upgradeTargetAppVersion = 6`. So on a deployed chain the governance-gated forks were unreachable past app-v6:

- app-v7 — content-validation
- app-v8 — quorum-gated upgrades
- app-v9 — nonce/replay
- app-v10 — corroboration integrity (#31)

This adds the missing submit surface.

## Changes

- **`internal/abci/app.go`** — export `MaxSupportedAppVersion()` (the readiness ceiling the operator command enforces); fix a stale `app-v9`→`app-v10` comment.
- **`cmd/sage-gui/upgrade_watchdog.go`** — `buildUpgradeProposeTx` now takes a `target` param so the watchdog (still passes the frozen const `6`) and the new operator command share **one** signing path; add `broadcastTxCommit` (returns the block-execution result, not just CheckTx).
- **`cmd/sage-gui/upgrade.go`** *(new)* — `sage-gui upgrade status` and `upgrade propose --target N`.
- **`cmd/sage-gui/main.go`** — dispatch + help.

## Design notes

**Strictly sequential by design.** The app-v7…app-v10 fork gates are *independent* per-applied-height booleans, but `currentAppVersion()` is a priority cascade returning the highest active gate, and the on-chain regression guard rejects `target <= current`. So a jump (e.g. app-v6 → app-v10) would activate **only** the top fork and **permanently strand** the skipped ones. `validateUpgradeTarget` (pure, unit-tested) refuses anything but `current + 1`, enforces the binary's max-supported ceiling, and requires the canonical `app-v<N>` plan name.

**Honest reporting.** The interactive command uses `broadcast_tx_commit`, so an already-pending plan or a non-admin proposer key — both Code-47 rejections produced under FinalizeBlock that `broadcast_tx_sync` never sees — surface as failures instead of a false `✓`.

**Non-fork, off-consensus.** The tx is built and signed client-side; `processUpgradePropose` is unchanged; app version stays 10; every historical block replays byte-identically.

## Validation

- `go build ./...`, `go vet`, `go test ./cmd/sage-gui/ ./internal/abci/`, `go test -race ./cmd/sage-gui/` — all green.
- New tests: `validateUpgradeTarget` table (sequential / regress / no-op / skip-ahead strand / canonical-name / ceiling), parameterized builder for targets 7–10, `broadcastTxCommit` result handling.

Thanks @ihubanov for the precise writeup. 🙏