### PR TITLE
fix(sage-gui): vault export/import — derive the node URL via restBaseURL, not a raw localhost concat

### DIFF
--- a/cmd/sage-gui/resturl_test.go
+++ b/cmd/sage-gui/resturl_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+// TestRestBaseURL pins the shared helper that seed.go, mcp_token.go and vault.go
+// use to turn cfg.RESTAddr into a base URL. The host:port form (the shipped
+// default, "127.0.0.1:8080") must NOT get "localhost" prepended — the bug that
+// vault.go's old `"http://localhost" + cfg.RESTAddr` concat produced
+// ("http://localhost127.0.0.1:8080", an unconnectable host). Only the bare
+// ":port" form gets localhost filled in.
+func TestRestBaseURL(t *testing.T) {
+	cases := []struct {
+		addr string
+		want string
+	}{
+		{"127.0.0.1:8080", "http://127.0.0.1:8080"}, // shipped default — must stay host:port
+		{":8080", "http://localhost:8080"},          // bare port — localhost filled in
+		{"sage.internal:8080", "http://sage.internal:8080"},
+		{"0.0.0.0:9090", "http://0.0.0.0:9090"},
+	}
+	for _, c := range cases {
+		if got := restBaseURL(c.addr); got != c.want {
+			t.Errorf("restBaseURL(%q) = %q, want %q", c.addr, got, c.want)
+		}
+	}
+}

--- a/cmd/sage-gui/vault.go
+++ b/cmd/sage-gui/vault.go
@@ -68,7 +68,7 @@ func runExport() error {
 
 	baseURL := os.Getenv("SAGE_API_URL")
 	if baseURL == "" {
-		baseURL = "http://localhost" + cfg.RESTAddr
+		baseURL = restBaseURL(cfg.RESTAddr)
 	}
 
 	fmt.Println("Exporting memories from SAGE...")
@@ -183,7 +183,7 @@ func runImport() error {
 
 	baseURL := os.Getenv("SAGE_API_URL")
 	if baseURL == "" {
-		baseURL = "http://localhost" + cfg.RESTAddr
+		baseURL = restBaseURL(cfg.RESTAddr)
 	}
 
 	// Read vault file.


### PR DESCRIPTION
## What

`sage-gui export` / `sage-gui import` build the node REST URL via the shared
`restBaseURL` helper instead of a raw `"http://localhost" + cfg.RESTAddr` concat.

## Why

When `SAGE_API_URL` is unset, `runExport`/`runImport` fell back to:

```go
baseURL = "http://localhost" + cfg.RESTAddr
```

On the shipped default `RESTAddr` (`"127.0.0.1:8080"`, `cmd/sage-gui/config.go`)
that produces **`http://localhost127.0.0.1:8080`** — an unconnectable host. So on a
stock install (no `SAGE_API_URL` set), `sage-gui export` / `sage-gui import` fail
with a misleading `is sage-gui serve running?` error even when the node is up.

The repo already has the right helper, `restBaseURL` (`cmd/sage-gui/node.go`), which
prepends `localhost` only for the bare `:port` form and otherwise keeps the host
as-is. The sibling commands that take the same `SAGE_API_URL`-unset fallback —
`seed.go` and `mcp_token.go` — already use it; `vault.go` was the lone holdout. The
result (`http://127.0.0.1:8080`) is functionally the documented `SAGE_API_URL`
default (`http://localhost:8080`, `main.go` / `docs/ARCHITECTURE.md`).

## How

- both call sites (`runExport`, `runImport`) now use `restBaseURL(cfg.RESTAddr)`.
- add `TestRestBaseURL` pinning `127.0.0.1:8080 → http://127.0.0.1:8080` (not the
  `localhost127.0.0.1:8080` the concat produced) vs `:8080 → http://localhost:8080`,
  so the concat bug can't regress.

Client-side operator CLI only — no tx, no ABCI, no consensus path touched.

## Tests

- `go build ./...`, `go vet ./...` clean
- `go test -race -count=1 ./cmd/sage-gui/...` clean (incl. the new `TestRestBaseURL`)
- `golangci-lint v2.12.2` (current CI pin) — 0 issues
