### PR TITLE
fix(sdk): MemoryRecord — read back the linked_memories the server emits

### DIFF
--- a/sdk/python/src/sage_sdk/models.py
+++ b/sdk/python/src/sage_sdk/models.py
@@ -64,6 +64,12 @@ class MemoryRecord(BaseModel):
     deprecated_at: datetime | None = None
     votes: list | None = None
     corroborations: list | None = None
+    # Memories linked to this one. The server emits `linked_memories` on the
+    # GET /v1/memory/{id} detail response (memory_handler.go), the OpenAPI
+    # MemoryRecord schema documents it, and link_memories() already lets a
+    # caller WRITE links — but the model dropped it on read, so links could be
+    # created yet never read back. Untyped list to match votes/corroborations.
+    linked_memories: list | None = None
     similarity_score: float | None = None
     # Provenance tag the submitter attached to the memory (e.g. "claude-code",
     # "chatgpt"). The server emits it as `provider` (json:"provider,omitempty")

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -28,6 +28,24 @@ def test_memory_record_tolerates_missing_provider(sample_memory):
     assert record.provider is None
 
 
+def test_memory_record_parses_linked_memories(sample_memory):
+    # The server emits `linked_memories` on the GET /v1/memory/{id} detail
+    # response and link_memories() lets a caller write links. The model must
+    # read them back so a caller who creates links can also see them.
+    from sage_sdk.models import MemoryRecord
+    links = [{"memory_id": "mem-2", "relation": "supports"}]
+    record = MemoryRecord(**{**sample_memory, "linked_memories": links})
+    assert record.linked_memories == links
+
+
+def test_memory_record_tolerates_missing_linked_memories(sample_memory):
+    # An older server (or a record with no links) omits the field; the additive
+    # Optional defaults to None so the model still validates (forward/back compat).
+    from sage_sdk.models import MemoryRecord
+    record = MemoryRecord(**sample_memory)
+    assert record.linked_memories is None
+
+
 def test_memory_record_invalid_type():
     from sage_sdk.models import MemoryRecord
     with pytest.raises(Exception):  # ValidationError


### PR DESCRIPTION
## What

Adds an Optional `linked_memories` field to the Python SDK `MemoryRecord` so the
SDK reads back the links the server already emits.

## Why

`GET /v1/memory/{id}` emits `linked_memories` on the detail response
(`api/rest/memory_handler.go`), the OpenAPI `MemoryRecord` schema documents it
(`api/openapi.yaml`), and `link_memories()` / `async link_memories()` already let a
caller **write** links. But the SDK `MemoryRecord` model had no `linked_memories`
field, so it silently dropped them on read — links could be created and never read
back. Filter/write-but-not-read, same asymmetry as #30 (`provider`).

## How

- one additive Optional field: `linked_memories: list | None = None`, typed as an
  untyped list to match the sibling `votes` / `corroborations` fields already on the
  model. Older servers / list responses omit it (`omitempty`) → defaults to `None`,
  forward/back compatible.
- shared by the sync and async clients, so both round-trip it.
- `test_memory_record_parses_linked_memories` + `_tolerates_missing_linked_memories`,
  mirroring the existing `provider` round-trip pair.

## Tests

- `pip install -e ".[dev]" && pytest` → 102 passed (the new pair + all existing).
  Matches the CI `Python SDK Tests` job.
- SDK-only, no server or consensus code touched; no version bump (left to the
  maintainer's release flow).

Same class as #30 (provider) and PR #24/#29 — a server response field the SDK
couldn't read back.
