### PR TITLE
feat(node): make CometBFT RPC/P2P ports configurable (SAGE_CMT_*)

### DIFF
--- a/cmd/sage-gui/cmtaddr_test.go
+++ b/cmd/sage-gui/cmtaddr_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+// TestCmtRPCAddr pins the SAGE_CMT_RPC_ADDR override and its default. The
+// default must stay the historical tcp://127.0.0.1:26657 so existing single-node
+// deployments are byte-for-byte unchanged; a set value wins verbatim so a second
+// personal node can be moved off 26657 to coexist on one host.
+func TestCmtRPCAddr(t *testing.T) {
+	t.Setenv("SAGE_CMT_RPC_ADDR", "")
+	if got := cmtRPCAddr(); got != "tcp://127.0.0.1:26657" {
+		t.Errorf("default cmtRPCAddr() = %q, want tcp://127.0.0.1:26657", got)
+	}
+	t.Setenv("SAGE_CMT_RPC_ADDR", "tcp://127.0.0.1:36657")
+	if got := cmtRPCAddr(); got != "tcp://127.0.0.1:36657" {
+		t.Errorf("override cmtRPCAddr() = %q, want tcp://127.0.0.1:36657", got)
+	}
+}
+
+// TestCmtRPCClientURL pins the listen-addr → dial-URL derivation: tcp:// becomes
+// http://, and a 0.0.0.0 wildcard listen host is dialed as 127.0.0.1 (you can't
+// reliably connect to the wildcard).
+func TestCmtRPCClientURL(t *testing.T) {
+	cases := []struct {
+		env  string
+		want string
+	}{
+		{"", "http://127.0.0.1:26657"},                      // default
+		{"tcp://127.0.0.1:36657", "http://127.0.0.1:36657"}, // moved port
+		{"tcp://0.0.0.0:26657", "http://127.0.0.1:26657"},   // wildcard → loopback dial
+	}
+	for _, c := range cases {
+		t.Setenv("SAGE_CMT_RPC_ADDR", c.env)
+		if got := cmtRPCClientURL(); got != c.want {
+			t.Errorf("cmtRPCClientURL() with SAGE_CMT_RPC_ADDR=%q = %q, want %q", c.env, got, c.want)
+		}
+	}
+}
+
+// TestCmtP2PAddr pins the SAGE_CMT_P2P_ADDR override and that the per-mode
+// fallback (loopback for personal, 0.0.0.0 for quorum) is preserved when the env
+// is unset — defaults stay unchanged for both modes.
+func TestCmtP2PAddr(t *testing.T) {
+	t.Setenv("SAGE_CMT_P2P_ADDR", "")
+	if got := cmtP2PAddr("tcp://127.0.0.1:26656"); got != "tcp://127.0.0.1:26656" {
+		t.Errorf("personal default cmtP2PAddr() = %q, want tcp://127.0.0.1:26656", got)
+	}
+	if got := cmtP2PAddr("tcp://0.0.0.0:26656"); got != "tcp://0.0.0.0:26656" {
+		t.Errorf("quorum default cmtP2PAddr() = %q, want tcp://0.0.0.0:26656", got)
+	}
+	t.Setenv("SAGE_CMT_P2P_ADDR", "tcp://127.0.0.1:36656")
+	if got := cmtP2PAddr("tcp://0.0.0.0:26656"); got != "tcp://127.0.0.1:36656" {
+		t.Errorf("override cmtP2PAddr() = %q, want tcp://127.0.0.1:36656", got)
+	}
+}

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -330,7 +330,7 @@ func runServe() (rerr error) {
 	cometCfg.SetRoot(cometHome)
 	cometCfg.Consensus.CreateEmptyBlocks = false
 	cometCfg.Consensus.CreateEmptyBlocksInterval = 0
-	cometCfg.RPC.ListenAddress = "tcp://127.0.0.1:26657"
+	cometCfg.RPC.ListenAddress = cmtRPCAddr()
 	cometCfg.Instrumentation.Prometheus = false
 
 	if cfg.Quorum.Enabled {
@@ -338,7 +338,7 @@ func runServe() (rerr error) {
 		cometCfg.Consensus.TimeoutCommit = 3 * time.Second
 		p2pAddr := cfg.Quorum.P2PAddr
 		if p2pAddr == "" {
-			p2pAddr = "tcp://0.0.0.0:26656"
+			p2pAddr = cmtP2PAddr("tcp://0.0.0.0:26656")
 		}
 		cometCfg.P2P.ListenAddress = p2pAddr
 		cometCfg.P2P.PersistentPeers = joinPeers(cfg.Quorum.Peers)
@@ -352,7 +352,7 @@ func runServe() (rerr error) {
 	} else {
 		// Personal mode: single validator, fast blocks, no P2P
 		cometCfg.Consensus.TimeoutCommit = 1 * time.Second
-		cometCfg.P2P.ListenAddress = "tcp://127.0.0.1:26656"
+		cometCfg.P2P.ListenAddress = cmtP2PAddr("tcp://127.0.0.1:26656")
 	}
 
 	pv := privval.LoadFilePV(
@@ -431,8 +431,8 @@ func runServe() (rerr error) {
 	// have to re-bootstrap admin manually.
 	ensureInitialAdmin(ctx, sqliteStore, logger)
 
-	// CometBFT RPC URL for tx broadcast
-	cometRPC := "http://127.0.0.1:26657"
+	// CometBFT RPC URL for tx broadcast — derived from the RPC listen address.
+	cometRPC := cmtRPCClientURL()
 
 	// Backfill on_chain_height and first_seen for agents already registered on-chain
 	// but missing these fields in SQLite (upgrade path from v3.5 → v3.7.6+)
@@ -834,6 +834,35 @@ func restBaseURL(addr string) string {
 	return "http://" + addr
 }
 
+// cmtRPCAddr returns the CometBFT RPC listen address. Overridable via
+// SAGE_CMT_RPC_ADDR so two personal nodes can coexist on one host; the default
+// preserves the historical tcp://127.0.0.1:26657. This is transport only — the
+// RPC port is not consensus state, so changing it is ABCI-determinism-neutral.
+func cmtRPCAddr() string {
+	if v := os.Getenv("SAGE_CMT_RPC_ADDR"); v != "" {
+		return v
+	}
+	return "tcp://127.0.0.1:26657"
+}
+
+// cmtRPCClientURL converts the RPC listen address into a URL the in-process
+// tx-broadcast client can dial: tcp:// → http://, and a 0.0.0.0 wildcard listen
+// host is dialed as 127.0.0.1 (you connect to loopback, not the wildcard).
+func cmtRPCClientURL() string {
+	u := strings.Replace(cmtRPCAddr(), "tcp://", "http://", 1)
+	return strings.Replace(u, "0.0.0.0", "127.0.0.1", 1)
+}
+
+// cmtP2PAddr returns the CometBFT P2P listen address, overridable via
+// SAGE_CMT_P2P_ADDR. def is the historical fallback used when the env is unset
+// (loopback for personal mode, 0.0.0.0 for quorum) so defaults stay unchanged.
+func cmtP2PAddr(def string) string {
+	if v := os.Getenv("SAGE_CMT_P2P_ADDR"); v != "" {
+		return v
+	}
+	return def
+}
+
 // initCometBFTConfig generates CometBFT config files for a single-validator node.
 func initCometBFTConfig(home string) error {
 	configDir := filepath.Join(home, "config")
@@ -885,12 +914,12 @@ func initCometBFTConfig(home string) error {
 	}
 
 	// Write minimal config.toml
-	configToml := `# SAGE Personal — CometBFT config
+	configToml := fmt.Sprintf(`# SAGE Personal — CometBFT config
 proxy_app = "kvstore"
 moniker = "sage-personal"
 
 [rpc]
-laddr = "tcp://127.0.0.1:26657"
+laddr = %q
 
 [p2p]
 laddr = ""
@@ -902,7 +931,7 @@ create_empty_blocks_after = "5s"
 
 [mempool]
 size = 1000
-`
+`, cmtRPCAddr())
 	return os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(configToml), 0600)
 }
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -30,6 +30,8 @@ notes which.
 | Variable | What it does | Default | Read by | Source |
 |----------|--------------|---------|---------|--------|
 | `REST_ADDR` | REST API listen address; overrides `config.yaml`. | `127.0.0.1:8080` | sage-gui | `cmd/sage-gui/config.go:156` |
+| `SAGE_CMT_RPC_ADDR` | CometBFT RPC listen address (also the tx-broadcast client target). Move it to run a second node on one host. | `tcp://127.0.0.1:26657` | sage-gui | `cmd/sage-gui/node.go:842` |
+| `SAGE_CMT_P2P_ADDR` | CometBFT P2P listen address. Personal mode defaults to loopback; quorum mode defaults to `tcp://0.0.0.0:26656` when unset. | `tcp://127.0.0.1:26656` | sage-gui | `cmd/sage-gui/node.go:860` |
 | `CORS_ALLOWED_ORIGINS` | Comma-separated allowlist of origins for REST CORS. | (none) | REST | `api/rest/server.go:222` |
 | `SAGE_COMET_RPC` | CometBFT RPC endpoint used by `sage-gui upgrade`. | (built-in) | sage-gui | `cmd/sage-gui/upgrade.go:44` |
 | `SAGE_TX_COMMIT_TIMEOUT_MS` | Timeout (ms) for `broadcast_tx_commit`. Raise it for unusually slow consensus. | `60000` (60s) | REST | `api/rest/memory_handler.go:1317` |

--- a/web/handler.go
+++ b/web/handler.go
@@ -1692,10 +1692,16 @@ func (h *DashboardHandler) handleHealth(w http.ResponseWriter, r *http.Request) 
 		health["memories"] = stats
 	}
 
-	// CometBFT chain stats
+	// CometBFT chain stats — dial the configured RPC endpoint (honors
+	// SAGE_CMT_RPC_ADDR via h.CometBFTRPC) so a node moved off 26657 reports its
+	// own chain state instead of querying the historical hardcoded port.
 	chain := map[string]any{}
+	cometRPC := h.CometBFTRPC
+	if cometRPC == "" {
+		cometRPC = "http://127.0.0.1:26657"
+	}
 	cometClient := &http.Client{Timeout: 2 * time.Second}
-	statusReq, _ := http.NewRequestWithContext(r.Context(), "GET", "http://127.0.0.1:26657/status", nil)
+	statusReq, _ := http.NewRequestWithContext(r.Context(), "GET", cometRPC+"/status", nil)
 	if statusResp, statusErr := cometClient.Do(statusReq); statusErr == nil {
 		defer statusResp.Body.Close()
 		var cometStatus struct {
@@ -1724,7 +1730,7 @@ func (h *DashboardHandler) handleHealth(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	// Peer details
-	netReq, _ := http.NewRequestWithContext(r.Context(), "GET", "http://127.0.0.1:26657/net_info", nil)
+	netReq, _ := http.NewRequestWithContext(r.Context(), "GET", cometRPC+"/net_info", nil)
 	if netResp, netErr := cometClient.Do(netReq); netErr == nil {
 		defer netResp.Body.Close()
 		var netInfo struct {


### PR DESCRIPTION
## What

Add two env knobs — `SAGE_CMT_RPC_ADDR` and `SAGE_CMT_P2P_ADDR` — to `sage-gui serve` so the CometBFT RPC (26657) and P2P (26656) listen ports are configurable instead of hardcoded. Defaults preserve today's ports exactly; with no env set the behavior is byte-for-byte identical to current.

## Why

`sage-gui serve` hardcoded the CometBFT RPC and P2P ports, so a second node can't run alongside an existing one on the same host even with a distinct `SAGE_HOME` and `REST_ADDR` — the two collide on 26657/26656 and the second `serve` fails with "address already in use". REST was already configurable via `REST_ADDR`; the CometBFT transport was the missing half. These two knobs close that gap and make personal-node coexistence on one host possible.

## How

Two env vars, both backward-compatible (unset → historical defaults):

- `SAGE_CMT_RPC_ADDR` default `tcp://127.0.0.1:26657` — RPC listen address, and the source the tx-broadcast client target is derived from
- `SAGE_CMT_P2P_ADDR` default `tcp://127.0.0.1:26656` — P2P listen (personal mode)

Implementation in `cmd/sage-gui/node.go`:

- All five hardcoded sites route through three package-level helpers (`cmtRPCAddr`, `cmtRPCClientURL`, `cmtP2PAddr`): RPC listen (`node.go:333`), personal P2P listen (`node.go:355`), quorum P2P default (`node.go:341`), tx-broadcast client URL (`node.go:435`), and the persisted `config.toml` template's rpc laddr (`node.go:922`).
- The tx-broadcast client URL is **derived** from the RPC listen address (`tcp://` → `http://`; a `0.0.0.0` wildcard listen host is dialed as `127.0.0.1`) rather than re-hardcoded, so the client can never drift from the server it's broadcasting to.
- The in-process node uses the programmatically-built `cometCfg`; the `node.go:333` override is authoritative. The on-disk `config.toml` rpc laddr is not re-read by the in-process node, so updating the template (`node.go:922`) is cosmetic-but-consistent, not functional — stated here so reviewers don't have to wonder which value wins.
- **Quorum mode is unchanged.** The quorum P2P fallback (`node.go:341`) keeps its historical `tcp://0.0.0.0:26656` default when the env is unset — the helper takes a per-mode fallback — so multi-host quorum still binds the wildcard. Only the personal-mode default is loopback.

## ABCI determinism

Consensus path untouched. The CometBFT RPC/P2P ports are node-local transport endpoints, not part of ABCI state or block production; nothing on the FinalizeBlock path reads them. Determinism-neutral.

## Tests

- `cmd/sage-gui/cmtaddr_test.go` covers default-preservation, env override, and the `tcp://`→`http://` + `0.0.0.0`→`127.0.0.1` client-URL derivation.
- `go test -race ./...` clean; `golangci-lint` clean.

Manual 2-node coexistence check:

1. **Default unchanged** — `sage-gui serve` with no new env binds 26657/26656 as before.
2. **Coexistence** — node A on defaults (`REST_ADDR=127.0.0.1:8080`); node B with `SAGE_HOME=~/.sage-second REST_ADDR=127.0.0.1:8099 SAGE_CMT_RPC_ADDR=tcp://127.0.0.1:36657 SAGE_CMT_P2P_ADDR=tcp://127.0.0.1:36656`. Both come up with no "address already in use", and a memory write/read round-trips on each REST port — confirming each node's tx broadcast targets its own RPC.
3. **Restart** — an already-initialized second `SAGE_HOME` restarted with the env set picks up the new ports.

## Out of scope

`internal/orchestrator/bundle.go:42` also hardcodes 26656 for multi-node *bundles*. That's a separate path from `serve` and a possible future follow-up; not addressed here.

The two new vars are documented in `docs/reference/environment-variables.md` (Server & networking table).
