### PR TITLE
fix(11.8.2): H-2 residual hygiene — CheckTx future-cap + EmbeddingHash docs + shelved app-v20 design

### DIFF
--- a/docs/reference/concepts/delegated-agent-proof-h2-disposition.md
+++ b/docs/reference/concepts/delegated-agent-proof-h2-disposition.md
@@ -1,0 +1,98 @@
+# Design record: delegated-agent-proof hardening (H-2 residual) — SHELVED for app-v20
+
+**Status: WON'T-FIX-YET (decision), with a pre-specified design shelved for a future fork.**
+This records why the v11.8 security review's H-2 residual is *not* being closed with a
+consensus fork now, what was shipped instead (11.8.2), and the exact app-v20 design to
+build if a revisit trigger fires.
+
+## Background
+
+`enforceDelegatedAgentProof` (internal/abci/agent_proof.go) enforces, in the FinalizeBlock
+consensus path, that a delegated tx (`PublicKey != AgentPubKey`) carries a valid agent
+signature over the action. v11.7.6 ("restore reliable MCP turns", 534b6fd) **relaxed** two
+rules, **ungated**:
+
+- **R1 — embedding authority:** the delegated `MemorySubmit` binding uses the NODE-derived
+  `EmbeddingHash` (`expected.EmbeddingHash = actual.MemorySubmit.EmbeddingHash`) instead of
+  reconstructing it from the agent-signed body (v11.7.4 provider-cutover design).
+- **R2 — timestamp:** `agentProofTimestampFresh` keeps only a lower bound (`ts >= now-skew`);
+  the upper bound was dropped so an idle single-validator chain (deterministic block time
+  lags the signing wall clock) does not reject legitimate delegated turns.
+
+The relaxation is a strict **superset** of the prior rule and is **baked into committed
+v11.7.6/7 history**. See the REPLAY-CRITICAL note on `verifySignedAgentAction`: any
+old-below/new-above fork gate (e.g. app-v19) would replay committed delegated turns under
+the stricter old rule, Code-109-reject them, and fork the AppHash of every upgraded chain.
+
+## Decision: do NOT spend a fork on R1/R2 now
+
+A deep, adversarially-verified design pass (converged, 0 breaks) rated the residuals
+**negligible (R1)** and **low (R2)** and found the "cross-chain key spread" urgency premise
+**false**:
+
+- **R1 is inert on-chain.** `EmbeddingHash` is write-only — the only non-assignment reads
+  in the non-test codebase are presence guards; everything the agent authorizes (content,
+  type, domain, confidence, classification, parent, task) is byte-bound via `ContentHash` +
+  `compareAgentPayload`. Only the submitting node (already inside the delegated trust
+  boundary; controls its own vector store) can stamp a false value, and embeddings are
+  per-node search index re-derived from agent-signed content.
+- **R2 is low.** The replay-marker horizon is airtight (`expiresAt = ts + skew`); the only
+  residuals (pre-signed stockpiles, permanent markers) require the agent's **own** signing
+  key, which subsumes the gain. The HTTP boundary already enforces a two-sided window.
+- **No cross-chain exposure:** v11.8 sync-relays sign the agent proof AND the outer tx with
+  the SAME local operator key (`buildSyncSubmitTx`), so `PublicKey == AgentPubKey`
+  short-circuits the delegated gate entirely; receiver effect is gated by the receiving
+  chain's own domain ACL.
+
+A fork would spend the next free rung (ceiling 19; v19 reserved for local-agents-default-READ),
+add a **forever** replay boundary, require AppHash-exclusion surgery across all hash rules,
+and **re-create the exact 534b6fd idle-chain regression** at cutover. Not worth it.
+
+## Shipped instead (11.8.2, zero consensus change)
+
+- **CheckTx-only advisory future cap** in `enforceDelegatedAgentProof` (`!claim` branch):
+  reject `AgentTimestamp > now + skew` at mempool admission. Closes raw-RPC injection of
+  far-future stockpiled proofs into honest mempools. Mempool policy is not consensus
+  (feeds neither AppHash nor LastResultsHash, never runs in replay), and it only loosens as
+  wall time advances — so it can never fork or regress. It MUST NEVER move to the
+  `claim=true` FinalizeBlock path.
+- **`EmbeddingHash` documented** as node-derived, lossy, unverified per-node search-index
+  metadata (`internal/tx/types.go`); guard tests freeze it as inert.
+- This design record + the revisit triggers below.
+
+## SHELVED design for app-v20 (build ONLY if a trigger fires)
+
+A single forward-only app-v20 fork ("anchored-nonce"), all behaviour changing only at
+`height > appV20AppliedHeight` (so all history + pre-activation blocks replay
+byte-identically; `postAppV20Fork` cloned from `postAppV19Fork`, strict `>`; ceiling bumped
+in lockstep; NOT OR'd into `postAppV18Rules`):
+
+- **Anchored nonce, zero codec change:** carry `SGAN || 0x01 || BE64(anchorHeight) ||
+  anchorAppHash(32) || entropy(8..64)` **inside the existing agent-signed `AgentNonce`**
+  (already in the signed message and the proof fingerprint — no signature-format or wire
+  change; pre-fork it is opaque bytes, so clients can adopt early).
+- **Anchor store:** a `blockanchor:` record (AppHash + blockTime per height), **EXCLUDED
+  from all AppHash rules**, with a boot assert that no such key exists while
+  `appV20AppliedHeight == 0`.
+- **Height-keyed single-use markers** replace the ts-keyed replay store.
+- **Freshness (above activation):** `(height - anchorHeight <= K)` (K ≈ 256) **OR**
+  `(blockTime - anchorTime <= skew)` — idle-safe by construction (no wall-clock upper bound
+  in consensus, so no 534b6fd regression), while killing indefinite pre-signed stockpiles
+  and permanent markers.
+- **Optional R1 rider:** post-activation, reject a non-empty `EmbeddingHash` on delegated
+  `MemorySubmit` (a pure byte-length check — deterministic), deprecating the field on-chain.
+- Ship as ONE fork. NEVER a wall-clock upper bound in FinalizeBlock; NEVER a retro-gate.
+
+## Revisit triggers (any one re-opens the decision)
+
+Check these at each release; they are also recorded in SAGE institutional memory.
+
+1. Any feature registers/permits **one agent key on multiple chains** as normal operation
+   (today false: sync relays are same-key and bypass the delegated gate).
+2. Delegated proofs start being **relayed or accepted cross-chain** in any flow.
+3. A **quorum / multi-tenant** deployment makes agent-key-compromise stockpiling a live
+   threat (on single-validator personal chains the node operator is already omnipotent).
+4. Any code path begins **reading `EmbeddingHash` beyond the presence guards** (the inert
+   guard test then fails — treat that failure as this trigger).
+5. **CometBFT v1.x proposer-based timestamps** land, making a plain `ts <= now + skew`
+   restore safe as a simpler alternative to the anchor design.

--- a/internal/abci/agent_proof.go
+++ b/internal/abci/agent_proof.go
@@ -57,6 +57,21 @@ func (app *SageApp) enforceDelegatedAgentProof(parsedTx *tx.ParsedTx, consensusT
 	if !agentProofTimestampFresh(parsedTx.AgentTimestamp, consensusTime) {
 		return fmt.Errorf("delegated agent proof timestamp is older than the 5-minute consensus window")
 	}
+	// Mempool hygiene ONLY (claim=false / CheckTx). Reject a delegated proof whose
+	// timestamp is far AHEAD of the local wall clock, so a raw-RPC client cannot inject
+	// far-future stockpiled proofs into an honest mempool; this mirrors the two-sided
+	// window the REST/MCP boundary already enforces (api/rest/middleware/auth.go).
+	// This upper bound MUST NEVER move to the consensus path (claim=true / FinalizeBlock,
+	// app.go's enforceDelegatedAgentProof(..., blockTime, true) call): a wall-clock upper
+	// bound there deterministically re-creates the v11.7.6 idle-chain rejection (block
+	// time lags the signing wall clock) and, applied to committed history, forks the
+	// AppHash — see the REPLAY-CRITICAL note on verifySignedAgentAction. CheckTx is not
+	// consensus (its result feeds neither AppHash nor LastResultsHash and never runs
+	// during replay), and the bound only LOOSENS as wall time advances, so a tx admitted
+	// once is never future-rejected on CheckTx recheck.
+	if !claim && parsedTx.AgentTimestamp > consensusTime.Unix()+int64(delegatedAgentProofSkew/time.Second) {
+		return fmt.Errorf("delegated agent proof timestamp is ahead of the local %s admission window", delegatedAgentProofSkew)
+	}
 
 	req, err := parseSignedAgentRequest(parsedTx.AgentRequest)
 	if err != nil {

--- a/internal/abci/agent_proof_test.go
+++ b/internal/abci/agent_proof_test.go
@@ -131,6 +131,38 @@ func TestAppV17DelegatedProofAcceptsWallClockAheadOfIdleConsensus(t *testing.T) 
 	assert.Equal(t, uint32(0), result.Code, result.Log)
 }
 
+// TestDelegatedProofMempoolFutureCapRejectsOnlyOnCheckTx pins the 11.8.2 mempool
+// hygiene bound: a delegated proof timestamped far AHEAD of the local wall clock is
+// rejected on the CheckTx (claim=false) path, while a proof within the 5-minute skew
+// (future or past) is accepted — and, critically, the CONSENSUS path (claim=true)
+// still ACCEPTS the far-future proof unchanged, so the cap never gates FinalizeBlock
+// (which would re-create the v11.7.6 idle-chain regression and fork committed history).
+func TestDelegatedProofMempoolFutureCapRejectsOnlyOnCheckTx(t *testing.T) {
+	app := setupTestApp(t)
+	app.appV17AppliedHeight = 5
+	agent := newAgentKey(t)
+	outer := newAgentKey(t)
+	now := time.Now().Truncate(time.Second)
+	// The domain name in the tx must equal the "name" in the signed request body, else
+	// verifySignedAgentAction (correctly) rejects the payload before the timestamp cap
+	// matters; the freshness/cap logic under test is independent of the action content.
+	req := []byte("POST /v1/domain/register\n{\"name\":\"cap\",\"description\":\"safe\"}")
+
+	// CheckTx (claim=false): far-future is rejected as mempool hygiene...
+	far := makeDelegatedDomainRegisterTx(t, agent, outer, req, now.Add(10*time.Minute), "cap", "safe", true)
+	require.ErrorContains(t, app.enforceDelegatedAgentProof(far, now, false), "ahead of the local")
+	// ...but a proof within +/- the skew (either side) is accepted.
+	nearFuture := makeDelegatedDomainRegisterTx(t, agent, outer, req, now.Add(4*time.Minute), "cap", "safe", true)
+	require.NoError(t, app.enforceDelegatedAgentProof(nearFuture, now, false))
+	nearPast := makeDelegatedDomainRegisterTx(t, agent, outer, req, now.Add(-4*time.Minute), "cap", "safe", true)
+	require.NoError(t, app.enforceDelegatedAgentProof(nearPast, now, false))
+
+	// Consensus path (claim=true) is UNTOUCHED: a far-future proof must still be ACCEPTED —
+	// freezing that the cap is CheckTx-only and never re-strictifies consensus.
+	farConsensus := makeDelegatedDomainRegisterTx(t, agent, outer, req, now.Add(11*time.Minute), "cap", "safe", true)
+	require.NoError(t, app.enforceDelegatedAgentProof(farConsensus, now, true))
+}
+
 // TestReplayGuardDelegatedMemorySubmitAcceptedBelowAppV19 is the H-2 replay guard.
 // The v11.7.6 delegated-proof relaxation (node-authoritative EmbeddingHash +
 // lower-bound-only timestamp) shipped ungated and is baked into every v11.7.6/7

--- a/internal/tx/types.go
+++ b/internal/tx/types.go
@@ -132,9 +132,18 @@ const (
 
 // MemorySubmit proposes a new memory object for consensus validation.
 type MemorySubmit struct {
-	MemoryID        string
-	ContentHash     []byte
-	EmbeddingHash   []byte
+	MemoryID    string
+	ContentHash []byte
+	// EmbeddingHash is NODE-derived, lossy, UNVERIFIED per-node search-index metadata:
+	// the receiving node regenerates the embedding server-side (memory_handler.go) and
+	// stamps this hash. It is NOT agent-signed and NOT consensus-verified — the delegated
+	// agent proof deliberately copies it into the expected payload rather than
+	// reconstructing it (agent_proof.go verifySignedAgentAction, the v11.7.4 provider-cutover
+	// design). It is write-only on-chain (only presence guards read it) and legitimately
+	// drifts from the live vector after provider cutovers (store.UpdateMemoryEmbedding
+	// rewrites the vector without touching it). NEVER treat this field as an integrity
+	// commitment; the agent-bound integrity anchor is ContentHash.
+	EmbeddingHash []byte
 	MemoryType      MemoryType
 	DomainTag       string
 	ConfidenceScore float64


### PR DESCRIPTION
Follow-up to #72, for **11.8.2**. **No consensus behaviour change** — the FinalizeBlock delegated-proof call is byte-untouched, so AppHash/LastResultsHash are identical at every height on every chain (replay-safe by construction).

## Why no fork (deep adversarial design pass, converged, 0 breaks)
Forking to tighten the v11.7.6 delegated-proof relaxation is **not worth it**:
- **R1 (node-authoritative `EmbeddingHash`) — inert on-chain.** Write-only (only presence-guards read it); everything the agent authorizes is byte-bound via `ContentHash`; only the submitting node (already inside the delegated trust boundary) can stamp a value; embeddings are per-node search index re-derived from agent-signed content.
- **R2 (dropped timestamp upper bound) — low.** Replay-marker horizon is airtight (`expiresAt = ts+skew`); the only residuals need the agent's **own** key. HTTP boundary already enforces a two-sided window.
- **No cross-chain exposure:** v11.8 sync-relays sign proof + outer tx with the **same** operator key, so `PublicKey == AgentPubKey` short-circuits the delegated gate entirely.
- A fork would spend the next rung, add a forever replay boundary, need AppHash-exclusion surgery, and **re-create the v11.7.6 idle-chain regression** at cutover.

## What this ships (zero consensus)
- **CheckTx-only future cap** in `enforceDelegatedAgentProof` (`!claim` path): rejects far-future stockpiled proofs at mempool admission. Never on the consensus path. `TestDelegatedProofMempoolFutureCapRejectsOnlyOnCheckTx` freezes that claim=true still accepts a far-future proof.
- **`EmbeddingHash` documented** as node-derived, lossy, unverified per-node search-index metadata (integrity anchor is `ContentHash`).
- **Decision record + shelved app-v20 "anchored-nonce" design + revisit triggers** (`docs/reference/concepts/delegated-agent-proof-h2-disposition.md`) — build the fork only if a trigger fires (e.g. any flow that spreads an agent key across chains).

## Verification
`golangci-lint run` = 0; `go build ./...`, `go vet ./...`, `go test ./internal/abci ./internal/tx` all green.