### PR TITLE
fix(mcp): sage_link missing from never-block-for-turn allowlist

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -331,7 +331,7 @@ func (s *Server) shouldBlockForTurn(toolName string) bool {
 	// Never block SAGE tools themselves.
 	switch toolName {
 	case "sage_turn", "sage_inception", "sage_red_pill", "sage_reflect", "sage_recall",
-		"sage_remember", "sage_forget", "sage_corroborate", "sage_list", "sage_status", "sage_timeline",
+		"sage_remember", "sage_forget", "sage_corroborate", "sage_link", "sage_list", "sage_status", "sage_timeline",
 		"sage_task", "sage_backlog", "sage_register",
 		"sage_pipe", "sage_inbox", "sage_pipe_result":
 		return false


### PR DESCRIPTION
## Problem
`sage_link` writes were silently dropped under turn discipline. The turn-checkpoint mechanism (`shouldBlockForTurn`) blocks tool calls that arrive after a turn's write budget is spent, but the never-block allowlist omitted `sage_link` — so batches of link requests committed only a fraction of their rows (observed: 13 requests → 0 writes in one batch).

## Fix
Add `sage_link` to the never-block switch in `shouldBlockForTurn`, alongside the other relationship/maintenance tools that must always complete. Relationship edges are low-cost metadata writes; dropping them silently corrupts the connectome without surfacing an error.

## Verification
Clean-room harness: pre-fix, batched `sage_link` calls dropped writes non-deterministically; post-fix, all link requests persist (verified on a fresh node).

1 line changed in `internal/mcp/server.go`.