### PR TITLE
fix(sdk): GovProposal — read back the created_at the server emits

### DIFF
--- a/sdk/python/src/sage_sdk/models.py
+++ b/sdk/python/src/sage_sdk/models.py
@@ -462,6 +462,13 @@ class GovProposal(BaseModel):
     expiry_height: int
     executed_height: int | None = None
     reason: str | None = None
+    # Wall-clock creation time the server stamps on every proposal row
+    # (governance_proposals.created_at, NOT NULL DEFAULT RFC3339 — always
+    # populated) and emits as `created_at` on BOTH the list and detail
+    # responses (json:"created_at,omitempty"). The model dropped it on read, so
+    # a caller listing/inspecting proposals could never see when each was
+    # raised. Additive Optional: older servers omit it, so it defaults to None.
+    created_at: datetime | None = None
 
 
 class GovVote(BaseModel):

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -92,6 +92,42 @@ def test_submit_request_valid():
     assert req.content == "Test memory content"
 
 
+def test_gov_proposal_parses_created_at():
+    # The server stamps governance_proposals.created_at (NOT NULL DEFAULT
+    # RFC3339) and emits it as `created_at` on both the list
+    # (ListGovProposals) and detail (GetGovProposal) responses. The model must
+    # read it back so a caller listing proposals can see when each was raised.
+    from sage_sdk.models import GovProposal
+    proposal = GovProposal.model_validate({
+        "proposal_id": "prop-1",
+        "operation": "add_validator",
+        "target_agent_id": "agent-1",
+        "proposer_id": "agent-0",
+        "status": "pending",
+        "created_height": 100,
+        "expiry_height": 200,
+        "reason": "onboard validator",
+        "created_at": "2026-06-12T08:42:00.000Z",
+    })
+    assert proposal.created_at == datetime(2026, 6, 12, 8, 42, tzinfo=proposal.created_at.tzinfo)
+
+
+def test_gov_proposal_tolerates_missing_created_at():
+    # An older server (or an omitempty-empty value) omits the field; the
+    # additive Optional defaults to None so the model still validates.
+    from sage_sdk.models import GovProposal
+    proposal = GovProposal.model_validate({
+        "proposal_id": "prop-1",
+        "operation": "add_validator",
+        "target_agent_id": "agent-1",
+        "proposer_id": "agent-0",
+        "status": "pending",
+        "created_height": 100,
+        "expiry_height": 200,
+    })
+    assert proposal.created_at is None
+
+
 def test_vote_request():
     from sage_sdk.models import VoteRequest
     vote = VoteRequest(decision="accept", rationale="Verified correct")


### PR DESCRIPTION
## What

Adds an additive Optional `created_at` field to the Python SDK `GovProposal`
model so it reads back the timestamp the server already emits on both the
governance list and detail endpoints.

## Why

The server always produces `created_at`:

- `governance_proposals.created_at` is `TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))` — populated on every insert.
- `ListGovProposals` and `GetGovProposal` both `SELECT COALESCE(created_at,'')` and scan into `GovProposal.CreatedAt` (`internal/store/sqlite.go:3736`, `json:"created_at,omitempty"`).
- `web/governance_handler.go` serializes that struct straight to the SDK on the list and detail dashboard endpoints.

The SDK `GovProposal` model ended at `reason` with no `created_at`, so a caller
using `client.governance_proposals()` / `governance_proposal_detail()` got the
timestamp silently discarded and could never see when a proposal was raised.
Same write-but-not-read asymmetry already fixed for `linked_memories` (#39) and
`provider` (#30).

## How

- `models.py`: one additive Optional field, `created_at: datetime | None = None` (`datetime` was already imported). Older servers omitting it default to `None` — back- and forward-compatible.
- `tests/test_models.py`: `test_gov_proposal_parses_created_at` (RFC3339 string → `datetime`) and `test_gov_proposal_tolerates_missing_created_at` (absent → `None`), mirroring the existing provider / linked_memories round-trip tests.

## ABCI determinism

Consensus path untouched — SDK-only change, no edits under `internal/abci/`,
`internal/store/` write paths, `internal/tx/`, or `internal/governance/`.

## Tests

16/16 pytest pass, including the two new `GovProposal` round-trip cases. Full CI green on the fork branch (Go Analyze, Lint, Test, Byzantine Fault Tests, Docker Build, CodeQL, Python SDK Tests).