### PR TITLE
feat(mcp): add sage_link tool for typed memory relationships

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -56,7 +56,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	result := resp.Result.(map[string]any)
 	tools := result["tools"].([]map[string]any)
-	assert.Len(t, tools, 20)
+	assert.Len(t, tools, 21)
 
 	// Collect tool names
 	names := make(map[string]bool)
@@ -73,6 +73,7 @@ func TestHandleToolsList(t *testing.T) {
 	assert.True(t, names["sage_gov_vote"])
 	assert.True(t, names["sage_gov_status"])
 	assert.True(t, names["sage_corroborate"])
+	assert.True(t, names["sage_link"])
 }
 
 func TestHandleToolsCall_UnknownTool(t *testing.T) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -308,6 +308,20 @@ func (s *Server) registerTools() map[string]Tool {
 			},
 			Handler: s.toolCorroborate,
 		},
+		"sage_link": {
+			Name:        "sage_link",
+			Description: "Create a typed relationship between two existing memories. Use this to build a knowledge graph over memory: record that one memory supports, contradicts, causes, precedes, or refines another. The link is directional (source → target). Common link_type values: related (default), supports, contradicts, causes, precedes, refines, duplicates — but any short relation label is accepted.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"source_id": map[string]any{"type": "string", "description": "ID of the source memory (the 'from' side of the relationship)"},
+					"target_id": map[string]any{"type": "string", "description": "ID of the target memory (the 'to' side of the relationship)"},
+					"link_type": map[string]any{"type": "string", "description": "Relationship type, e.g. supports, contradicts, causes, precedes, refines, related", "default": "related"},
+				},
+				"required": []string{"source_id", "target_id"},
+			},
+			Handler: s.toolLink,
+		},
 	}
 	return tools
 }
@@ -681,6 +695,35 @@ func (s *Server) toolForget(ctx context.Context, params map[string]any) (any, er
 		"memory_id": memoryID,
 		"status":    "challenged",
 		"reason":    reason,
+	}, nil
+}
+
+// toolLink creates a typed, directional relationship between two memories.
+// The /v1/memory/link endpoint already accepts a free-form link_type; this tool
+// is the MCP surface for it (sage_task only ever links as "related"), so agents
+// can record supports / contradicts / causes / precedes edges to build a graph.
+func (s *Server) toolLink(ctx context.Context, params map[string]any) (any, error) {
+	sourceID, _ := params["source_id"].(string)
+	targetID, _ := params["target_id"].(string)
+	if sourceID == "" || targetID == "" {
+		return nil, fmt.Errorf("source_id and target_id are required")
+	}
+	linkType := stringParam(params, "link_type", "related")
+
+	body, _ := json.Marshal(map[string]string{
+		"source_id": sourceID,
+		"target_id": targetID,
+		"link_type": linkType,
+	})
+	if err := s.doSignedJSON(ctx, "POST", "/v1/memory/link", body, nil); err != nil {
+		return nil, fmt.Errorf("link memories: %w", err)
+	}
+
+	return map[string]any{
+		"source_id": sourceID,
+		"target_id": targetID,
+		"link_type": linkType,
+		"status":    "linked",
 	}, nil
 }
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -277,6 +277,71 @@ func TestSageCorroborate_MissingID(t *testing.T) {
 	assert.Contains(t, err.Error(), "memory_id is required")
 }
 
+func TestSageLink(t *testing.T) {
+	var linkBody map[string]string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/memory/link" {
+			_ = json.NewDecoder(r.Body).Decode(&linkBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "linked"})
+	}))
+	defer ts.Close()
+
+	_, priv, _ := ed25519.GenerateKey(nil)
+	s := NewServer(ts.URL, priv)
+
+	result, err := s.toolLink(context.Background(), map[string]any{
+		"source_id": "mem-a",
+		"target_id": "mem-b",
+		"link_type": "contradicts",
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	assert.Equal(t, "mem-a", m["source_id"])
+	assert.Equal(t, "mem-b", m["target_id"])
+	assert.Equal(t, "contradicts", m["link_type"])
+	assert.Equal(t, "linked", m["status"])
+
+	// The typed link_type must reach the node verbatim — not be coerced to
+	// "related" the way sage_task's hardcoded link does.
+	assert.Equal(t, "contradicts", linkBody["link_type"])
+	assert.Equal(t, "mem-a", linkBody["source_id"])
+	assert.Equal(t, "mem-b", linkBody["target_id"])
+}
+
+func TestSageLink_DefaultsToRelated(t *testing.T) {
+	var linkBody map[string]string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/memory/link" {
+			_ = json.NewDecoder(r.Body).Decode(&linkBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "linked"})
+	}))
+	defer ts.Close()
+
+	_, priv, _ := ed25519.GenerateKey(nil)
+	s := NewServer(ts.URL, priv)
+
+	_, err := s.toolLink(context.Background(), map[string]any{
+		"source_id": "mem-a",
+		"target_id": "mem-b",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "related", linkBody["link_type"])
+}
+
+func TestSageLink_MissingIDs(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	s := NewServer("http://localhost:9999", priv)
+
+	_, err := s.toolLink(context.Background(), map[string]any{"source_id": "mem-a"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
 func TestSageList(t *testing.T) {
 	ts := mockSageAPI(t)
 	defer ts.Close()


### PR DESCRIPTION
## What
Adds a `sage_link` MCP tool that creates a typed, directional relationship between two existing memories: `source → target` with a `link_type` such as `supports`, `contradicts`, `causes`, `precedes`, or `refines` (default `related`). It is the MCP surface over the existing `POST /v1/memory/link` REST endpoint.

## Why
The typed-link capability already exists at the REST layer — `handleLinkMemories` accepts a free-form `link_type`. It was unreachable from MCP: the only MCP path that creates links is `sage_task`, and `toolTask` hardcodes `link_type: "related"`. Agents could create untyped "related" edges but could not record that one memory supports, contradicts, or causes another.

This exposes the full vocabulary already supported by the node, so agents can build a typed knowledge graph over memory rather than a flat related-only mesh.

## How
- adds the `sage_link` tool definition and the `toolLink` handler (`internal/mcp/tools.go`)
- `toolLink` POSTs to the existing `/v1/memory/link` endpoint via the established signed-JSON path; the `link_type` is passed verbatim, not coerced
- defaults `link_type` to `related` when omitted, matching the REST default
- no REST, store, or consensus change — strictly an MCP wrapper over an existing endpoint

Same shape as the `sage_corroborate` MCP tool: a thin MCP wrapper exposing a REST capability the node already implements.

## ABCI determinism
No consensus-path code touched. `sage_link` issues the same `/v1/memory/link` request the REST endpoint already serves; the store and FinalizeBlock path are unchanged. The MCP layer only constructs and forwards the request.

## Tests
- `TestSageLink` — asserts a typed `link_type` (e.g. `supports`) reaches the node verbatim, not coerced to `related`
- `TestSageLink_DefaultsToRelated` — omitted `link_type` defaults to `related`
- `TestSageLink_MissingIDs` — missing source/target IDs are rejected
- tool-count assertion updated 20 → 21
- full CI green on the fork
