### PR TITLE
feat(recall): surface corroboration_count on memory recall

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -144,7 +144,18 @@ components:
           format: double
           minimum: 0
           maximum: 1
-          description: Confidence score assigned by the proposing agent.
+          description: >-
+            Current confidence at query time: the agent-assigned score after
+            time decay and the corroboration boost are applied.
+        corroboration_count:
+          type: integer
+          minimum: 0
+          description: >-
+            Number of distinct corroborations backing this memory — the
+            multiplier behind the corroboration boost in confidence_score.
+            Returned on recall paths (/v1/memory/query, /search, /hybrid) so
+            readers can tell a low score caused by no corroboration (a fresh,
+            untested belief) from one caused by time decay (a once-solid fact).
         classification:
           type: integer
           minimum: 0

--- a/api/rest/handlers_test.go
+++ b/api/rest/handlers_test.go
@@ -582,6 +582,49 @@ func TestQueryMemory(t *testing.T) {
 	assert.Equal(t, "test-id", resp.Results[0].MemoryID)
 }
 
+// TestQueryMemory_ExposesCorroborationCount verifies recall surfaces the number of
+// corroborations backing a memory — the signal that lets a reader tell a fresh,
+// uncorroborated belief apart from a once-solid fact that has merely decayed.
+func TestQueryMemory_ExposesCorroborationCount(t *testing.T) {
+	srv, memStore, _ := newTestServer(t, "")
+
+	memStore.memories["corr-id"] = &memory.MemoryRecord{
+		MemoryID:        "corr-id",
+		SubmittingAgent: "agent-1",
+		Content:         "Corroborated fact",
+		ContentHash:     []byte{4, 5, 6},
+		MemoryType:      memory.TypeFact,
+		DomainTag:       "crypto",
+		ConfidenceScore: 0.9,
+		Status:          memory.StatusCommitted,
+		CreatedAt:       time.Now().Add(-24 * time.Hour),
+	}
+	// Two distinct agents corroborate this memory.
+	memStore.corroborations["corr-id"] = []*store.Corroboration{
+		{MemoryID: "corr-id", AgentID: "agent-2"},
+		{MemoryID: "corr-id", AgentID: "agent-3"},
+	}
+
+	embedding := make([]float32, 1536)
+	for i := range embedding {
+		embedding[i] = 0.1
+	}
+	body, _ := json.Marshal(QueryMemoryRequest{Embedding: embedding, TopK: 10})
+
+	req, _ := signedRequest(t, http.MethodPost, "/v1/memory/query", body)
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp QueryMemoryResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Equal(t, 1, resp.TotalCount)
+	assert.Equal(t, "corr-id", resp.Results[0].MemoryID)
+	assert.Equal(t, 2, resp.Results[0].CorroborationCount,
+		"recall must surface the corroboration count backing the confidence score")
+}
+
 func TestGetMemory(t *testing.T) {
 	srv, memStore, _ := newTestServer(t, "")
 

--- a/api/rest/memory_handler.go
+++ b/api/rest/memory_handler.go
@@ -92,19 +92,24 @@ const (
 
 // MemoryResult is a memory record with computed confidence.
 type MemoryResult struct {
-	MemoryID        string     `json:"memory_id"`
-	SubmittingAgent string     `json:"submitting_agent"`
-	Content         string     `json:"content"`
-	ContentHash     string     `json:"content_hash"`
-	MemoryType      string     `json:"memory_type"`
-	DomainTag       string     `json:"domain_tag"`
-	ConfidenceScore float64    `json:"confidence_score"`
-	Classification  int        `json:"classification"`
-	Status          string     `json:"status"`
-	ParentHash      string     `json:"parent_hash,omitempty"`
-	TaskStatus      string     `json:"task_status,omitempty"`
-	CreatedAt       time.Time  `json:"created_at"`
-	CommittedAt     *time.Time `json:"committed_at,omitempty"`
+	MemoryID        string  `json:"memory_id"`
+	SubmittingAgent string  `json:"submitting_agent"`
+	Content         string  `json:"content"`
+	ContentHash     string  `json:"content_hash"`
+	MemoryType      string  `json:"memory_type"`
+	DomainTag       string  `json:"domain_tag"`
+	ConfidenceScore float64 `json:"confidence_score"`
+	// CorroborationCount is the number of distinct corroborations backing this
+	// memory — the multiplier behind the corroboration boost in ConfidenceScore.
+	// Exposing it lets readers distinguish a low score caused by no corroboration
+	// (a fresh, untested belief) from one caused by time decay (a once-solid fact).
+	CorroborationCount int        `json:"corroboration_count"`
+	Classification     int        `json:"classification"`
+	Status             string     `json:"status"`
+	ParentHash         string     `json:"parent_hash,omitempty"`
+	TaskStatus         string     `json:"task_status,omitempty"`
+	CreatedAt          time.Time  `json:"created_at"`
+	CommittedAt        *time.Time `json:"committed_at,omitempty"`
 }
 
 // MemoryDetailResponse is a memory record with votes and corroborations.
@@ -665,18 +670,19 @@ func (s *Server) handleQueryMemory(w http.ResponseWriter, r *http.Request) {
 		currentConf := memory.ComputeConfidence(rec.ConfidenceScore, rec.CreatedAt, now, len(corrs), rec.DomainTag)
 
 		results = append(results, &MemoryResult{
-			MemoryID:        rec.MemoryID,
-			SubmittingAgent: rec.SubmittingAgent,
-			Content:         rec.Content,
-			ContentHash:     hex.EncodeToString(rec.ContentHash),
-			MemoryType:      string(rec.MemoryType),
-			DomainTag:       rec.DomainTag,
-			ConfidenceScore: currentConf,
-			Classification:  int(memClass),
-			Status:          string(rec.Status),
-			ParentHash:      rec.ParentHash,
-			CreatedAt:       rec.CreatedAt,
-			CommittedAt:     rec.CommittedAt,
+			MemoryID:           rec.MemoryID,
+			SubmittingAgent:    rec.SubmittingAgent,
+			Content:            rec.Content,
+			ContentHash:        hex.EncodeToString(rec.ContentHash),
+			MemoryType:         string(rec.MemoryType),
+			DomainTag:          rec.DomainTag,
+			ConfidenceScore:    currentConf,
+			CorroborationCount: len(corrs),
+			Classification:     int(memClass),
+			Status:             string(rec.Status),
+			ParentHash:         rec.ParentHash,
+			CreatedAt:          rec.CreatedAt,
+			CommittedAt:        rec.CommittedAt,
 		})
 	}
 
@@ -882,18 +888,19 @@ func (s *Server) handleSearchMemory(w http.ResponseWriter, r *http.Request) {
 		currentConf := memory.ComputeConfidence(rec.ConfidenceScore, rec.CreatedAt, now, len(corrs), rec.DomainTag)
 
 		results = append(results, &MemoryResult{
-			MemoryID:        rec.MemoryID,
-			SubmittingAgent: rec.SubmittingAgent,
-			Content:         rec.Content,
-			ContentHash:     hex.EncodeToString(rec.ContentHash),
-			MemoryType:      string(rec.MemoryType),
-			DomainTag:       rec.DomainTag,
-			ConfidenceScore: currentConf,
-			Classification:  int(memClass),
-			Status:          string(rec.Status),
-			ParentHash:      rec.ParentHash,
-			CreatedAt:       rec.CreatedAt,
-			CommittedAt:     rec.CommittedAt,
+			MemoryID:           rec.MemoryID,
+			SubmittingAgent:    rec.SubmittingAgent,
+			Content:            rec.Content,
+			ContentHash:        hex.EncodeToString(rec.ContentHash),
+			MemoryType:         string(rec.MemoryType),
+			DomainTag:          rec.DomainTag,
+			ConfidenceScore:    currentConf,
+			CorroborationCount: len(corrs),
+			Classification:     int(memClass),
+			Status:             string(rec.Status),
+			ParentHash:         rec.ParentHash,
+			CreatedAt:          rec.CreatedAt,
+			CommittedAt:        rec.CommittedAt,
 		})
 	}
 
@@ -1093,18 +1100,19 @@ func (s *Server) handleHybridSearchMemory(w http.ResponseWriter, r *http.Request
 		currentConf := memory.ComputeConfidence(rec.ConfidenceScore, rec.CreatedAt, now, len(corrs), rec.DomainTag)
 
 		results = append(results, &MemoryResult{
-			MemoryID:        rec.MemoryID,
-			SubmittingAgent: rec.SubmittingAgent,
-			Content:         rec.Content,
-			ContentHash:     hex.EncodeToString(rec.ContentHash),
-			MemoryType:      string(rec.MemoryType),
-			DomainTag:       rec.DomainTag,
-			ConfidenceScore: currentConf,
-			Classification:  int(memClass),
-			Status:          string(rec.Status),
-			ParentHash:      rec.ParentHash,
-			CreatedAt:       rec.CreatedAt,
-			CommittedAt:     rec.CommittedAt,
+			MemoryID:           rec.MemoryID,
+			SubmittingAgent:    rec.SubmittingAgent,
+			Content:            rec.Content,
+			ContentHash:        hex.EncodeToString(rec.ContentHash),
+			MemoryType:         string(rec.MemoryType),
+			DomainTag:          rec.DomainTag,
+			ConfidenceScore:    currentConf,
+			CorroborationCount: len(corrs),
+			Classification:     int(memClass),
+			Status:             string(rec.Status),
+			ParentHash:         rec.ParentHash,
+			CreatedAt:          rec.CreatedAt,
+			CommittedAt:        rec.CommittedAt,
 		})
 	}
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -538,13 +538,14 @@ func (s *Server) toolRecall(ctx context.Context, params map[string]any) (any, er
 	memories := make([]map[string]any, 0, len(queryResp.Results))
 	for _, r := range queryResp.Results {
 		memories = append(memories, map[string]any{
-			"memory_id":  r.MemoryID,
-			"content":    r.Content,
-			"domain":     r.DomainTag,
-			"confidence": r.ConfidenceScore,
-			"type":       r.MemoryType,
-			"status":     r.Status,
-			"created_at": r.CreatedAt,
+			"memory_id":           r.MemoryID,
+			"content":             r.Content,
+			"domain":              r.DomainTag,
+			"confidence":          r.ConfidenceScore,
+			"corroboration_count": r.CorroborationCount,
+			"type":                r.MemoryType,
+			"status":              r.Status,
+			"created_at":          r.CreatedAt,
 		})
 	}
 
@@ -560,13 +561,14 @@ func (s *Server) toolRecall(ctx context.Context, params map[string]any) (any, er
 // belt-and-braces retry-on-vault-encryption branch in toolRecall.
 type recallResp struct {
 	Results []struct {
-		MemoryID        string  `json:"memory_id"`
-		Content         string  `json:"content"`
-		DomainTag       string  `json:"domain_tag"`
-		ConfidenceScore float64 `json:"confidence_score"`
-		MemoryType      string  `json:"memory_type"`
-		Status          string  `json:"status"`
-		CreatedAt       string  `json:"created_at"`
+		MemoryID           string  `json:"memory_id"`
+		Content            string  `json:"content"`
+		DomainTag          string  `json:"domain_tag"`
+		ConfidenceScore    float64 `json:"confidence_score"`
+		CorroborationCount int     `json:"corroboration_count"`
+		MemoryType         string  `json:"memory_type"`
+		Status             string  `json:"status"`
+		CreatedAt          string  `json:"created_at"`
 	} `json:"results"`
 	TotalCount int `json:"total_count"`
 }


### PR DESCRIPTION
## What
Adds a `corroboration_count` integer to recall results across the three recall paths — `POST /v1/memory/query`, `/v1/memory/search`, `/v1/memory/hybrid` (`handleQueryMemory`, `handleSearchMemory`, `handleHybridSearchMemory`) — and to the MCP `recall` tool output. The value is the number of distinct corroborations backing the memory: the same `len(corrs)` the handler already computes.

Also corrects the OpenAPI `confidence_score` description. It read "Confidence score assigned by the proposing agent", but the recall paths return the value computed at query time — post-decay, post-corroboration-boost — not the proposer's stored input. The description now says so.

## Why
A low `confidence_score` is ambiguous from the score alone. A fresh, untested belief with no corroboration and a once-solid fact that has aged out under time decay can land on the same number. A reader cannot tell "never confirmed" from "confirmed once, now stale" without the corroboration count.

The handler already has the number. Each recall path calls `memory.ComputeConfidence(rec.ConfidenceScore, rec.CreatedAt, now, len(corrs), rec.DomainTag)` — it just discards `len(corrs)` after feeding it to the score. This surfaces the value the server already paid to fetch.

## How
- adds `corroboration_count` to the recall result struct, populated from the existing `len(corrs)` already passed into `ComputeConfidence`
- `ComputeConfidence` is untouched: no new query, no extra corroboration fetch, no scoring change — purely read-side surfacing
- threads the same field through the MCP `recall` tool output
- corrects the stale `confidence_score` OpenAPI description to reflect the computed at-query-time value

Same additive read-side pattern as the merged `provider` (#30), `linked_memories` (#39), and `GovProposal.created_at` (#42) surfacings — a value the server already holds but did not expose on read.

## ABCI determinism
No consensus-path code touched. `ComputeConfidence`, the store, the ABCI app, and the FinalizeBlock path are all unchanged. This adds a field to a read-side REST/MCP response struct; it does not enter the deterministic write path.

## Tests
- `TestQueryMemory_ExposesCorroborationCount` — seeds 2 corroborations on a memory, asserts recall returns `corroboration_count = 2`
- full CI green on the fork (Go/JS Analyze, Lint, Test, Byzantine Fault Tests, Docker Build, CodeQL, Python SDK Tests)
