### PR TITLE
fix(web): content-hash asset version so dashboard JS isn't served stale after a deploy

### DIFF
--- a/web/handler.go
+++ b/web/handler.go
@@ -370,6 +370,30 @@ func (h *DashboardHandler) RegisterRoutes(r chi.Router) {
 		staticFS, _ := fs.Sub(StaticFS, "static")
 		fileServer := http.FileServer(http.FS(staticFS))
 
+		// Content-hash asset version for cache-busting. index.html's ?v token was
+		// hardcoded (never bumped across releases) and app.js imports mri-brain.js
+		// with NO version — so browsers/CDNs served stale JS after a deploy (the
+		// fix only showed in incognito). This hash changes whenever any embedded
+		// asset changes, so each build serves fresh asset URLs.
+		assetVer := func() string {
+			h := sha256.New()
+			var files []string
+			_ = fs.WalkDir(staticFS, ".", func(p string, d fs.DirEntry, err error) error {
+				if err == nil && !d.IsDir() {
+					files = append(files, p)
+				}
+				return nil
+			})
+			sort.Strings(files)
+			for _, p := range files {
+				if b, e := fs.ReadFile(staticFS, p); e == nil {
+					h.Write([]byte(p))
+					h.Write(b)
+				}
+			}
+			return hex.EncodeToString(h.Sum(nil))[:12]
+		}()
+
 		r.Get("/ui/*", func(w http.ResponseWriter, r *http.Request) {
 			// Strip /ui prefix
 			path := strings.TrimPrefix(r.URL.Path, "/ui")
@@ -411,6 +435,16 @@ func (h *DashboardHandler) RegisterRoutes(r chi.Router) {
 			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 			w.Header().Set("Pragma", "no-cache")
 			w.Header().Set("Expires", "0")
+
+			// Cache-busting: replace the (previously hardcoded) ?v token with the
+			// content hash, and inject it into app.js's version-less mri-brain.js
+			// import — so a new build always serves fresh JS through any cache/CDN.
+			if strings.HasSuffix(path, ".html") {
+				f = bytes.ReplaceAll(f, []byte("?v=678"), []byte("?v="+assetVer))
+			} else if strings.HasSuffix(path, ".js") {
+				f = bytes.ReplaceAll(f, []byte("from './mri-brain.js'"), []byte("from './mri-brain.js?v="+assetVer+"'"))
+				f = bytes.ReplaceAll(f, []byte("?v=678"), []byte("?v="+assetVer))
+			}
 
 			w.Write(f) //nolint:errcheck,gosec // static embedded file, not user input
 		})


### PR DESCRIPTION
## What

The CEREBRUM dashboard's cache-busting is broken two ways:

- `index.html`'s `?v` token is **hardcoded** (`?v=678`) and never bumped across releases;
- `app.js` imports `mri-brain.js` with **no version at all**.

So after a new build, browsers and CDNs keep serving the *previous* JS — a shipped fix only shows up in a private/incognito window or after a manual hard-refresh.

## How

Replace the static token with a **content hash** computed once at route registration over every `go:embed`'d static asset (sorted path + bytes → sha256 → first 12 hex). On each `/ui/*` response the hash is substituted into `index.html`'s `?v` token and injected into `app.js`'s version-less `mri-brain.js` import. Every build therefore serves fresh asset URLs, and a stale cache can't mask a deployed change. The hash is stable for a given binary and only moves when an embedded asset actually changes.

## Why this way

The assets are embedded (`//go:embed all:static`), so the content hash is available at startup with zero runtime cost beyond one walk at registration. No manual version bumping to forget; the version is derived from the bytes themselves.

## Verification

- Confirmed the replaced literals exist in the current assets (`?v=678` in `index.html`; `import … from './mri-brain.js'` in `app.js`), so the substitutions hit their targets rather than silently no-op'ing.
- `go build` re-embeds cleanly; `go vet ./web/` clean.

Independent of the MRI WebGL fix, but complementary — this is what makes any dashboard fix actually reach users through a warm cache.
