### PR TITLE
feat(node): full SAGE_CMT_RPC/P2P coverage (sage-cli, upgrade, bundles)

### DIFF
--- a/cmd/sage-cli/main.go
+++ b/cmd/sage-cli/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/l33tdawg/sage/internal/auth"
@@ -56,7 +57,9 @@ func printUsage() {
 	fmt.Println("  health    Check SAGE API health")
 	fmt.Println()
 	fmt.Println("Environment:")
-	fmt.Println("  SAGE_API_URL  API base URL (default: http://localhost:8080)")
+	fmt.Println("  SAGE_API_URL        API base URL (default: http://localhost:8080)")
+	fmt.Println("  SAGE_CMT_RPC_ADDR   CometBFT RPC listen address for `status`; set when the")
+	fmt.Println("                      node was moved off 26657 (default: scan 26657-26957)")
 }
 
 func cmdKeygen() {
@@ -82,13 +85,28 @@ func cmdKeygen() {
 	}
 }
 
-func cmdStatus() {
-	urls := []string{
+// statusRPCURLs returns the CometBFT /status endpoints to probe. When
+// SAGE_CMT_RPC_ADDR is set the node has been moved off the default RPC port, so
+// we query exactly that endpoint — mirroring cmd/sage-gui's cmtRPCClientURL
+// derivation (tcp:// → http://, a 0.0.0.0 wildcard listen host dialed as
+// 127.0.0.1). Unset preserves the historical scan of the local quorum dev
+// cluster (26657/26757/26857/26957).
+func statusRPCURLs() []string {
+	if v := os.Getenv("SAGE_CMT_RPC_ADDR"); v != "" {
+		u := strings.Replace(v, "tcp://", "http://", 1)
+		u = strings.Replace(u, "0.0.0.0", "127.0.0.1", 1)
+		return []string{u + "/status"}
+	}
+	return []string{
 		"http://localhost:26657/status",
 		"http://localhost:26757/status",
 		"http://localhost:26857/status",
 		"http://localhost:26957/status",
 	}
+}
+
+func cmdStatus() {
+	urls := statusRPCURLs()
 
 	client := &http.Client{Timeout: 5 * time.Second}
 

--- a/cmd/sage-cli/status_test.go
+++ b/cmd/sage-cli/status_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestStatusRPCURLs pins the SAGE_CMT_RPC_ADDR behavior of `sage-cli status`:
+// unset preserves the historical scan of the local quorum dev cluster; a set
+// value collapses to that one moved endpoint with the same tcp://→http:// and
+// 0.0.0.0→127.0.0.1 derivation cmd/sage-gui uses.
+func TestStatusRPCURLs(t *testing.T) {
+	t.Setenv("SAGE_CMT_RPC_ADDR", "")
+	want := []string{
+		"http://localhost:26657/status",
+		"http://localhost:26757/status",
+		"http://localhost:26857/status",
+		"http://localhost:26957/status",
+	}
+	if got := statusRPCURLs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("default statusRPCURLs() = %v, want %v", got, want)
+	}
+
+	cases := []struct {
+		env  string
+		want string
+	}{
+		{"tcp://127.0.0.1:36657", "http://127.0.0.1:36657/status"}, // moved port
+		{"tcp://0.0.0.0:26657", "http://127.0.0.1:26657/status"},   // wildcard → loopback dial
+	}
+	for _, c := range cases {
+		t.Setenv("SAGE_CMT_RPC_ADDR", c.env)
+		got := statusRPCURLs()
+		if len(got) != 1 || got[0] != c.want {
+			t.Errorf("statusRPCURLs() with SAGE_CMT_RPC_ADDR=%q = %v, want [%q]", c.env, got, c.want)
+		}
+	}
+}

--- a/cmd/sage-gui/upgrade.go
+++ b/cmd/sage-gui/upgrade.go
@@ -44,7 +44,10 @@ func defaultCometRPC() string {
 	if v := os.Getenv("SAGE_COMET_RPC"); v != "" {
 		return v
 	}
-	return "http://127.0.0.1:26657"
+	// Fall back to the node's own configured RPC so `upgrade` targets a node
+	// moved via SAGE_CMT_RPC_ADDR without a second env var. cmtRPCClientURL
+	// returns the historical http://127.0.0.1:26657 when that env is unset.
+	return cmtRPCClientURL()
 }
 
 // runUpgrade dispatches `sage-gui upgrade <subcommand>`.
@@ -94,8 +97,8 @@ propose flags:
                     Accepts an agent.key seed or a CometBFT priv_validator_key.json.
                     Use past app-v8 when the chain-admin identity isn't your default
                     agent.key (issue #34).
-  --rpc <url>       CometBFT RPC endpoint (default: $SAGE_COMET_RPC or
-                    http://127.0.0.1:26657).
+  --rpc <url>       CometBFT RPC endpoint (default: $SAGE_COMET_RPC, else derived
+                    from $SAGE_CMT_RPC_ADDR, else http://127.0.0.1:26657).
   --yes             Skip the confirmation prompt.
   --wait            Stay attached after the propose lands and heartbeat the chain
                     until the fork activates. At app-v12+ an idle chain mints no

--- a/cmd/sage-gui/upgrade_rpc_test.go
+++ b/cmd/sage-gui/upgrade_rpc_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+// TestDefaultCometRPC pins the precedence for `sage-gui upgrade`'s RPC target:
+// explicit SAGE_COMET_RPC wins; otherwise it derives from SAGE_CMT_RPC_ADDR so a
+// moved node is reached without a second env var; both unset preserves the
+// historical http://127.0.0.1:26657.
+func TestDefaultCometRPC(t *testing.T) {
+	// SAGE_COMET_RPC wins outright, even when SAGE_CMT_RPC_ADDR is also set.
+	t.Setenv("SAGE_CMT_RPC_ADDR", "tcp://127.0.0.1:36657")
+	t.Setenv("SAGE_COMET_RPC", "http://example:9999")
+	if got := defaultCometRPC(); got != "http://example:9999" {
+		t.Errorf("defaultCometRPC() = %q, want SAGE_COMET_RPC override", got)
+	}
+
+	// No SAGE_COMET_RPC → derived from SAGE_CMT_RPC_ADDR (wildcard → loopback).
+	t.Setenv("SAGE_COMET_RPC", "")
+	t.Setenv("SAGE_CMT_RPC_ADDR", "tcp://0.0.0.0:36657")
+	if got := defaultCometRPC(); got != "http://127.0.0.1:36657" {
+		t.Errorf("defaultCometRPC() = %q, want derived http://127.0.0.1:36657", got)
+	}
+
+	// Both unset → historical default preserved.
+	t.Setenv("SAGE_CMT_RPC_ADDR", "")
+	if got := defaultCometRPC(); got != "http://127.0.0.1:26657" {
+		t.Errorf("defaultCometRPC() = %q, want default http://127.0.0.1:26657", got)
+	}
+}

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -30,10 +30,10 @@ notes which.
 | Variable | What it does | Default | Read by | Source |
 |----------|--------------|---------|---------|--------|
 | `REST_ADDR` | REST API listen address; overrides `config.yaml`. | `127.0.0.1:8080` | sage-gui | `cmd/sage-gui/config.go:156` |
-| `SAGE_CMT_RPC_ADDR` | CometBFT RPC listen address (also the tx-broadcast client target). Move it to run a second node on one host. | `tcp://127.0.0.1:26657` | sage-gui | `cmd/sage-gui/node.go:842` |
-| `SAGE_CMT_P2P_ADDR` | CometBFT P2P listen address. Personal mode defaults to loopback; quorum mode defaults to `tcp://0.0.0.0:26656` when unset. | `tcp://127.0.0.1:26656` | sage-gui | `cmd/sage-gui/node.go:860` |
+| `SAGE_CMT_RPC_ADDR` | CometBFT RPC listen address (also the tx-broadcast client target, the web health panel, `sage-cli status`, and the `sage-gui upgrade` RPC default). Move it to run a second node on one host. | `tcp://127.0.0.1:26657` | sage-gui, sage-cli | `cmd/sage-gui/node.go:842` |
+| `SAGE_CMT_P2P_ADDR` | CometBFT P2P listen address. Personal mode defaults to loopback; quorum mode defaults to `tcp://0.0.0.0:26656` when unset. Generated agent bundles leave `p2p_addr` blank so this env override applies. | `tcp://127.0.0.1:26656` | sage-gui | `cmd/sage-gui/node.go:860` |
 | `CORS_ALLOWED_ORIGINS` | Comma-separated allowlist of origins for REST CORS. | (none) | REST | `api/rest/server.go:222` |
-| `SAGE_COMET_RPC` | CometBFT RPC endpoint used by `sage-gui upgrade`. | (built-in) | sage-gui | `cmd/sage-gui/upgrade.go:44` |
+| `SAGE_COMET_RPC` | CometBFT RPC endpoint for `sage-gui upgrade`; takes precedence over `SAGE_CMT_RPC_ADDR` for that command. | (built-in) | sage-gui | `cmd/sage-gui/upgrade.go:44` |
 | `SAGE_TX_COMMIT_TIMEOUT_MS` | Timeout (ms) for `broadcast_tx_commit`. Raise it for unusually slow consensus. | `60000` (60s) | REST | `api/rest/memory_handler.go:1317` |
 | `SAGE_NO_BROWSER` | If set to any non-empty value, don't auto-open a browser when the node starts. | (unset → opens browser) | sage-gui | `cmd/sage-gui/node.go:724` |
 

--- a/internal/orchestrator/bundle.go
+++ b/internal/orchestrator/bundle.go
@@ -39,7 +39,10 @@ embedding:
 
 quorum:
   enabled: true
-  p2p_addr: "tcp://0.0.0.0:26656"
+  # P2P listen address. Blank binds the historical default tcp://0.0.0.0:26656;
+  # override per-host with SAGE_CMT_P2P_ADDR (e.g. to run two quorum agents on
+  # one machine). A hardcoded value here would shadow that env override.
+  p2p_addr: ""
   peers:
     - "%s"
 `, agent.Name, primaryAddr)

--- a/internal/orchestrator/bundle_test.go
+++ b/internal/orchestrator/bundle_test.go
@@ -1,0 +1,60 @@
+package orchestrator
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+// TestGenerateBundleBlankP2PAddr asserts the generated agent config.yaml leaves
+// quorum.p2p_addr blank. node.go only applies the SAGE_CMT_P2P_ADDR override (and
+// its tcp://0.0.0.0:26656 default) when p2p_addr is empty, so a hardcoded value
+// here would shadow the override and block two quorum agents coexisting on one
+// host — the gap this change closes.
+func TestGenerateBundleBlankP2PAddr(t *testing.T) {
+	dir := t.TempDir()
+	agent := &store.AgentEntry{Name: "alpha", AgentID: "abc123", Role: "member", Clearance: 1}
+
+	zipPath, err := GenerateBundle(dir, agent, make([]byte, 32), "tcp://primary:26656")
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	cfg := readZipEntry(t, zipPath, "sage-agent-alpha/config.yaml")
+	if !strings.Contains(cfg, `p2p_addr: ""`) {
+		t.Errorf("config.yaml should leave p2p_addr blank, got:\n%s", cfg)
+	}
+	if strings.Contains(cfg, `p2p_addr: "tcp://0.0.0.0:26656"`) {
+		t.Errorf("config.yaml must not hardcode the P2P port (it shadows SAGE_CMT_P2P_ADDR):\n%s", cfg)
+	}
+}
+
+func readZipEntry(t *testing.T, zipPath, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(zipPath)
+	if err != nil {
+		t.Fatalf("read zip: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	for _, f := range zr.File {
+		if f.Name == name {
+			rc, err := f.Open()
+			if err != nil {
+				t.Fatalf("open entry %q: %v", name, err)
+			}
+			defer rc.Close()
+			b, _ := io.ReadAll(rc)
+			return string(b)
+		}
+	}
+	t.Fatalf("entry %q not found in bundle", name)
+	return ""
+}


### PR DESCRIPTION
## What

Follow-up to #50. That PR made the CometBFT RPC/P2P ports configurable for `sage-gui serve`, but several sibling consumers still dialed/bound the historical ports — so a node moved off `26657`/`26656` was only half-moved. This closes the remaining code sites so the `SAGE_CMT_*` knobs are honored end-to-end.

## Changes

- **`sage-cli status`** — honors `SAGE_CMT_RPC_ADDR`, deriving the dial URL the same way `cmd/sage-gui` does (`tcp://`→`http://`, `0.0.0.0` wildcard→`127.0.0.1`). Unset preserves the historical `26657-26957` local-cluster scan.
- **`sage-gui upgrade`** — `defaultCometRPC()` now falls back to the node's configured RPC (`cmtRPCClientURL()`) so `upgrade` reaches a moved node without a second env var. Explicit `SAGE_COMET_RPC` still takes precedence; the `26657` default is unchanged.
- **orchestrator bundle** — the generated agent `config.yaml` now emits a **blank** `quorum.p2p_addr`. `node.go` only applies the `SAGE_CMT_P2P_ADDR` override (and its `tcp://0.0.0.0:26656` default) when `p2p_addr` is empty, so the previously hardcoded value *shadowed* the override and blocked two quorum agents coexisting on one host. Blank preserves the exact default bind.
- **docs** — `docs/reference/environment-variables.md` updated for the new readers/precedence.

## Out of scope (intentional)

`deploy/*` compose manifests keep their per-container internal port + host-mapping scheme (each container is its own netns; `docker-compose.test.yml` already maps `36657` etc. for host-level coexistence). `cmd/amid` already has its own `COMET_RPC` flag/env.

## Determinism

Transport-only, consensus path untouched — same determinism-neutral footing as #50.

## Tests

- `cmd/sage-cli`: `statusRPCURLs` default-scan vs override + wildcard derivation.
- `cmd/sage-gui`: `defaultCometRPC` precedence (`SAGE_COMET_RPC` > derived > default).
- `internal/orchestrator`: `GenerateBundle` emits blank `p2p_addr` (no hardcoded port).
- `go build ./...`, `go vet`, `gofmt` all clean; all defaults byte-for-byte unchanged when env unset.