### PR TITLE
fix(rest): add-member handlers — honor explicit clearance:0 (PUBLIC)

### DIFF
--- a/api/rest/addmember_clearance_test.go
+++ b/api/rest/addmember_clearance_test.go
@@ -1,0 +1,118 @@
+package rest
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+// These guard the org/dept add-member endpoints against the clearance-0
+// escalation: an explicit clearance of 0 (ClearancePublic — a valid level that
+// gates reads, internal/tx/types.go) must be carried verbatim into the
+// broadcast tx, not silently coerced to INTERNAL (1). Only an OMITTED clearance
+// falls back to the safe INTERNAL default. Same class as the agent-permission
+// "Bug 2" fix; here a bare int couldn't tell "0" from "absent".
+
+// newAddMemberCometMock returns a CometBFT stub that records the broadcast tx
+// hex into *captured and acks Code 0.
+func newAddMemberCometMock(t *testing.T, captured *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*captured = r.URL.Query().Get("tx")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"result": map[string]interface{}{"code": 0, "hash": "ADDMEMBER_TX"},
+		})
+	}))
+}
+
+func decodeAddMemberTx(t *testing.T, capturedTxHex string) *tx.ParsedTx {
+	t.Helper()
+	require.NotEmpty(t, capturedTxHex, "broadcast should have been invoked")
+	txBytes, err := hex.DecodeString(capturedTxHex[2:]) // strip 0x prefix
+	require.NoError(t, err)
+	parsed, err := tx.DecodeTx(txBytes)
+	require.NoError(t, err)
+	return parsed
+}
+
+const addMemberTarget = "1111111111111111111111111111111111111111111111111111111111111111"
+
+func TestOrgAddMember_ExplicitPublicClearance_NotEscalated(t *testing.T) {
+	var capturedTxHex string
+	cometMock := newAddMemberCometMock(t, &capturedTxHex)
+	defer cometMock.Close()
+	srv, _, _ := newTestServer(t, cometMock.URL)
+
+	body := []byte(`{"agent_id":"` + addMemberTarget + `","clearance":0}`)
+	req, _ := signedRequest(t, http.MethodPost, "/v1/org/acme/member", body)
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
+	parsed := decodeAddMemberTx(t, capturedTxHex)
+	require.NotNil(t, parsed.OrgAddMember)
+	assert.Equal(t, tx.ClearancePublic, parsed.OrgAddMember.Clearance,
+		"explicit clearance:0 (PUBLIC) must NOT be escalated to INTERNAL")
+}
+
+func TestOrgAddMember_OmittedClearance_DefaultsInternal(t *testing.T) {
+	var capturedTxHex string
+	cometMock := newAddMemberCometMock(t, &capturedTxHex)
+	defer cometMock.Close()
+	srv, _, _ := newTestServer(t, cometMock.URL)
+
+	body := []byte(`{"agent_id":"` + addMemberTarget + `"}`)
+	req, _ := signedRequest(t, http.MethodPost, "/v1/org/acme/member", body)
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
+	parsed := decodeAddMemberTx(t, capturedTxHex)
+	require.NotNil(t, parsed.OrgAddMember)
+	assert.Equal(t, tx.ClearanceInternal, parsed.OrgAddMember.Clearance,
+		"omitted clearance must default to the safe INTERNAL level")
+}
+
+func TestDeptAddMember_ExplicitPublicClearance_NotEscalated(t *testing.T) {
+	var capturedTxHex string
+	cometMock := newAddMemberCometMock(t, &capturedTxHex)
+	defer cometMock.Close()
+	srv, _, _ := newTestServer(t, cometMock.URL)
+
+	body := []byte(`{"agent_id":"` + addMemberTarget + `","clearance":0}`)
+	req, _ := signedRequest(t, http.MethodPost, "/v1/org/acme/dept/eng/member", body)
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
+	parsed := decodeAddMemberTx(t, capturedTxHex)
+	require.NotNil(t, parsed.DeptAddMember)
+	assert.Equal(t, tx.ClearancePublic, parsed.DeptAddMember.Clearance,
+		"explicit clearance:0 (PUBLIC) must NOT be escalated to INTERNAL")
+}
+
+func TestDeptAddMember_OmittedClearance_DefaultsInternal(t *testing.T) {
+	var capturedTxHex string
+	cometMock := newAddMemberCometMock(t, &capturedTxHex)
+	defer cometMock.Close()
+	srv, _, _ := newTestServer(t, cometMock.URL)
+
+	body := []byte(`{"agent_id":"` + addMemberTarget + `"}`)
+	req, _ := signedRequest(t, http.MethodPost, "/v1/org/acme/dept/eng/member", body)
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
+	parsed := decodeAddMemberTx(t, capturedTxHex)
+	require.NotNil(t, parsed.DeptAddMember)
+	assert.Equal(t, tx.ClearanceInternal, parsed.DeptAddMember.Clearance,
+		"omitted clearance must default to the safe INTERNAL level")
+}

--- a/api/rest/dept_handler.go
+++ b/api/rest/dept_handler.go
@@ -23,8 +23,13 @@ type DeptRegisterReq struct {
 
 // DeptAddMemberReq is the JSON body for POST /v1/org/{org_id}/dept/{dept_id}/member.
 type DeptAddMemberReq struct {
-	AgentID   string `json:"agent_id"`
-	Clearance int    `json:"clearance,omitempty"`
+	AgentID string `json:"agent_id"`
+	// Pointer so an explicit clearance of 0 (ClearancePublic — a valid level
+	// that gates reads) is distinguishable from an omitted field. A bare int
+	// can't tell "0" from "absent", which silently escalated PUBLIC members to
+	// INTERNAL. Mirrors the *int pattern on the agent-permission endpoint
+	// (see Bug 2, v6.8.4 hotfix, api/rest/agent_handler.go).
+	Clearance *int   `json:"clearance,omitempty"`
 	Role      string `json:"role,omitempty"`
 }
 
@@ -163,8 +168,11 @@ func (s *Server) handleDeptAddMember(w http.ResponseWriter, r *http.Request) {
 		writeProblem(w, http.StatusBadRequest, "Missing agent ID", "agent_id is required")
 		return
 	}
-	if req.Clearance == 0 {
-		req.Clearance = 1 // Default to INTERNAL
+	// Only a missing clearance falls back to the safe INTERNAL default; an
+	// explicit 0 (ClearancePublic) is honored verbatim.
+	clearance := 1
+	if req.Clearance != nil {
+		clearance = *req.Clearance
 	}
 	if req.Role == "" {
 		req.Role = "member"
@@ -178,7 +186,7 @@ func (s *Server) handleDeptAddMember(w http.ResponseWriter, r *http.Request) {
 			OrgID:     orgID,
 			DeptID:    deptID,
 			AgentID:   req.AgentID,
-			Clearance: tx.ClearanceLevel(req.Clearance), // #nosec G115 -- validated small int
+			Clearance: tx.ClearanceLevel(clearance), // #nosec G115 -- validated small int
 			Role:      req.Role,
 		},
 	}

--- a/api/rest/org_handler.go
+++ b/api/rest/org_handler.go
@@ -24,8 +24,13 @@ type OrgRegisterReq struct {
 
 // OrgAddMemberReq is the JSON body for POST /v1/org/{org_id}/member.
 type OrgAddMemberReq struct {
-	AgentID   string `json:"agent_id"`
-	Clearance int    `json:"clearance,omitempty"`
+	AgentID string `json:"agent_id"`
+	// Pointer so an explicit clearance of 0 (ClearancePublic — a valid level
+	// that gates reads) is distinguishable from an omitted field. A bare int
+	// can't tell "0" from "absent", which silently escalated PUBLIC members to
+	// INTERNAL. Mirrors the *int pattern on the agent-permission endpoint
+	// (see Bug 2, v6.8.4 hotfix, api/rest/agent_handler.go).
+	Clearance *int   `json:"clearance,omitempty"`
 	Role      string `json:"role,omitempty"`
 }
 
@@ -273,8 +278,11 @@ func (s *Server) handleOrgAddMember(w http.ResponseWriter, r *http.Request) {
 		writeProblem(w, http.StatusBadRequest, "Missing agent ID", "agent_id is required")
 		return
 	}
-	if req.Clearance == 0 {
-		req.Clearance = 1 // Default to INTERNAL
+	// Only a missing clearance falls back to the safe INTERNAL default; an
+	// explicit 0 (ClearancePublic) is honored verbatim.
+	clearance := 1
+	if req.Clearance != nil {
+		clearance = *req.Clearance
 	}
 	if req.Role == "" {
 		req.Role = "member"
@@ -287,7 +295,7 @@ func (s *Server) handleOrgAddMember(w http.ResponseWriter, r *http.Request) {
 		OrgAddMember: &tx.OrgAddMember{
 			OrgID:     orgID,
 			AgentID:   req.AgentID,
-			Clearance: tx.ClearanceLevel(req.Clearance), // #nosec G115 -- validated small int
+			Clearance: tx.ClearanceLevel(clearance), // #nosec G115 -- validated small int
 			Role:      req.Role,
 		},
 	}


### PR DESCRIPTION
## What

The org and dept add-member REST endpoints silently escalate an explicitly-requested PUBLIC clearance (`clearance: 0`) to INTERNAL (`1`). After this fix, an explicit `0` is carried verbatim into the broadcast tx; an omitted `clearance` field still defaults to INTERNAL.

## Why

`clearance: 0` is `ClearancePublic` — a real, named clearance level ("Readable by any federated org", `internal/tx/types.go:90`), not a sentinel. It gates reads: a member's clearance is compared `clearance >= memoryClassification` (`internal/store/badger.go:2812`), so a clearance-0 member should read only PUBLIC memories.

`handleOrgAddMember` (`api/rest/org_handler.go`) and `handleDeptAddMember` (`api/rest/dept_handler.go`) declared `Clearance int` and ran `if req.Clearance == 0 { req.Clearance = 1 /* Default to INTERNAL */ }`. A bare int cannot distinguish an explicit `0` from an omitted field, so an explicit `clearance: 0` was coerced to `1` — granting the member INTERNAL read access they did not request. Because the SDK's `DeptAddMemberRequest`/`OrgAddMember` default `clearance: int = 1`, the only way to *ask* for PUBLIC is to send `0`, which the server then bumped back to `1`. The PUBLIC-clearance member was unreachable end to end.

This is the identical bug class already fixed on the agent-permission endpoint — "Bug 2" in the v6.8.4 hotfix bundle, documented at `api/rest/agent_handler.go:281` ("would silently demote the agent to clearance=1"). That path was fixed by making the request field a pointer (`Clearance *int`, `agent_handler.go:245`) so absent and explicit-0 are distinguishable, with a regression test (`TestSetPermission_PartialUpdate_PreservesClearance`, `api/rest/permission_handler_test.go`). This applies the same established pattern to the two add-member handlers that were left unpatched.

## How

- `OrgAddMemberReq`/`DeptAddMemberReq`: `Clearance` is now `*int`.
- Replaces `if req.Clearance == 0 { req.Clearance = 1 }` with `clearance := 1; if req.Clearance != nil { clearance = *req.Clearance }` — nil (omitted) keeps the safe INTERNAL default, explicit `0` is honored verbatim into the broadcast tx.
- Mirrors the pointer technique already in `agent_handler.go`; no new mechanism introduced.

## ABCI determinism

No consensus path is touched. This changes the REST request shape and the REST default-mapping only. The on-chain tx already carries a concrete `ClearanceLevel`; the tx encoding, the `internal/tx` types, and the `FinalizeBlock` path are unchanged. Replay is byte-identical.

## Tests

- New `api/rest/addmember_clearance_test.go`: 4 tests (org + dept × explicit-0-not-escalated + omitted-defaults-internal) that decode the captured broadcast tx and assert the `Clearance` carried, mirroring the Bug 2 test style.
- `go test ./api/rest/`, `go vet`, and golangci-lint clean. Full CI green on the fork branch (Go/JS Analyze, Lint, Test, Byzantine Fault Tests, Docker Build, CodeQL, Python SDK Tests).