### PR TITLE
fix(web): clear SSE write deadline so heartbeats survive the server WriteTimeout

### DIFF
--- a/web/sse.go
+++ b/web/sse.go
@@ -100,6 +100,16 @@ func (b *SSEBroadcaster) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
+	// SSE is a long-lived stream, but the http.Server has WriteTimeout set
+	// (15s). That timeout is an ABSOLUTE per-connection write deadline — the
+	// heartbeat below does NOT reset it — so without clearing it the server
+	// guillotines every SSE connection at 15s mid-stream, which the browser
+	// reports as ERR_INCOMPLETE_CHUNKED_ENCODING and then reconnects, producing
+	// a connect/drop/reconnect storm. Clear the write deadline so the heartbeat
+	// is what actually governs liveness.
+	rc := http.NewResponseController(w)
+	_ = rc.SetWriteDeadline(time.Time{}) //nolint:errcheck // best-effort; unsupported writers keep prior behaviour
+
 	ch := b.Subscribe()
 	if ch == nil {
 		http.Error(w, "too many connections", http.StatusServiceUnavailable)
@@ -111,9 +121,10 @@ func (b *SSEBroadcaster) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, ": connected\n\n")
 	flusher.Flush()
 
-	// Heartbeat ticker — keeps the connection alive past the HTTP server's WriteTimeout.
-	// Without this, idle SSE connections get killed every WriteTimeout seconds,
-	// causing a connect/disconnect cycle in the chain activity log.
+	// Heartbeat ticker — periodic SSE comments so a dead/half-open client is
+	// detected (the Write fails, ctx cancels) and proxies don't idle-close the
+	// stream. (The WriteTimeout guillotine is handled above by clearing the
+	// write deadline; the heartbeat alone never cured it.)
 	heartbeat := time.NewTicker(10 * time.Second)
 	defer heartbeat.Stop()
 


### PR DESCRIPTION
## Problem
Dashboard SSE connections were being severed every `WriteTimeout` seconds, producing a connect/disconnect storm in the chain activity log and `ERR_INCOMPLETE_CHUNKED_ENCODING` in the browser.

The heartbeat ticker was meant to keep the stream alive, but `http.Server.WriteTimeout` is an **absolute** per-connection deadline — it is set when the connection is accepted and is *not* reset by subsequent writes. Heartbeats write into a connection that the server has already scheduled to guillotine.

## Fix
Clear the write deadline for the lifetime of the SSE handler via `http.NewResponseController(w).SetWriteDeadline(time.Time{})`. This opts the long-lived stream out of the global `WriteTimeout` without weakening it for normal (short) request handlers. Heartbeats now do their job.

Also corrected the heartbeat comment to describe the actual mechanism.

## Verification
Reproduced the disconnect cycle against a server with a short `WriteTimeout`; after the change the SSE stream stays open indefinitely and heartbeats flush cleanly.

`web/sse.go` only.