### PR TITLE
feat(consensus): add v11.9 scoped quorum foundation

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -928,12 +928,130 @@ components:
         parent:
           type: string
 
+    ScopeDomain:
+      type: object
+      required: [name, subtree]
+      properties:
+        name:
+          type: string
+        subtree:
+          type: boolean
+
+    ScopeMember:
+      type: object
+      required: [validator_id, assigned_weight, joined_revision, active]
+      properties:
+        validator_id:
+          type: string
+        assigned_weight:
+          type: integer
+          format: uint64
+        joined_revision:
+          type: integer
+          format: uint64
+        active:
+          type: boolean
+
+    ScopeRecord:
+      type: object
+      required: [scope_id, revision, revision_hash, state, controller_validator_id, created_height, updated_height, domains, members]
+      properties:
+        scope_id:
+          type: string
+          pattern: '^[^/]+$'
+        revision:
+          type: integer
+          format: uint64
+        revision_hash:
+          type: string
+          description: Domain-separated SHA-256 audit anchor for this revision.
+        state:
+          type: string
+          enum: [active, paused, retired]
+        controller_validator_id:
+          type: string
+        created_height:
+          type: integer
+          format: int64
+        updated_height:
+          type: integer
+          format: int64
+        domains:
+          type: array
+          items:
+            $ref: "#/components/schemas/ScopeDomain"
+        members:
+          type: array
+          items:
+            $ref: "#/components/schemas/ScopeMember"
+
+    ScopeListResponse:
+      type: object
+      required: [scopes, count]
+      properties:
+        scopes:
+          type: array
+          items:
+            $ref: "#/components/schemas/ScopeRecord"
+        count:
+          type: integer
+
+    ScopeActionMember:
+      type: object
+      required: [validator_id, assigned_weight]
+      properties:
+        validator_id:
+          type: string
+        assigned_weight:
+          type: integer
+          format: uint64
+          minimum: 1
+        joined_revision:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Required after revision 1; may be omitted for a new scope.
+        active:
+          type: boolean
+          default: true
+
+    ScopeActionTemplate:
+      type: object
+      required: [scope_id, revision, state, controller_validator_id, domains, members]
+      properties:
+        scope_id:
+          type: string
+          pattern: '^[^/]+$'
+        revision:
+          type: integer
+          format: uint64
+          minimum: 1
+        state:
+          type: string
+          enum: [active, paused, retired]
+        controller_validator_id:
+          type: string
+        domains:
+          type: array
+          minItems: 1
+          items:
+            type: string
+        members:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/ScopeActionMember"
+      description: >-
+        Guided app-v20 scope proposal. The server bytewise-sorts domains and
+        members, defaults omitted member active flags to true, sets both
+        consensus-owned heights to zero, validates ScopeRecordV1 invariants,
+        and emits the canonical binary governance payload.
+
     # -- Governance (v8.0 payload-aware) ----------------------------------------
     GovProposeRequest:
       type: object
       required:
         - operation
-        - target_id
         - reason
       properties:
         operation:
@@ -944,6 +1062,8 @@ components:
             - update_power
             - domain_reassign
             - memory_domain_repair
+            - sync_group_action
+            - scope_action
           description: >-
             Governance operation. `memory_domain_repair` (app-v16, 2/3 quorum) is
             the domainless-forget remediation — it carries a base64 JSON
@@ -952,13 +1072,16 @@ components:
             `domain_reassign` (v8.0) is the
             access-control recovery primitive — it carries the target
             DomainReassign body via the `payload` field rather than the
-            scalar target_* fields.
+            scalar target_* fields. `scope_action` (app-v20) accepts either
+            the guided `scope` object or the legacy canonical binary
+            ScopeRecordV1 `payload`; the two fields are mutually exclusive.
         target_id:
           type: string
           description: >-
             Hex-encoded validator pubkey for validator-set ops; reused as
             the proposal-keying identifier for `domain_reassign` (typically
-            the dotted-path domain name).
+            the dotted-path domain name). Required except when a
+            `scope_action` supplies `scope.scope_id`, from which it is derived.
         target_pubkey:
           type: string
           description: Hex-encoded Ed25519 public key (required for add_validator).
@@ -980,7 +1103,11 @@ components:
             `domain_reassign`, the JSON-encoded body
             `{domain, new_owner_id, parent_domain, open_to_shared}` that
             the subsequent TxTypeDomainReassign execution tx must reproduce
-            byte-for-byte. Empty for legacy validator-set ops.
+            byte-for-byte. For legacy `scope_action` callers, the canonical
+            binary ScopeRecordV1 template with zero system-owned heights.
+            Mutually exclusive with `scope`; empty for validator-set ops.
+        scope:
+          $ref: "#/components/schemas/ScopeActionTemplate"
 
     GovProposeResponse:
       type: object
@@ -1383,6 +1510,30 @@ components:
           type: boolean
         cometbft:
           type: boolean
+        scoped_projection:
+          type: object
+          description: >-
+            v11.9 canonical scoped-content projection status. When required is
+            true and ok is false, readiness fails closed with HTTP 503.
+          required:
+            - checked
+            - required
+            - ok
+            - records
+            - rebuilt
+          properties:
+            checked:
+              type: boolean
+            required:
+              type: boolean
+            ok:
+              type: boolean
+            records:
+              type: integer
+            rebuilt:
+              type: integer
+            detail:
+              type: string
 
     ProblemDetails:
       type: object
@@ -3190,6 +3341,54 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /v1/scopes:
+    get:
+      operationId: listScopes
+      summary: List canonical v11.9 quorum scopes (operator/admin only).
+      tags:
+        - Governance
+      responses:
+        "200":
+          description: Canonical scope heads in scope-ID order.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScopeListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /v1/scopes/{scope_id}:
+    get:
+      operationId: getScope
+      summary: Read one canonical v11.9 quorum scope (operator/admin only).
+      tags:
+        - Governance
+      parameters:
+        - name: scope_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Canonical scope head and immutable current-revision anchor.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScopeRecord"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   # -- Embeddings ---------------------------------------------------------
   /v1/embed:
     post:
@@ -3708,7 +3907,7 @@ paths:
   /ready:
     get:
       operationId: readinessCheck
-      summary: Readiness probe — checks PostgreSQL and CometBFT connectivity.
+      summary: Readiness probe — checks storage, CometBFT, and scoped projection integrity.
       tags:
         - Operational
       security: []

--- a/api/rest/governance_handler.go
+++ b/api/rest/governance_handler.go
@@ -3,10 +3,12 @@ package rest
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/l33tdawg/sage/internal/scope"
 	"github.com/l33tdawg/sage/internal/tx"
 )
 
@@ -17,16 +19,19 @@ import (
 // Payload (added v8.0) is an optional base64-encoded blob carrying operation-
 // specific data. For OpDomainReassign it's the JSON-encoded DomainReassign
 // body {domain, new_owner_id, parent_domain, open_to_shared} that the
-// executing TxTypeDomainReassign tx must reproduce byte-for-byte. Legacy
-// validator-set ops (add/remove/update_power) leave Payload empty.
+// executing TxTypeDomainReassign tx must reproduce byte-for-byte. App-v20
+// scope_action accepts either a canonical binary scope record in Payload or a
+// guided Scope template that the node canonicalizes. Legacy validator-set ops
+// (add/remove/update_power) leave both empty.
 type GovProposeRequest struct {
-	Operation    string `json:"operation"`
-	TargetID     string `json:"target_id"`
-	TargetPubkey string `json:"target_pubkey,omitempty"`
-	TargetPower  int64  `json:"target_power,omitempty"`
-	ExpiryBlocks int64  `json:"expiry_blocks,omitempty"`
-	Reason       string `json:"reason"`
-	Payload      string `json:"payload,omitempty"`
+	Operation    string                  `json:"operation"`
+	TargetID     string                  `json:"target_id"`
+	TargetPubkey string                  `json:"target_pubkey,omitempty"`
+	TargetPower  int64                   `json:"target_power,omitempty"`
+	ExpiryBlocks int64                   `json:"expiry_blocks,omitempty"`
+	Reason       string                  `json:"reason"`
+	Payload      string                  `json:"payload,omitempty"`
+	Scope        *scope.ProposalTemplate `json:"scope,omitempty"`
 }
 
 // GovProposeResponse is the JSON body for a successful proposal.
@@ -70,11 +75,7 @@ func (s *Server) handleGovPropose(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Operation == "" {
-		writeProblem(w, http.StatusBadRequest, "Missing operation", "operation is required (add_validator, remove_validator, update_power).")
-		return
-	}
-	if req.TargetID == "" {
-		writeProblem(w, http.StatusBadRequest, "Missing target_id", "target_id is required.")
+		writeProblem(w, http.StatusBadRequest, "Missing operation", "operation is required (add_validator, remove_validator, update_power, domain_reassign, memory_domain_repair, sync_group_action, scope_action).")
 		return
 	}
 	if req.Reason == "" {
@@ -87,6 +88,10 @@ func (s *Server) handleGovPropose(w http.ResponseWriter, r *http.Request) {
 		writeProblem(w, http.StatusBadRequest, "Invalid operation", err.Error())
 		return
 	}
+	if op == tx.GovOpScopeAction && !s.isPostV20ForNextTx() {
+		writeProblem(w, http.StatusConflict, "Scope governance is not active", "scope_action requires app-v20 activation.")
+		return
+	}
 
 	var pubKeyBytes []byte
 	if req.TargetPubkey != "" {
@@ -97,17 +102,14 @@ func (s *Server) handleGovPropose(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// v8.0: optional base64-encoded payload carries operation-specific data
-	// (e.g. JSON DomainReassign body for OpDomainReassign). The raw bytes are
-	// stored verbatim on the proposal record so the executing tx can verify
-	// body-vs-proposal parity. Legacy ops leave this empty.
+	// v8.0 payloads remain byte-for-byte base64. For app-v20 scope_action,
+	// structured input is converted into the same canonical binary record and
+	// the target ID can be derived from scope_id.
 	var payloadBytes []byte
-	if req.Payload != "" {
-		payloadBytes, err = base64.StdEncoding.DecodeString(req.Payload)
-		if err != nil {
-			writeProblem(w, http.StatusBadRequest, "Invalid payload", "payload must be valid base64.")
-			return
-		}
+	req.TargetID, payloadBytes, err = resolveGovProposalPayload(op, req.TargetID, req.Payload, req.Scope)
+	if err != nil {
+		writeProblem(w, http.StatusBadRequest, "Invalid governance payload", err.Error())
+		return
 	}
 
 	proposeTx := &tx.ParsedTx{
@@ -163,6 +165,43 @@ func (s *Server) handleGovPropose(w http.ResponseWriter, r *http.Request) {
 		TxHash:     txHash,
 		Status:     "voting",
 	})
+}
+
+func resolveGovProposalPayload(op tx.GovProposalOp, targetID, rawPayload string, template *scope.ProposalTemplate) (string, []byte, error) {
+	if template != nil {
+		if op != tx.GovOpScopeAction {
+			return "", nil, errors.New("scope is only valid for scope_action")
+		}
+		if rawPayload != "" {
+			return "", nil, errors.New("payload and scope are mutually exclusive")
+		}
+		encoded, err := scope.EncodeProposalTemplate(*template)
+		if err != nil {
+			return "", nil, fmt.Errorf("scope: %w", err)
+		}
+		if targetID == "" {
+			targetID = template.ScopeID
+		} else if targetID != template.ScopeID {
+			return "", nil, fmt.Errorf("target_id %q does not match scope_id %q", targetID, template.ScopeID)
+		}
+		return targetID, encoded, nil
+	}
+
+	var payload []byte
+	if rawPayload != "" {
+		decoded, err := base64.StdEncoding.DecodeString(rawPayload)
+		if err != nil {
+			return "", nil, errors.New("payload must be valid base64")
+		}
+		payload = decoded
+	}
+	if targetID == "" {
+		return "", nil, errors.New("target_id is required")
+	}
+	if op == tx.GovOpScopeAction && len(payload) == 0 {
+		return "", nil, errors.New("scope_action requires either payload or scope")
+	}
+	return targetID, payload, nil
 }
 
 // handleGovVote handles POST /v1/governance/vote.
@@ -312,7 +351,9 @@ func parseGovOp(s string) (tx.GovProposalOp, error) {
 		return tx.GovOpMemoryDomainRepair, nil
 	case "sync_group_action":
 		return tx.GovOpSyncGroupAction, nil
+	case "scope_action":
+		return tx.GovOpScopeAction, nil
 	default:
-		return 0, fmt.Errorf("operation must be one of: add_validator, remove_validator, update_power, domain_reassign, memory_domain_repair, sync_group_action")
+		return 0, fmt.Errorf("operation must be one of: add_validator, remove_validator, update_power, domain_reassign, memory_domain_repair, sync_group_action, scope_action")
 	}
 }

--- a/api/rest/governance_handler_test.go
+++ b/api/rest/governance_handler_test.go
@@ -1,8 +1,13 @@
 package rest
 
 import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/l33tdawg/sage/internal/scope"
 	"github.com/l33tdawg/sage/internal/tx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,14 +26,63 @@ func TestParseGovOp_MemoryDomainRepair(t *testing.T) {
 	assert.Equal(t, uint8(6), uint8(op), "must match governance.OpMemoryDomainRepair = 6")
 }
 
+func TestResolveGovProposalPayloadBuildsCanonicalScope(t *testing.T) {
+	template := &scope.ProposalTemplate{
+		ScopeID: "scope-a", Revision: 1, State: "active",
+		ControllerValidatorID: "validator-a",
+		Domains:               []string{"research.private", "research"},
+		Members: []scope.ProposalMember{
+			{ValidatorID: "validator-b", AssignedWeight: 1},
+			{ValidatorID: "validator-a", AssignedWeight: 2},
+		},
+	}
+	targetID, payload, err := resolveGovProposalPayload(tx.GovOpScopeAction, "", "", template)
+	require.NoError(t, err)
+	assert.Equal(t, "scope-a", targetID)
+	record, err := scope.Decode(payload)
+	require.NoError(t, err)
+	assert.Equal(t, []scope.Domain{{Name: "research"}, {Name: "research.private"}}, record.Domains)
+	assert.Zero(t, record.CreatedHeight)
+	assert.Zero(t, record.UpdatedHeight)
+}
+
+func TestResolveGovProposalPayloadRejectsAmbiguousOrMismatchedScope(t *testing.T) {
+	template := &scope.ProposalTemplate{
+		ScopeID: "scope-a", Revision: 1, State: "active",
+		ControllerValidatorID: "validator-a", Domains: []string{"research"},
+		Members: []scope.ProposalMember{{ValidatorID: "validator-a", AssignedWeight: 1}},
+	}
+	_, _, err := resolveGovProposalPayload(tx.GovOpScopeAction, "scope-a", base64.StdEncoding.EncodeToString([]byte("raw")), template)
+	assert.ErrorContains(t, err, "mutually exclusive")
+	_, _, err = resolveGovProposalPayload(tx.GovOpScopeAction, "scope-b", "", template)
+	assert.ErrorContains(t, err, "does not match")
+	_, _, err = resolveGovProposalPayload(tx.GovOpAddValidator, "validator-a", "", template)
+	assert.ErrorContains(t, err, "only valid")
+	_, _, err = resolveGovProposalPayload(tx.GovOpScopeAction, "scope-a", "", nil)
+	assert.ErrorContains(t, err, "requires either")
+}
+
+func TestScopeActionConstructionFailsClosedBeforeAppV20(t *testing.T) {
+	server := &Server{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/governance/propose", strings.NewReader(`{
+		"operation":"scope_action","target_id":"scope-a","reason":"form scope","payload":"AQ=="
+	}`))
+	resp := httptest.NewRecorder()
+	server.handleGovPropose(resp, req)
+	assert.Equal(t, http.StatusConflict, resp.Code)
+	assert.Contains(t, resp.Body.String(), "app-v20")
+}
+
 // TestParseGovOp_KnownAndUnknown pins the rest of the mapping so the repair addition
 // didn't disturb the legacy ops, and an unknown op still errors.
 func TestParseGovOp_KnownAndUnknown(t *testing.T) {
 	for s, want := range map[string]tx.GovProposalOp{
-		"add_validator":    tx.GovOpAddValidator,
-		"remove_validator": tx.GovOpRemoveValidator,
-		"update_power":     tx.GovOpUpdatePower,
-		"domain_reassign":  tx.GovOpDomainReassign,
+		"add_validator":     tx.GovOpAddValidator,
+		"remove_validator":  tx.GovOpRemoveValidator,
+		"update_power":      tx.GovOpUpdatePower,
+		"domain_reassign":   tx.GovOpDomainReassign,
+		"sync_group_action": tx.GovOpSyncGroupAction,
+		"scope_action":      tx.GovOpScopeAction,
 	} {
 		got, err := parseGovOp(s)
 		require.NoError(t, err, s)

--- a/api/rest/scope_handler.go
+++ b/api/rest/scope_handler.go
@@ -1,0 +1,134 @@
+package rest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/l33tdawg/sage/api/rest/middleware"
+	"github.com/l33tdawg/sage/internal/scope"
+)
+
+type scopeDomainResponse struct {
+	Name    string `json:"name"`
+	Subtree bool   `json:"subtree"`
+}
+
+type scopeMemberResponse struct {
+	ValidatorID    string `json:"validator_id"`
+	AssignedWeight uint64 `json:"assigned_weight"`
+	JoinedRevision uint64 `json:"joined_revision"`
+	Active         bool   `json:"active"`
+}
+
+type scopeRecordResponse struct {
+	ScopeID               string                `json:"scope_id"`
+	Revision              uint64                `json:"revision"`
+	RevisionHash          string                `json:"revision_hash"`
+	State                 string                `json:"state"`
+	ControllerValidatorID string                `json:"controller_validator_id"`
+	CreatedHeight         int64                 `json:"created_height"`
+	UpdatedHeight         int64                 `json:"updated_height"`
+	Domains               []scopeDomainResponse `json:"domains"`
+	Members               []scopeMemberResponse `json:"members"`
+}
+
+func (s *Server) handleListScopes(w http.ResponseWriter, r *http.Request) {
+	if !s.scopeReadAuthorized(r) {
+		writeProblem(w, http.StatusForbidden, "Forbidden", "scope topology is visible only to the node operator or an administrator.")
+		return
+	}
+	if s.badgerStore == nil {
+		writeProblem(w, http.StatusServiceUnavailable, "Scope state unavailable", "canonical scope storage is not configured.")
+		return
+	}
+	records, err := s.badgerStore.ListScopeRecords()
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "Scope state invalid", err.Error())
+		return
+	}
+	views := make([]scopeRecordResponse, 0, len(records))
+	for i := range records {
+		view, err := s.scopeRecordView(&records[i])
+		if err != nil {
+			writeProblem(w, http.StatusInternalServerError, "Scope state invalid", err.Error())
+			return
+		}
+		views = append(views, view)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"scopes": views, "count": len(views)})
+}
+
+func (s *Server) handleGetScope(w http.ResponseWriter, r *http.Request) {
+	if !s.scopeReadAuthorized(r) {
+		writeProblem(w, http.StatusForbidden, "Forbidden", "scope topology is visible only to the node operator or an administrator.")
+		return
+	}
+	if s.badgerStore == nil {
+		writeProblem(w, http.StatusServiceUnavailable, "Scope state unavailable", "canonical scope storage is not configured.")
+		return
+	}
+	record, err := s.badgerStore.GetScopeRecord(chi.URLParam(r, "scope_id"))
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "Scope state invalid", err.Error())
+		return
+	}
+	if record == nil {
+		writeProblem(w, http.StatusNotFound, "Scope not found", "No canonical scope exists with that id.")
+		return
+	}
+	view, err := s.scopeRecordView(record)
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "Scope state invalid", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, view)
+}
+
+func (s *Server) scopeReadAuthorized(r *http.Request) bool {
+	callerID := middleware.ContextAgentID(r.Context())
+	return s.callerIsOperatorOrAdmin(r.Context(), callerID)
+}
+
+func (s *Server) scopeRecordView(record *scope.Record) (scopeRecordResponse, error) {
+	digest, err := s.badgerStore.GetScopeRevisionHash(record.ScopeID, record.Revision)
+	if err != nil {
+		return scopeRecordResponse{}, err
+	}
+	if len(digest) != sha256.Size {
+		return scopeRecordResponse{}, fmt.Errorf("scope %q revision %d is missing its audit anchor", record.ScopeID, record.Revision)
+	}
+	domains := make([]scopeDomainResponse, 0, len(record.Domains))
+	for _, domain := range record.Domains {
+		domains = append(domains, scopeDomainResponse{Name: domain.Name, Subtree: domain.Subtree})
+	}
+	members := make([]scopeMemberResponse, 0, len(record.Members))
+	for _, member := range record.Members {
+		members = append(members, scopeMemberResponse{
+			ValidatorID: member.ValidatorID, AssignedWeight: member.AssignedWeight,
+			JoinedRevision: member.JoinedRevision, Active: member.Active,
+		})
+	}
+	return scopeRecordResponse{
+		ScopeID: record.ScopeID, Revision: record.Revision, RevisionHash: hex.EncodeToString(digest),
+		State: scopeStateString(record.State), ControllerValidatorID: record.ControllerValidatorID,
+		CreatedHeight: record.CreatedHeight, UpdatedHeight: record.UpdatedHeight,
+		Domains: domains, Members: members,
+	}, nil
+}
+
+func scopeStateString(state scope.State) string {
+	switch state {
+	case scope.StateActive:
+		return "active"
+	case scope.StatePaused:
+		return "paused"
+	case scope.StateRetired:
+		return "retired"
+	default:
+		return "unknown"
+	}
+}

--- a/api/rest/scope_handler_test.go
+++ b/api/rest/scope_handler_test.go
@@ -1,0 +1,73 @@
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/api/rest/middleware"
+	"github.com/l33tdawg/sage/internal/scope"
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+func scopeReadRouter(server *Server, callerID string) http.Handler {
+	r := chi.NewRouter()
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			next.ServeHTTP(w, req.WithContext(middleware.WithAgentID(req.Context(), callerID)))
+		})
+	})
+	r.Get("/v1/scopes", server.handleListScopes)
+	r.Get("/v1/scopes/{scope_id}", server.handleGetScope)
+	return r
+}
+
+func TestScopeReadSurfaceIsCanonicalAndOperatorOnly(t *testing.T) {
+	bs, err := store.NewBadgerStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bs.CloseBadger() })
+	record := scope.Record{
+		ScopeID: "scope-a", Revision: 1, State: scope.StateActive,
+		ControllerValidatorID: "validator-a", CreatedHeight: 10, UpdatedHeight: 10,
+		Domains: []scope.Domain{{Name: "research"}},
+		Members: []scope.Member{{ValidatorID: "validator-a", AssignedWeight: 7, JoinedRevision: 1, Active: true}},
+	}
+	require.NoError(t, bs.SetScopeRecord(record))
+	server := &Server{badgerStore: bs, nodeOperatorID: "operator", logger: zerolog.Nop()}
+
+	rr := httptest.NewRecorder()
+	scopeReadRouter(server, "operator").ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/scopes", nil))
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var listed struct {
+		Scopes []scopeRecordResponse `json:"scopes"`
+		Count  int                   `json:"count"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &listed))
+	require.Equal(t, 1, listed.Count)
+	require.Len(t, listed.Scopes, 1)
+	assert.Equal(t, "scope-a", listed.Scopes[0].ScopeID)
+	assert.Equal(t, "active", listed.Scopes[0].State)
+	assert.Len(t, listed.Scopes[0].RevisionHash, 64)
+	assert.Equal(t, uint64(7), listed.Scopes[0].Members[0].AssignedWeight)
+
+	rr = httptest.NewRecorder()
+	scopeReadRouter(server, "operator").ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/scopes/scope-a", nil))
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var got scopeRecordResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	assert.Equal(t, listed.Scopes[0], got)
+
+	rr = httptest.NewRecorder()
+	scopeReadRouter(server, "ordinary-agent").ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/scopes", nil))
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+
+	rr = httptest.NewRecorder()
+	scopeReadRouter(server, "operator").ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/scopes/missing", nil))
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}

--- a/api/rest/server.go
+++ b/api/rest/server.go
@@ -77,6 +77,9 @@ type Server struct {
 	// transactions carry the proof envelope before their first eligible block.
 	// nil preserves the legacy wire encoding used by tests and pre-v17 nodes.
 	postV17ForNextTxFn func() bool
+	// postV20ForNextTxFn prevents operator surfaces from constructing a scope
+	// proposal before app-v20 consensus can apply it. nil is fail-closed.
+	postV20ForNextTxFn func() bool
 
 	// federation is the v11 OFF-consensus transport (recall proxy, co-commit
 	// receipt exchange, cross-fed agreement setup). nil disables every
@@ -210,6 +213,16 @@ func (s *Server) SetPostV17ForNextTxAccessor(fn func() bool) {
 
 func (s *Server) isPostV17ForNextTx() bool {
 	return s.postV17ForNextTxFn != nil && s.postV17ForNextTxFn()
+}
+
+// SetPostV20ForNextTxAccessor wires the dynamic app-v20 scope-construction
+// gate. Callers should pass app.IsAppV20ActiveForNextTx.
+func (s *Server) SetPostV20ForNextTxAccessor(fn func() bool) {
+	s.postV20ForNextTxFn = fn
+}
+
+func (s *Server) isPostV20ForNextTx() bool {
+	return s.postV20ForNextTxFn != nil && s.postV20ForNextTxFn()
 }
 
 // loadValidatorSigningKey loads the CometBFT validator private key so that
@@ -421,6 +434,10 @@ func (s *Server) setupRouter() chi.Router {
 		r.Post("/v1/governance/propose", s.handleGovPropose)
 		r.Post("/v1/governance/vote", s.handleGovVote)
 		r.Post("/v1/governance/cancel", s.handleGovCancel)
+
+		// v11.9 canonical scope topology (operator/admin read-only).
+		r.Get("/v1/scopes", s.handleListScopes)
+		r.Get("/v1/scopes/{scope_id}", s.handleGetScope)
 
 		// HTTP MCP token management — admin issues tokens for external MCP
 		// clients (ChatGPT, Cursor, etc.) that can't sign every request with

--- a/cmd/amid/main.go
+++ b/cmd/amid/main.go
@@ -85,6 +85,36 @@ func main() {
 	}
 	defer func() { _ = app.Close() }()
 
+	// v11.9 recovery: canonical scoped envelopes live in Badger and must be
+	// verified into PostgreSQL before this replica advertises serving readiness.
+	// A failure does not stop consensus from catching up, but /ready remains 503
+	// so traffic cannot be routed to an incomplete selected-domain projection.
+	if contents, listErr := app.GetBadgerStore().ListScopedContents(); listErr != nil {
+		health.SetScopedProjectionStatus(metrics.ScopedProjectionStatus{Required: true, Detail: listErr.Error()})
+		logger.Warn().Err(listErr).Msg("scoped serving projection state is unreadable")
+	} else if len(contents) == 0 {
+		health.SetScopedProjectionStatus(metrics.ScopedProjectionStatus{OK: true})
+	} else {
+		rebuilt, rebuildErr := app.RebuildScopedProjection(context.Background())
+		projectionStatus := metrics.ScopedProjectionStatus{
+			Required: true,
+			OK:       rebuildErr == nil && rebuilt == len(contents),
+			Records:  len(contents),
+			Rebuilt:  rebuilt,
+		}
+		if rebuildErr != nil {
+			projectionStatus.Detail = rebuildErr.Error()
+		} else if !projectionStatus.OK {
+			projectionStatus.Detail = fmt.Sprintf("rebuilt %d of %d scoped records", rebuilt, len(contents))
+		}
+		health.SetScopedProjectionStatus(projectionStatus)
+		if !projectionStatus.OK {
+			logger.Warn().Str("detail", projectionStatus.Detail).Msg("scoped serving projection is not ready")
+		} else {
+			logger.Info().Int("records", rebuilt).Msg("scoped serving projection verified from canonical state")
+		}
+	}
+
 	// Content-validation enforcement advisory (non-fatal): warn when the app-v7
 	// fork is active but this binary has no validator registry compiled in, so
 	// this node won't enforce the gate. A mixed fleet (some nodes wired, some
@@ -309,6 +339,7 @@ func startServices(ctx context.Context, app *sageabci.SageApp, restAddr, metrics
 	// height. Advisory only — the consensus path uses app.postV8Fork(height).
 	restServer.SetPostV8ForkAccessor(app.IsPostV8Fork)
 	restServer.SetPostV17ForNextTxAccessor(app.IsAppV17ActiveForNextTx)
+	restServer.SetPostV20ForNextTxAccessor(app.IsAppV20ActiveForNextTx)
 
 	if tlsCert != "" && tlsKey != "" {
 		// TLS mode: load certs and start HTTPS.

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -249,6 +249,12 @@ func runServe() (rerr error) {
 		_ = sqliteStore.Close()
 	}()
 
+	// Created before the ABCI app so canonical scoped-projection recovery can
+	// publish a fail-closed readiness state during construction.
+	health := metrics.NewHealthChecker()
+	health.Version = version
+	health.SetPostgresHealth(true) // SQLite is always "healthy"
+
 	// Optional cross-encoder reranker on the hybrid recall path. Off by
 	// default; operator turns it on with SAGE_RERANK_ENABLED=1 and
 	// SAGE_RERANK_URL=<tei-endpoint>. v7.1 ships this as additive polish
@@ -406,6 +412,46 @@ func runServe() (rerr error) {
 		_ = app.Close()
 	}()
 
+	// v11.9 recovery: Badger is the canonical scoped-content source after
+	// snapshot/state sync; SQLite is only the serving projection. Verify and
+	// rebuild it before advertising readiness. A locked vault is allowed to boot
+	// consensus, but /ready remains fail-closed until the operator unlocks and
+	// this callback succeeds.
+	rebuildScopedProjection := func(rebuildCtx context.Context) (int, error) {
+		contents, listErr := badgerStore.ListScopedContents()
+		if listErr != nil {
+			health.SetScopedProjectionStatus(metrics.ScopedProjectionStatus{Required: true, Detail: listErr.Error()})
+			return 0, listErr
+		}
+		status := metrics.ScopedProjectionStatus{Required: len(contents) > 0, Records: len(contents)}
+		if len(contents) == 0 {
+			status.OK = true
+			health.SetScopedProjectionStatus(status)
+			return 0, nil
+		}
+		if sqliteStore.VaultLocked() {
+			status.Detail = "vault locked; scoped serving projection rebuild deferred"
+			health.SetScopedProjectionStatus(status)
+			return 0, fmt.Errorf("%s", status.Detail)
+		}
+		rebuilt, rebuildErr := app.RebuildScopedProjection(rebuildCtx)
+		status.Rebuilt = rebuilt
+		status.OK = rebuildErr == nil && rebuilt == len(contents)
+		if rebuildErr != nil {
+			status.Detail = rebuildErr.Error()
+		} else if !status.OK {
+			status.Detail = fmt.Sprintf("rebuilt %d of %d scoped records", rebuilt, len(contents))
+			rebuildErr = fmt.Errorf("%s", status.Detail)
+		}
+		health.SetScopedProjectionStatus(status)
+		return rebuilt, rebuildErr
+	}
+	if rebuilt, rebuildErr := rebuildScopedProjection(ctx); rebuildErr != nil {
+		logger.Warn().Err(rebuildErr).Msg("scoped serving projection is not ready")
+	} else if rebuilt > 0 {
+		logger.Info().Int("records", rebuilt).Msg("scoped serving projection verified from canonical state")
+	}
+
 	// Block-retention window (issue #40): bound blockstore growth by telling
 	// CometBFT it may prune blocks older than the window. Local node policy —
 	// never consensus state — so modes can default differently: personal nodes
@@ -506,11 +552,6 @@ func runServe() (rerr error) {
 
 	// Create embedding provider
 	embedProvider := createEmbeddingProvider(cfg, logger)
-
-	// Health checker
-	health := metrics.NewHealthChecker()
-	health.Version = version
-	health.SetPostgresHealth(true) // SQLite is always "healthy"
 
 	// Embedder health watchdog: keeps /ready's semantic-recall signal current so a
 	// down embedding provider surfaces as "degraded" instead of a silently
@@ -686,6 +727,7 @@ func runServe() (rerr error) {
 	// height. Advisory only — the consensus path uses app.postV8Fork(height).
 	restServer.SetPostV8ForkAccessor(app.IsPostV8Fork)
 	restServer.SetPostV17ForNextTxAccessor(app.IsAppV17ActiveForNextTx)
+	restServer.SetPostV20ForNextTxAccessor(app.IsAppV20ActiveForNextTx)
 
 	// v7.1: tell the REST layer which ed25519 public key identifies the local
 	// node operator. Requests signed with this key bypass the cross-agent
@@ -737,6 +779,15 @@ func runServe() (rerr error) {
 	dashboard.TunnelClient = tunnelClientMgr  // managed OpenAI tunnel-client for ChatGPT/Codex
 	dashboard.BadgerStore = badgerStore       // Wire on-chain RBAC for agent isolation
 	dashboard.PostV8ForkFn = app.IsPostV8Fork // v8.0: ancestor-walk grants on post-fork dashboards
+	dashboard.ScopedProjectionRebuildFn = func(rebuildCtx context.Context) (int, error) {
+		rebuilt, rebuildErr := rebuildScopedProjection(rebuildCtx)
+		if rebuildErr != nil {
+			logger.Warn().Err(rebuildErr).Msg("scoped serving projection rebuild incomplete")
+		} else if rebuilt > 0 {
+			logger.Info().Int("records", rebuilt).Msg("scoped serving projection ready after vault unlock")
+		}
+		return rebuilt, rebuildErr
+	}
 
 	// Bridge REST API events to dashboard SSE for the chain activity log
 	restServer.OnEvent = func(eventType, memoryID, domain, content string, data any) {
@@ -805,7 +856,8 @@ func runServe() (rerr error) {
 	dashboard.ValidatorCountFn = app.ValidatorCount // authoritative single-validator check for agent ops
 	dashboard.AppV18ActiveFn = app.IsAppV18ActiveForNextTx
 	dashboard.AppV19ActiveFn = app.IsAppV19ActiveForNextTx // app-v19: local-agents-default-READ flip (off-consensus)
-	dashboard.StrictRBAC = cfg.RBAC.Strict                 // opt-out of the app-v19 default-read flip
+	dashboard.AppV20ActiveFn = app.IsAppV20ActiveForNextTx
+	dashboard.StrictRBAC = cfg.RBAC.Strict // opt-out of the app-v19 default-read flip
 	// Embeddings setup: flip the config to the bundled Ollama + nomic-embed-text
 	// provider (the node re-reads it on restart). The embedder is locked to this.
 	dashboard.SetEmbeddingProvider = func(provider string) error {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-07):** **v11.8.0 is the current release.** This document records the v11.7 slate and the v11.8 synchronization-group release as shipped and looks forward to v11.9, the v11.10–v11.13 productization bridge, and the v12 completion milestone. Everything past v11.8 is planned, not promised, and carries no date.
+**Status (2026-07):** **v11.8.5 is the current release.** This document records the v11.7 slate and the v11.8 synchronization-group release as shipped and looks forward to v11.9, the v11.10–v11.13 productization bridge, and the v12 completion milestone. Everything past v11.8 is planned, not promised, and carries no date.
 
 **Hard constraint driving the whole plan:** no chain reset, no operator-typed commands. Existing chains must upgrade in place across all future releases.
 
@@ -124,9 +124,9 @@ Extend the agent-to-agent pipe (today a node-local inbox) across a federation li
 
 ### Domain-scoped quorum + self-healing replication
 
-Turn selected shared domains into hardened replicated canonical state across validator groups. Validators independently evaluate proposed memories, commit only quorum-approved results, and retain replicated full content plus all serving indexes. A surviving **greater-than-two-thirds voting-power quorum** continues accepting memories while a member is offline; authenticated replay or state sync catches it up when it returns.
+Turn selected shared domains into hardened replicated canonical state across validator groups. A v11.9 scope is contained inside one SAGE consensus chain: its on-chain roster names existing validators, its exact domain allowlist prevents scope bleed, and its canonical Badger content mirror lets recovering nodes rebuild serving indexes. Validators independently evaluate proposed memories and commit only quorum-approved results. A surviving **greater-than-two-thirds voting-power quorum** continues accepting memories while a member is offline; ordered committed-block replay catches it up when it returns, and a separate network-safe ABCI state-sync path remains a release gate. The v11.8 SQLite/cross-chain Synchronization Group remains an off-consensus sharing overlay; v11.9 does not relabel it as BFT. SAGE's existing full local rollback snapshot contains private node material and must never be reused as a network payload.
 
-The release gate includes offline-write/catch-up, snapshot/state-sync recovery, validator and membership reconfiguration, revocation, conflict/degraded-mode behavior, and chaos testing. Topologies remain honest: four equal-power validators tolerate one offline validator; three equal-power validators do not continue with only two online because CometBFT requires more than two-thirds voting power. The design must choose explicitly between domain-specific quorum shards and an extension of federation domain sync; it must never tunnel or replicate the whole current chain if that exposes unselected domains.
+The release gate includes offline-write/catch-up, snapshot/state-sync recovery, validator and membership reconfiguration, revocation, conflict/degraded-mode behavior, and chaos testing. Topologies remain honest: four equal-power validators tolerate one offline validator; three equal-power validators do not continue with only two online because CometBFT requires more than two-thirds voting power. The chosen model is an exact-domain quorum scope inside one existing chain, not an extension of cross-chain federation sync. State-sync activation is boot-only whole-application replacement with crash journaling and validator-only P2P authorization; the ABCI endpoints remain disabled until its kill-point and multi-process gates pass. It must never reuse the private local rollback bundle or expose it to a federation peer.
 
 ---
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -23,7 +23,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`environment-variables.md`](environment-variables.md) | Every env var SAGE reads (`SAGE_HOME`, embeddings, hybrid recall, TLS, snapshots, …), with defaults and the `file:line` that consumes each. |
 | [`concepts/memory-lifecycle.md`](concepts/memory-lifecycle.md) | submit → proposed → committed/deprecated; node-local vs on-chain data; confidence decay; corroboration. |
 | [`concepts/clearance-classification.md`](concepts/clearance-classification.md) | Per-record classification (0–4), the REST-vs-wire default gotcha, and the per-record query gate. |
-| [`concepts/rbac-orgs-federation.md`](concepts/rbac-orgs-federation.md) | Orgs, departments, agent clearance, cross-org federation, and the five-gate query pipeline. |
+| [`concepts/rbac-orgs-federation.md`](concepts/rbac-orgs-federation.md) | Orgs, departments, agent clearance, cross-org federation, the five-gate query pipeline, and the app-v20 one-chain quorum-scope boundary. |
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
@@ -45,6 +45,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | Know if a memory will decay | [`concepts/memory-lifecycle.md`](concepts/memory-lifecycle.md) |
 | Understand why your chain's block height isn't moving | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) |
 | Make sure submitted memories actually get committed (not stuck at `proposed`) | [`concepts/voter-operations.md`](concepts/voter-operations.md) |
+| Distinguish internet federation, app-v20 quorum replication, and local-vs-network snapshot recovery | [`concepts/rbac-orgs-federation.md`](concepts/rbac-orgs-federation.md) — “v11.9 quorum scopes are not cross-chain federation” |
 | Configure SAGE via environment variables | [`environment-variables.md`](environment-variables.md) |
 
 ---

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -251,6 +251,113 @@ The `FederationID` is deterministic: computed from the two org IDs + height to a
 
 ---
 
+## v11.9 quorum scopes are not cross-chain federation
+
+The v11.6–v11.8 federation path connects independent SAGE chains and copies
+selected domains through an authenticated off-consensus transport. An app-v20
+quorum scope instead lives inside one CometBFT chain and names validators that
+already belong to that chain. It does not merge independent chains or replace
+libp2p relay/NAT traversal (`internal/abci/app.go:627-631`,
+`internal/governance/types.go:53-58`).
+
+`OpScopeAction` governance creates, advances, pauses, or permanently retires the
+canonical scope record. Its exact-domain allowlist and integer member weights
+are stored in Badger with immutable per-revision audit anchors
+(`internal/store/scope_state.go:46-185`). A scoped memory submission atomically
+pins the current roster/denominator and a recoverable content envelope; quorum
+requires a strict greater-than-two-thirds integer comparison, so exactly 2/3 is
+not sufficient (`internal/store/scoped_memory_state.go:25-93`,
+`internal/scope/ballot.go:154-162`).
+
+Badger remains the recovery authority. After ordered block replay or verified
+local snapshot restore, the node verifies each canonical envelope and rebuilds
+its SQL serving projection in a transaction. `/ready` returns 503 while
+canonical scoped records exist but that projection is locked, incomplete, or
+invalid; a locked SQLite vault retries on operator unlock
+(`internal/abci/scoped_recovery.go:21-86`, `internal/metrics/health.go`). The
+catch-up integration proof compares every replayed AppHash and confirms that an
+unselected domain has no canonical scoped envelope
+(`internal/abci/appv20_recovery_integration_test.go:41-150`).
+
+The existing snapshot package is an operator-local rollback format. It can
+contain SQLite, CometBFT databases, node/validator keys, vault material, local
+configuration, and a binary, so it must never be sent over ABCI/P2P
+(`internal/snapshot/snapshot.go:1-9`). Its v11.9 integration test restores the
+bundle, deletes SQLite, recomputes AppHash, reloads app-v20, and rebuilds scoped
+content plus classification from Badger
+(`internal/abci/appv20_recovery_integration_test.go:152-285`). Network state sync
+is not yet implemented: the ABCI app advertises no snapshots, rejects offers,
+returns no chunks, and aborts apply (`internal/abci/app.go:6547-6566`). A future
+enabled network path must therefore use the separate dormant consensus-only,
+key-free format described below.
+
+Crash replay is height-bound rather than a nonce bypass. Scoped votes store the
+immutable first decision and its FinalizeBlock height atomically; only an exact
+submit envelope or exact vote at that same behind height can rebuild projection
+writes after a failed Commit (`internal/store/scoped_memory_state.go:214-324`,
+`internal/abci/scoped_memory.go:97-207`). The forced-failure integration test
+reopens the stores after failed submit and quorum-reaching vote commits, matches
+the original AppHashes, restores all SQL votes, and confirms that the same
+signed vote at a later height is still rejected
+(`internal/abci/appv20_recovery_integration_test.go:287-426`).
+
+The dormant network-state-sync substrate is isolated in `internal/statesync`.
+Its canonical metadata binds CometBFT's trusted height/AppHash to a bounded
+chunked Badger backup, hashes every chunk and the complete stream, caps chunks
+at 8 MiB and count at 512, and rejects the unrelated local rollback manifest
+(`internal/statesync/format.go:1-230`). Its disk assembler accepts out-of-order
+delivery, makes an exact duplicate idempotent, rejects corrupt/incorrect-size
+chunks, and verifies the whole backup before an atomic file rename
+(`internal/statesync/assembler.go:15-198`). Tests include malformed canonical
+encodings, wrong trusted hashes, interrupted/incomplete assembly, and a real
+Badger backup/load with an identical AppHash (`internal/statesync/format_test.go`).
+The ABCI endpoints stay disabled even though these format proofs pass.
+
+The producer and receiver foundations are also dormant. Export makes a bounded
+live Badger backup, requires an app-v20 reload verifier to match the committed
+AppHash, atomically publishes only metadata/chunks, rejects extra files and
+symlinks, and hashes a chunk again immediately before read
+(`internal/statesync/exporter.go:23-362`). Receiver preparation loads only into
+a new staging directory, reopens it read-only so validation cannot backfill or
+mutate consensus state, requires exact persisted height plus active app-v20,
+recomputes the narrow AppHash, validates all canonical scoped state, and removes
+the stage on failure (`internal/store/badger.go`,
+`internal/abci/scoped_state_sync.go:19-139`,
+`internal/abci/scoped_recovery.go:73-114`). No code swaps that directory into a
+live application yet, so `ListSnapshots` still advertises none.
+
+The accepted activation design deliberately avoids changing `BadgerStore.db`
+inside a serving process. It replaces the whole ABCI application bundle during
+boot, journals the filesystem/Comet persistence crash window, delays REST,
+dashboard, projection, snapshot-scheduler, and worker construction until the
+runtime is sealed, and requires an authenticated validator-only P2P allowlist.
+This is design work, not enabled behavior; the detailed gates are in
+[`../../v11.9-state-sync-activation.md`](../../v11.9-state-sync-activation.md).
+The first non-activating pieces are code: a bounded canonical/fsynced journal
+and pure Comet-vs-live recovery decision (`internal/statesync/activation.go`),
+plus a writable no-migration opener that preserves the already verified
+AppHash (`internal/store/badger.go:105-128`). No function performs the live
+directory rename yet.
+
+Scope proposals no longer require operators or agents to hand-encode that
+binary record. REST/dashboard accept a structured `scope` template, MCP exposes
+the same guided object, and both Python clients provide
+`governance_propose_scope`. The server sorts domains and members canonically,
+owns the zero proposal heights, preserves explicit historical join revisions,
+and rejects `payload` plus `scope` ambiguity. CEREBRUM builds controller and
+roster choices from the live CometBFT validator set's canonical Ed25519 IDs,
+not from ordinary dashboard-agent IDs; the consensus execution path rechecks
+the same authority. Scope IDs are one REST path segment and therefore cannot
+contain `/`
+(`internal/scope/proposal.go:9-94`, `api/rest/governance_handler.go:105-204`).
+
+Operator/admin visibility is available through `GET /v1/scopes`,
+`GET /v1/scopes/{scope_id}`, `sage_scope_list`, and `sage_scope_get`. These
+surfaces expose topology and audit hashes, never grant domain ownership, RBAC,
+federation access, or administrator authority.
+
+---
+
 ## REST Endpoints Reference
 
 | Method | Path | Tx Type | Description |
@@ -274,6 +381,8 @@ The `FederationID` is deterministic: computed from the two org IDs + height to a
 | GET | `/v1/access/grants/{agent_id}` | — | List active grants for agent |
 | POST | `/v1/domain/register` | `TxTypeDomainRegister` | Explicitly register domain ownership |
 | GET | `/v1/domain/{name}` | — | Get domain owner and metadata |
+| GET | `/v1/scopes` | — | List canonical app-v20 quorum scopes (operator/admin) |
+| GET | `/v1/scopes/{scope_id}` | — | Read one canonical app-v20 quorum scope (operator/admin) |
 
 ---
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -2,7 +2,7 @@ Reconciled against internal/mcp at SAGE v11.8.5.
 
 # SAGE MCP Tools Reference
 
-SAGE exposes 23 MCP tools over JSON-RPC 2.0. Stdio tools sign REST calls with
+SAGE exposes 25 MCP tools over JSON-RPC 2.0. Stdio tools sign REST calls with
 the local Ed25519 identity; SSE and Streamable-HTTP use the MCP bearer-token/OAuth
 flow. Only consensus-committed memories are returned to callers.
 
@@ -666,20 +666,29 @@ otherwise.
 
 ### sage_gov_propose
 
-**Purpose:** Submit a governance proposal to add, remove, or update a validator.
-Requires admin role.
+**Purpose:** Submit a governance proposal, including validator operations,
+Synchronization Group decisions, and app-v20 canonical scope actions. Requires
+admin role.
 
-**Source:** `tools.go:258-273` (definition), `tools.go:1860-1908` (handler)
+**Source:** `tools.go:287-328` (definition), `tools.go:2377-2444` (handler)
 
 **Parameters:**
 
 | Name            | Type   | Required | Description |
 |-----------------|--------|----------|-------------|
-| `operation`     | string | yes      | `add_validator`, `remove_validator`, or `update_power`. |
-| `target_id`     | string | yes      | Hex-encoded agent/validator ID. |
+| `operation`     | string | yes      | `add_validator`, `remove_validator`, `update_power`, `sync_group_action`, or `scope_action`. |
+| `target_id`     | string | conditional | Validator ID for validator ops; optional for `scope_action` when `scope.scope_id` is present. |
 | `reason`        | string | yes      | Human-readable justification. |
 | `target_pubkey` | string | no       | Hex-encoded Ed25519 public key. Required for `add_validator`. |
 | `target_power`  | int    | no       | Voting power. Required for `add_validator` and `update_power`. |
+| `payload`       | string | no       | Legacy base64 operation payload; mutually exclusive with `scope`. |
+| `scope`         | object | no       | Preferred guided `scope_action` template: scope ID/revision/state/controller, exact domains, and weighted members. The node canonicalizes it into `ScopeRecordV1`. |
+
+For revision 1, `joined_revision` may be omitted and each omitted `active`
+defaults to true. Later revisions must preserve each existing member's exact
+historical `joined_revision`. The node rejects duplicate domains/members,
+invalid lifecycle states, inactive controllers, zero weights, scope IDs that
+contain `/`, ambiguous `payload` + `scope`, and target/scope ID mismatches.
 
 **Returns:**
 - `proposal_id`, `tx_hash`, `status`, `operation`, `target_id`, `reason`.
@@ -742,6 +751,30 @@ rejected.
 
 ---
 
+### sage_scope_list
+
+**Purpose:** List canonical app-v20 quorum scopes with exact selected domains,
+pinned integer weights, lifecycle state, and immutable current-revision hash.
+Node-operator/admin only.
+
+**Parameters:** none.
+
+**REST:** `GET /v1/scopes`
+
+---
+
+### sage_scope_get
+
+**Purpose:** Read one canonical app-v20 quorum scope. Node-operator/admin only.
+
+| Name       | Type   | Required | Description |
+|------------|--------|----------|-------------|
+| `scope_id` | string | yes      | Exact canonical scope ID. |
+
+**REST:** `GET /v1/scopes/{scope_id}`
+
+---
+
 ## Discrepancies
 
 ### Boot sequence vs tool list
@@ -765,9 +798,10 @@ None. All tools mentioned in CLAUDE.md, MEMORY.md, and the MCP server
 but not part of the boot sequence. They are used only when a caller needs to
 strengthen/connect memories or resolve an open challenge.
 
-`sage_gov_propose`, `sage_gov_vote`, `sage_gov_status` — governance tools —
-are not part of the boot sequence. This is correct: they are admin/validator
-operations, not agent memory operations.
+`sage_gov_propose`, `sage_gov_vote`, `sage_gov_status`, `sage_scope_list`, and
+`sage_scope_get` — governance/scope tools — are not part of the boot sequence.
+This is correct: they are operator/admin/validator operations, not agent memory
+operations.
 
 `sage_pipe`, `sage_inbox`, `sage_pipe_result` — pipeline tools — are also not
 part of the boot sequence. Also correct: pipeline is checked automatically
@@ -785,7 +819,7 @@ registration name from `sage_register` is untouched.
 
 ## Summary
 
-**23 tools documented:**
+**25 tools documented:**
 
 | Category     | Tools |
 |--------------|-------|
@@ -795,4 +829,4 @@ registration name from `sage_register` is untouched.
 | Tasks        | `sage_task`, `sage_backlog` |
 | Identity     | `sage_register`, `sage_rename` |
 | Pipeline     | `sage_pipe`, `sage_inbox`, `sage_pipe_result` |
-| Governance   | `sage_gov_propose`, `sage_gov_vote`, `sage_gov_status` |
+| Governance   | `sage_gov_propose`, `sage_gov_vote`, `sage_gov_status`, `sage_scope_list`, `sage_scope_get` |

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1011,12 +1011,15 @@ governance_propose(
     target_pubkey: str | None = None,
     target_power: int | None = None,
     payload: dict | bytes | None = None,
+    scope: ScopeActionTemplate | dict[str, Any] | None = None,
 ) -> GovProposeResponse
 ```
 
 `POST /v1/governance/propose`
 
-Known `operation` values: `"add_validator"`, `"remove_validator"`, `"update_power"`, `"domain_reassign"` (v8.0+).
+Known `operation` values include `"add_validator"`, `"remove_validator"`,
+`"update_power"`, `"domain_reassign"`, `"memory_domain_repair"`,
+`"sync_group_action"`, and `"scope_action"` (app-v20).
 
 `payload` encoding (source: `client.py:64`):
 - `dict` → JSON-encoded (compact) then base64-encoded onto the wire.
@@ -1024,8 +1027,27 @@ Known `operation` values: `"add_validator"`, `"remove_validator"`, `"update_powe
 - `None` → field omitted entirely.
 
 `domain_reassign` expects a payload dict with keys `domain`, `new_owner_id`, `parent_domain`, `open_to_shared`.
+`scope_action` should use `scope`; the server canonicalizes the guided template
+and owns the zero proposal heights. `scope` and `payload` are mutually
+exclusive. Legacy callers may still supply pre-encoded canonical bytes.
 
 Returns `GovProposeResponse(proposal_id, tx_hash, status)`.
+
+---
+
+#### `governance_propose_scope()`
+
+```python
+governance_propose_scope(
+    scope: ScopeActionTemplate | dict[str, Any],
+    reason: str,
+) -> GovProposeResponse
+```
+
+Convenience wrapper for `operation="scope_action"`; derives `target_id` from
+`scope_id` and sends structured JSON (`client.py:968-980`). For revision 1,
+member `active` defaults to true and `joined_revision` may be omitted. Later
+revisions must preserve historical join revisions.
 
 ---
 
@@ -1052,6 +1074,28 @@ governance_cancel(proposal_id: str) -> GovCancelResponse
 `POST /v1/governance/cancel`
 
 Proposer only. Returns `GovCancelResponse(tx_hash, status)`.
+
+---
+
+#### `list_scopes()`
+
+```python
+list_scopes() -> ScopeListResponse
+```
+
+`GET /v1/scopes`. Node-operator/admin only. Returns canonical v11.9 scope
+heads, exact domain allowlists, assigned integer weights, and revision anchors.
+
+---
+
+#### `get_scope()`
+
+```python
+get_scope(scope_id: str) -> ScopeRecord
+```
+
+`GET /v1/scopes/{scope_id}`. Node-operator/admin only. The clients URL-escape
+the canonical single-segment scope ID.
 
 ---
 
@@ -1231,11 +1275,11 @@ except SageAPIError as e:
 
 ## Method Count Summary
 
-**`SageClient`**: 63 public methods
-**`AsyncSageClient`**: 63 public methods (`reassign_domain` is sync-only; `close` is async-only)
+**`SageClient`**: 65 public methods
+**`AsyncSageClient`**: 65 public methods (`reassign_domain` is sync-only; `close` is async-only)
 
 Groups: Health (2), Memory (8), Embeddings (1), Tasks (2), Voting/Validation
 (5), Agents (6), Validator (2), Pipeline (6), Access Control (4), Domains (3
 shared + sync-only `reassign_domain`), Organizations (7), Departments (6),
-Federation (5), Governance (5), and async lifecycle (1) = 64 distinct methods
-across both clients (counting the 62 shared methods once).
+Federation (5), Governance and scope visibility (7), and async lifecycle (1) =
+66 distinct methods across both clients (counting the 64 shared methods once).

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -904,17 +904,44 @@ Revoking an agreement atomically purges its sync policy, controller binding, and
 
 Submit a governance proposal. Broadcasts `TxTypeGovPropose`.
 
-**Request body** (`governance_handler.go:22-30`):
+**Request body** (`governance_handler.go:26-35`):
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `operation` | string | yes | `add_validator`, `remove_validator`, `update_power`, `domain_reassign`, `memory_domain_repair` |
-| `target_id` | string | yes | Hex validator pubkey for validator ops; domain keying ID for `domain_reassign` |
+| `operation` | string | yes | `add_validator`, `remove_validator`, `update_power`, `domain_reassign`, `memory_domain_repair`, `sync_group_action`, `scope_action` |
+| `target_id` | string | conditional | Hex validator pubkey for validator ops; operation key for other ops. May be omitted only when `scope_action` supplies `scope.scope_id`; otherwise it is required. |
 | `reason` | string | yes | |
 | `target_pubkey` | string | no | Hex Ed25519 pubkey, required for `add_validator` |
 | `target_power` | int64 | no | Validator power for add/update ops |
 | `expiry_blocks` | int64 | no | 0 = chain default |
-| `payload` | string | no | Base64-encoded operation-specific body. For `domain_reassign`: base64(JSON `{domain, new_owner_id, parent_domain, open_to_shared}`). The executing `POST /v1/domain/reassign` tx must reproduce this payload byte-for-byte. For `memory_domain_repair` (app-v16, 2/3 quorum): base64(JSON `[{"memory_id","domain"}]`) — the backfill applies directly on proposal execution (no follow-up tx), writing the on-chain domain only for a memory that exists, has no domain yet, and whose target domain is registered. |
+| `payload` | string | no | Base64-encoded operation-specific body. For `domain_reassign`: base64(JSON `{domain, new_owner_id, parent_domain, open_to_shared}`). The executing `POST /v1/domain/reassign` tx must reproduce this payload byte-for-byte. For `memory_domain_repair` (app-v16, 2/3 quorum): base64(JSON `[{"memory_id","domain"}]`) — the backfill applies directly on proposal execution. Legacy `scope_action` callers may pass canonical binary `ScopeRecordV1`; mutually exclusive with `scope`. |
+| `scope` | object | no | Preferred guided `scope_action` template: `{scope_id, revision, state, controller_validator_id, domains: string[], members: [{validator_id, assigned_weight, joined_revision?, active?}]}`. `scope_id` is one non-empty path segment (no `/`). The node sorts domains/members bytewise, defaults `active` to true and `joined_revision` to 1 only for revision 1, fixes both heights to zero, then encodes canonical `ScopeRecordV1`. |
+
+For app-v20 scope formation, use the structured form rather than constructing
+binary bytes (`governance_handler.go:105-113`, `scope/proposal.go:33-81`):
+
+```json
+{
+  "operation": "scope_action",
+  "reason": "form the research replica quorum",
+  "scope": {
+    "scope_id": "research-quorum",
+    "revision": 1,
+    "state": "active",
+    "controller_validator_id": "<validator-id>",
+    "domains": ["research"],
+    "members": [
+      {"validator_id": "<validator-id>", "assigned_weight": 1}
+    ]
+  }
+}
+```
+
+Later revisions must provide every member's historical `joined_revision`; this
+prevents a convenience client from silently rewriting roster history
+(`scope/proposal.go:22-30`, `scope/proposal.go:50-68`). `payload` and `scope`
+are mutually exclusive, and an explicit `target_id` must equal `scope_id`
+(`governance_handler.go:170-204`).
 
 **Response** (HTTP 200):
 
@@ -956,6 +983,27 @@ Cancel a pending governance proposal. Proposer or admin.
 | `proposal_id` | string | yes |
 
 **Response** (HTTP 200): `{"tx_hash": "...", "status": "cancelled"}`
+
+---
+
+### `GET /v1/scopes`
+
+List canonical v11.9 scope heads in bytewise scope-ID order. Read-only and
+restricted to the node operator or an administrator because the response
+contains validator topology. Each record includes its current domain-separated
+SHA-256 `revision_hash`, exact domain allowlist, pinned integer weights, state,
+and materialized consensus heights.
+
+**Response** (HTTP 200): `{"scopes": [...], "count": 1}`
+
+---
+
+### `GET /v1/scopes/{scope_id}`
+
+Return one canonical v11.9 scope head with the same shape as an entry from
+`GET /v1/scopes`. Returns 404 when absent and fails closed if its immutable
+revision audit anchor is missing. Scope IDs cannot contain `/`; clients URL-
+escape the remaining path-segment characters. Node-operator/admin only.
 
 ---
 
@@ -1236,8 +1284,9 @@ The `version` field is intentionally omitted — `/health` is reachable through 
 
 ### `GET /ready`
 
-Readiness probe. Checks the store (postgres/SQLite), CometBFT, and the embedding
-provider. No auth. (`internal/metrics/health.go`)
+Readiness probe. Checks the store (PostgreSQL/SQLite), CometBFT, the embedding
+provider, and any required v11.9 scoped serving projection. No auth.
+(`internal/metrics/health.go`)
 
 **Response** (HTTP 200 or 503):
 
@@ -1246,6 +1295,14 @@ provider. No auth. (`internal/metrics/health.go`)
   "status": "ready",          // ready | degraded | not_ready
   "postgres": true,
   "cometbft": true,
+  "scoped_projection": {
+    "checked": true,
+    "required": true,        // canonical scoped envelopes exist in Badger
+    "ok": true,
+    "records": 42,
+    "rebuilt": 42,
+    "detail": ""
+  },
   "embedder": {
     "checked": true,          // false until the watchdog's first probe
     "ok": true,
@@ -1258,7 +1315,10 @@ provider. No auth. (`internal/metrics/health.go`)
 ```
 
 Status semantics:
-- `not_ready` → **HTTP 503**: core infrastructure (store or CometBFT) is down.
+- `not_ready` → **HTTP 503**: core infrastructure (store or CometBFT) is down,
+  or canonical scoped envelopes exist but the local SQL serving projection is
+  locked, incomplete, or failed verification. A locked SQLite vault retries the
+  scoped rebuild after unlock.
 - `degraded` → **HTTP 200** by default: core is up but a *semantic* embedder has been
   probed and is unreachable, so hybrid/semantic recall has dropped to keyword-only.
   The node still serves. Pass `?strict=1` to make this a **503** for gates that

--- a/docs/v11.9-PLAN.md
+++ b/docs/v11.9-PLAN.md
@@ -15,8 +15,14 @@ recovery decision logic, and a writable no-migration verified-store opener, but
 no directory switch or runtime delegation. Guided canonical scope formation is
 now available through REST, MCP/CEREBRUM, the dashboard, and both Python
 clients. The dashboard derives its roster from the live CometBFT validator
-set's canonical Ed25519 identities rather than ordinary agent rows. Remaining
-release work includes real
+set's canonical Ed25519 identities rather than ordinary agent rows. The current
+REST submit path still attaches user tags after consensus only on the receiving
+SQLite node; binding normalized tags into the app-v20 transaction/action proof,
+canonical scoped envelope, and projection rebuild is therefore an explicit
+pre-release gate. Validator removal also still lacks the app-v20 scope
+interlock and operator drain visibility: the consensus path fails later scoped
+submissions closed when a removed validator remains in the roster, but the
+scope head still appears active. Remaining release work includes real
 multi-process partition/chaos proof and reconfiguration stress. This document
 is not a claim that v11.8 synchronization groups already provide BFT or that
 v11.9 is released.
@@ -68,10 +74,13 @@ The current memory model keeps only hash/status/classification in Badger and
 keeps content and serving indexes in the projection. That is insufficient for a
 new validator or a state-synced node to prove it holds the complete selected
 domain. Therefore v11.9 adds a **canonical scoped-content mirror** in Badger.
-For a scope-selected memory it contains the canonical submitted envelope needed
-to rebuild the serving projection: id, content, type, domain, classification,
-confidence, timestamps, tags, author, and content hash. It is written only by
-the deterministic app-v20 FinalizeBlock path and is covered by AppHash.
+For a scope-selected memory the delivered envelope contains id, content, type,
+domain, classification, confidence, timestamps, author, and content hash. It is
+written only by the deterministic app-v20 FinalizeBlock path and is covered by
+AppHash. User tags are still node-local post-commit metadata in the current
+submit path; the release must add canonical normalized tags to the signed
+post-v20 transaction and this envelope so projection recovery does not silently
+drop them.
 
 The selected implementation model is therefore:
 
@@ -364,11 +373,17 @@ The release is not ready until all of the following pass:
 5. Member removal, weight change, pause, and retirement are prospective and
    cannot alter an existing ballot's pinned denominator.
 6. A nonmember, a removed member, an unrelated validator, stale revision, and
-   domain collision all fail closed.
+   domain collision all fail closed. Removing a CometBFT validator that remains
+   active in a scope must be rejected until a governance-approved scope
+   revision/pause is in place, with pending ballots surfaced as a drain
+   requirement; a misleading active-but-unusable scope is not release-ready.
 7. Ordered offline replay and verified local snapshot restore rebuild selected
    scoped content and serving indexes, verify query results and hashes, and prove
-   that an unselected domain receives no canonical scoped envelope. These
-   integration proofs exist; real multi-process execution remains required.
+   that an unselected domain receives no canonical scoped envelope. Canonically
+   normalized tags must be action-bound, AppHash-covered, and restored with the
+   projection; the current node-local post-commit tag path does not satisfy this
+   gate. The other integration proofs exist; real multi-process execution
+   remains required.
 8. The separate network-safe snapshot format/export/preparation path passes canonical codec,
    malformed/oversized, out-of-order/chunk-retry, wrong-AppHash, local-manifest
    rejection, complete-backup hash, extra/private-file and symlink rejection,
@@ -398,6 +413,8 @@ The release is not ready until all of the following pass:
    The network-safe format, assembler, verified exporter/catalog, and read-only
    receiver preparation gate are implemented; authorized ABCI serving, atomic
    activation/rebinding, multi-process chaos, and release hardening remain.
+   Canonical post-v20 tag binding and recovery also remain before the scoped
+   envelope is complete.
    Guided canonical formation is available through REST, MCP/CEREBRUM, the
    dashboard, and both Python SDK clients without hand-encoding binary scope
    records. CEREBRUM's selectable roster is the live chain validator set, and

--- a/docs/v11.9-PLAN.md
+++ b/docs/v11.9-PLAN.md
@@ -1,0 +1,408 @@
+# v11.9 — Domain-Scoped Quorum and Canonical Replica State
+
+**Status: foundation and recovery implementation in progress (2026-07-15).**
+The dormant app-v20 gate, canonical scope/ballot/content codecs, governance
+formation, scoped acceptance, projection recovery/readiness, operator read
+surfaces, ordered ABCI catch-up proof, and verified local snapshot recovery
+exist. Exact scoped submit/vote replay also survives a forced projection failure
+between `FinalizeBlock` and `Commit` without weakening later-height nonce replay
+protection. A separate consensus-only state-sync wire format, verified disk
+assembler, AppHash-checked Badger-only exporter/catalog, and read-only receiver
+preparation gate now exist. The ABCI endpoints remain disabled until atomic
+live-store activation/rebinding and join authorization are proven. The accepted
+boot-only activation design now has a canonical fsynced journal, fail-closed
+recovery decision logic, and a writable no-migration verified-store opener, but
+no directory switch or runtime delegation. Guided canonical scope formation is
+now available through REST, MCP/CEREBRUM, the dashboard, and both Python
+clients. The dashboard derives its roster from the live CometBFT validator
+set's canonical Ed25519 identities rather than ordinary agent rows. Remaining
+release work includes real
+multi-process partition/chaos proof and reconfiguration stress. This document
+is not a claim that v11.8 synchronization groups already provide BFT or that
+v11.9 is released.
+
+## 1. Outcome and boundary
+
+v11.9 makes a selected set of domains into canonical, recoverable replicated
+state inside **one SAGE consensus chain**. The participating nodes are
+validators of that chain. A scope has an on-chain roster, an explicit domain
+allowlist, deterministic member weights, and a greater-than-two-thirds
+application quorum for scoped memories. An offline validator can catch up by
+ordered committed-block replay today. Canonical scoped content also survives a
+verified local snapshot with a discarded SQL projection. CometBFT network state
+sync remains a release gate, not a delivered capability.
+
+This is intentionally not an attempt to turn the v11.8 cross-chain
+Synchronization Group overlay into cross-chain BFT:
+
+- v11.8 groups connect independent chains. Their SQLite tables, controller
+  journal, pairwise treaties, and locally signed imported copies remain an
+  off-consensus sharing feature.
+- A v11.9 quorum scope is contained within one chain. Its members are existing
+  validators identified by their on-chain validator/agent IDs; it does not use
+  `member_chain_id` as a consensus identity because every cluster member has the
+  same chain ID.
+- The v11.8 SQLite group model may remain a UI/projection and migration aid, but
+  is never an authority for v11.9 admission, quorum, revocation, or recovery.
+- Federation and Natter remain transport only. They neither participate in the
+  scope quorum nor receive unselected-domain metadata.
+
+That separation is the release's first safety property: no selected scope can
+make a private domain, an unrelated federation peer, or a v11.8 controller
+part of consensus authority.
+
+## 2. Existing substrate and the design decision
+
+The existing chain already gives v11.9 three load-bearing primitives:
+
+1. CometBFT orders the transaction and replicates Badger state to the current
+   validator set.
+2. `TxTypeMemoryVote` and `validator.CheckQuorum` provide the application-level
+   accept/reject stage after block inclusion.
+3. Badger state is AppHash-covered and locally snapshotable; PostgreSQL/SQLite
+   is a serving projection, not the consensus source of truth. The ABCI network
+   state-sync methods are currently disabled, so network state sync cannot yet
+   be counted as recovery proof.
+
+The current memory model keeps only hash/status/classification in Badger and
+keeps content and serving indexes in the projection. That is insufficient for a
+new validator or a state-synced node to prove it holds the complete selected
+domain. Therefore v11.9 adds a **canonical scoped-content mirror** in Badger.
+For a scope-selected memory it contains the canonical submitted envelope needed
+to rebuild the serving projection: id, content, type, domain, classification,
+confidence, timestamps, tags, author, and content hash. It is written only by
+the deterministic app-v20 FinalizeBlock path and is covered by AppHash.
+
+The selected implementation model is therefore:
+
+```
+agent submit → CometBFT block → app-v20 scope lookup
+                                    ├─ unscoped: current memory lifecycle
+                                    └─ scoped: proposed + canonical content mirror
+                                                     ↓
+                    eligible scoped validators cast normal memory votes
+                                                     ↓
+                        >2/3 scoped weight → committed canonical replica
+                                                     ↓
+       ordered replay / verified local snapshot → rebuild SQL and serving indexes
+                    future network-safe ABCI state sync → same rebuild gate
+```
+
+The normal global validator quorum remains unchanged for unscoped domains. A
+scope does not alter CometBFT's block-finality threshold; it controls the
+SAGE-level acceptance of memories in its explicit domain allowlist.
+
+## 3. Invariants
+
+Any implementation or optimization that violates one of these is a no-go.
+
+1. **Pre-app-v20 replay identity.** With no applied `app-v20` record, the new
+   binary must reproduce historical AppHashes byte-for-byte. There must be no
+   new state write, transaction acceptance branch, validator-side request
+   construction change, or changed `Info().AppVersion` on that path.
+2. **One-chain authority.** A scope member is an active on-chain validator of
+   this chain. Federation identities, SQLite rows, HTTP headers, and controller
+   metadata are never evidence of consensus membership.
+3. **Explicit domain isolation.** Only an exact selected domain or its declared
+   subtree belongs to a scope. An unmatched domain uses the existing global
+   quorum. Scope lookup must be deterministic, reject overlapping active scopes,
+   and disclose no unselected-domain roster or content metadata.
+4. **On-chain source of truth.** Scope roster, revision, active/retired state,
+   selected domains, and canonical scoped records live in Badger and are
+   AppHash-covered. PostgreSQL/SQLite caches may be discarded and rebuilt.
+5. **Pinned denominator.** A memory's quorum denominator is the active scope
+   roster and its exact integer weights as of the submit block. Later member
+   changes cannot change an already-proposed memory's denominator.
+6. **Strict supermajority.** Acceptance requires `accept_weight * 3 >
+   total_weight * 2`, not a floating-point approximation. A three equal-weight
+   member scope with only two online members does not continue if the chain's
+   own configured BFT rules require more than two thirds.
+7. **Removal and revocation fail closed.** A roster change only affects future
+   proposals after its activation block. It cannot resurrect a revoked member's
+   vote, widen an existing scope, or remove the pinned evidence needed to finish
+   an older proposal. New scope writes pause if the canonical roster is absent,
+   malformed, retired, or inconsistent with the active validator set.
+8. **Canonical content recovery.** A scoped memory cannot be reported healthy
+   until its canonical envelope is present and hashes to the normal memory hash.
+   Local snapshot restore and projection rebuild verify this today; network
+   state sync must pass the same check before it may be enabled.
+9. **No implicit privilege.** Scope membership gives only scoped validator vote
+   weight. It grants neither domain ownership, agent RBAC, federation access,
+   administrator authority, nor permission to read unselected records.
+10. **Determinism.** App-v20 state codecs use fixed-width integers or
+    length-prefixed byte strings, sorted collections, a leading schema-version
+    byte, bounded decode sizes, and no maps/time.Now/external I/O in
+    FinalizeBlock. Floating-point fields inherited from an already accepted
+    transaction are encoded as raw fixed-width IEEE-754 bits and are never used
+    for quorum arithmetic.
+
+## 4. App-v20 activation
+
+v11.9 consumes the next unused application version: `app-v20`. It must use the
+same governed upgrade machinery as current post-app-v8 upgrades:
+
+- canonical name `app-v20`, target version `20`;
+- existing upgrade-propose / validator-vote path, so a >2/3 validator-power
+  governance decision schedules the fork;
+- the existing 200-block minimum activation floor; and
+- strict consensus activation at `H_activation + 1`.
+
+The implementation adds a dormant `appV20AppliedHeight`, refresh-on-boot arm,
+`postAppV20Fork(height)`, `currentAppVersion()` top case, and
+`MaxSupportedAppVersion() == 20` in one change. It must also extend every lower
+**additive** skip-ahead helper that app-v20 subsumes, while deliberately not
+turning on the independent app-v18 administrator override. The test suite must
+exercise direct skip to v20, activation-boundary replay, constructor recovery,
+and the dormant AppHash equality proof.
+
+App-v20 is the first behavioral change in this release. It does not alter any
+pre-v20 transaction encoding; instead it enables the new scope transaction
+types and state writes only at heights strictly after activation.
+
+## 5. Canonical state model and codec
+
+All v11.9 keys are in Badger and use a new `state:scope:` namespace. The key
+layout is fixed before code is merged:
+
+| Key | Value | Purpose |
+| --- | --- | --- |
+| `state:scope:<id>` | `ScopeRecordV1` | roster head, revision, state, domains, members |
+| `state:scope-domain:<domain>` | scope id | exact deterministic domain lookup |
+| `state:scope-proposal:<memory-id>` | `ScopeBallotV1` | pinned roster/weights and vote lifecycle |
+| `state:scope-content:<memory-id>` | `ScopedMemoryV1` | canonical recoverable submitted envelope |
+| `state:scope-revision:<id>:<n>` | SHA-256 head | immutable audit/revision anchor |
+
+Each value begins with `0x01` (schema version), followed by a bounded,
+length-prefixed binary encoding. Strings and byte slices are prefixed by a
+big-endian uint32 length; member and domain vectors have a uint32 count; ids,
+members, and domains are sorted bytewise before encoding. `uint64` is used for
+revision and weight. Empty or duplicate fields, unknown enum values, malformed
+UTF-8 domain strings, oversized fields, and trailing bytes are decode failures.
+
+`ScopeRecordV1` contains:
+
+```
+schema_version | scope_id | revision | state(active|paused|retired)
+controller_validator_id | created_height | updated_height
+domains[] { domain, subtree }
+members[] { validator_id, assigned_weight, joined_revision, active }
+```
+
+`assigned_weight` is an integer, non-zero, and is distinct from the current
+float PoE reputation score. In schema v1 it is the complete governance-assigned
+allocation: `ScopeBallotV1.effective_weight` copies it verbatim at submission.
+Live PoE does not reweight a scoped ballot; ordinary unscoped quorum continues
+to use the existing PoE path. Any later formula combining PoE with scope
+allocation requires a new schema version rather than silently changing v1's
+denominator. A scope's active total must be non-zero.
+
+The initial implementation accepts exact domains only. Subtree scopes are a
+separate, explicitly tested `subtree=true` extension; it cannot be inferred
+from a prefix match because overlapping prefixes create hidden scope capture.
+
+`ScopedMemoryV1` is not an alternate user API. It is the canonical deterministic
+copy of the already accepted `MemorySubmit` data. Its content hash and identity
+must agree with the normal Badger memory record before either state is written.
+The consensus state contains no embedding; embeddings and search indexes are
+locally rebuildable projections.
+
+## 6. Transactions and authorization
+
+v11.9 reuses the existing signed `GovPropose` transaction envelope for scope
+formation. `OpScopeAction` is a new app-v20-gated governance operation whose
+payload is the complete canonical next `ScopeRecordV1` template. This avoids a
+second direct-mutation transaction family and keeps one immutable byte string
+as both the voted decision and the applied authority.
+
+The minimal transaction family is:
+
+| Operation | Effect | Authority |
+| --- | --- | --- |
+| `OpScopeAction` create | creates revision 1 with domains, members and weights | governance supermajority; proposer and members must be active validators |
+| `OpScopeAction` update | adds/removes domains or members, changes weights, pauses/resumes | governance supermajority; revision advances by exactly one |
+| `OpScopeAction` retire | permanently retires a scope and removes future mapping | governance supermajority over the exact retired record |
+| `ScopeRecover` | installs a verified canonical-content chunk for an existing scoped memory when rebuilding a projection | only the deterministic block path; not a public remote-write escape hatch |
+
+Group formation and every material roster change are governance-attested. A
+single controller key is not sufficient. The proposal payload is the complete
+next `ScopeRecordV1` template itself; its created/updated heights are zero in the
+signed payload and are materialized from the deterministic quorum-execution
+block. Execution re-verifies the exact accepted payload, current revision,
+sorted membership, active validator eligibility, non-zero total weight,
+registered exact domains, and no domain collision. There is no direct scope
+mutation transaction or remote-write escape hatch.
+
+The formation slice implements create, revision-checked update, pause/resume,
+and permanent retire through `OpScopeAction`; it does not add a generic
+free-form mutation endpoint. CEREBRUM and MCP may construct only canonical
+payloads and must surface the scheduled governance decision rather than
+claiming an immediate topology change.
+
+## 7. Scoped memory lifecycle
+
+At `postAppV20Fork(height)`:
+
+1. `processMemorySubmit` performs the existing identity, RBAC, content, nonce,
+   and domain checks first.
+2. If the domain has no active scope mapping, the exact current lifecycle runs.
+3. If it maps to an active scope, the app derives and stores a `ScopeBallotV1`
+   snapshot and `ScopedMemoryV1` in the same deterministic block state change
+   as the ordinary proposed memory. Any failure rejects the transaction; there
+   is no partially mirrored scoped memory.
+4. `processMemoryVote` accepts a scoped vote only from an active member pinned
+   in that ballot. It uses the stored effective integer weights, not a live
+   roster query. Nonmember votes are rejected rather than counted at zero.
+5. A strict scoped supermajority commits. If every pinned member has cast a
+   terminal vote without a supermajority, the memory becomes deprecated. A
+   missing/offline member leaves the proposal pending; it is an availability
+   event, not permission to lower the denominator.
+
+Existing normal-memory vote records remain immutable. The scope ballot is a
+supplementary record and no compatibility reader may mistake an unscoped memory
+for a scoped one. The existing immediate-commit co-author envelope is rejected
+for active or paused scoped domains in v1; supporting it requires a new signed
+co-commit schema that explicitly binds the scope revision and ballot authority.
+
+## 8. Membership changes, revocation, and recovery
+
+- A member must be active in the on-chain validator set at scope-create/update
+  execution. Removing that validator via the existing governance path requires
+  a scope update or pauses every affected scope for future submissions.
+- Removing a member is prospective: it creates a new revision for new ballots;
+  older ballots retain their original proof denominator and may finish only
+  under it. The operator UI reports this honestly as a drain requirement.
+- A revoked member's future scoped vote and all new scoped submissions are
+  rejected after the new revision. It cannot restore itself with a stale
+  revision or by replaying an old `ScopeUpdate`.
+- Ordered committed-block replay is the currently implemented catch-up path. An
+  integration proof holds one replica offline, advances the other through a
+  selected submit, an unselected submit, and scoped votes, then replays the
+  exact blocks and compares every intermediate AppHash. Only the selected
+  memory receives a canonical scoped envelope.
+- Scoped votes persist their first FinalizeBlock height beside the immutable
+  decision. If a projection flush fails after Badger was written but before
+  committed height advances, the canonical scoped submit envelope or exact
+  decision+height pair authorizes reconstruction of only that lost projection
+  batch. A changed transaction or later height still fails the ordinary nonce
+  guard. The integration proof exercises both submit and quorum-reaching vote
+  crash windows across real store reopen cycles.
+- On boot, a node validates every `ScopedMemoryV1` against its memory hash/status
+  and rebuilds missing SQL rows plus clearance metadata transactionally.
+  `/ready` fails closed while canonical scoped envelopes exist but that
+  projection is missing or invalid; a locked SQLite vault retries the rebuild
+  immediately after operator unlock, followed by normal serving-index repair.
+- The existing `internal/snapshot` bundle is **operator-local rollback only**.
+  It includes SQLite, CometBFT databases, node and validator key files, optional
+  vault material, config, and optionally the executable. It must never be
+  advertised or transmitted as an ABCI/P2P snapshot. The local integration
+  proof verifies the bundle, restores app-v20 and canonical scoped state,
+  deletes SQLite completely, then rebuilds and re-verifies the projection.
+- CometBFT ABCI state sync is not enabled yet: `ListSnapshots` advertises none,
+  `OfferSnapshot` rejects, and `ApplySnapshotChunk` aborts. The separate
+  `internal/statesync` foundation now provides a canonical consensus-only
+  metadata format, trusted height/AppHash binding, per-chunk and whole-backup
+  hashes, strict 64 KiB–8 MiB chunk and 512-chunk limits, malformed-input fuzz
+  coverage, fresh-directory disk assembly, retry-safe exact chunk delivery, and
+  a real Badger backup/load AppHash round trip. The local rollback manifest is
+  rejected by its format decoder.
+- The streaming exporter/catalog and receiver preparation gate now exist. The
+  exporter bounds the live backup, requires an app-v20 verifier to reload the
+  staged bytes and match the committed AppHash before atomic publication, emits
+  only metadata plus chunks, rejects unexpected/private files or symlinks, and
+  verifies each chunk immediately before serving. The receiver assembles into a
+  new directory, loads a fresh Badger database, reopens it read-only, requires
+  exact persisted height and active app-v20 audit, recomputes the narrow AppHash,
+  validates every scoped envelope/ballot/lifecycle record, and deletes all
+  staged state on failure.
+- Enabling those endpoints still requires atomically activating the prepared
+  database without leaving stale app/store/governance pointers and keeping
+  `/ready` false until scoped projection recovery succeeds. Snapshot serving
+  must be limited to an explicitly authorized validator-join/Comet peer path,
+  never a general federation peer. The format excludes
+  SQLite/PostgreSQL data, CometBFT node/validator keys and databases, vault keys,
+  local config, logs, and binaries by construction.
+- The accepted activation/join design is
+  [`v11.9-state-sync-activation.md`](v11.9-state-sync-activation.md): a boot-only
+  whole-application bundle replacement, crash-recovery journal, delayed service
+  construction, and authenticated validator-only P2P allowlist. It explicitly
+  rejects a live `BadgerStore.db` swap and documents the Comet persistence crash
+  window that must be closed before endpoint activation.
+- Snapshot restore and a discarded local projection remain first-class tests.
+  A node must never serve a claimed-committed scoped memory whose canonical
+  mirror is absent or mismatched.
+
+v11.9 does not promise cross-chain deletion, per-chain lifecycle convergence,
+or a right to erase copies from pre-v11.9 federation peers.
+
+## 9. Threat model and negative cases
+
+| Threat | Required defence |
+| --- | --- |
+| Controller or dashboard compromise | cannot mutate a scope without a governance-approved exact record |
+| Stale roster/replay | revision predecessor, immutable revision hash, strict next-revision check, and AppHash replication |
+| Validator removed mid-flight | ballot pins old membership; new scope writes pause until a prospective revision is committed |
+| Weight manipulation | non-zero integer allocation, deterministic effective-weight conversion, stored ballot snapshot, exact integer threshold |
+| Metadata leak from unselected domains | exact scope lookup, no global scope enumeration to federation peers, scope/domain collision rejection |
+| Partial content loss after state sync | Badger canonical envelope + hash verification before projection/serving readiness |
+| Off-consensus cache poisoning | Badger is authoritative; SQLite/PostgreSQL values are rebuilt or rejected on mismatch |
+| Local rollback bundle exfiltration | never expose it through ABCI/P2P; network state sync uses a separate key-free, config-free, consensus-only format |
+| Network partition | CometBFT and the application denominator remain unchanged; no local override or quorum relaxation |
+
+## 10. Release gates
+
+The release is not ready until all of the following pass:
+
+1. app-v20 dormant replay produces identical AppHashes for historical fixtures;
+   a direct v20 skip-ahead has correct lower-gate subsumption and does not enable
+   app-v18's administrator override.
+2. Codec fuzz/negative tests reject malformed, non-canonical, oversized,
+   duplicate, unsorted, and trailing-byte scope records.
+3. Multi-validator determinism tests execute identical create/update/vote blocks
+   on independent apps and compare AppHash, scope head, ballots, and events.
+4. Four equal-weight validators continue with three honest online members;
+   three equal-weight validators with only two do not lower their denominator.
+5. Member removal, weight change, pause, and retirement are prospective and
+   cannot alter an existing ballot's pinned denominator.
+6. A nonmember, a removed member, an unrelated validator, stale revision, and
+   domain collision all fail closed.
+7. Ordered offline replay and verified local snapshot restore rebuild selected
+   scoped content and serving indexes, verify query results and hashes, and prove
+   that an unselected domain receives no canonical scoped envelope. These
+   integration proofs exist; real multi-process execution remains required.
+8. The separate network-safe snapshot format/export/preparation path passes canonical codec,
+   malformed/oversized, out-of-order/chunk-retry, wrong-AppHash, local-manifest
+   rejection, complete-backup hash, extra/private-file and symlink rejection,
+   post-publication tamper detection, real Badger reload, persisted-height and
+   active-app-v20 checks, read-only narrow-AppHash recomputation, malformed
+   canonical-scope rejection, and failed-stage cleanup tests. Unauthorized-peer,
+   interrupted process apply, atomic live activation/rebinding, and readiness
+   tests remain before the ABCI endpoints can be enabled. The existing local
+   rollback bundle is never accepted as this payload.
+9. Crash between FinalizeBlock/Commit, projection failure/replay, and stale-cache
+   replacement have deterministic in-process integration proofs. Multi-process
+   double-delivery, network partition, process kill/restart, and unavailable
+   PostgreSQL recovery remain required chaos gates.
+10. Full root and race suites, exact lint, frontend/SDK checks where surfaces
+   change, and an adversarial consensus review pass before release branching.
+
+## 11. Delivery slices
+
+1. **Foundation:** app-v20 dormant gate, versioned scope codec/store, exact
+   codec and replay tests; no user-facing operation is enabled before the gate.
+2. **Formation:** governance-bound create/update/retire decisions and
+   deterministic Badger roster state; domain-collision and authorization tests.
+3. **Acceptance:** scoped ballots, integer quorum path, canonical scoped-content
+   writes, membership/revocation semantics, and multi-validator replay tests.
+4. **Recovery:** projection rebuilder and readiness are implemented; ordered
+   replay and local snapshot/projection-loss integration proofs are implemented.
+   The network-safe format, assembler, verified exporter/catalog, and read-only
+   receiver preparation gate are implemented; authorized ABCI serving, atomic
+   activation/rebinding, multi-process chaos, and release hardening remain.
+   Guided canonical formation is available through REST, MCP/CEREBRUM, the
+   dashboard, and both Python SDK clients without hand-encoding binary scope
+   records. CEREBRUM's selectable roster is the live chain validator set, and
+   the consensus path independently re-verifies it.
+
+Each slice must preserve the invariants above on its own. No slice may claim
+that v11.9 is live merely because schema fields, a dashboard control, or an
+off-consensus cache exists.

--- a/docs/v11.9-PLAN.md
+++ b/docs/v11.9-PLAN.md
@@ -279,7 +279,8 @@ co-commit schema that explicitly binds the scope revision and ballot authority.
   a scope update or pauses every affected scope for future submissions.
 - Removing a member is prospective: it creates a new revision for new ballots;
   older ballots retain their original proof denominator and may finish only
-  under it. The operator UI reports this honestly as a drain requirement.
+  under it. Before release, the operator UI must report this honestly as a
+  drain requirement.
 - A revoked member's future scoped vote and all new scoped submissions are
   rejected after the new revision. It cannot restore itself with a stale
   revision or by replaying an old `ScopeUpdate`.

--- a/docs/v11.9-state-sync-activation.md
+++ b/docs/v11.9-state-sync-activation.md
@@ -1,0 +1,282 @@
+# v11.9 State-Sync Activation and Join Authorization
+
+**Status:** accepted implementation design. The canonical fsynced activation
+journal, pure recovery decision logic, and writable no-migration Badger opener
+are implemented; directory switching, runtime delegation, and endpoints remain
+disabled.
+
+This document closes the architectural question between SAGE's verified
+consensus-only snapshot receiver and CometBFT's ABCI state-sync endpoints. It
+does not enable those endpoints. The existing fail-closed stubs remain the
+correct production behavior until every acceptance test in section 9 passes
+(`internal/abci/app.go:6563-6582`).
+
+## 1. Boundary
+
+State sync is a same-chain validator/bootstrap mechanism. It is not the v11.8
+independent-chain synchronization overlay and it is not a general federation
+download endpoint.
+
+The network format contains only a Badger consensus backup plus canonical
+metadata and chunk hashes. It must never contain SQLite/PostgreSQL projections,
+CometBFT databases, node or validator keys, vault keys, local configuration,
+logs, or binaries. The older operator rollback snapshot explicitly contains
+local/private material and is never accepted by the network decoder.
+
+Delivered substrate:
+
+- `internal/statesync/format.go` — bounded canonical metadata, trusted height
+  and AppHash binding, chunk hashes, and full-backup hash.
+- `internal/statesync/assembler.go` — fresh-directory, retry-safe disk assembly.
+- `internal/statesync/exporter.go` — verified Badger-only publication and
+  fail-closed catalog/chunk loading.
+- `internal/abci/scoped_state_sync.go` — fresh-directory restore, exact height,
+  app-v20 audit, narrow AppHash, stored AppHash, and canonical scoped-state
+  verification without activation.
+- `internal/statesync/activation.go` — bounded canonical activation journal,
+  atomic fsynced journal replacement, symlink/path rejection, and fail-closed
+  Comet-vs-live recovery decisions. It does not rename a database.
+- `internal/store/badger.go:105-128` — writable open of an existing verified
+  state-sync database without constructor migrations/backfills.
+
+## 2. Why a live Badger rename is rejected
+
+The current process distributes concrete pointers before and after CometBFT
+starts:
+
+- `SageApp` owns a concrete `*store.BadgerStore`, validator set, governance
+  engine bound to that store, and cached app state
+  (`internal/abci/app.go:248-255`, `internal/abci/app.go:1833-1851`).
+- the local CometBFT client is created against one concrete `*SageApp`
+  (`cmd/sage-gui/node_controller.go:111-119`).
+- the nonce allocator, projection rebuilder, local snapshot scheduler, upgrade
+  watchdog, REST server, and dashboard all capture the original store or raw
+  `*badger.DB` handle (`cmd/sage-gui/node.go:388-448`,
+  `cmd/sage-gui/node.go:498-510`, `cmd/sage-gui/node.go:692-730`,
+  `cmd/sage-gui/node.go:761-790`).
+- the local rollback scheduler retains the raw database handle, not a dynamic
+  accessor (`internal/snapshot/snapshot.go:110-116`).
+
+Renaming a prepared directory under these objects would leave some readers on
+the old database and others on the new one. Mutating `BadgerStore.db` alone is
+also unsafe: typed store methods call the field directly without a process-wide
+lease, so a concurrent REST read or snapshot backup could race a close/swap.
+
+Therefore activation must replace the complete consensus application bundle
+during boot, before ordinary services are constructed. It must not hot-swap a
+store inside an already serving `SageApp`.
+
+## 3. Chosen runtime ownership model
+
+Introduce one `BootStateSyncRuntime` implementing the CometBFT ABCI application
+interface. The runtime owns exactly one immutable bundle:
+
+```text
+ConsensusBundle
+├── SageApp
+├── BadgerStore
+├── ValidatorSet
+├── GovernanceEngine
+├── AppState / fork caches
+└── expected height + AppHash
+```
+
+All normal ABCI methods take a short runtime read lease and delegate to the
+current bundle. State-sync methods are implemented by the runtime itself, not
+by the old `SageApp`, so the final chunk can replace the complete bundle without
+closing an object that is still executing its own method.
+
+The runtime accepts activation only in a one-shot boot phase. Once CometBFT has
+persisted the synchronized state and the runtime is sealed, `OfferSnapshot`
+rejects and `ApplySnapshotChunk` aborts for the lifetime of that process. A
+serving node cannot be moved to another snapshot.
+
+`SageNodeController` must hold the ABCI application interface/runtime rather
+than a concrete `*SageApp`. After the runtime seals, startup obtains the final
+bundle and only then constructs:
+
+1. projection recovery and `/ready` state;
+2. the local rollback snapshot scheduler with the final raw Badger handle;
+3. nonce-floor and upgrade-watchdog callbacks;
+4. REST, dashboard, MCP, federation, and background workers.
+
+The current early projection rebuild and snapshot-scheduler construction at
+`cmd/sage-gui/node.go:415-510` move behind this seal. This removes the need for
+dynamic store proxies in every handler.
+
+## 4. Activation state machine
+
+Only these forward transitions are valid:
+
+```text
+disabled
+   └─> discovering ─> assembling ─> prepared
+                                      └─> activated_pending_comet ─> sealed
+                   any error ─> failed
+```
+
+- **disabled:** default; current fail-closed ABCI behavior.
+- **discovering:** one trusted Comet offer is validated against format, height,
+  metadata hash, and light-client AppHash.
+- **assembling:** chunks may arrive out of order; exact duplicates are
+  idempotent. A changed duplicate, wrong size/hash, unknown index, or second
+  offer rejects the snapshot.
+- **prepared:** the backup has been loaded into a fresh Badger directory and
+  passed all read-only app-v20 verification. Live state is untouched.
+- **activated_pending_comet:** the verified directory is active in a newly
+  constructed consensus bundle, but CometBFT may not yet have bootstrapped its
+  own state/block stores.
+- **sealed:** CometBFT's persisted height/AppHash is at or beyond the snapshot,
+  the old Badger directory can be retired, projection recovery has completed,
+  and ordinary services may start.
+- **failed:** readiness remains false; no normal serving starts. A retry always
+  creates new staging paths and cannot reuse unverified chunks.
+
+No transition may lower the trusted height or change the trusted AppHash.
+
+## 5. Crash-safe filesystem transaction
+
+Activation uses a small fsynced journal outside both Badger directories. The
+journal contains only paths, phase, snapshot height, metadata hash, and trusted
+AppHash; never keys or memory contents.
+
+1. Write `prepared` journal and fsync the journal plus parent directory.
+2. Acquire the runtime write lease; assert there is no active delegated ABCI
+   call and no pending projection batch.
+3. Close only the old consensus Badger handle. The shared off-chain projection
+   is process-owned and must not be closed by bundle replacement.
+4. Rename live Badger to a unique quarantine path; rename prepared Badger to
+   the canonical live path; fsync the parent.
+5. Open the received database with a new writable **no-backfill** constructor.
+   `NewBadgerStore` cannot be used because its upgrade backfills can mutate the
+   just-verified AppHash (`internal/store/badger.go:45-82`).
+6. Construct a fresh `SageApp`/validator set/governance engine, then re-check
+   height, active app-v20 audit, and AppHash from the writable handle.
+7. Publish the new immutable bundle and fsync
+   `activated_pending_comet` before the final chunk returns `ACCEPT`.
+8. CometBFT calls `Info` and verifies exact app version, height, and AppHash
+   before it reports restore success. CometBFT then bootstraps its state and
+   block stores asynchronously; SAGE must not treat the earlier ABCI `ACCEPT`
+   as completion.
+9. After CometBFT persistence is observed, write `sealed`, fsync, remove the
+   quarantine directory, and remove the journal.
+
+On boot, journal recovery compares the persisted CometBFT height with the
+snapshot height before opening SAGE Badger:
+
+- Comet height below snapshot: restore the quarantined old Badger and retry
+  state sync; the prior ABCI activation was never committed by CometBFT.
+- Comet height at or above snapshot with matching trusted state: keep the new
+  Badger and finish sealing.
+- missing/ambiguous directories, equal height with a different trusted hash, or
+  impossible phase combinations: fail closed and require operator recovery.
+
+This recovery check must run before the ABCI handshake. Otherwise an app height
+ahead of CometBFT can brick startup.
+
+## 6. Internet join authorization
+
+ABCI `ListSnapshots` and `LoadSnapshotChunk` do not receive the requesting peer
+identity. Application code therefore cannot enforce a per-request allowlist.
+Authorization must be established at the authenticated CometBFT P2P connection
+boundary before snapshots are advertised.
+
+State-sync serving requires a **validator-only P2P profile**:
+
+- `pex = false`, no seeds, and no learned-peer dialing;
+- `max_num_inbound_peers = 0`;
+- every existing validator and the one time-bounded joining node ID is listed
+  in `unconditional_peer_ids` so only authenticated, explicitly listed inbound
+  identities bypass the zero limit;
+- the same IDs are `private_peer_ids` so addresses are not gossiped;
+- persistent peers contain only the expected validator mesh;
+- the join approval binds chain ID, joining Comet node ID, validator public key,
+  app-v20 compatibility, expiry, and snapshot height floor.
+
+CometBFT v0.38.15 checks the authenticated node ID against unconditional peers
+before applying the inbound limit; ordinary inbound peers are rejected once
+the configured limit is reached (`p2p/switch.go:693-709` in the pinned module).
+SAGE's current quorum profile disables PEX but still leaves the default inbound
+limit and therefore is **not** sufficient for snapshot serving
+(`cmd/sage-gui/node.go:575-590`).
+
+The existing LAN non-validator join flow is not silently converted to this
+profile: today the host does not add the guest node ID to its own allowlist.
+The internet join ceremony must update both sides atomically or roll both back.
+
+The receiver also checks every `ApplySnapshotChunk.sender` against the approved
+provider set and returns it in `reject_senders` on mismatch. This is defence in
+depth; it does not replace connection-level serving authorization.
+
+## 7. Readiness and serving
+
+`/ready` remains false from discovery through activation and projection rebuild.
+After `sealed`, startup runs canonical scoped projection recovery against the
+final bundle. Readiness becomes true only when:
+
+- CometBFT has persisted and verified the synchronized height/AppHash;
+- canonical scoped-state verification still succeeds on the writable store;
+- every scoped content envelope has a matching rebuilt serving record and
+  classification;
+- the vault is unlocked when encrypted projection writes require it;
+- local snapshot scheduling was rebound to the final Badger handle.
+
+Consensus may continue while an encrypted projection waits for unlock, but
+REST/MCP memory serving stays fail closed, matching the current readiness model
+(`cmd/sage-gui/node.go:415-453`).
+
+## 8. Endpoint behavior
+
+- `ListSnapshots`: only when runtime serving mode is explicitly armed and the
+  validator-only P2P profile has passed startup validation. Return only verified
+  catalog entries.
+- `OfferSnapshot`: only during boot discovery; validate Comet fields through
+  `statesync.ValidateOffer`, join ticket, height floor, and app-v20 compatibility.
+- `LoadSnapshotChunk`: load from the verified catalog and rehash immediately
+  before return. Never read local rollback paths.
+- `ApplySnapshotChunk`: enforce session, sender, bounds, duplicate semantics,
+  assembler verification, fresh Badger preparation, and the activation journal.
+
+Any missing join authorization, invalid P2P profile, active serving process,
+local snapshot metadata, or incomplete crash recovery keeps the present
+empty/reject/abort behavior.
+
+## 9. Acceptance tests before enabling
+
+1. Runtime delegation is race-tested while normal ABCI calls execute; a bundle
+   replacement waits for all readers and no method observes two bundles.
+2. Kill at every journal/fsync/rename/open/publish/Comet-bootstrap boundary;
+   restart deterministically restores old or seals new state without manual
+   directory edits.
+3. Comet's post-apply `Info` sees exact height, AppHash, and app version.
+4. Wrong hash/height/version, malformed scope, changed duplicate, wrong sender,
+   expired join ticket, and second concurrent offer all fail closed.
+5. A non-allowlisted internet peer cannot establish the P2P session or obtain
+   metadata/chunks; the approved joining node can.
+6. The local rollback manifest and directories containing keys/config/binaries
+   remain unadvertised and decoder-rejected.
+7. Projection database absent, poisoned, locked, or temporarily unavailable:
+   consensus state remains canonical and `/ready` stays false until exact rebuild.
+8. Three independent processes reproduce the same AppHash after one joins by
+   state sync, catches up by blocks, then participates in a 3-of-4 scoped vote.
+9. Partition and reconfiguration tests prove denominator pinning: 3-of-4
+   continues; 2-of-3 remains pending; removed/added validators affect only new
+   ballots.
+10. Full Go test/vet/race, Python SDK, CEREBRUM static checks, and an adversarial
+    review pass are green with the endpoints enabled.
+
+## 10. Implementation order
+
+1. **Partially delivered:** writable no-backfill store opener, canonical journal,
+   and pure recovery decision. Finish the verified quarantine/live directory
+   executor and pre-handshake Comet state reader.
+2. Introduce `BootStateSyncRuntime` with bundle leases and dormant endpoint
+   implementations; keep feature configuration off.
+3. Move projection/snapshot/REST/dashboard/worker construction behind runtime
+   sealing and add fail-closed startup health reporting.
+4. Add reciprocal validator-node allowlist/join-ticket configuration and tests.
+5. Add kill-point and real multi-process harnesses.
+6. Enable snapshot serving first on an explicitly opted-in validator; enable
+   receiving only after crash recovery and readiness gates pass.
+
+No step may turn the endpoints on merely because the happy-path restore works.

--- a/internal/abci/app.go
+++ b/internal/abci/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/l33tdawg/sage/internal/memory"
 	"github.com/l33tdawg/sage/internal/metrics"
 	"github.com/l33tdawg/sage/internal/poe"
+	"github.com/l33tdawg/sage/internal/scope"
 	"github.com/l33tdawg/sage/internal/store"
 	"github.com/l33tdawg/sage/internal/tx"
 	"github.com/l33tdawg/sage/internal/validator"
@@ -478,6 +479,15 @@ type SageApp struct {
 	// {Name:"app-v19", TargetAppVersion:19}.
 	appV19AppliedHeight int64 // 0 => fork dormant
 
+	// appV20AppliedHeight gates the v11.9 domain-scoped quorum foundation.
+	// It is independent/additive, strict >, and dormant on every current chain;
+	// the activation block is still evaluated under the prior rules. app-v20
+	// subsumes the additive v8..v17/v19 rule chain but deliberately does not
+	// enable app-v18's independent administrator override. The v11.9 scope
+	// transaction/state branches must key off postAppV20Fork, never this field
+	// directly, so pre-activation replay remains byte-identical.
+	appV20AppliedHeight int64 // 0 => fork dormant
+
 	// retainBlocks, when > 0, is the number of most-recent blocks Commit asks
 	// CometBFT to keep: ResponseCommit.RetainHeight = height - retainBlocks
 	// (clamped at 0 = keep everything). Pruning is LOCAL and advisory — it never
@@ -613,6 +623,12 @@ const appV18UpgradeName = "app-v18"
 // effect is off-consensus: the local-agents-default-READ flip in
 // web/handler.go, gated on IsAppV19ActiveForNextTx.
 const appV19UpgradeName = "app-v19"
+
+// appV20UpgradeName is the canonical activation-record name for the v11.9
+// domain-scoped quorum foundation. It is the next independent fork after the
+// behavior-empty app-v19 gate and must not reuse app-v18, whose activation has
+// a separate live RBAC-administrator effect.
+const appV20UpgradeName = "app-v20"
 
 // postV8Fork is the consensus-side fork-gate predicate. Use it inside
 // processTx and other height-aware paths. Strict greater-than mirrors
@@ -984,6 +1000,13 @@ func (app *SageApp) postAppV19Fork(height int64) bool {
 	return app.appV19AppliedHeight > 0 && height > app.appV19AppliedHeight
 }
 
+// postAppV20Fork is the consensus-side boundary for the v11.9 scoped-quorum
+// rules. It is strict so the applied-upgrade record is committed under the
+// previous rule set and all replicas begin the new behavior at H+1.
+func (app *SageApp) postAppV20Fork(height int64) bool {
+	return app.appV20AppliedHeight > 0 && height > app.appV20AppliedHeight
+}
+
 // postAppV17Rules reports whether app-v17's consensus rules are in force at
 // this height. app-v18 subsumes those additive rules on a skip-ahead chain;
 // historical blocks still collapse to exactly their original gate.
@@ -993,7 +1016,7 @@ func (app *SageApp) postAppV19Fork(height int64) bool {
 //
 //nolint:unused // C1 mints the empty gate; the first callsites land with C2/C3
 func (app *SageApp) postAppV17Rules(height int64) bool {
-	return app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height)
+	return app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height) || app.postAppV20Fork(height)
 }
 
 func (app *SageApp) postAppV18Rules(height int64) bool {
@@ -1010,7 +1033,7 @@ func (app *SageApp) postAppV18Rules(height int64) bool {
 //
 //nolint:unused // behavior-empty gate; no consensus callsite reads it (D adds zero processTx branch)
 func (app *SageApp) postAppV19Rules(height int64) bool {
-	return app.postAppV19Fork(height)
+	return app.postAppV19Fork(height) || app.postAppV20Fork(height)
 }
 
 // IsAppV17ActiveForNextTx is the REST-side transaction-construction accessor.
@@ -1041,7 +1064,15 @@ func (app *SageApp) IsAppV18ActiveForNextTx() bool {
 // consumer is web/handler.go's local-agents-default-READ flip (DashboardHandler
 // .AppV19ActiveFn).
 func (app *SageApp) IsAppV19ActiveForNextTx() bool {
-	return app.appV19AppliedHeight > 0 && app.state != nil && app.state.Height >= app.appV19AppliedHeight
+	return app.state != nil && app.postAppV19Rules(app.state.Height+1)
+}
+
+// IsAppV20ActiveForNextTx is the construction-side gate for v11.9 scope
+// governance. It flips immediately after the activation block commits, so REST,
+// MCP, and CEREBRUM do not submit op==8 while consensus still treats it as the
+// historical inert unknown operation.
+func (app *SageApp) IsAppV20ActiveForNextTx() bool {
+	return app.state != nil && app.postAppV20Fork(app.state.Height+1)
 }
 
 // postAppV16Rules reports whether app-v16's consensus rules are in force at this
@@ -1051,7 +1082,7 @@ func (app *SageApp) IsAppV19ActiveForNextTx() bool {
 // Collapses to exactly postAppV16Fork on every existing chain
 // (appV17AppliedHeight==0), so historical blocks replay byte-identically.
 func (app *SageApp) postAppV16Rules(height int64) bool {
-	return app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height)
+	return app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height) || app.postAppV20Fork(height)
 }
 
 // shouldRecordMemoryDomain reports whether a successful submit must persist its
@@ -1080,7 +1111,7 @@ func (app *SageApp) shouldRecordMemoryDomain(height int64) bool {
 // higher gates are 0, so this collapses to exactly postAppV8Fork and historical
 // blocks replay byte-identically.
 func (app *SageApp) postAppV8Rules(height int64) bool {
-	return app.postAppV8Fork(height) || app.postAppV9Fork(height) || app.postAppV10Fork(height) || app.postAppV11Fork(height) || app.postAppV12Fork(height) || app.postAppV13Fork(height) || app.postAppV15Fork(height) || app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height)
+	return app.postAppV8Fork(height) || app.postAppV9Fork(height) || app.postAppV10Fork(height) || app.postAppV11Fork(height) || app.postAppV12Fork(height) || app.postAppV13Fork(height) || app.postAppV15Fork(height) || app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height) || app.postAppV20Fork(height)
 }
 
 // postAppV9Rules reports whether app-v9's consensus rules (consensus-path
@@ -1091,7 +1122,7 @@ func (app *SageApp) postAppV8Rules(height int64) bool {
 // postAppV9Fork on every existing chain (appV10/appV11AppliedHeight==0), so replay
 // is byte-identical.
 func (app *SageApp) postAppV9Rules(height int64) bool {
-	return app.postAppV9Fork(height) || app.postAppV10Fork(height) || app.postAppV11Fork(height) || app.postAppV12Fork(height) || app.postAppV13Fork(height) || app.postAppV15Fork(height) || app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height)
+	return app.postAppV9Fork(height) || app.postAppV10Fork(height) || app.postAppV11Fork(height) || app.postAppV12Fork(height) || app.postAppV13Fork(height) || app.postAppV15Fork(height) || app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height) || app.postAppV20Fork(height)
 }
 
 // postAppV10Rules reports whether app-v10's consensus rules (corroboration
@@ -1103,7 +1134,7 @@ func (app *SageApp) postAppV9Rules(height int64) bool {
 // when app-v11 landed — app-v10 was the highest fork until then and needed no
 // subsumption helper.
 func (app *SageApp) postAppV10Rules(height int64) bool {
-	return app.postAppV10Fork(height) || app.postAppV11Fork(height) || app.postAppV12Fork(height) || app.postAppV13Fork(height) || app.postAppV15Fork(height) || app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height)
+	return app.postAppV10Fork(height) || app.postAppV11Fork(height) || app.postAppV12Fork(height) || app.postAppV13Fork(height) || app.postAppV15Fork(height) || app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height) || app.postAppV20Fork(height)
 }
 
 // postAppV11Rules reports whether app-v11's consensus rules (the per-node
@@ -1114,7 +1145,7 @@ func (app *SageApp) postAppV10Rules(height int64) bool {
 // postAppV11Fork on every existing chain (appV12AppliedHeight==0), so
 // historical blocks replay byte-identically.
 func (app *SageApp) postAppV11Rules(height int64) bool {
-	return app.postAppV11Fork(height) || app.postAppV12Fork(height) || app.postAppV13Fork(height) || app.postAppV15Fork(height) || app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height)
+	return app.postAppV11Fork(height) || app.postAppV12Fork(height) || app.postAppV13Fork(height) || app.postAppV15Fork(height) || app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height) || app.postAppV20Fork(height)
 }
 
 // postAppV12Rules reports whether app-v12's consensus rule (the FLAWED
@@ -1152,7 +1183,7 @@ func (app *SageApp) postAppV13Rules(height int64) bool {
 // postAppV12Rules/postAppV13Rules — those are mutually-exclusive
 // AppHash-REPLACEMENT rules, deliberately non-subsumed.
 func (app *SageApp) postAppV15Rules(height int64) bool {
-	return app.postAppV15Fork(height) || app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height)
+	return app.postAppV15Fork(height) || app.postAppV16Fork(height) || app.postAppV17Fork(height) || app.postAppV18Fork(height) || app.postAppV19Fork(height) || app.postAppV20Fork(height)
 }
 
 // refreshAppV9Fork populates appV9AppliedHeight from the persisted upgrade
@@ -1347,6 +1378,20 @@ func (app *SageApp) refreshAppV19Fork() {
 	}
 	if rec != nil {
 		app.appV19AppliedHeight = rec.AppliedHeight
+	}
+}
+
+// refreshAppV20Fork restores the v11.9 gate from the committed upgrade audit
+// trail during construction. A missing record leaves the gate dormant, which is
+// the replay-compatible state for every pre-v11.9 chain.
+func (app *SageApp) refreshAppV20Fork() {
+	rec, err := app.badgerStore.GetAppliedUpgrade(appV20UpgradeName)
+	if err != nil {
+		app.logger.Warn().Err(err).Str("name", appV20UpgradeName).Msg("read app-v20 applied-upgrade record")
+		return
+	}
+	if rec != nil {
+		app.appV20AppliedHeight = rec.AppliedHeight
 	}
 }
 
@@ -1760,6 +1805,7 @@ func NewSageApp(badgerPath string, postgresURL string, logger zerolog.Logger) (*
 	app.refreshAppV17Fork()
 	app.refreshAppV18Fork()
 	app.refreshAppV19Fork()
+	app.refreshAppV20Fork()
 	app.reconcilePoEForkMonotonicity()
 
 	// Reload persisted validators from BadgerDB (survives restart)
@@ -1821,6 +1867,7 @@ func NewSageAppWithStores(bs *store.BadgerStore, offchain store.OffchainStore, l
 	app.refreshAppV17Fork()
 	app.refreshAppV18Fork()
 	app.refreshAppV19Fork()
+	app.refreshAppV20Fork()
 	app.reconcilePoEForkMonotonicity()
 
 	persistedVals, err := bs.LoadValidators()
@@ -1886,6 +1933,8 @@ func NewSageAppWithStores(bs *store.BadgerStore, offchain store.OffchainStore, l
 // 6 <= 7, so the watchdog stops without re-proposing.
 func (app *SageApp) currentAppVersion() uint64 {
 	switch {
+	case app.appV20AppliedHeight > 0:
+		return 20 // app-v20 (v11.9 domain-scoped quorum foundation) — highest gate
 	case app.appV19AppliedHeight > 0:
 		return 19 // app-v19 (empty scaffolding gate, v11.8 — off-consensus default-read flip only) — highest gate
 	case app.appV18AppliedHeight > 0:
@@ -1928,13 +1977,13 @@ func (app *SageApp) currentAppVersion() uint64 {
 }
 
 // maxSupportedAppVersion is the highest app version this binary has a compiled
-// fork gate for (currently app-v19). It is the readiness ceiling for upgrade
+// fork gate for (currently app-v20). It is the readiness ceiling for upgrade
 // auto-voting: a validator must never vote to activate an upgrade it cannot
 // execute — doing so would commit consensus version.app=N while the binary
 // still runs at N-1, halting the chain on the next CometBFT handshake (the
 // maxSupportedAppVersion footgun). Bump this in lockstep with every new
 // appV<N>UpgradeName fork gate added above.
-const maxSupportedAppVersion uint64 = 19
+const maxSupportedAppVersion uint64 = 20
 
 // MaxSupportedAppVersion returns the highest app version this binary has a
 // compiled fork gate for. Operator tooling (cmd/sage-gui `upgrade propose`)
@@ -2510,6 +2559,9 @@ func (app *SageApp) FinalizeBlock(_ context.Context, req *abcitypes.RequestFinal
 		if plan.Name == appV19UpgradeName {
 			app.appV19AppliedHeight = req.Height
 		}
+		if plan.Name == appV20UpgradeName {
+			app.appV20AppliedHeight = req.Height
+		}
 		if plan.Name == appV12UpgradeName {
 			app.appV12AppliedHeight = req.Height
 		}
@@ -2685,6 +2737,15 @@ func (app *SageApp) processTx(parsedTx *tx.ParsedTx, height int64, blockTime tim
 				return &abcitypes.ExecTxResult{Code: 4, Log: fmt.Sprintf("nonce lookup error: %v", nerr)}
 			}
 			if parsedTx.Nonce <= currentNonce && currentNonce > 0 {
+				// FinalizeBlock writes Badger before Commit flushes the SQL projection
+				// and persists state.Height. After a crash in that gap, CometBFT
+				// replays the exact block against those already-written effects. app-v20
+				// scoped records carry enough height-bound canonical evidence to
+				// recognize that one case and reconstruct only the lost projection
+				// writes. Every other consumed nonce remains a hard rejection.
+				if replayResult, exact := app.replayScopedFinalizeTx(parsedTx, height, blockTime); exact {
+					return replayResult
+				}
 				metrics.TxRejectedTotal.WithLabelValues("replay_nonce_consensus").Inc()
 				return &abcitypes.ExecTxResult{Code: 4, Log: fmt.Sprintf("nonce too low: got %d, expected > %d (rejected in consensus path)", parsedTx.Nonce, currentNonce)}
 			}
@@ -3016,13 +3077,8 @@ func (app *SageApp) processMemorySubmit(parsedTx *tx.ParsedTx, height int64, blo
 		}
 	}
 
-	// Generate memory ID if not provided
-	memoryID := submit.MemoryID
-	if memoryID == "" {
-		// Deterministic ID from content hash + height + agent (NO uuid.New()!)
-		h := sha256.Sum256([]byte(fmt.Sprintf("%x:%d:%s", submit.ContentHash, height, agentID)))
-		memoryID = hex.EncodeToString(h[:16])
-	}
+	// Generate memory ID if not provided.
+	memoryID := memoryIDForSubmit(submit, height, agentID)
 
 	// #3 (reverse): a normal memory must not clobber an existing co-commit that owns
 	// this id. The processCoCommitSubmit reclaim covers a normal squat being taken
@@ -3089,8 +3145,22 @@ func (app *SageApp) processMemorySubmit(parsedTx *tx.ParsedTx, height int64, blo
 		}
 	}
 
-	if setErr := app.badgerStore.SetMemoryHash(memoryID, contentHash, string(memory.StatusProposed)); setErr != nil {
-		return &abcitypes.ExecTxResult{Code: 12, Log: fmt.Sprintf("badger write error: %v", setErr)}
+	// app-v20: an active exact-domain scope pins its roster and canonical
+	// recoverable envelope in the same Badger transaction as the ordinary memory
+	// record. Unscoped domains retain the byte-identical historical path.
+	scopedSubmission := false
+	if app.postAppV20Fork(height) {
+		var scopeErr error
+		scopedSubmission, scopeErr = app.setScopedMemorySubmission(submit, memoryID, agentID, contentHash, height, blockTime)
+		if scopeErr != nil {
+			return &abcitypes.ExecTxResult{Code: 19, Log: "scoped memory submit rejected: " + scopeErr.Error()}
+		}
+	}
+
+	if !scopedSubmission {
+		if setErr := app.badgerStore.SetMemoryHash(memoryID, contentHash, string(memory.StatusProposed)); setErr != nil {
+			return &abcitypes.ExecTxResult{Code: 12, Log: fmt.Sprintf("badger write error: %v", setErr)}
+		}
 	}
 
 	// v8.4 records the memory's domain on-chain so checkAndApplyQuorum can read it
@@ -3099,7 +3169,7 @@ func (app *SageApp) processMemorySubmit(parsedTx *tx.ParsedTx, height int64, blo
 	// independently of v8.4. Both gates are strict >, keeping historical blocks and
 	// each activation block byte-identical. Shared domains are recorded too — the
 	// quorum decides per-vote whether to use domain-conditional weight or the scalar.
-	if submit.DomainTag != "" && app.shouldRecordMemoryDomain(height) {
+	if !scopedSubmission && submit.DomainTag != "" && app.shouldRecordMemoryDomain(height) {
 		if domErr := app.badgerStore.SetMemoryDomain(memoryID, submit.DomainTag); domErr != nil {
 			app.logger.Error().Err(domErr).Str("memory_id", memoryID).Msg("set memory domain")
 		}
@@ -3115,7 +3185,7 @@ func (app *SageApp) processMemorySubmit(parsedTx *tx.ParsedTx, height int64, blo
 	// First post-fork writer wins. Post-fork only; the strict-> gate keeps pre-fork
 	// blocks + the activation block byte-identical (no memauthor: key enters the
 	// AppHash keyspace until H_act+1).
-	if app.postAppV10Rules(height) {
+	if !scopedSubmission && app.postAppV10Rules(height) {
 		if existing, gErr := app.badgerStore.GetMemoryAuthor(memoryID); gErr == nil && existing == "" {
 			if authErr := app.badgerStore.SetMemoryAuthor(memoryID, agentID); authErr != nil {
 				app.logger.Error().Err(authErr).Str("memory_id", memoryID).Msg("app-v10 set memory author")
@@ -3177,8 +3247,10 @@ func (app *SageApp) processMemorySubmit(parsedTx *tx.ParsedTx, height int64, blo
 	// compat for old txs that omit the classification byte still defaults
 	// to INTERNAL in tx/codec.go decodeMemorySubmit.
 	classification := uint8(submit.Classification)
-	if classErr := app.badgerStore.SetMemoryClassification(memoryID, classification); classErr != nil {
-		app.logger.Error().Err(classErr).Str("memory_id", memoryID).Msg("failed to set memory classification")
+	if !scopedSubmission {
+		if classErr := app.badgerStore.SetMemoryClassification(memoryID, classification); classErr != nil {
+			app.logger.Error().Err(classErr).Str("memory_id", memoryID).Msg("failed to set memory classification")
+		}
 	}
 
 	app.pendingWrites = append(app.pendingWrites, pendingWrite{
@@ -3196,6 +3268,18 @@ func (app *SageApp) processMemorySubmit(parsedTx *tx.ParsedTx, height int64, blo
 		Data: []byte(memoryID),
 		Log:  fmt.Sprintf("memory %s submitted", memoryID),
 	}
+}
+
+// memoryIDForSubmit is shared by normal execution and the app-v20 exact-block
+// crash-replay recognizer. Keep this byte-for-byte equivalent to the historical
+// derivation: it intentionally hashes the submitted ContentHash field before
+// processMemorySubmit's empty-hash fallback.
+func memoryIDForSubmit(submit *tx.MemorySubmit, height int64, agentID string) string {
+	if submit.MemoryID != "" {
+		return submit.MemoryID
+	}
+	h := sha256.Sum256([]byte(fmt.Sprintf("%x:%d:%s", submit.ContentHash, height, agentID)))
+	return hex.EncodeToString(h[:16])
 }
 
 // maxCoCommitCoauthors caps the coauthor count on a single co-commit envelope.
@@ -3418,6 +3502,15 @@ func (app *SageApp) processCoCommitSubmit(parsedTx *tx.ParsedTx, height int64, b
 				}
 			}
 		}
+	}
+
+	// app-v20: co-commit has its own immediate-commit authority model and cannot
+	// safely inherit a scope ballot without a new jointly-signed envelope schema.
+	// Refuse it for an active/paused scoped domain so it cannot bypass the pinned
+	// scoped quorum path. Retired scopes release their mapping and resume the
+	// ordinary unscoped lifecycle by design.
+	if err := app.rejectScopedCoCommit(env.Domain, height); err != nil {
+		return &abcitypes.ExecTxResult{Code: 97, Log: "co-commit: " + err.Error()}
 	}
 
 	// #3 namespace-collision defense + resubmit guard. SharedID is content-derived,
@@ -3778,6 +3871,21 @@ func (app *SageApp) processMemoryVote(parsedTx *tx.ParsedTx, height int64, block
 		return &abcitypes.ExecTxResult{Code: 13, Log: fmt.Sprintf("vote rejected: %s is not in the validator set", validatorID[:16])}
 	}
 
+	// app-v20: if this memory has a pinned scope ballot, only a member of that
+	// exact historical ballot may vote. Roster updates are prospective and a
+	// live-scope lookup must never rewrite an in-flight denominator.
+	var scopedBallot *scope.Ballot
+	if app.postAppV20Fork(height) {
+		var ballotErr error
+		scopedBallot, ballotErr = app.badgerStore.GetScopeBallot(vote.MemoryID)
+		if ballotErr != nil {
+			return &abcitypes.ExecTxResult{Code: 13, Log: "vote rejected: scope ballot lookup failed: " + ballotErr.Error()}
+		}
+		if scopedBallot != nil && !scopeBallotHasMember(*scopedBallot, validatorID) {
+			return &abcitypes.ExecTxResult{Code: 13, Log: fmt.Sprintf("vote rejected: %s is not a pinned member of scope ballot %s", validatorID[:16], scopedBallot.ScopeID)}
+		}
+	}
+
 	app.logger.Info().
 		Str("memory_id", vote.MemoryID).
 		Str("validator_id", validatorID[:16]).
@@ -3785,16 +3893,27 @@ func (app *SageApp) processMemoryVote(parsedTx *tx.ParsedTx, height int64, block
 		Msg("processing vote")
 
 	// Store vote on-chain
-	voteKey := fmt.Sprintf("vote:%s:%s", vote.MemoryID, validatorID)
-	if err := app.badgerStore.SetState(voteKey, []byte(decision)); err != nil {
-		return &abcitypes.ExecTxResult{Code: 14, Log: fmt.Sprintf("badger write error: %v", err)}
+	newVote := true
+	if scopedBallot != nil {
+		var voteErr error
+		newVote, voteErr = app.badgerStore.SetScopedVote(vote.MemoryID, validatorID, decision, height)
+		if voteErr != nil {
+			return &abcitypes.ExecTxResult{Code: 14, Log: fmt.Sprintf("scoped vote rejected: %v", voteErr)}
+		}
+	} else {
+		voteKey := fmt.Sprintf("vote:%s:%s", vote.MemoryID, validatorID)
+		if err := app.badgerStore.SetState(voteKey, []byte(decision)); err != nil {
+			return &abcitypes.ExecTxResult{Code: 14, Log: fmt.Sprintf("badger write error: %v", err)}
+		}
 	}
 
 	// Increment on-chain validator vote stats for PoE scoring
-	accepted := decision == "accept"
-	uHeight := uint64(height) // #nosec G115 -- height is always non-negative
-	if err := app.badgerStore.IncrementVoteStats(validatorID, accepted, uHeight, app.postV8_3Fork(height)); err != nil {
-		app.logger.Error().Err(err).Str("validator", validatorID).Msg("failed to increment vote stats")
+	if newVote {
+		accepted := decision == "accept"
+		uHeight := uint64(height) // #nosec G115 -- height is always non-negative
+		if err := app.badgerStore.IncrementVoteStats(validatorID, accepted, uHeight, app.postV8_3Fork(height)); err != nil {
+			app.logger.Error().Err(err).Str("validator", validatorID).Msg("failed to increment vote stats")
+		}
 	}
 
 	// Buffer PostgreSQL vote write
@@ -3817,6 +3936,20 @@ func (app *SageApp) processMemoryVote(parsedTx *tx.ParsedTx, height int64, block
 }
 
 func (app *SageApp) checkAndApplyQuorum(memoryID string, height int64, blockTime time.Time) {
+	// app-v20 scope ballots use their pinned integer denominator. The unscoped
+	// path below remains untouched and continues to use current PoE weighting.
+	if app.postAppV20Fork(height) {
+		ballot, err := app.badgerStore.GetScopeBallot(memoryID)
+		if err != nil {
+			app.logger.Error().Err(err).Str("memory_id", memoryID).Msg("scope ballot lookup failed during quorum")
+			return
+		}
+		if ballot != nil {
+			app.checkAndApplyScopedQuorum(*ballot, height, blockTime)
+			return
+		}
+	}
+
 	// Get all validators sorted
 	validators := app.validators.GetAll()
 	votes := make(map[string]bool)
@@ -4132,9 +4265,16 @@ func (app *SageApp) processMemoryChallenge(parsedTx *tx.ParsedTx, height int64, 
 			if rec.ChallengerID == challengerID {
 				return &abcitypes.ExecTxResult{Code: 93, Log: fmt.Sprintf("challenge: agent %s already opened this challenge; a DISTINCT modify-verb holder must confirm", challengerID[:16])}
 			}
-			// Confirm → deprecated (terminal): nil the hash (matches the legacy
-			// deprecate shape) and clear the open-challenge record.
-			if err := app.badgerStore.ResolveChallenge(challenge.MemoryID, nil, string(memory.StatusDeprecated)); err != nil {
+			// Confirm → deprecated (terminal). Unscoped memories retain the legacy
+			// nil-hash shape; app-v20 scoped memories preserve their canonical hash
+			// so state-sync projection recovery remains verifiable.
+			var resolvedHash []byte
+			if _, scopedHash, scopedErr := app.scopedLifecycleState(challenge.MemoryID, height); scopedErr != nil {
+				return &abcitypes.ExecTxResult{Code: 16, Log: "challenge: " + scopedErr.Error()}
+			} else if scopedHash != nil {
+				resolvedHash = scopedHash
+			}
+			if err := app.badgerStore.ResolveChallenge(challenge.MemoryID, resolvedHash, string(memory.StatusDeprecated)); err != nil {
 				return &abcitypes.ExecTxResult{Code: 16, Log: err.Error()}
 			}
 			app.pendingWrites = append(app.pendingWrites, pendingWrite{
@@ -4219,7 +4359,20 @@ func (app *SageApp) processMemoryChallenge(parsedTx *tx.ParsedTx, height int64, 
 
 	// A challenge that passes BFT consensus (included in a block) is decisive —
 	// the memory is deprecated immediately. The block inclusion IS the consensus.
-	if err := app.badgerStore.SetMemoryHash(challenge.MemoryID, nil, string(memory.StatusDeprecated)); err != nil {
+	// A pending scoped ballot transitions atomically with the ordinary status;
+	// an already-committed ballot remains the historical acceptance proof while
+	// the later lifecycle status changes and retains the canonical content hash.
+	if scopedBallot, scopedHash, scopedErr := app.scopedLifecycleState(challenge.MemoryID, height); scopedErr != nil {
+		return &abcitypes.ExecTxResult{Code: 16, Log: "challenge: " + scopedErr.Error()}
+	} else if scopedBallot != nil && scopedBallot.State == scope.BallotPending {
+		if err := app.badgerStore.SetScopedMemoryVerdict(challenge.MemoryID, scope.BallotDeprecated); err != nil {
+			return &abcitypes.ExecTxResult{Code: 16, Log: err.Error()}
+		}
+	} else if scopedBallot != nil {
+		if err := app.badgerStore.SetMemoryHash(challenge.MemoryID, scopedHash, string(memory.StatusDeprecated)); err != nil {
+			return &abcitypes.ExecTxResult{Code: 16, Log: err.Error()}
+		}
+	} else if err := app.badgerStore.SetMemoryHash(challenge.MemoryID, nil, string(memory.StatusDeprecated)); err != nil {
 		return &abcitypes.ExecTxResult{Code: 16, Log: err.Error()}
 	}
 
@@ -6407,22 +6560,24 @@ func (app *SageApp) Query(_ context.Context, req *abcitypes.RequestQuery) (*abci
 	}
 }
 
-// ListSnapshots is not used in Phase 1.
+// ListSnapshots deliberately advertises no network snapshots. The existing
+// internal/snapshot bundle contains private local material and is not an ABCI
+// payload; state sync stays disabled until a consensus-only format exists.
 func (app *SageApp) ListSnapshots(_ context.Context, req *abcitypes.RequestListSnapshots) (*abcitypes.ResponseListSnapshots, error) {
 	return &abcitypes.ResponseListSnapshots{}, nil
 }
 
-// OfferSnapshot is not used in Phase 1.
+// OfferSnapshot rejects while network-safe state sync is unimplemented.
 func (app *SageApp) OfferSnapshot(_ context.Context, req *abcitypes.RequestOfferSnapshot) (*abcitypes.ResponseOfferSnapshot, error) {
 	return &abcitypes.ResponseOfferSnapshot{Result: abcitypes.ResponseOfferSnapshot_REJECT}, nil
 }
 
-// LoadSnapshotChunk is not used in Phase 1.
+// LoadSnapshotChunk returns no local rollback-bundle bytes over the network.
 func (app *SageApp) LoadSnapshotChunk(_ context.Context, req *abcitypes.RequestLoadSnapshotChunk) (*abcitypes.ResponseLoadSnapshotChunk, error) {
 	return &abcitypes.ResponseLoadSnapshotChunk{}, nil
 }
 
-// ApplySnapshotChunk is not used in Phase 1.
+// ApplySnapshotChunk aborts while network-safe state sync is unimplemented.
 func (app *SageApp) ApplySnapshotChunk(_ context.Context, req *abcitypes.RequestApplySnapshotChunk) (*abcitypes.ResponseApplySnapshotChunk, error) {
 	return &abcitypes.ResponseApplySnapshotChunk{Result: abcitypes.ResponseApplySnapshotChunk_ABORT}, nil
 }
@@ -6519,6 +6674,17 @@ func (app *SageApp) processGovPropose(parsedTx *tx.ParsedTx, height int64, _ tim
 		}
 	}
 
+	// app-v20: a scope action is the governance decision itself. Its payload is
+	// one canonical, versioned scope-record template; consensus supplies only
+	// the execution heights after quorum. Keep this validation fork-aware so a
+	// historical pre-v20 op==8 remains the same inert unknown operation that an
+	// older binary would record and later fail to apply.
+	if app.postAppV20Fork(height) && op == governance.OpScopeAction {
+		if _, scopeErr := app.prepareScopeProposal(gp.TargetID, gp.TargetPubKey, gp.TargetPower, gp.Payload, proposerID, height, false); scopeErr != nil {
+			return &abcitypes.ExecTxResult{Code: 72, Log: "governance propose: invalid OpScopeAction: " + scopeErr.Error()}
+		}
+	}
+
 	proposalID, propErr := app.govEngine.Propose(
 		proposerID, op, gp.TargetID, gp.TargetPubKey,
 		gp.TargetPower, gp.ExpiryBlocks, gp.Reason, height,
@@ -6544,7 +6710,7 @@ func (app *SageApp) processGovPropose(parsedTx *tx.ParsedTx, height int64, _ tim
 		writeType: "gov_proposal",
 		data: govProposalData{
 			ProposalID:    proposalID,
-			Operation:     opToString(op),
+			Operation:     app.governanceOperationName(op, height),
 			TargetID:      gp.TargetID,
 			TargetPower:   gp.TargetPower,
 			ProposerID:    proposerID,
@@ -7305,6 +7471,14 @@ func (app *SageApp) applyGovernanceProposal(proposal *governance.ProposalState, 
 		return nil, app.applyMemoryDomainRepair(proposal, height)
 	}
 
+	// app-v20: quorum execution directly installs the exact scope record voted
+	// on by validators. Dispatch before validator pubkey derivation because the
+	// TargetID is a scope ID, not an Ed25519 key. Before the fork op==8 retains
+	// the historical unknown-op path for byte-identical replay.
+	if proposal.Operation == governance.OpScopeAction && app.postAppV20Fork(height) {
+		return nil, app.applyScopeProposal(proposal, height)
+	}
+
 	// OpDomainReassign has NO validator-set effect: the transfer is applied by the
 	// separate DomainReassign tx (processDomainReassign), not here. Return cleanly
 	// so it does not fall through to the validator-pubkey derivation below, whose
@@ -7490,9 +7664,21 @@ func opToString(op governance.ProposalOp) string {
 		return "upgrade"
 	case governance.OpMemoryDomainRepair:
 		return "memory_domain_repair"
+	case governance.OpScopeAction:
+		return "scope_action"
 	default:
 		return fmt.Sprintf("unknown_%d", op)
 	}
+}
+
+// governanceOperationName keeps the off-chain projection replay-compatible:
+// before app-v20, op==8 was unknown and must retain its historical label even
+// though the upgraded binary knows the future operation name.
+func (app *SageApp) governanceOperationName(op governance.ProposalOp, height int64) string {
+	if op == governance.OpScopeAction && !app.postAppV20Fork(height) {
+		return fmt.Sprintf("unknown_%d", op)
+	}
+	return opToString(op)
 }
 
 // voteDecisionToGovString converts a tx.VoteDecision to governance vote string.

--- a/internal/abci/appv18_admin_access_test.go
+++ b/internal/abci/appv18_admin_access_test.go
@@ -37,7 +37,7 @@ func TestAppV18ForkGateAndVersionLockstep(t *testing.T) {
 	assert.True(t, app.postAppV17Rules(11), "v18 subsumes lower additive rules")
 	assert.Equal(t, uint64(18), app.currentAppVersion())
 	assert.Equal(t, tx.CanonicalUpgradeName(18), appV18UpgradeName)
-	assert.Equal(t, uint64(19), MaxSupportedAppVersion())
+	assert.Equal(t, uint64(20), MaxSupportedAppVersion())
 	app.state.Height = 10
 	assert.True(t, app.IsAppV17ActiveForNextTx(), "v18 skip-ahead must enable v17 REST/CheckTx construction")
 

--- a/internal/abci/appv20_recovery_integration_test.go
+++ b/internal/abci/appv20_recovery_integration_test.go
@@ -1,0 +1,447 @@
+package abci
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/memory"
+	"github.com/l33tdawg/sage/internal/scope"
+	sagesnapshot "github.com/l33tdawg/sage/internal/snapshot"
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/tx"
+	"github.com/l33tdawg/sage/internal/validator"
+)
+
+func finalizeAndCommitV20Block(t *testing.T, app *SageApp, req *abcitypes.RequestFinalizeBlock) *abcitypes.ResponseFinalizeBlock {
+	t.Helper()
+	resp, err := app.FinalizeBlock(context.Background(), req)
+	require.NoError(t, err)
+	_, err = app.Commit(context.Background(), &abcitypes.RequestCommit{})
+	require.NoError(t, err)
+	return resp
+}
+
+func signedV20Tx(t *testing.T, parsed *tx.ParsedTx, signer agentKey) []byte {
+	t.Helper()
+	require.NoError(t, tx.SignTx(parsed, signer.priv))
+	raw, err := tx.EncodeTx(parsed)
+	require.NoError(t, err)
+	return raw
+}
+
+// TestAppV20OfflineReplicaCatchesUpByOrderedABCIReplay models a validator that
+// misses several committed blocks, then receives those exact blocks in order.
+// This is deliberately an ABCI replay proof, not a claim that CometBFT network
+// state sync is implemented. The latter needs a separate public snapshot format.
+func TestAppV20OfflineReplicaCatchesUpByOrderedABCIReplay(t *testing.T) {
+	validators := []agentKey{
+		deterministicScopedAgent(1),
+		deterministicScopedAgent(33),
+		deterministicScopedAgent(65),
+	}
+	sort.Slice(validators, func(i, j int) bool { return validators[i].id < validators[j].id })
+
+	buildReplica := func() *SageApp {
+		app := setupTestApp(t)
+		app.appV20AppliedHeight = 1
+		for _, key := range validators {
+			require.NoError(t, app.validators.AddValidator(&validator.ValidatorInfo{
+				ID: key.id, PublicKey: key.pub, Power: 10,
+			}))
+		}
+		for _, domain := range []string{"research", "private-notes"} {
+			require.NoError(t, app.badgerStore.RegisterDomain(domain, validators[0].id, "", 1))
+			require.NoError(t, app.badgerStore.SetAccessGrant(domain, validators[0].id, 2, 0, validators[0].id))
+		}
+		installScopeForValidators(t, app, "scope-replay", "research", 1, scope.StateActive, validators)
+		return app
+	}
+
+	leader := buildReplica()
+	offline := buildReplica()
+	type committedBlock struct {
+		req     *abcitypes.RequestFinalizeBlock
+		appHash []byte
+		txCode  uint32
+		txData  []byte
+	}
+	blocks := make([]committedBlock, 0, 5)
+	appendLeaderBlock := func(height int64, raw []byte) *abcitypes.ResponseFinalizeBlock {
+		req := &abcitypes.RequestFinalizeBlock{
+			Height: height,
+			Time:   time.Unix(1_000+height, 0).UTC(),
+			Txs:    [][]byte{raw},
+		}
+		resp := finalizeAndCommitV20Block(t, leader, req)
+		require.Len(t, resp.TxResults, 1)
+		require.Zero(t, resp.TxResults[0].Code, resp.TxResults[0].Log)
+		blocks = append(blocks, committedBlock{
+			req: req, appHash: append([]byte(nil), resp.AppHash...),
+			txCode: resp.TxResults[0].Code, txData: append([]byte(nil), resp.TxResults[0].Data...),
+		})
+		return resp
+	}
+
+	scopedSubmit := makeMemorySubmitTx(t, validators[0], "research", "selected canonical knowledge")
+	scopedSubmit.Nonce = 1
+	scopedResp := appendLeaderBlock(2, signedV20Tx(t, scopedSubmit, validators[0]))
+	scopedMemoryID := string(scopedResp.TxResults[0].Data)
+	require.NotEmpty(t, scopedMemoryID)
+
+	unselectedSubmit := makeMemorySubmitTx(t, validators[0], "private-notes", "local content outside the selected scope")
+	unselectedSubmit.Nonce = 2
+	unselectedResp := appendLeaderBlock(3, signedV20Tx(t, unselectedSubmit, validators[0]))
+	unselectedMemoryID := string(unselectedResp.TxResults[0].Data)
+	require.NotEmpty(t, unselectedMemoryID)
+
+	for i, key := range validators {
+		nonce := uint64(1)
+		if i == 0 {
+			nonce = 3
+		}
+		vote := &tx.ParsedTx{
+			Type:  tx.TxTypeMemoryVote,
+			Nonce: nonce,
+			MemoryVote: &tx.MemoryVote{
+				MemoryID: scopedMemoryID,
+				Decision: tx.VoteDecisionAccept,
+			},
+		}
+		appendLeaderBlock(int64(4+i), signedV20Tx(t, vote, key))
+	}
+
+	// The second validator now catches up solely by replaying the exact ordered
+	// block inputs. Compare every intermediate AppHash, not merely the final one.
+	for _, block := range blocks {
+		resp := finalizeAndCommitV20Block(t, offline, block.req)
+		require.Len(t, resp.TxResults, 1)
+		assert.Equal(t, block.txCode, resp.TxResults[0].Code, "tx result diverged at height %d", block.req.Height)
+		assert.Equal(t, block.txData, resp.TxResults[0].Data, "tx data diverged at height %d", block.req.Height)
+		assert.Equal(t, block.appHash, resp.AppHash, "AppHash diverged at height %d", block.req.Height)
+	}
+
+	leaderBallot, err := leader.badgerStore.GetScopeBallot(scopedMemoryID)
+	require.NoError(t, err)
+	offlineBallot, err := offline.badgerStore.GetScopeBallot(scopedMemoryID)
+	require.NoError(t, err)
+	assert.Equal(t, leaderBallot, offlineBallot)
+	require.NotNil(t, offlineBallot)
+	assert.Equal(t, scope.BallotCommitted, offlineBallot.State)
+
+	leaderContent, err := leader.badgerStore.ListScopedContents()
+	require.NoError(t, err)
+	offlineContent, err := offline.badgerStore.ListScopedContents()
+	require.NoError(t, err)
+	assert.Equal(t, leaderContent, offlineContent)
+	require.Len(t, offlineContent, 1, "only selected domains receive canonical recoverable envelopes")
+	assert.Equal(t, scopedMemoryID, offlineContent[0].MemoryID)
+	notSelected, err := offline.badgerStore.GetScopedContent(unselectedMemoryID)
+	require.NoError(t, err)
+	assert.Nil(t, notSelected, "an unselected domain must not leak into scoped recovery state")
+}
+
+// TestAppV20LocalSnapshotRestoresCanonicalScopeAndRebuildsLostProjection
+// exercises the existing operator rollback bundle end to end. It intentionally
+// deletes the restored SQLite database before boot to prove that AppHash-covered
+// scoped content in Badger is sufficient to reconstruct the local read model.
+func TestAppV20LocalSnapshotRestoresCanonicalScopeAndRebuildsLostProjection(t *testing.T) {
+	root := t.TempDir()
+	sourceData := filepath.Join(root, "source", "data")
+	restoredData := filepath.Join(root, "restored", "data")
+	require.NoError(t, os.MkdirAll(filepath.Join(sourceData, "badger"), 0o700))
+	seedV20SnapshotFilesystem(t, sourceData)
+
+	badgerStore, err := store.NewBadgerStore(filepath.Join(sourceData, "badger"))
+	require.NoError(t, err)
+	require.NoError(t, badgerStore.MarkUpgradeApplied(appV20UpgradeName, 20, 1))
+	sqliteStore, err := store.NewSQLiteStore(context.Background(), filepath.Join(sourceData, "sage.db"))
+	require.NoError(t, err)
+	app, err := NewSageAppWithStores(badgerStore, sqliteStore, zerolog.Nop())
+	require.NoError(t, err)
+	sourceClosed := false
+	t.Cleanup(func() {
+		if !sourceClosed {
+			_ = app.Close()
+		}
+	})
+
+	validators := []agentKey{
+		deterministicScopedAgent(1),
+		deterministicScopedAgent(33),
+		deterministicScopedAgent(65),
+	}
+	sort.Slice(validators, func(i, j int) bool { return validators[i].id < validators[j].id })
+	persistedValidators := make(map[string]int64, len(validators))
+	for _, key := range validators {
+		require.NoError(t, app.validators.AddValidator(&validator.ValidatorInfo{
+			ID: key.id, PublicKey: key.pub, Power: 10,
+		}))
+		persistedValidators[key.id] = 10
+	}
+	require.NoError(t, badgerStore.SaveValidators(persistedValidators))
+	require.NoError(t, badgerStore.RegisterDomain("research", validators[0].id, "", 1))
+	require.NoError(t, badgerStore.SetAccessGrant("research", validators[0].id, 2, 0, validators[0].id))
+	installScopeForValidators(t, app, "scope-snapshot", "research", 1, scope.StateActive, validators)
+
+	submit := makeMemorySubmitTx(t, validators[0], "research", "survives snapshot without its SQL projection")
+	submit.Nonce = 1
+	submitResp := finalizeAndCommitV20Block(t, app, &abcitypes.RequestFinalizeBlock{
+		Height: 2, Time: time.Unix(2_000, 0).UTC(), Txs: [][]byte{signedV20Tx(t, submit, validators[0])},
+	})
+	require.Zero(t, submitResp.TxResults[0].Code, submitResp.TxResults[0].Log)
+	memoryID := string(submitResp.TxResults[0].Data)
+	for i, key := range validators {
+		nonce := uint64(1)
+		if i == 0 {
+			nonce = 2
+		}
+		vote := &tx.ParsedTx{
+			Type:  tx.TxTypeMemoryVote,
+			Nonce: nonce,
+			MemoryVote: &tx.MemoryVote{
+				MemoryID: memoryID,
+				Decision: tx.VoteDecisionAccept,
+			},
+		}
+		resp := finalizeAndCommitV20Block(t, app, &abcitypes.RequestFinalizeBlock{
+			Height: int64(3 + i), Time: time.Unix(int64(2_003+i), 0).UTC(),
+			Txs: [][]byte{signedV20Tx(t, vote, key)},
+		})
+		require.Zero(t, resp.TxResults[0].Code, resp.TxResults[0].Log)
+	}
+
+	appHash, err := badgerStore.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	const snapshotHeight = int64(5)
+	manifest, err := sagesnapshot.Take(context.Background(), sourceData, snapshotHeight, appHash, "app-v20-scoped-recovery", sagesnapshot.Options{
+		BinaryVersion: "v11.9-test",
+		IncludeBinary: false,
+		LiveBadger:    badgerStore.DB(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, appHash, manifest.AppHash)
+	snapshotDir := filepath.Join(sourceData, "snapshots", "5")
+	require.NoError(t, sagesnapshot.Verify(snapshotDir))
+	require.NoError(t, app.Close())
+	sourceClosed = true
+
+	restoredHeight, err := sagesnapshot.Restore(snapshotDir, restoredData)
+	require.NoError(t, err)
+	assert.Equal(t, snapshotHeight, restoredHeight)
+	// Simulate total loss of the local query projection. Canonical recovery
+	// must need only the restored consensus database.
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		removeErr := os.Remove(filepath.Join(restoredData, "sage.db") + suffix)
+		require.True(t, removeErr == nil || os.IsNotExist(removeErr), "remove discarded projection%s: %v", suffix, removeErr)
+	}
+
+	restoredBadger, err := store.NewBadgerStore(filepath.Join(restoredData, "badger"))
+	require.NoError(t, err)
+	restoredSQLite, err := store.NewSQLiteStore(context.Background(), filepath.Join(restoredData, "sage.db"))
+	require.NoError(t, err)
+	restoredApp, err := NewSageAppWithStores(restoredBadger, restoredSQLite, zerolog.Nop())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = restoredApp.Close() })
+
+	restoredHash, err := restoredBadger.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	assert.Equal(t, manifest.AppHash, restoredHash)
+	assert.True(t, restoredApp.IsAppV20ActiveForNextTx(), "the applied app-v20 audit must survive restore")
+	rebuilt, err := restoredApp.RebuildScopedProjection(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, rebuilt)
+	rebuilt, err = restoredApp.RebuildScopedProjection(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, rebuilt, "projection rebuild remains idempotent after snapshot restore")
+
+	projected, err := restoredSQLite.GetMemory(context.Background(), memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, submit.MemorySubmit.Content, projected.Content)
+	assert.Equal(t, submit.MemorySubmit.ContentHash, projected.ContentHash)
+	assert.Equal(t, "research", projected.DomainTag)
+	assert.Equal(t, validators[0].id, projected.SubmittingAgent)
+	assert.Equal(t, memory.StatusCommitted, projected.Status)
+	classification, err := restoredSQLite.GetMemoryClassificationLocal(context.Background(), memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, int(submit.MemorySubmit.Classification), classification)
+
+	restoredContents, err := restoredBadger.ListScopedContents()
+	require.NoError(t, err)
+	require.Len(t, restoredContents, 1)
+	assert.Equal(t, memoryID, restoredContents[0].MemoryID)
+	restoredBallot, err := restoredBadger.GetScopeBallot(memoryID)
+	require.NoError(t, err)
+	require.NotNil(t, restoredBallot)
+	assert.Equal(t, scope.BallotCommitted, restoredBallot.State)
+}
+
+// TestAppV20ScopedCrashBetweenFinalizeAndCommitReplaysProjection proves the
+// crash window called out by Commit's durability contract. Badger already
+// contains the scoped consensus effects and consumed nonce, while persisted
+// state.Height and SQLite remain behind. The exact block replay must recover;
+// the same signed transaction at any later height must remain rejected.
+func TestAppV20ScopedCrashBetweenFinalizeAndCommitReplaysProjection(t *testing.T) {
+	root := t.TempDir()
+	badgerPath := filepath.Join(root, "badger")
+	sqlitePath := filepath.Join(root, "sage.db")
+	require.NoError(t, os.MkdirAll(badgerPath, 0o700))
+
+	badgerStore, err := store.NewBadgerStore(badgerPath)
+	require.NoError(t, err)
+	require.NoError(t, badgerStore.MarkUpgradeApplied(appV20UpgradeName, 20, 1))
+	sqliteStore, err := store.NewSQLiteStore(context.Background(), sqlitePath)
+	require.NoError(t, err)
+	app, err := NewSageAppWithStores(badgerStore, sqliteStore, zerolog.Nop())
+	require.NoError(t, err)
+	currentApp := app
+	t.Cleanup(func() {
+		if currentApp != nil {
+			_ = currentApp.Close()
+		}
+	})
+
+	validators := []agentKey{
+		deterministicScopedAgent(1),
+		deterministicScopedAgent(33),
+		deterministicScopedAgent(65),
+	}
+	sort.Slice(validators, func(i, j int) bool { return validators[i].id < validators[j].id })
+	persistedValidators := make(map[string]int64, len(validators))
+	for _, key := range validators {
+		require.NoError(t, app.validators.AddValidator(&validator.ValidatorInfo{
+			ID: key.id, PublicKey: key.pub, Power: 10,
+		}))
+		persistedValidators[key.id] = 10
+	}
+	require.NoError(t, badgerStore.SaveValidators(persistedValidators))
+	require.NoError(t, badgerStore.RegisterDomain("research", validators[0].id, "", 1))
+	require.NoError(t, badgerStore.SetAccessGrant("research", validators[0].id, 2, 0, validators[0].id))
+	installScopeForValidators(t, app, "scope-crash", "research", 1, scope.StateActive, validators)
+
+	submit := makeMemorySubmitTx(t, validators[0], "research", "finalized before projection crash")
+	submit.Nonce = 1
+	rawSubmit := signedV20Tx(t, submit, validators[0])
+	submitBlock := &abcitypes.RequestFinalizeBlock{
+		Height: 2, Time: time.Unix(3_002, 0).UTC(), Txs: [][]byte{rawSubmit},
+	}
+	// Inject a permanent SQL failure only after construction. FinalizeBlock
+	// writes canonical Badger state; Commit must panic before SaveState.
+	app.offchainStore = &busyInjectingStore{OffchainStore: sqliteStore, alwaysFail: true}
+	app.flushMaxRetries = 1
+	firstSubmitResp, err := app.FinalizeBlock(context.Background(), submitBlock)
+	require.NoError(t, err)
+	require.Zero(t, firstSubmitResp.TxResults[0].Code, firstSubmitResp.TxResults[0].Log)
+	memoryID := string(firstSubmitResp.TxResults[0].Data)
+	requireCommitPanicV20(t, app)
+	require.NoError(t, app.Close())
+	currentApp = nil
+
+	openRecoveredApp := func() (*SageApp, *store.SQLiteStore) {
+		t.Helper()
+		bs, openErr := store.NewBadgerStore(badgerPath)
+		require.NoError(t, openErr)
+		projection, openErr := store.NewSQLiteStore(context.Background(), sqlitePath)
+		require.NoError(t, openErr)
+		recovered, openErr := NewSageAppWithStores(bs, projection, zerolog.Nop())
+		require.NoError(t, openErr)
+		return recovered, projection
+	}
+
+	app, sqliteStore = openRecoveredApp()
+	currentApp = app
+	assert.Equal(t, int64(0), app.state.Height, "failed Commit must leave persisted height behind")
+	rebuilt, err := app.RebuildScopedProjection(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, rebuilt)
+	replayedSubmitResp := finalizeAndCommitV20Block(t, app, submitBlock)
+	require.Zero(t, replayedSubmitResp.TxResults[0].Code, replayedSubmitResp.TxResults[0].Log)
+	assert.Equal(t, firstSubmitResp.TxResults[0].Data, replayedSubmitResp.TxResults[0].Data)
+	assert.Equal(t, firstSubmitResp.AppHash, replayedSubmitResp.AppHash)
+	projected, err := sqliteStore.GetMemory(context.Background(), memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, memory.StatusProposed, projected.Status)
+
+	// Two votes commit normally. The quorum-reaching third vote then crashes in
+	// the same FinalizeBlock→Commit gap and must recover from its immutable
+	// decision+height witness without re-crediting validator statistics.
+	for i := 0; i < 2; i++ {
+		nonce := uint64(1)
+		if i == 0 {
+			nonce = 2
+		}
+		vote := &tx.ParsedTx{Type: tx.TxTypeMemoryVote, Nonce: nonce, MemoryVote: &tx.MemoryVote{
+			MemoryID: memoryID, Decision: tx.VoteDecisionAccept,
+		}}
+		resp := finalizeAndCommitV20Block(t, app, &abcitypes.RequestFinalizeBlock{
+			Height: int64(3 + i), Time: time.Unix(int64(3_003+i), 0).UTC(),
+			Txs: [][]byte{signedV20Tx(t, vote, validators[i])},
+		})
+		require.Zero(t, resp.TxResults[0].Code, resp.TxResults[0].Log)
+	}
+	finalVote := &tx.ParsedTx{Type: tx.TxTypeMemoryVote, Nonce: 1, MemoryVote: &tx.MemoryVote{
+		MemoryID: memoryID, Decision: tx.VoteDecisionAccept,
+	}}
+	rawFinalVote := signedV20Tx(t, finalVote, validators[2])
+	finalVoteBlock := &abcitypes.RequestFinalizeBlock{
+		Height: 5, Time: time.Unix(3_005, 0).UTC(), Txs: [][]byte{rawFinalVote},
+	}
+	app.offchainStore = &busyInjectingStore{OffchainStore: sqliteStore, alwaysFail: true}
+	app.flushMaxRetries = 1
+	firstFinalVoteResp, err := app.FinalizeBlock(context.Background(), finalVoteBlock)
+	require.NoError(t, err)
+	require.Zero(t, firstFinalVoteResp.TxResults[0].Code, firstFinalVoteResp.TxResults[0].Log)
+	requireCommitPanicV20(t, app)
+	require.NoError(t, app.Close())
+	currentApp = nil
+
+	app, sqliteStore = openRecoveredApp()
+	currentApp = app
+	assert.Equal(t, int64(4), app.state.Height)
+	rebuilt, err = app.RebuildScopedProjection(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, rebuilt)
+	projected, err = sqliteStore.GetMemory(context.Background(), memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, memory.StatusCommitted, projected.Status)
+	replayedFinalVoteResp := finalizeAndCommitV20Block(t, app, finalVoteBlock)
+	require.Zero(t, replayedFinalVoteResp.TxResults[0].Code, replayedFinalVoteResp.TxResults[0].Log)
+	assert.Equal(t, firstFinalVoteResp.AppHash, replayedFinalVoteResp.AppHash)
+	votes, err := sqliteStore.GetVotes(context.Background(), memoryID)
+	require.NoError(t, err)
+	assert.Len(t, votes, 3)
+	persistedState, err := LoadState(app.badgerStore)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), persistedState.Height)
+
+	lateReplay := app.processTx(finalVote, 6, time.Unix(3_006, 0).UTC())
+	assert.Equal(t, uint32(4), lateReplay.Code, "height-bound recovery must not weaken ordinary nonce replay protection")
+}
+
+func requireCommitPanicV20(t *testing.T, app *SageApp) {
+	t.Helper()
+	defer func() {
+		require.NotNil(t, recover(), "Commit must halt when the projection flush fails")
+	}()
+	_, _ = app.Commit(context.Background(), &abcitypes.RequestCommit{})
+}
+
+func seedV20SnapshotFilesystem(t *testing.T, dataDir string) {
+	t.Helper()
+	cometData := filepath.Join(dataDir, "cometbft", "data", "blockstore.db")
+	require.NoError(t, os.MkdirAll(cometData, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(cometData, "CURRENT"), []byte("MANIFEST-000001\n"), 0o600))
+	configDir := filepath.Join(dataDir, "cometbft", "config")
+	require.NoError(t, os.MkdirAll(configDir, 0o700))
+	for _, name := range []string{"genesis.json", "node_key.json", "priv_validator_key.json"} {
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, name), []byte(`{"fixture":true}`), 0o600))
+	}
+}

--- a/internal/abci/appv20_scope_governance_test.go
+++ b/internal/abci/appv20_scope_governance_test.go
@@ -1,0 +1,268 @@
+package abci
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/governance"
+	"github.com/l33tdawg/sage/internal/scope"
+	"github.com/l33tdawg/sage/internal/tx"
+	"github.com/l33tdawg/sage/internal/validator"
+)
+
+func scopeTemplate(scopeID, controller, domain string, revision uint64, state scope.State, members ...scope.Member) scope.Record {
+	return scope.Record{
+		ScopeID:               scopeID,
+		Revision:              revision,
+		State:                 state,
+		ControllerValidatorID: controller,
+		Domains:               []scope.Domain{{Name: domain}},
+		Members:               members,
+	}
+}
+
+func makeScopeGovProposeTx(t *testing.T, proposer agentKey, record scope.Record, targetID string, nonce uint64) []byte {
+	t.Helper()
+	payload, err := scope.Encode(record)
+	require.NoError(t, err)
+	reason := "govern canonical replication scope"
+	pubKey, sig, bodyHash, ts := signAgentProof(t, proposer, []byte(reason))
+	parsed := &tx.ParsedTx{
+		Type:  tx.TxTypeGovPropose,
+		Nonce: nonce,
+		GovPropose: &tx.GovPropose{
+			Operation: tx.GovOpScopeAction,
+			TargetID:  targetID,
+			Reason:    reason,
+			Payload:   payload,
+		},
+		AgentPubKey:    pubKey,
+		AgentSig:       sig,
+		AgentBodyHash:  bodyHash,
+		AgentTimestamp: ts,
+	}
+	require.NoError(t, tx.SignTx(parsed, proposer.priv))
+	encoded, err := tx.EncodeTx(parsed)
+	require.NoError(t, err)
+	return encoded
+}
+
+func finalizeScopeBlock(t *testing.T, app *SageApp, height int64, blockTime time.Time, rawTx []byte) *abcitypes.ResponseFinalizeBlock {
+	t.Helper()
+	resp, err := app.FinalizeBlock(context.Background(), &abcitypes.RequestFinalizeBlock{
+		Height: height,
+		Time:   blockTime,
+		Txs:    [][]byte{rawTx},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TxResults, 1)
+	return resp
+}
+
+func TestAppV20ScopeGovernanceLifecycle(t *testing.T) {
+	app, admin := setupGovTestApp(t)
+	app.appV20AppliedHeight = 1
+	require.NoError(t, app.badgerStore.RegisterDomain("research", admin.id, "", 1))
+
+	members := []scope.Member{{
+		ValidatorID: admin.id, AssignedWeight: 10, JoinedRevision: 1, Active: true,
+	}}
+	create := scopeTemplate("scope-research", admin.id, "research", 1, scope.StateActive, members...)
+	resp := finalizeScopeBlock(t, app, 2, time.Unix(2, 0), makeScopeGovProposeTx(t, admin, create, create.ScopeID, 1))
+	require.Zero(t, resp.TxResults[0].Code, resp.TxResults[0].Log)
+	assert.Empty(t, resp.ValidatorUpdates, "scope governance never mutates the CometBFT validator set")
+
+	created, err := app.badgerStore.GetScopeRecord(create.ScopeID)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assert.Equal(t, int64(2), created.CreatedHeight)
+	assert.Equal(t, int64(2), created.UpdatedHeight)
+	assert.Equal(t, scope.StateActive, created.State)
+	mapped, err := app.badgerStore.GetScopeForDomain("research")
+	require.NoError(t, err)
+	assert.Equal(t, created, mapped)
+
+	update := create
+	update.Revision = 2
+	update.State = scope.StatePaused
+	resp = finalizeScopeBlock(t, app, 52, time.Unix(52, 0), makeScopeGovProposeTx(t, admin, update, update.ScopeID, 2))
+	require.Zero(t, resp.TxResults[0].Code, resp.TxResults[0].Log)
+	paused, err := app.badgerStore.GetScopeRecord(update.ScopeID)
+	require.NoError(t, err)
+	require.NotNil(t, paused)
+	assert.Equal(t, uint64(2), paused.Revision)
+	assert.Equal(t, scope.StatePaused, paused.State)
+	assert.Equal(t, int64(2), paused.CreatedHeight, "created height is consensus-owned and immutable")
+	assert.Equal(t, int64(52), paused.UpdatedHeight)
+
+	retire := update
+	retire.Revision = 3
+	retire.State = scope.StateRetired
+	resp = finalizeScopeBlock(t, app, 102, time.Unix(102, 0), makeScopeGovProposeTx(t, admin, retire, retire.ScopeID, 3))
+	require.Zero(t, resp.TxResults[0].Code, resp.TxResults[0].Log)
+	retired, err := app.badgerStore.GetScopeRecord(retire.ScopeID)
+	require.NoError(t, err)
+	require.NotNil(t, retired)
+	assert.Equal(t, scope.StateRetired, retired.State)
+	mapped, err = app.badgerStore.GetScopeForDomain("research")
+	require.NoError(t, err)
+	assert.Nil(t, mapped, "retirement atomically releases the exact-domain mapping")
+}
+
+func TestAppV20ScopeProposalRejectsNonCanonicalAuthority(t *testing.T) {
+	member := newAgentKey(t)
+	baseRecord := scopeTemplate("scope-a", member.id, "audit", 1, scope.StateActive, scope.Member{
+		ValidatorID: member.id, AssignedWeight: 5, JoinedRevision: 1, Active: true,
+	})
+
+	tests := []struct {
+		name   string
+		mutate func(app *SageApp, admin agentKey, record *scope.Record, proposal *tx.GovPropose)
+		want   string
+	}{
+		{
+			name: "target mismatch",
+			mutate: func(_ *SageApp, _ agentKey, _ *scope.Record, proposal *tx.GovPropose) {
+				proposal.TargetID = "scope-b"
+			},
+			want: "does not match scope_id",
+		},
+		{
+			name: "proposer chooses heights",
+			mutate: func(_ *SageApp, _ agentKey, record *scope.Record, _ *tx.GovPropose) {
+				record.CreatedHeight = 7
+				record.UpdatedHeight = 7
+			},
+			want: "must be zero",
+		},
+		{
+			name: "unregistered domain",
+			mutate: func(_ *SageApp, _ agentKey, record *scope.Record, _ *tx.GovPropose) {
+				record.Domains[0].Name = "missing"
+			},
+			want: "not registered on-chain",
+		},
+		{
+			name: "non-validator member",
+			mutate: func(_ *SageApp, _ agentKey, record *scope.Record, _ *tx.GovPropose) {
+				record.ControllerValidatorID = member.id
+				record.Members[0].ValidatorID = member.id
+			},
+			want: "not an active on-chain validator",
+		},
+		{
+			name: "nonzero target power",
+			mutate: func(_ *SageApp, _ agentKey, _ *scope.Record, proposal *tx.GovPropose) {
+				proposal.TargetPower = 1
+			},
+			want: "target_power must be zero",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app, admin := setupGovTestApp(t)
+			app.appV20AppliedHeight = 1
+			require.NoError(t, app.badgerStore.RegisterDomain("audit", admin.id, "", 1))
+			record := baseRecord
+			record.ControllerValidatorID = admin.id
+			record.Members = []scope.Member{{
+				ValidatorID: admin.id, AssignedWeight: 5, JoinedRevision: 1, Active: true,
+			}}
+			proposal := &tx.GovPropose{Operation: tx.GovOpScopeAction, TargetID: record.ScopeID}
+			tc.mutate(app, admin, &record, proposal)
+			payload, err := scope.Encode(record)
+			require.NoError(t, err)
+			proposal.Payload = payload
+			result := app.processGovPropose(&tx.ParsedTx{PublicKey: admin.pub, GovPropose: proposal}, 2, time.Unix(2, 0))
+			assert.Equal(t, uint32(72), result.Code)
+			assert.Contains(t, result.Log, tc.want)
+		})
+	}
+}
+
+func TestAppV20ScopeUpdatePinsJoinRevisionAndRejectsCollision(t *testing.T) {
+	app, admin := setupGovTestApp(t)
+	app.appV20AppliedHeight = 1
+	require.NoError(t, app.badgerStore.RegisterDomain("audit", admin.id, "", 1))
+	require.NoError(t, app.badgerStore.RegisterDomain("security", admin.id, "", 1))
+
+	existing := scopeTemplate("scope-a", admin.id, "audit", 1, scope.StateActive, scope.Member{
+		ValidatorID: admin.id, AssignedWeight: 10, JoinedRevision: 1, Active: true,
+	})
+	existing.CreatedHeight = 2
+	existing.UpdatedHeight = 2
+	require.NoError(t, app.badgerStore.SetScopeRecord(existing))
+
+	t.Run("existing member cannot rewrite join revision", func(t *testing.T) {
+		next := existing
+		next.Revision = 2
+		next.CreatedHeight = 0
+		next.UpdatedHeight = 0
+		next.Members[0].JoinedRevision = 2
+		payload, err := scope.Encode(next)
+		require.NoError(t, err)
+		_, err = app.prepareScopeProposal(next.ScopeID, nil, 0, payload, admin.id, 52, false)
+		require.ErrorContains(t, err, "joined_revision is immutable")
+	})
+
+	t.Run("another scope cannot capture an existing mapping", func(t *testing.T) {
+		other := scopeTemplate("scope-b", admin.id, "audit", 1, scope.StateActive, scope.Member{
+			ValidatorID: admin.id, AssignedWeight: 10, JoinedRevision: 1, Active: true,
+		})
+		payload, err := scope.Encode(other)
+		require.NoError(t, err)
+		_, err = app.prepareScopeProposal(other.ScopeID, nil, 0, payload, admin.id, 52, false)
+		require.ErrorContains(t, err, "already bound to scope")
+	})
+}
+
+func TestPreAppV20ScopeOperationRemainsInertUnknownGovernance(t *testing.T) {
+	app, admin := setupGovTestApp(t)
+	require.Zero(t, app.appV20AppliedHeight)
+	require.NoError(t, app.badgerStore.RegisterDomain("research", admin.id, "", 1))
+	record := scopeTemplate("future-scope", admin.id, "research", 1, scope.StateActive, scope.Member{
+		ValidatorID: admin.id, AssignedWeight: 10, JoinedRevision: 1, Active: true,
+	})
+
+	resp := finalizeScopeBlock(t, app, 2, time.Unix(2, 0), makeScopeGovProposeTx(t, admin, record, record.ScopeID, 1))
+	require.Zero(t, resp.TxResults[0].Code, resp.TxResults[0].Log)
+	got, err := app.badgerStore.GetScopeRecord(record.ScopeID)
+	require.NoError(t, err)
+	assert.Nil(t, got, "pre-v20 op==8 follows the historical unknown-op apply path")
+	proposalID := governance.ComputeProposalID(admin.id, 2, governance.OpScopeAction, record.ScopeID)
+	proposal, err := app.govEngine.LoadProposal(proposalID)
+	require.NoError(t, err)
+	assert.Equal(t, governance.StatusExecuted, proposal.Status, "legacy governance still records and votes the unknown op")
+}
+
+func TestAppV20ScopeProposalRequiresValidatorProposer(t *testing.T) {
+	app := setupTestApp(t)
+	app.appV20AppliedHeight = 1
+	admin := newAgentKey(t)
+	registerAgent(t, app, admin, "admin", "admin")
+	require.NoError(t, app.badgerStore.RegisterDomain("audit", admin.id, "", 1))
+	member := newAgentKey(t)
+	require.NoError(t, app.validators.AddValidator(&validator.ValidatorInfo{ID: member.id, PublicKey: member.pub, Power: 10}))
+	record := scopeTemplate("scope-a", member.id, "audit", 1, scope.StateActive, scope.Member{
+		ValidatorID: member.id, AssignedWeight: 10, JoinedRevision: 1, Active: true,
+	})
+	payload, err := scope.Encode(record)
+	require.NoError(t, err)
+	result := app.processGovPropose(&tx.ParsedTx{
+		PublicKey: admin.pub,
+		GovPropose: &tx.GovPropose{
+			Operation: tx.GovOpScopeAction,
+			TargetID:  record.ScopeID,
+			Payload:   payload,
+		},
+	}, 2, time.Unix(2, 0))
+	assert.Equal(t, uint32(72), result.Code)
+	assert.Contains(t, result.Log, "proposer")
+	assert.Contains(t, result.Log, "not an active on-chain validator")
+}

--- a/internal/abci/appv20_scoped_memory_test.go
+++ b/internal/abci/appv20_scoped_memory_test.go
@@ -1,0 +1,342 @@
+package abci
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/memory"
+	"github.com/l33tdawg/sage/internal/scope"
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/tx"
+	"github.com/l33tdawg/sage/internal/validator"
+)
+
+func deterministicScopedAgent(seedByte byte) agentKey {
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = seedByte + byte(i)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	return agentKey{pub: pub, priv: priv, id: hex.EncodeToString(pub)}
+}
+
+func setupScopedMemoryApp(t *testing.T, validatorCount int) (*SageApp, []agentKey, string) {
+	t.Helper()
+	app := setupTestApp(t)
+	app.appV20AppliedHeight = 1
+	validators := make([]agentKey, validatorCount)
+	for i := range validators {
+		validators[i] = newAgentKey(t)
+		require.NoError(t, app.validators.AddValidator(&validator.ValidatorInfo{
+			ID: validators[i].id, PublicKey: validators[i].pub, Power: 10,
+		}))
+	}
+	sort.Slice(validators, func(i, j int) bool { return validators[i].id < validators[j].id })
+	domain := "research"
+	require.NoError(t, app.badgerStore.RegisterDomain(domain, validators[0].id, "", 1))
+	require.NoError(t, app.badgerStore.SetAccessGrant(domain, validators[0].id, 2, 0, validators[0].id))
+	return app, validators, domain
+}
+
+func installScopeForValidators(t *testing.T, app *SageApp, scopeID, domain string, revision uint64, state scope.State, validators []agentKey) scope.Record {
+	t.Helper()
+	members := make([]scope.Member, 0, len(validators))
+	for _, member := range validators {
+		members = append(members, scope.Member{
+			ValidatorID: member.id, AssignedWeight: 1, JoinedRevision: 1, Active: true,
+		})
+	}
+	record := scope.Record{
+		ScopeID: scopeID, Revision: revision, State: state,
+		ControllerValidatorID: validators[0].id,
+		CreatedHeight:         1,
+		UpdatedHeight:         int64(revision),
+		Domains:               []scope.Domain{{Name: domain}},
+		Members:               members,
+	}
+	require.NoError(t, app.badgerStore.SetScopeRecord(record))
+	return record
+}
+
+func scopedVote(t *testing.T, app *SageApp, validatorKey agentKey, memoryID string, decision tx.VoteDecision, height int64) uint32 {
+	t.Helper()
+	result := app.processMemoryVote(&tx.ParsedTx{
+		PublicKey: validatorKey.pub,
+		MemoryVote: &tx.MemoryVote{
+			MemoryID: memoryID,
+			Decision: decision,
+		},
+	}, height, time.Unix(height, 0))
+	return result.Code
+}
+
+func TestAppV20ScopedBallotPinsRosterAcrossScopeUpdate(t *testing.T) {
+	app, validators, domain := setupScopedMemoryApp(t, 5)
+	// The fifth current validator is deliberately outside the four-member scope.
+	record := installScopeForValidators(t, app, "scope-research", domain, 1, scope.StateActive, validators[:4])
+
+	submit := makeMemorySubmitTx(t, validators[0], domain, "pinned canonical memory")
+	result := app.processMemorySubmit(submit, 2, time.Unix(2, 0))
+	require.Zero(t, result.Code, result.Log)
+	memoryID := string(result.Data)
+	ballot, err := app.badgerStore.GetScopeBallot(memoryID)
+	require.NoError(t, err)
+	require.NotNil(t, ballot)
+	assert.Equal(t, record.ScopeID, ballot.ScopeID)
+	assert.Equal(t, uint64(1), ballot.ScopeRevision)
+	assert.Len(t, ballot.Members, 4)
+	assert.Equal(t, uint64(4), ballot.TotalWeight)
+	content, err := app.badgerStore.GetScopedContent(memoryID)
+	require.NoError(t, err)
+	require.NotNil(t, content)
+	assert.Equal(t, submit.MemorySubmit.Content, content.Content)
+
+	assert.Equal(t, uint32(13), scopedVote(t, app, validators[4], memoryID, tx.VoteDecisionAccept, 3), "current-chain outsider is not a scoped ballot member")
+	require.Zero(t, scopedVote(t, app, validators[0], memoryID, tx.VoteDecisionAccept, 4))
+	require.Zero(t, scopedVote(t, app, validators[1], memoryID, tx.VoteDecisionAccept, 5))
+	_, status, err := app.badgerStore.GetMemoryHash(memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, string(memory.StatusProposed), status, "two of four is below strict scoped quorum")
+
+	// Prospective revision removes validators[2:]; the old ballot must remain
+	// four members, and a removed-from-scope (but still on-chain) validator can
+	// finish that historical ballot under its pinned authority.
+	record.Revision = 2
+	record.UpdatedHeight = 6
+	record.Members = record.Members[:2]
+	require.NoError(t, app.badgerStore.SetScopeRecord(record))
+	ballotAfter, err := app.badgerStore.GetScopeBallot(memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, ballot, ballotAfter)
+	require.Zero(t, scopedVote(t, app, validators[3], memoryID, tx.VoteDecisionAccept, 7))
+
+	hash, status, err := app.badgerStore.GetMemoryHash(memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, string(memory.StatusCommitted), status)
+	assert.Equal(t, submit.MemorySubmit.ContentHash, hash, "scoped terminal transition preserves the canonical hash")
+	terminal, err := app.badgerStore.GetScopeBallot(memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, scope.BallotCommitted, terminal.State)
+}
+
+func TestAppV20ScopedQuorumRequiresStrictlyMoreThanTwoThirds(t *testing.T) {
+	app, validators, domain := setupScopedMemoryApp(t, 3)
+	installScopeForValidators(t, app, "scope-strict", domain, 1, scope.StateActive, validators)
+	result := app.processMemorySubmit(makeMemorySubmitTx(t, validators[0], domain, "strict threshold"), 2, time.Unix(2, 0))
+	require.Zero(t, result.Code, result.Log)
+	memoryID := string(result.Data)
+
+	require.Zero(t, scopedVote(t, app, validators[0], memoryID, tx.VoteDecisionAccept, 3))
+	require.Zero(t, scopedVote(t, app, validators[1], memoryID, tx.VoteDecisionAccept, 4))
+	_, status, err := app.badgerStore.GetMemoryHash(memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, string(memory.StatusProposed), status, "exactly 2/3 must not commit")
+	require.Zero(t, scopedVote(t, app, validators[2], memoryID, tx.VoteDecisionReject, 5))
+	_, status, err = app.badgerStore.GetMemoryHash(memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, string(memory.StatusDeprecated), status, "all voted without strict supermajority is terminal")
+}
+
+func TestAppV20ScopedQuorumTopologyBoundaries(t *testing.T) {
+	t.Run("three of four commits", func(t *testing.T) {
+		app, validators, domain := setupScopedMemoryApp(t, 4)
+		installScopeForValidators(t, app, "scope-three-of-four", domain, 1, scope.StateActive, validators)
+		result := app.processMemorySubmit(makeMemorySubmitTx(t, validators[0], domain, "three of four topology"), 2, time.Unix(2, 0))
+		require.Zero(t, result.Code, result.Log)
+		memoryID := string(result.Data)
+
+		for i := 0; i < 3; i++ {
+			require.Zero(t, scopedVote(t, app, validators[i], memoryID, tx.VoteDecisionAccept, int64(3+i)))
+		}
+		_, status, err := app.badgerStore.GetMemoryHash(memoryID)
+		require.NoError(t, err)
+		assert.Equal(t, string(memory.StatusCommitted), status, "3/4 is strictly greater than 2/3")
+	})
+
+	t.Run("two of three remains pending while third is absent", func(t *testing.T) {
+		app, validators, domain := setupScopedMemoryApp(t, 3)
+		installScopeForValidators(t, app, "scope-two-of-three", domain, 1, scope.StateActive, validators)
+		result := app.processMemorySubmit(makeMemorySubmitTx(t, validators[0], domain, "two of three topology"), 2, time.Unix(2, 0))
+		require.Zero(t, result.Code, result.Log)
+		memoryID := string(result.Data)
+
+		for i := 0; i < 2; i++ {
+			require.Zero(t, scopedVote(t, app, validators[i], memoryID, tx.VoteDecisionAccept, int64(3+i)))
+		}
+		_, status, err := app.badgerStore.GetMemoryHash(memoryID)
+		require.NoError(t, err)
+		assert.Equal(t, string(memory.StatusProposed), status, "exactly 2/3 cannot commit and an absent vote is not rejection")
+		ballot, err := app.badgerStore.GetScopeBallot(memoryID)
+		require.NoError(t, err)
+		require.NotNil(t, ballot)
+		assert.Equal(t, scope.BallotPending, ballot.State)
+	})
+}
+
+func TestAppV20ScopedSubmitFailsClosedWithoutPartialState(t *testing.T) {
+	app, validators, domain := setupScopedMemoryApp(t, 1)
+	record := installScopeForValidators(t, app, "scope-guard", domain, 1, scope.StateActive, validators)
+
+	badHash := makeMemorySubmitTx(t, validators[0], domain, "hash mismatch")
+	badHash.MemorySubmit.MemoryID = "bad-hash-memory"
+	wrong := sha256.Sum256([]byte("different"))
+	badHash.MemorySubmit.ContentHash = wrong[:]
+	result := app.processMemorySubmit(badHash, 2, time.Unix(2, 0))
+	assert.Equal(t, uint32(19), result.Code)
+	_, _, err := app.badgerStore.GetMemoryHash("bad-hash-memory")
+	require.Error(t, err)
+	ballot, err := app.badgerStore.GetScopeBallot("bad-hash-memory")
+	require.NoError(t, err)
+	assert.Nil(t, ballot)
+
+	record.Revision = 2
+	record.State = scope.StatePaused
+	record.UpdatedHeight = 3
+	require.NoError(t, app.badgerStore.SetScopeRecord(record))
+	paused := makeMemorySubmitTx(t, validators[0], domain, "paused scope")
+	paused.MemorySubmit.MemoryID = "paused-memory"
+	result = app.processMemorySubmit(paused, 4, time.Unix(4, 0))
+	assert.Equal(t, uint32(19), result.Code)
+	assert.Contains(t, result.Log, "not active")
+	_, _, err = app.badgerStore.GetMemoryHash("paused-memory")
+	require.Error(t, err)
+	require.ErrorContains(t, app.rejectScopedCoCommit(domain, 4), "unsupported for scoped domains")
+}
+
+func TestAppV20ScopedReplicaAppHashDeterminism(t *testing.T) {
+	validators := []agentKey{
+		deterministicScopedAgent(1),
+		deterministicScopedAgent(33),
+		deterministicScopedAgent(65),
+		deterministicScopedAgent(97),
+	}
+	sort.Slice(validators, func(i, j int) bool { return validators[i].id < validators[j].id })
+	buildReplica := func() *SageApp {
+		app := setupTestApp(t)
+		app.appV20AppliedHeight = 1
+		for _, key := range validators {
+			require.NoError(t, app.validators.AddValidator(&validator.ValidatorInfo{ID: key.id, PublicKey: key.pub, Power: 10}))
+		}
+		require.NoError(t, app.badgerStore.RegisterDomain("research", validators[0].id, "", 1))
+		require.NoError(t, app.badgerStore.SetAccessGrant("research", validators[0].id, 2, 0, validators[0].id))
+		installScopeForValidators(t, app, "scope-replica", "research", 1, scope.StateActive, validators)
+		return app
+	}
+	left, right := buildReplica(), buildReplica()
+
+	submit := makeMemorySubmitTx(t, validators[0], "research", "replicated canonical envelope")
+	submit.Nonce = 1
+	require.NoError(t, tx.SignTx(submit, validators[0].priv))
+	rawSubmit, err := tx.EncodeTx(submit)
+	require.NoError(t, err)
+	blockTime := time.Unix(1000, 0)
+	finalizeBoth := func(height int64, raw []byte) (*abcitypes.ResponseFinalizeBlock, *abcitypes.ResponseFinalizeBlock) {
+		leftResp, err := left.FinalizeBlock(context.Background(), &abcitypes.RequestFinalizeBlock{Height: height, Time: blockTime, Txs: [][]byte{raw}})
+		require.NoError(t, err)
+		rightResp, err := right.FinalizeBlock(context.Background(), &abcitypes.RequestFinalizeBlock{Height: height, Time: blockTime, Txs: [][]byte{raw}})
+		require.NoError(t, err)
+		assert.Equal(t, leftResp.AppHash, rightResp.AppHash, "replicas diverged at height %d", height)
+		return leftResp, rightResp
+	}
+	leftResp, rightResp := finalizeBoth(2, rawSubmit)
+	require.Zero(t, leftResp.TxResults[0].Code, leftResp.TxResults[0].Log)
+	require.Zero(t, rightResp.TxResults[0].Code, rightResp.TxResults[0].Log)
+	memoryID := string(leftResp.TxResults[0].Data)
+	assert.Equal(t, memoryID, string(rightResp.TxResults[0].Data))
+
+	for i := 0; i < 3; i++ {
+		nonce := uint64(1)
+		if i == 0 {
+			nonce = 2 // validator[0] authored the submit with nonce 1
+		}
+		vote := &tx.ParsedTx{
+			Type: tx.TxTypeMemoryVote, Nonce: nonce,
+			MemoryVote: &tx.MemoryVote{MemoryID: memoryID, Decision: tx.VoteDecisionAccept},
+		}
+		require.NoError(t, tx.SignTx(vote, validators[i].priv))
+		rawVote, err := tx.EncodeTx(vote)
+		require.NoError(t, err)
+		leftResp, rightResp = finalizeBoth(int64(3+i), rawVote)
+		require.Zero(t, leftResp.TxResults[0].Code, leftResp.TxResults[0].Log)
+		require.Zero(t, rightResp.TxResults[0].Code, rightResp.TxResults[0].Log)
+	}
+	leftBallot, err := left.badgerStore.GetScopeBallot(memoryID)
+	require.NoError(t, err)
+	rightBallot, err := right.badgerStore.GetScopeBallot(memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, leftBallot, rightBallot)
+	assert.Equal(t, scope.BallotCommitted, leftBallot.State)
+	leftContent, err := left.badgerStore.GetScopedContent(memoryID)
+	require.NoError(t, err)
+	rightContent, err := right.badgerStore.GetScopedContent(memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, leftContent, rightContent)
+}
+
+func TestAppV20ScopedProjectionRebuildFromCanonicalBadger(t *testing.T) {
+	app, validators, domain := setupScopedMemoryApp(t, 1)
+	installScopeForValidators(t, app, "scope-recovery", domain, 1, scope.StateActive, validators)
+	submit := makeMemorySubmitTx(t, validators[0], domain, "recoverable after projection loss")
+	result := app.processMemorySubmit(submit, 2, time.Unix(200, 0))
+	require.Zero(t, result.Code, result.Log)
+	memoryID := string(result.Data)
+	require.Zero(t, scopedVote(t, app, validators[0], memoryID, tx.VoteDecisionAccept, 3))
+
+	projection, err := store.NewSQLiteStore(context.Background(), filepath.Join(t.TempDir(), "rebuilt.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = projection.Close() })
+	// Seed a poisoned local row: rebuild must replace canonical fields from
+	// Badger rather than accepting the cache as authority.
+	require.NoError(t, projection.InsertMemory(context.Background(), &memory.MemoryRecord{
+		MemoryID: memoryID, SubmittingAgent: "attacker", Content: "poisoned",
+		ContentHash: []byte("wrong"), MemoryType: memory.TypeFact,
+		DomainTag: "other", ConfidenceScore: 0.1, Status: memory.StatusProposed,
+		CreatedAt: time.Unix(1, 0),
+	}))
+	app.offchainStore = projection
+	rebuilt, err := app.RebuildScopedProjection(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, rebuilt)
+	rebuilt, err = app.RebuildScopedProjection(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, rebuilt, "projection recovery is idempotent")
+
+	projected, err := projection.GetMemory(context.Background(), memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, submit.MemorySubmit.Content, projected.Content)
+	assert.Equal(t, submit.MemorySubmit.ContentHash, projected.ContentHash)
+	assert.Equal(t, validators[0].id, projected.SubmittingAgent)
+	assert.Equal(t, domain, projected.DomainTag)
+	assert.Equal(t, memory.StatusCommitted, projected.Status)
+	assert.Equal(t, time.Unix(200, 0).UTC(), projected.CreatedAt.UTC())
+	classification, err := projection.GetMemoryClassificationLocal(context.Background(), memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, int(submit.MemorySubmit.Classification), classification)
+
+	challenge := app.processMemoryChallenge(makeMemoryChallengeTx(t, validators[0], memoryID, "retire bad knowledge"), 4, time.Unix(400, 0))
+	require.Zero(t, challenge.Code, challenge.Log)
+	hashAfterChallenge, statusAfterChallenge, err := app.badgerStore.GetMemoryHash(memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, submit.MemorySubmit.ContentHash, hashAfterChallenge, "later scoped lifecycle transitions must preserve the recovery hash")
+	assert.Equal(t, string(memory.StatusDeprecated), statusAfterChallenge)
+	acceptedBallot, err := app.badgerStore.GetScopeBallot(memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, scope.BallotCommitted, acceptedBallot.State, "later deprecation does not erase the original acceptance proof")
+	rebuilt, err = app.RebuildScopedProjection(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, rebuilt)
+	projected, err = projection.GetMemory(context.Background(), memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, memory.StatusDeprecated, projected.Status)
+}

--- a/internal/abci/appv20_scoped_memory_test.go
+++ b/internal/abci/appv20_scoped_memory_test.go
@@ -238,8 +238,8 @@ func TestAppV20ScopedReplicaAppHashDeterminism(t *testing.T) {
 	submit := makeMemorySubmitTx(t, validators[0], "research", "replicated canonical envelope")
 	submit.Nonce = 1
 	require.NoError(t, tx.SignTx(submit, validators[0].priv))
-	rawSubmit, err := tx.EncodeTx(submit)
-	require.NoError(t, err)
+	rawSubmit, encodeSubmitErr := tx.EncodeTx(submit)
+	require.NoError(t, encodeSubmitErr)
 	blockTime := time.Unix(1000, 0)
 	finalizeBoth := func(height int64, raw []byte) (*abcitypes.ResponseFinalizeBlock, *abcitypes.ResponseFinalizeBlock) {
 		leftResp, err := left.FinalizeBlock(context.Background(), &abcitypes.RequestFinalizeBlock{Height: height, Time: blockTime, Txs: [][]byte{raw}})

--- a/internal/abci/replay_appv20_test.go
+++ b/internal/abci/replay_appv20_test.go
@@ -1,0 +1,73 @@
+package abci
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/abci/types"
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+// TestAppV20ForkGateAndVersionLockstep covers the dormant v11.9 fork gate,
+// activation boundary, canonical name, and advertised binary ceiling. The
+// higher v20 gate must subsume the additive lower rules but never light up the
+// independent app-v18 administrator override on a direct skip.
+func TestAppV20ForkGateAndVersionLockstep(t *testing.T) {
+	app := setupTestApp(t)
+	assert.False(t, app.postAppV20Fork(100))
+	assert.False(t, app.IsAppV20ActiveForNextTx())
+	assert.Equal(t, uint64(1), app.currentAppVersion())
+	assert.Equal(t, tx.CanonicalUpgradeName(20), appV20UpgradeName)
+	assert.Equal(t, uint64(20), MaxSupportedAppVersion())
+
+	app.appV20AppliedHeight = 100
+	app.state.Height = 100
+	assert.False(t, app.postAppV20Fork(100), "activation block remains pre-fork")
+	assert.True(t, app.postAppV20Fork(101), "v20 starts strictly after activation")
+	assert.True(t, app.IsAppV20ActiveForNextTx(), "operator surfaces may construct the first post-activation scope action")
+	assert.True(t, app.postAppV8Rules(101), "v20 subsumes additive v8 rules")
+	assert.True(t, app.postAppV17Rules(101), "v20 subsumes delegated-proof rules")
+	assert.True(t, app.postAppV19Rules(101), "v20 subsumes the v19 readiness rule")
+	assert.False(t, app.postAppV18Rules(101), "v20 must not enable the independent admin override")
+	assert.Equal(t, uint64(20), app.currentAppVersion())
+}
+
+// TestReplayAppV20BootRefreshAndDormantAppHash protects the two properties that
+// make shipping an unactivated fork safe: the persisted audit record restores
+// the gate on boot, and a chain with no such record still produces identical
+// AppHashes across replicas.
+func TestReplayAppV20BootRefreshAndDormantAppHash(t *testing.T) {
+	bs := setupTestBadger(t)
+	dbPath := filepath.Join(t.TempDir(), "appv20-boot-refresh.db")
+	sqlite, err := store.NewSQLiteStore(context.Background(), dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { sqlite.Close() })
+
+	require.NoError(t, bs.MarkUpgradeApplied(appV20UpgradeName, 20, 4200))
+	app, err := NewSageAppWithStores(bs, sqlite, zerolog.Nop())
+	require.NoError(t, err)
+	assert.Equal(t, int64(4200), app.appV20AppliedHeight)
+	assert.True(t, app.postAppV20Fork(4201))
+
+	blockTime := time.Now().Truncate(time.Second)
+	regTx := encodeSelfSignedRegister(t, deterministicAgentKey(t), "operator")
+	commit := func() []byte {
+		candidate := setupTestApp(t)
+		require.Zero(t, candidate.appV20AppliedHeight)
+		resp, err := candidate.FinalizeBlock(context.Background(), &types.RequestFinalizeBlock{
+			Height: 5, Time: blockTime, Txs: [][]byte{regTx},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.TxResults, 1)
+		require.Zero(t, resp.TxResults[0].Code, resp.TxResults[0].Log)
+		return resp.AppHash
+	}
+	assert.Equal(t, commit(), commit(), "dormant app-v20 must replay byte-identically")
+}

--- a/internal/abci/scope_governance.go
+++ b/internal/abci/scope_governance.go
@@ -1,0 +1,158 @@
+package abci
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/l33tdawg/sage/internal/governance"
+	"github.com/l33tdawg/sage/internal/scope"
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+// prepareScopeProposal validates an app-v20 governance payload entirely from
+// committed consensus state and returns the record with its system-owned block
+// heights materialized. Payload heights must be zero: proposers cannot predict
+// or choose the block in which quorum will execute the decision.
+//
+// allowReplay is used only by proposal application. It permits the exact same
+// already-materialized revision to pass again after deterministic crash replay;
+// proposal creation never accepts a stale revision.
+func (app *SageApp) prepareScopeProposal(targetID string, targetPubKey []byte, targetPower int64, payload []byte, proposerID string, height int64, allowReplay bool) (scope.Record, error) {
+	if len(targetPubKey) != 0 {
+		return scope.Record{}, errors.New("target_pubkey must be empty")
+	}
+	if targetPower != 0 {
+		return scope.Record{}, errors.New("target_power must be zero")
+	}
+	if len(payload) == 0 {
+		return scope.Record{}, errors.New("payload is empty")
+	}
+
+	next, err := scope.Decode(payload)
+	if err != nil {
+		return scope.Record{}, fmt.Errorf("decode canonical scope record: %w", err)
+	}
+	if targetID != next.ScopeID {
+		return scope.Record{}, fmt.Errorf("target_id %q does not match scope_id %q", targetID, next.ScopeID)
+	}
+	if next.CreatedHeight != 0 || next.UpdatedHeight != 0 {
+		return scope.Record{}, errors.New("created_height and updated_height must be zero in a proposal")
+	}
+	if proposerID != "" {
+		if proposer, ok := app.validators.GetValidator(proposerID); !ok || proposer.Power <= 0 {
+			return scope.Record{}, fmt.Errorf("proposer %q is not an active on-chain validator", proposerID)
+		}
+	}
+
+	// Every roster identity is resolved against this chain's current validator
+	// set. Federation identities and off-chain rows are deliberately irrelevant.
+	for _, member := range next.Members {
+		validatorInfo, ok := app.validators.GetValidator(member.ValidatorID)
+		if !ok || validatorInfo.Power <= 0 {
+			return scope.Record{}, fmt.Errorf("scope member %q is not an active on-chain validator", member.ValidatorID)
+		}
+	}
+
+	// Refuse future-domain capture: a scope can select only domains that already
+	// exist in canonical Badger state. It also cannot overlap another live scope.
+	for _, domain := range next.Domains {
+		owner, ownerErr := app.badgerStore.GetDomainOwner(domain.Name)
+		if ownerErr != nil || owner == "" {
+			return scope.Record{}, fmt.Errorf("domain %q is not registered on-chain", domain.Name)
+		}
+		mapped, mapErr := app.badgerStore.GetScopeForDomain(domain.Name)
+		if mapErr != nil {
+			return scope.Record{}, fmt.Errorf("resolve domain %q scope: %w", domain.Name, mapErr)
+		}
+		if mapped != nil && mapped.ScopeID != next.ScopeID {
+			return scope.Record{}, fmt.Errorf("domain %q is already bound to scope %q", domain.Name, mapped.ScopeID)
+		}
+	}
+
+	existing, err := app.badgerStore.GetScopeRecord(next.ScopeID)
+	if err != nil {
+		return scope.Record{}, err
+	}
+	if existing == nil {
+		if next.Revision != 1 {
+			return scope.Record{}, fmt.Errorf("new scope revision must be 1, got %d", next.Revision)
+		}
+		if next.State != scope.StateActive {
+			return scope.Record{}, errors.New("new scope must start active")
+		}
+		next.CreatedHeight = height
+		next.UpdatedHeight = height
+		return next, nil
+	}
+	if existing.State == scope.StateRetired {
+		return scope.Record{}, store.ErrScopeRetired
+	}
+
+	// Applying the exact same accepted revision twice is a no-op. This is not a
+	// public stale-revision escape hatch: only the apply path enables it, and the
+	// fully materialized bytes (including execution height) must match.
+	if allowReplay && next.Revision == existing.Revision {
+		next.CreatedHeight = existing.CreatedHeight
+		next.UpdatedHeight = height
+		nextBytes, nextErr := scope.Encode(next)
+		existingBytes, existingErr := scope.Encode(*existing)
+		if nextErr == nil && existingErr == nil && bytes.Equal(nextBytes, existingBytes) {
+			return next, nil
+		}
+		return scope.Record{}, fmt.Errorf("%w: revision %d is not an exact replay", store.ErrScopeRevision, next.Revision)
+	}
+	if existing.Revision == math.MaxUint64 || next.Revision != existing.Revision+1 {
+		return scope.Record{}, fmt.Errorf("%w: next revision must be %d", store.ErrScopeRevision, existing.Revision+1)
+	}
+	if height < existing.CreatedHeight {
+		return scope.Record{}, errors.New("execution height precedes scope creation")
+	}
+
+	joinedAt := make(map[string]uint64, len(existing.Members))
+	for _, member := range existing.Members {
+		joinedAt[member.ValidatorID] = member.JoinedRevision
+	}
+	for _, member := range next.Members {
+		if prior, ok := joinedAt[member.ValidatorID]; ok {
+			if member.JoinedRevision != prior {
+				return scope.Record{}, fmt.Errorf("member %q joined_revision is immutable", member.ValidatorID)
+			}
+		} else if member.JoinedRevision != next.Revision {
+			return scope.Record{}, fmt.Errorf("new member %q must join at revision %d", member.ValidatorID, next.Revision)
+		}
+	}
+
+	next.CreatedHeight = existing.CreatedHeight
+	next.UpdatedHeight = height
+	return next, nil
+}
+
+// applyScopeProposal installs a quorum-executed app-v20 scope decision. It
+// revalidates the complete payload at execution time before the atomic store
+// writer advances the canonical record and exact-domain mappings.
+func (app *SageApp) applyScopeProposal(proposal *governance.ProposalState, height int64) error {
+	record, err := app.prepareScopeProposal(
+		proposal.TargetID,
+		proposal.TargetPubKey,
+		proposal.TargetPower,
+		proposal.Payload,
+		proposal.ProposerID,
+		height,
+		true,
+	)
+	if err != nil {
+		return fmt.Errorf("scope action: %w", err)
+	}
+	if err := app.badgerStore.SetScopeRecord(record); err != nil {
+		return fmt.Errorf("scope action: persist record: %w", err)
+	}
+	app.logger.Info().
+		Str("proposal_id", proposal.ProposalID).
+		Str("scope_id", record.ScopeID).
+		Uint64("revision", record.Revision).
+		Int64("height", height).
+		Msg("app-v20 scope action applied")
+	return nil
+}

--- a/internal/abci/scoped_memory.go
+++ b/internal/abci/scoped_memory.go
@@ -1,0 +1,337 @@
+package abci
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+
+	"github.com/l33tdawg/sage/internal/auth"
+	"github.com/l33tdawg/sage/internal/memory"
+	"github.com/l33tdawg/sage/internal/scope"
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+// setScopedMemorySubmission writes the app-v20 supplementary state when the
+// submitted exact domain belongs to an active scope. The boolean is false for
+// an ordinary unscoped domain, preserving the historical submit path.
+func (app *SageApp) setScopedMemorySubmission(submit *tx.MemorySubmit, memoryID, agentID string, contentHash []byte, height int64, blockTime time.Time) (bool, error) {
+	record, err := app.badgerStore.GetScopeForDomain(submit.DomainTag)
+	if err != nil {
+		return false, err
+	}
+	if record == nil {
+		return false, nil
+	}
+	if record.State != scope.StateActive {
+		return false, fmt.Errorf("scope %q is not active", record.ScopeID)
+	}
+
+	members := make([]scope.BallotMember, 0, len(record.Members))
+	var total uint64
+	for _, member := range record.Members {
+		if !member.Active {
+			continue
+		}
+		validatorInfo, ok := app.validators.GetValidator(member.ValidatorID)
+		if !ok || validatorInfo.Power <= 0 {
+			return false, fmt.Errorf("active scope member %q is not an active on-chain validator", member.ValidatorID)
+		}
+		if math.MaxUint64-total < member.AssignedWeight {
+			return false, errors.New("active scope weight total overflows uint64")
+		}
+		total += member.AssignedWeight
+		members = append(members, scope.BallotMember{
+			ValidatorID:     member.ValidatorID,
+			EffectiveWeight: member.AssignedWeight,
+		})
+	}
+	if len(members) == 0 || total == 0 {
+		return false, errors.New("scope has no active weighted members")
+	}
+
+	// The canonical mirror must prove the ordinary memory hash. Supplying a raw
+	// ContentHash that does not hash the submitted content is rejected for a
+	// scoped memory rather than making recovery attest an inconsistent envelope.
+	wantHash := sha256.Sum256([]byte(submit.Content))
+	if !bytes.Equal(contentHash, wantHash[:]) {
+		return false, errors.New("content_hash does not match canonical content")
+	}
+
+	ballot := scope.Ballot{
+		MemoryID:        memoryID,
+		ScopeID:         record.ScopeID,
+		ScopeRevision:   record.Revision,
+		SubmittedHeight: height,
+		State:           scope.BallotPending,
+		Members:         members,
+		TotalWeight:     total,
+	}
+	content := scope.Content{
+		MemoryID:          memoryID,
+		ScopeID:           record.ScopeID,
+		ScopeRevision:     record.Revision,
+		SubmittingAgentID: agentID,
+		ContentHash:       append([]byte(nil), contentHash...),
+		MemoryType:        byte(submit.MemoryType),
+		Domain:            submit.DomainTag,
+		ConfidenceScore:   submit.ConfidenceScore,
+		Content:           submit.Content,
+		ParentHash:        submit.ParentHash,
+		Classification:    byte(submit.Classification),
+		TaskStatus:        submit.TaskStatus,
+		SubmittedHeight:   height,
+		SubmittedUnix:     blockTime.Unix(),
+	}
+	if err := app.badgerStore.SetScopedMemorySubmission(ballot, content); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// replayScopedFinalizeTx recognizes only an exact app-v20 scoped transaction
+// whose Badger effects already exist at the same height while persisted
+// state.Height is still behind. That state can arise when FinalizeBlock
+// succeeded but Commit crashed before its SQL flush/SaveState boundary. The
+// canonical envelope or immutable vote-height record is the replay witness.
+//
+// The function performs no consensus write. It reconstructs the projection
+// batch that the failed Commit lost and returns the original successful result.
+// A later block, changed payload/decision, ordinary unscoped transaction, or
+// merely reused nonce cannot satisfy the height-bound evidence.
+func (app *SageApp) replayScopedFinalizeTx(parsedTx *tx.ParsedTx, height int64, blockTime time.Time) (*abcitypes.ExecTxResult, bool) {
+	if app.state == nil || app.state.Height >= height || !app.postAppV20Fork(height) {
+		return nil, false
+	}
+
+	switch parsedTx.Type {
+	case tx.TxTypeMemorySubmit:
+		submit := parsedTx.MemorySubmit
+		if submit == nil {
+			return nil, false
+		}
+		submittingAgent, err := verifyAgentIdentity(parsedTx)
+		if err != nil {
+			return nil, false
+		}
+		memoryID := memoryIDForSubmit(submit, height, submittingAgent)
+		content, err := app.badgerStore.GetScopedContent(memoryID)
+		if err != nil || content == nil {
+			return nil, false
+		}
+		effectiveHash := submit.ContentHash
+		if len(effectiveHash) == 0 {
+			computed := sha256.Sum256([]byte(submit.Content))
+			effectiveHash = computed[:]
+		}
+		if content.MemoryID != memoryID || content.SubmittingAgentID != submittingAgent ||
+			content.SubmittedHeight != height || content.SubmittedUnix != blockTime.Unix() ||
+			content.Domain != submit.DomainTag || content.Content != submit.Content ||
+			content.MemoryType != byte(submit.MemoryType) ||
+			content.Classification != byte(submit.Classification) ||
+			content.TaskStatus != submit.TaskStatus ||
+			math.Float64bits(content.ConfidenceScore) != math.Float64bits(submit.ConfidenceScore) ||
+			!bytes.Equal(content.ContentHash, effectiveHash) ||
+			content.ParentHash != submit.ParentHash {
+			return nil, false
+		}
+		onChainHash, status, err := app.badgerStore.GetMemoryHash(memoryID)
+		if err != nil || !bytes.Equal(onChainHash, content.ContentHash) {
+			return nil, false
+		}
+		ballot, err := app.badgerStore.GetScopeBallot(memoryID)
+		if err != nil || ballot == nil || ballot.SubmittedHeight != height ||
+			ballot.MemoryID != memoryID || ballot.ScopeID != content.ScopeID ||
+			ballot.ScopeRevision != content.ScopeRevision {
+			return nil, false
+		}
+		if err := validateRecoveredScopeStatus(ballot.State, status); err != nil {
+			return nil, false
+		}
+
+		app.pendingWrites = append(app.pendingWrites,
+			pendingWrite{writeType: "memory", data: &memory.MemoryRecord{
+				MemoryID: memoryID, SubmittingAgent: submittingAgent,
+				Content: submit.Content, ContentHash: append([]byte(nil), content.ContentHash...),
+				EmbeddingHash: append([]byte(nil), submit.EmbeddingHash...),
+				MemoryType:    memory.MemoryType(txMemoryTypeToStringValue(content.MemoryType)),
+				DomainTag:     content.Domain, ConfidenceScore: content.ConfidenceScore,
+				Status: memory.MemoryStatus(status), ParentHash: content.ParentHash,
+				TaskStatus: memory.TaskStatus(content.TaskStatus), CreatedAt: blockTime,
+			}},
+			pendingWrite{writeType: "mem_classification", data: &memClassificationData{
+				MemoryID: memoryID, Classification: store.ClearanceLevel(content.Classification),
+			}},
+		)
+		return &abcitypes.ExecTxResult{
+			Code: 0, Data: []byte(memoryID), Log: fmt.Sprintf("memory %s submitted", memoryID),
+		}, true
+
+	case tx.TxTypeMemoryVote:
+		vote := parsedTx.MemoryVote
+		if vote == nil {
+			return nil, false
+		}
+		validatorID := auth.PublicKeyToAgentID(parsedTx.PublicKey)
+		decision := voteDecisionToString(vote.Decision)
+		storedDecision, storedHeight, ok, err := app.badgerStore.GetScopedVote(vote.MemoryID, validatorID)
+		if err != nil || !ok || storedHeight != height || storedDecision != decision {
+			return nil, false
+		}
+		ballot, err := app.badgerStore.GetScopeBallot(vote.MemoryID)
+		if err != nil || ballot == nil || !scopeBallotHasMember(*ballot, validatorID) {
+			return nil, false
+		}
+		app.pendingWrites = append(app.pendingWrites, pendingWrite{writeType: "vote", data: &store.ValidationVote{
+			MemoryID: vote.MemoryID, ValidatorID: validatorID, Decision: decision,
+			Rationale: vote.Rationale, BlockHeight: height, CreatedAt: blockTime,
+		}})
+		if ballot.State == scope.BallotCommitted || ballot.State == scope.BallotDeprecated {
+			status := memory.StatusDeprecated
+			if ballot.State == scope.BallotCommitted {
+				status = memory.StatusCommitted
+			}
+			app.pendingWrites = append(app.pendingWrites, pendingWrite{writeType: "status_update", data: &statusUpdate{
+				MemoryID: vote.MemoryID, Status: status, At: blockTime,
+			}})
+		}
+		return &abcitypes.ExecTxResult{Code: 0, Log: fmt.Sprintf("vote recorded for memory %s", vote.MemoryID)}, true
+	}
+
+	return nil, false
+}
+
+func scopeBallotHasMember(ballot scope.Ballot, validatorID string) bool {
+	for _, member := range ballot.Members {
+		if member.ValidatorID == validatorID {
+			return true
+		}
+	}
+	return false
+}
+
+// scopedLifecycleState returns the verified canonical state needed by later
+// challenge/recovery transitions. A scoped terminal transition must preserve
+// this hash even though the historical unscoped path stores a nil hash.
+func (app *SageApp) scopedLifecycleState(memoryID string, height int64) (*scope.Ballot, []byte, error) {
+	if !app.postAppV20Fork(height) {
+		return nil, nil, nil
+	}
+	ballot, err := app.badgerStore.GetScopeBallot(memoryID)
+	if err != nil || ballot == nil {
+		return ballot, nil, err
+	}
+	content, err := app.badgerStore.GetScopedContent(memoryID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if content == nil || content.MemoryID != ballot.MemoryID || content.ScopeID != ballot.ScopeID || content.ScopeRevision != ballot.ScopeRevision {
+		return nil, nil, errors.New("scope ballot has no matching canonical content")
+	}
+	computed := sha256.Sum256([]byte(content.Content))
+	if !bytes.Equal(computed[:], content.ContentHash) {
+		return nil, nil, errors.New("scoped canonical content hash is invalid")
+	}
+	return ballot, append([]byte(nil), content.ContentHash...), nil
+}
+
+func (app *SageApp) rejectScopedCoCommit(domain string, height int64) error {
+	if !app.postAppV20Fork(height) || domain == "" {
+		return nil
+	}
+	record, err := app.badgerStore.GetScopeForDomain(domain)
+	if err != nil {
+		return err
+	}
+	if record != nil {
+		return fmt.Errorf("domain %q belongs to scope %q; co-commit is unsupported for scoped domains", domain, record.ScopeID)
+	}
+	return nil
+}
+
+// checkAndApplyScopedQuorum evaluates only the pinned ballot snapshot. The v1
+// effective weight is the governance-assigned integer copied verbatim at
+// submission; live PoE and later scope revisions cannot change this decision.
+func (app *SageApp) checkAndApplyScopedQuorum(ballot scope.Ballot, height int64, blockTime time.Time) {
+	if ballot.State != scope.BallotPending {
+		return
+	}
+	votes := make(map[string]string, len(ballot.Members))
+	var acceptWeight uint64
+	for _, member := range ballot.Members {
+		voteData, err := app.badgerStore.GetState(fmt.Sprintf("vote:%s:%s", ballot.MemoryID, member.ValidatorID))
+		if err != nil || voteData == nil {
+			continue
+		}
+		decision := string(voteData)
+		votes[member.ValidatorID] = decision
+		if decision == "accept" {
+			if math.MaxUint64-acceptWeight < member.EffectiveWeight {
+				app.logger.Error().Str("memory_id", ballot.MemoryID).Msg("scoped accept weight overflow")
+				return
+			}
+			acceptWeight += member.EffectiveWeight
+		}
+	}
+
+	reached := scope.HasStrictSupermajority(acceptWeight, ballot.TotalWeight)
+	allVoted := len(votes) == len(ballot.Members)
+	if !reached && !allVoted {
+		return
+	}
+	verdict := scope.BallotDeprecated
+	status := memory.StatusDeprecated
+	finalAccepted := false
+	if reached {
+		verdict = scope.BallotCommitted
+		status = memory.StatusCommitted
+		finalAccepted = true
+	}
+	if err := app.badgerStore.SetScopedMemoryVerdict(ballot.MemoryID, verdict); err != nil {
+		app.logger.Error().Err(err).Str("memory_id", ballot.MemoryID).Msg("scoped verdict write failed")
+		return
+	}
+
+	app.pendingWrites = append(app.pendingWrites, pendingWrite{
+		writeType: "status_update",
+		data: &statusUpdate{
+			MemoryID: ballot.MemoryID,
+			Status:   status,
+			At:       blockTime,
+		},
+	})
+
+	// Feed the same verdict-correctness accumulators used by ordinary quorum,
+	// once, from terminal non-abstain votes. Ballot state prevents repeat credit.
+	matches := make(map[string]bool, len(votes))
+	for validatorID, decision := range votes {
+		if decision == "abstain" {
+			continue
+		}
+		matches[validatorID] = (decision == "accept") == finalAccepted
+	}
+	if len(matches) > 0 {
+		if err := app.badgerStore.UpdateVerdictStats(matches); err != nil {
+			app.logger.Error().Err(err).Str("memory_id", ballot.MemoryID).Msg("scoped verdict stats update")
+		}
+		if content, err := app.badgerStore.GetScopedContent(ballot.MemoryID); err == nil && content != nil {
+			if err := app.badgerStore.UpdateDomainVerdictStats(content.Domain, matches); err != nil {
+				app.logger.Error().Err(err).Str("memory_id", ballot.MemoryID).Str("domain", content.Domain).Msg("scoped domain verdict stats update")
+			}
+		}
+	}
+	app.logger.Info().
+		Str("memory_id", ballot.MemoryID).
+		Str("scope_id", ballot.ScopeID).
+		Uint64("scope_revision", ballot.ScopeRevision).
+		Uint64("accept_weight", acceptWeight).
+		Uint64("total_weight", ballot.TotalWeight).
+		Bool("accepted", finalAccepted).
+		Int64("height", height).
+		Msg("scoped memory reached terminal quorum")
+}

--- a/internal/abci/scoped_recovery.go
+++ b/internal/abci/scoped_recovery.go
@@ -1,0 +1,169 @@
+package abci
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/l33tdawg/sage/internal/memory"
+	"github.com/l33tdawg/sage/internal/scope"
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+// RebuildScopedProjection verifies every AppHash-covered scoped envelope and
+// upserts it into the local SQL projection. It performs no consensus write and
+// is safe to rerun after snapshot/state sync or loss of the projection DB.
+// Callers should keep the affected scope unready if this returns an error.
+func (app *SageApp) RebuildScopedProjection(ctx context.Context) (int, error) {
+	verified, err := app.verifiedScopedContents()
+	if err != nil {
+		return 0, err
+	}
+	rebuilt := 0
+	for _, recovered := range verified {
+		content := recovered.content
+		status := recovered.status
+
+		record := &memory.MemoryRecord{
+			MemoryID:        content.MemoryID,
+			SubmittingAgent: content.SubmittingAgentID,
+			Content:         content.Content,
+			ContentHash:     append([]byte(nil), content.ContentHash...),
+			MemoryType:      memory.MemoryType(txMemoryTypeToStringValue(content.MemoryType)),
+			DomainTag:       content.Domain,
+			ConfidenceScore: content.ConfidenceScore,
+			Status:          memory.MemoryStatus(status),
+			ParentHash:      content.ParentHash,
+			TaskStatus:      memory.TaskStatus(content.TaskStatus),
+			CreatedAt:       time.Unix(content.SubmittedUnix, 0).UTC(),
+		}
+		// Keep the row and its classification projection atomic. A crash or a
+		// transient SQL error must leave either the previous projection or the
+		// complete verified replacement, never canonical content with stale
+		// clearance metadata (or the reverse).
+		if err := app.offchainStore.RunInTx(ctx, func(projection store.OffchainStore) error {
+			if err := projection.InsertMemory(ctx, record); err != nil {
+				return fmt.Errorf("insert projection: %w", err)
+			}
+			if err := projection.UpdateMemoryClassification(ctx, content.MemoryID, store.ClearanceLevel(content.Classification)); err != nil {
+				return fmt.Errorf("classification projection: %w", err)
+			}
+			projected, err := projection.GetMemory(ctx, content.MemoryID)
+			if err != nil || !recoveredProjectionMatches(projected, record) {
+				return errors.New("projection verification failed")
+			}
+			return nil
+		}); err != nil {
+			return rebuilt, fmt.Errorf("scoped recovery %q: %w", content.MemoryID, err)
+		}
+		rebuilt++
+	}
+	return rebuilt, nil
+}
+
+type verifiedScopedContent struct {
+	content scope.Content
+	status  string
+}
+
+// VerifyScopedCanonicalState validates every AppHash-covered scoped envelope,
+// ballot, content hash, and ordinary lifecycle record without consulting or
+// mutating the SQL projection. State-sync preparation runs this before a staged
+// Badger database is eligible for activation.
+func (app *SageApp) VerifyScopedCanonicalState() (int, error) {
+	verified, err := app.verifiedScopedContents()
+	return len(verified), err
+}
+
+func (app *SageApp) verifiedScopedContents() ([]verifiedScopedContent, error) {
+	contents, err := app.badgerStore.ListScopedContents()
+	if err != nil {
+		return nil, err
+	}
+	verified := make([]verifiedScopedContent, 0, len(contents))
+	for _, content := range contents {
+		ballot, err := app.badgerStore.GetScopeBallot(content.MemoryID)
+		if err != nil {
+			return nil, fmt.Errorf("scoped recovery %q: invalid ballot: %w", content.MemoryID, err)
+		}
+		if ballot == nil {
+			return nil, fmt.Errorf("scoped recovery %q: missing ballot", content.MemoryID)
+		}
+		if ballot.MemoryID != content.MemoryID || ballot.ScopeID != content.ScopeID ||
+			ballot.ScopeRevision != content.ScopeRevision || ballot.SubmittedHeight != content.SubmittedHeight {
+			return nil, fmt.Errorf("scoped recovery %q: ballot/content identity mismatch", content.MemoryID)
+		}
+		computed := sha256.Sum256([]byte(content.Content))
+		if !bytes.Equal(computed[:], content.ContentHash) {
+			return nil, fmt.Errorf("scoped recovery %q: canonical content hash mismatch", content.MemoryID)
+		}
+		onChainHash, status, err := app.badgerStore.GetMemoryHash(content.MemoryID)
+		if err != nil || !bytes.Equal(onChainHash, content.ContentHash) {
+			return nil, fmt.Errorf("scoped recovery %q: ordinary memory hash mismatch", content.MemoryID)
+		}
+		if err := validateRecoveredScopeStatus(ballot.State, status); err != nil {
+			return nil, fmt.Errorf("scoped recovery %q: %w", content.MemoryID, err)
+		}
+		verified = append(verified, verifiedScopedContent{content: content, status: status})
+	}
+	return verified, nil
+}
+
+func validateRecoveredScopeStatus(ballotState scope.BallotState, status string) error {
+	switch ballotState {
+	case scope.BallotPending:
+		if status != string(memory.StatusProposed) {
+			return fmt.Errorf("pending ballot has ordinary status %q", status)
+		}
+	case scope.BallotCommitted:
+		// A later challenge/deprecation changes the ordinary lifecycle but does
+		// not erase the original accepted-ballot proof.
+		if status != string(memory.StatusCommitted) && status != string(memory.StatusChallenged) && status != string(memory.StatusDeprecated) {
+			return fmt.Errorf("committed ballot has ordinary status %q", status)
+		}
+	case scope.BallotDeprecated:
+		if status != string(memory.StatusDeprecated) {
+			return fmt.Errorf("deprecated ballot has ordinary status %q", status)
+		}
+	default:
+		return fmt.Errorf("unknown ballot state %d", ballotState)
+	}
+	return nil
+}
+
+func txMemoryTypeToStringValue(value byte) string {
+	switch value {
+	case 1:
+		return "fact"
+	case 2:
+		return "observation"
+	case 3:
+		return "inference"
+	case 4:
+		return "task"
+	default:
+		return ""
+	}
+}
+
+func recoveredProjectionMatches(actual, expected *memory.MemoryRecord) bool {
+	if actual == nil || expected == nil {
+		return false
+	}
+	return actual.MemoryID == expected.MemoryID &&
+		actual.SubmittingAgent == expected.SubmittingAgent &&
+		actual.Content == expected.Content &&
+		bytes.Equal(actual.ContentHash, expected.ContentHash) &&
+		actual.MemoryType == expected.MemoryType &&
+		actual.DomainTag == expected.DomainTag &&
+		math.Float64bits(actual.ConfidenceScore) == math.Float64bits(expected.ConfidenceScore) &&
+		actual.Status == expected.Status &&
+		// TaskStatus is deliberately excluded. It is a local workflow field that
+		// can legitimately advance after submission; InsertMemory preserves an
+		// existing value and restores the submitted value only into a lost row.
+		actual.ParentHash == expected.ParentHash
+}

--- a/internal/abci/scoped_state_sync.go
+++ b/internal/abci/scoped_state_sync.go
@@ -1,0 +1,139 @@
+package abci
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+
+	badger "github.com/dgraph-io/badger/v4"
+
+	"github.com/l33tdawg/sage/internal/statesync"
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+// AppV20StateSyncBackupVerifier returns the exporter callback for a committed
+// app-v20 height. It loads the backup into an isolated database, verifies the
+// persisted height/fork, recomputes the narrow AppHash, and validates every
+// canonical scoped envelope without mutating the live node.
+func AppV20StateSyncBackupVerifier(height uint64) statesync.BackupVerifier {
+	return func(ctx context.Context, backupPath string) ([]byte, error) {
+		parent, err := os.MkdirTemp("", "sage-state-sync-verify-")
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = os.RemoveAll(parent) }()
+		return inspectAppV20StateSyncBackup(ctx, backupPath, filepath.Join(parent, "badger"), height)
+	}
+}
+
+// PrepareAppV20StateSyncBackup loads and fully verifies a received backup into
+// a fresh staging directory. It never touches the live Badger directory and
+// removes targetDir on every failure. Successful atomic activation/rebinding is
+// deliberately a separate release gate.
+func PrepareAppV20StateSyncBackup(ctx context.Context, backupPath, targetDir string, height uint64, expectedAppHash []byte) error {
+	if len(expectedAppHash) != sha256.Size {
+		return errors.New("state sync expected AppHash must be SHA-256 sized")
+	}
+	computed, err := inspectAppV20StateSyncBackup(ctx, backupPath, targetDir, height)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(computed, expectedAppHash) {
+		_ = os.RemoveAll(targetDir)
+		return errors.New("prepared state sync AppHash does not match trusted AppHash")
+	}
+	return nil
+}
+
+func inspectAppV20StateSyncBackup(ctx context.Context, backupPath, targetDir string, height uint64) ([]byte, error) {
+	if backupPath == "" || targetDir == "" || height == 0 || height > math.MaxInt64 {
+		return nil, errors.New("state sync backup path, target, and positive int64 height are required")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	stat, err := os.Lstat(backupPath)
+	if err != nil || !stat.Mode().IsRegular() || stat.Size() <= 0 || uint64(stat.Size()) > statesync.MaxSnapshotBytes { // #nosec G115 -- positive checked first
+		return nil, errors.New("state sync backup is missing, non-regular, empty, or oversized")
+	}
+	if _, err := os.Stat(targetDir); err == nil {
+		return nil, errors.New("state sync target already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(targetDir), 0o700); err != nil {
+		return nil, err
+	}
+	if err := os.Mkdir(targetDir, 0o700); err != nil {
+		return nil, err
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			_ = os.RemoveAll(targetDir)
+		}
+	}()
+
+	db, err := badger.Open(badger.DefaultOptions(targetDir).WithLogger(nil))
+	if err != nil {
+		return nil, fmt.Errorf("open state sync staging badger: %w", err)
+	}
+	backup, err := os.Open(backupPath) //nolint:gosec // caller-selected regular backup file
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	loadErr := db.Load(backup, 16)
+	closeBackupErr := backup.Close()
+	closeDBErr := db.Close()
+	if loadErr != nil {
+		return nil, fmt.Errorf("load state sync Badger backup: %w", loadErr)
+	}
+	if closeBackupErr != nil {
+		return nil, closeBackupErr
+	}
+	if closeDBErr != nil {
+		return nil, closeDBErr
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	readOnly, err := store.OpenBadgerStoreReadOnly(targetDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = readOnly.CloseBadger() }()
+	state, err := LoadState(readOnly)
+	if err != nil {
+		return nil, fmt.Errorf("load staged app state: %w", err)
+	}
+	if state.Height != int64(height) { // #nosec G115 -- bounded above by MaxInt64
+		return nil, fmt.Errorf("staged app height %d does not match snapshot height %d", state.Height, height)
+	}
+	applied, err := readOnly.GetAppliedUpgrade(appV20UpgradeName)
+	if err != nil {
+		return nil, err
+	}
+	if applied == nil || applied.TargetAppVersion != 20 || applied.AppliedHeight <= 0 || int64(height) <= applied.AppliedHeight { // #nosec G115 -- bounded above by MaxInt64
+		return nil, errors.New("state sync backup is not from an active post-app-v20 height")
+	}
+	computed, err := readOnly.ComputeAppHashExcludingBookkeeping()
+	if err != nil {
+		return nil, err
+	}
+	if len(state.AppHash) != sha256.Size || !bytes.Equal(state.AppHash, computed) {
+		return nil, errors.New("staged persisted AppHash does not match staged Badger state")
+	}
+	probe := &SageApp{badgerStore: readOnly}
+	if _, err := probe.VerifyScopedCanonicalState(); err != nil {
+		return nil, fmt.Errorf("verify staged scoped state: %w", err)
+	}
+	keep = true
+	return computed, nil
+}

--- a/internal/abci/scoped_state_sync.go
+++ b/internal/abci/scoped_state_sync.go
@@ -54,23 +54,23 @@ func inspectAppV20StateSyncBackup(ctx context.Context, backupPath, targetDir str
 	if backupPath == "" || targetDir == "" || height == 0 || height > math.MaxInt64 {
 		return nil, errors.New("state sync backup path, target, and positive int64 height are required")
 	}
-	if err := ctx.Err(); err != nil {
-		return nil, err
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, contextErr
 	}
-	stat, err := os.Lstat(backupPath)
-	if err != nil || !stat.Mode().IsRegular() || stat.Size() <= 0 || uint64(stat.Size()) > statesync.MaxSnapshotBytes { // #nosec G115 -- positive checked first
+	stat, statErr := os.Lstat(backupPath)
+	if statErr != nil || !stat.Mode().IsRegular() || stat.Size() <= 0 || uint64(stat.Size()) > statesync.MaxSnapshotBytes { // #nosec G115 -- positive checked first
 		return nil, errors.New("state sync backup is missing, non-regular, empty, or oversized")
 	}
-	if _, err := os.Stat(targetDir); err == nil {
+	if _, targetErr := os.Stat(targetDir); targetErr == nil {
 		return nil, errors.New("state sync target already exists")
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return nil, err
+	} else if !errors.Is(targetErr, os.ErrNotExist) {
+		return nil, targetErr
 	}
-	if err := os.MkdirAll(filepath.Dir(targetDir), 0o700); err != nil {
-		return nil, err
+	if mkdirParentErr := os.MkdirAll(filepath.Dir(targetDir), 0o700); mkdirParentErr != nil {
+		return nil, mkdirParentErr
 	}
-	if err := os.Mkdir(targetDir, 0o700); err != nil {
-		return nil, err
+	if mkdirTargetErr := os.Mkdir(targetDir, 0o700); mkdirTargetErr != nil {
+		return nil, mkdirTargetErr
 	}
 	keep := false
 	defer func() {
@@ -100,8 +100,8 @@ func inspectAppV20StateSyncBackup(ctx context.Context, backupPath, targetDir str
 	if closeDBErr != nil {
 		return nil, closeDBErr
 	}
-	if err := ctx.Err(); err != nil {
-		return nil, err
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, contextErr
 	}
 
 	readOnly, err := store.OpenBadgerStoreReadOnly(targetDir)

--- a/internal/abci/scoped_state_sync_test.go
+++ b/internal/abci/scoped_state_sync_test.go
@@ -1,0 +1,128 @@
+package abci
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/scope"
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/tx"
+	"github.com/l33tdawg/sage/internal/validator"
+)
+
+func TestPrepareAppV20StateSyncBackupValidatesWithoutActivating(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "source-badger")
+	source, err := store.NewBadgerStore(sourcePath)
+	require.NoError(t, err)
+	require.NoError(t, source.MarkUpgradeApplied(appV20UpgradeName, 20, 1))
+	projection, err := store.NewSQLiteStore(context.Background(), filepath.Join(root, "source.db"))
+	require.NoError(t, err)
+	app, err := NewSageAppWithStores(source, projection, zerolog.Nop())
+	require.NoError(t, err)
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			_ = app.Close()
+		}
+	})
+
+	validators := []agentKey{deterministicScopedAgent(1), deterministicScopedAgent(33), deterministicScopedAgent(65)}
+	sort.Slice(validators, func(i, j int) bool { return validators[i].id < validators[j].id })
+	for _, key := range validators {
+		require.NoError(t, app.validators.AddValidator(&validator.ValidatorInfo{ID: key.id, PublicKey: key.pub, Power: 10}))
+	}
+	require.NoError(t, source.RegisterDomain("research", validators[0].id, "", 1))
+	require.NoError(t, source.SetAccessGrant("research", validators[0].id, 2, 0, validators[0].id))
+	installScopeForValidators(t, app, "scope-state-sync", "research", 1, scope.StateActive, validators)
+	submit := makeMemorySubmitTx(t, validators[0], "research", "network-safe staged recovery")
+	result := app.processMemorySubmit(submit, 2, time.Unix(4_002, 0).UTC())
+	require.Zero(t, result.Code, result.Log)
+	memoryID := string(result.Data)
+	for i := range validators {
+		require.Zero(t, scopedVote(t, app, validators[i], memoryID, tx.VoteDecisionAccept, int64(3+i)))
+	}
+
+	app.state.Height = 5
+	appHash, err := source.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	app.state.AppHash = append([]byte(nil), appHash...)
+	require.NoError(t, SaveState(source, app.state))
+	appHash, err = source.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	app.state.AppHash = append([]byte(nil), appHash...)
+	require.NoError(t, SaveState(source, app.state))
+
+	backupPath := filepath.Join(root, "badger.backup")
+	backup, err := os.OpenFile(backupPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = source.DB().Backup(backup, 0)
+	require.NoError(t, err)
+	require.NoError(t, backup.Close())
+	require.NoError(t, app.Close())
+	closed = true
+
+	target := filepath.Join(root, "prepared-badger")
+	require.NoError(t, PrepareAppV20StateSyncBackup(context.Background(), backupPath, target, 5, appHash))
+	prepared, err := store.OpenBadgerStoreReadOnly(target)
+	require.NoError(t, err)
+	preparedContent, err := prepared.GetScopedContent(memoryID)
+	require.NoError(t, err)
+	require.NotNil(t, preparedContent)
+	assert.Equal(t, submit.MemorySubmit.Content, preparedContent.Content)
+	preparedHash, err := prepared.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	assert.Equal(t, appHash, preparedHash)
+	require.NoError(t, prepared.CloseBadger())
+
+	verifierHash, err := AppV20StateSyncBackupVerifier(5)(context.Background(), backupPath)
+	require.NoError(t, err)
+	assert.Equal(t, appHash, verifierHash)
+	wrongHash := bytes.Repeat([]byte{0xff}, len(appHash))
+	wrongTarget := filepath.Join(root, "wrong-target")
+	require.ErrorContains(t, PrepareAppV20StateSyncBackup(context.Background(), backupPath, wrongTarget, 5, wrongHash), "trusted AppHash")
+	_, err = os.Stat(wrongTarget)
+	assert.ErrorIs(t, err, os.ErrNotExist, "failed preparation removes all staged state")
+	require.ErrorContains(t, PrepareAppV20StateSyncBackup(context.Background(), backupPath, filepath.Join(root, "wrong-height"), 6, appHash), "height")
+	require.ErrorContains(t, PrepareAppV20StateSyncBackup(context.Background(), backupPath, target, 5, appHash), "already exists")
+}
+
+func TestPrepareAppV20StateSyncBackupRejectsMalformedCanonicalScope(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "badger")
+	bs, err := store.NewBadgerStore(path)
+	require.NoError(t, err)
+	require.NoError(t, bs.MarkUpgradeApplied(appV20UpgradeName, 20, 1))
+	require.NoError(t, bs.DB().Update(func(txn *badger.Txn) error {
+		return txn.Set([]byte("state:scope-content:malformed"), []byte("not-a-canonical-envelope"))
+	}))
+	state := &AppState{Height: 2}
+	hash, err := bs.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	state.AppHash = hash
+	require.NoError(t, SaveState(bs, state))
+	hash, err = bs.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	state.AppHash = hash
+	require.NoError(t, SaveState(bs, state))
+	backupPath := filepath.Join(root, "badger.backup")
+	backup, err := os.OpenFile(backupPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = bs.DB().Backup(backup, 0)
+	require.NoError(t, err)
+	require.NoError(t, backup.Close())
+	require.NoError(t, bs.CloseBadger())
+
+	err = PrepareAppV20StateSyncBackup(context.Background(), backupPath, filepath.Join(root, "prepared"), 2, hash)
+	require.ErrorContains(t, err, "verify staged scoped state")
+}

--- a/internal/governance/types.go
+++ b/internal/governance/types.go
@@ -50,6 +50,12 @@ const (
 	// The governance engine records/votes it durably; it has no consensus-state
 	// apply effect and is consumed only by the federation controller gate.
 	OpSyncGroupAction ProposalOp = 7
+	// OpScopeAction (app-v20) carries one canonical scope.Record template in
+	// Payload. A 2/3 governance quorum directly materializes its system-owned
+	// heights and installs the record in AppHash-covered Badger state. Creation,
+	// revision, pause/resume, and permanent retirement all use this exact-record
+	// operation; there is no controller-only mutation path.
+	OpScopeAction ProposalOp = 8
 )
 
 // ProposalStatus represents the current state of a governance proposal.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -103,7 +103,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	result := resp.Result.(map[string]any)
 	tools := result["tools"].([]map[string]any)
-	assert.Len(t, tools, 23)
+	assert.Len(t, tools, 25)
 
 	// Collect tool names
 	names := make(map[string]bool)
@@ -120,6 +120,8 @@ func TestHandleToolsList(t *testing.T) {
 	assert.True(t, names["sage_gov_propose"])
 	assert.True(t, names["sage_gov_vote"])
 	assert.True(t, names["sage_gov_status"])
+	assert.True(t, names["sage_scope_list"])
+	assert.True(t, names["sage_scope_get"])
 	assert.True(t, names["sage_corroborate"])
 	assert.True(t, names["sage_link"])
 	assert.True(t, names["sage_rename"])

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -286,17 +286,43 @@ func (s *Server) registerTools() map[string]Tool {
 
 		"sage_gov_propose": {
 			Name:        "sage_gov_propose",
-			Description: "Submit a governance proposal to add, remove, or update a validator. Requires admin role.",
+			Description: "Submit a governance proposal. Validator-set operations use scalar fields; app-v20 scope_action accepts a guided scope object that the node encodes canonically. Requires admin role.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"operation":     map[string]any{"type": "string", "enum": []string{"add_validator", "remove_validator", "update_power", "sync_group_action"}, "description": "Governance operation; sync_group_action attests one exact federation journal digest"},
-					"target_id":     map[string]any{"type": "string", "description": "Hex-encoded agent/validator ID"},
+					"operation":     map[string]any{"type": "string", "enum": []string{"add_validator", "remove_validator", "update_power", "sync_group_action", "scope_action"}, "description": "Governance operation"},
+					"target_id":     map[string]any{"type": "string", "description": "Validator ID for validator ops; optional for scope_action when scope.scope_id is supplied"},
 					"target_pubkey": map[string]any{"type": "string", "description": "Hex-encoded Ed25519 public key (required for add_validator)"},
 					"target_power":  map[string]any{"type": "integer", "description": "Voting power (required for add_validator and update_power)"},
 					"reason":        map[string]any{"type": "string", "description": "Human-readable justification for the proposal"},
+					"payload":       map[string]any{"type": "string", "description": "Optional legacy base64 operation payload; mutually exclusive with scope"},
+					"scope": map[string]any{
+						"type":        "object",
+						"description": "Guided app-v20 scope_action template; the node sorts it canonically and owns the execution heights",
+						"properties": map[string]any{
+							"scope_id":                map[string]any{"type": "string"},
+							"revision":                map[string]any{"type": "integer", "minimum": 1},
+							"state":                   map[string]any{"type": "string", "enum": []string{"active", "paused", "retired"}},
+							"controller_validator_id": map[string]any{"type": "string"},
+							"domains":                 map[string]any{"type": "array", "minItems": 1, "items": map[string]any{"type": "string"}},
+							"members": map[string]any{
+								"type": "array", "minItems": 1,
+								"items": map[string]any{
+									"type": "object",
+									"properties": map[string]any{
+										"validator_id":    map[string]any{"type": "string"},
+										"assigned_weight": map[string]any{"type": "integer", "minimum": 1},
+										"joined_revision": map[string]any{"type": "integer", "minimum": 1, "description": "May be omitted only for revision 1"},
+										"active":          map[string]any{"type": "boolean", "default": true},
+									},
+									"required": []string{"validator_id", "assigned_weight"},
+								},
+							},
+						},
+						"required": []string{"scope_id", "revision", "state", "controller_validator_id", "domains", "members"},
+					},
 				},
-				"required": []string{"operation", "target_id", "reason"},
+				"required": []string{"operation", "reason"},
 			},
 			Handler: s.toolGovPropose,
 		},
@@ -323,6 +349,27 @@ func (s *Server) registerTools() map[string]Tool {
 				},
 			},
 			Handler: s.toolGovStatus,
+		},
+		"sage_scope_list": {
+			Name:        "sage_scope_list",
+			Description: "List canonical app-v20 quorum scopes, their exact domain allowlists, pinned integer weights, lifecycle state, and revision audit anchors. Requires node-operator or admin access.",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+			Handler: s.toolScopeList,
+		},
+		"sage_scope_get": {
+			Name:        "sage_scope_get",
+			Description: "Read one canonical app-v20 quorum scope by exact scope ID. Requires node-operator or admin access.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"scope_id": map[string]any{"type": "string", "description": "Exact canonical scope ID"},
+				},
+				"required": []string{"scope_id"},
+			},
+			Handler: s.toolScopeGet,
 		},
 		"sage_corroborate": {
 			Name:        "sage_corroborate",
@@ -2330,9 +2377,19 @@ func (s *Server) checkPipelineInbox(ctx context.Context) map[string]any {
 func (s *Server) toolGovPropose(ctx context.Context, params map[string]any) (any, error) {
 	operation := stringParam(params, "operation", "")
 	if operation == "" {
-		return nil, fmt.Errorf("operation is required (add_validator, remove_validator, update_power, sync_group_action)")
+		return nil, fmt.Errorf("operation is required (add_validator, remove_validator, update_power, sync_group_action, scope_action)")
 	}
 	targetID := stringParam(params, "target_id", "")
+	scopeTemplate, hasScope := params["scope"]
+	if hasScope {
+		scopeMap, ok := scopeTemplate.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("scope must be an object")
+		}
+		if targetID == "" {
+			targetID = stringParam(scopeMap, "scope_id", "")
+		}
+	}
 	if targetID == "" {
 		return nil, fmt.Errorf("target_id is required")
 	}
@@ -2343,17 +2400,26 @@ func (s *Server) toolGovPropose(ctx context.Context, params map[string]any) (any
 
 	targetPubkey := stringParam(params, "target_pubkey", "")
 	targetPower := intParam(params, "target_power", 0)
+	payload := stringParam(params, "payload", "")
 
 	reqBody := map[string]any{
 		"operation": operation,
-		"target_id": targetID,
 		"reason":    reason,
+	}
+	if targetID != "" {
+		reqBody["target_id"] = targetID
 	}
 	if targetPubkey != "" {
 		reqBody["target_pubkey"] = targetPubkey
 	}
 	if targetPower > 0 {
 		reqBody["target_power"] = targetPower
+	}
+	if payload != "" {
+		reqBody["payload"] = payload
+	}
+	if hasScope {
+		reqBody["scope"] = scopeTemplate
 	}
 
 	body, _ := json.Marshal(reqBody)
@@ -2406,6 +2472,27 @@ func (s *Server) toolGovVote(ctx context.Context, params map[string]any) (any, e
 		"proposal_id": proposalID,
 		"decision":    decision,
 	}, nil
+}
+
+func (s *Server) toolScopeList(ctx context.Context, _ map[string]any) (any, error) {
+	var response map[string]any
+	if err := s.doSignedJSON(ctx, "GET", "/v1/scopes", nil, &response); err != nil {
+		return nil, fmt.Errorf("list canonical scopes: %w", err)
+	}
+	return response, nil
+}
+
+func (s *Server) toolScopeGet(ctx context.Context, params map[string]any) (any, error) {
+	scopeID := stringParam(params, "scope_id", "")
+	if scopeID == "" {
+		return nil, fmt.Errorf("scope_id is required")
+	}
+	var response map[string]any
+	path := "/v1/scopes/" + url.PathEscape(scopeID)
+	if err := s.doSignedJSON(ctx, "GET", path, nil, &response); err != nil {
+		return nil, fmt.Errorf("get canonical scope: %w", err)
+	}
+	return response, nil
 }
 
 // toolCorroborate wraps POST /v1/memory/{memory_id}/corroborate, the one

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -315,6 +315,43 @@ func TestSageCorroborate_MissingID(t *testing.T) {
 	assert.Contains(t, err.Error(), "memory_id is required")
 }
 
+func TestSageGovProposePassesGuidedScopeTemplate(t *testing.T) {
+	var requestBody map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/governance/propose", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&requestBody))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"proposal_id": "proposal-1", "tx_hash": "tx-1", "status": "voting",
+		})
+	}))
+	defer ts.Close()
+
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	s := NewServer(ts.URL, priv)
+	scopeTemplate := map[string]any{
+		"scope_id": "scope-a", "revision": 1, "state": "active",
+		"controller_validator_id": "validator-a",
+		"domains":                 []any{"research"},
+		"members": []any{map[string]any{
+			"validator_id": "validator-a", "assigned_weight": 1,
+		}},
+	}
+	result, err := s.toolGovPropose(context.Background(), map[string]any{
+		"operation": "scope_action", "reason": "form research quorum", "scope": scopeTemplate,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "scope-a", requestBody["target_id"])
+	forwardedScope, ok := requestBody["scope"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "scope-a", forwardedScope["scope_id"])
+	assert.Equal(t, "validator-a", forwardedScope["controller_validator_id"])
+	assert.Equal(t, float64(1), forwardedScope["revision"])
+	assert.NotContains(t, requestBody, "payload")
+	assert.Equal(t, "scope-a", result.(map[string]any)["target_id"])
+}
+
 func TestSageLink(t *testing.T) {
 	var linkBody map[string]string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/metrics/health.go
+++ b/internal/metrics/health.go
@@ -33,12 +33,26 @@ type VoterStatus struct {
 	PendingProposed          int     `json:"pending_proposed"`            // node-local count of status='proposed'
 }
 
+// ScopedProjectionStatus reports whether AppHash-covered v11.9 scoped content
+// has been verified into this node's local serving projection. Consensus can
+// remain healthy while this is false, but the node must not advertise serving
+// readiness until canonical scoped records are queryable locally.
+type ScopedProjectionStatus struct {
+	Checked  bool   `json:"checked"`
+	Required bool   `json:"required"`
+	OK       bool   `json:"ok"`
+	Records  int    `json:"records"`
+	Rebuilt  int    `json:"rebuilt"`
+	Detail   string `json:"detail,omitempty"`
+}
+
 // HealthChecker tracks the health status of dependencies.
 type HealthChecker struct {
 	postgresOK atomic.Bool
 	cometbftOK atomic.Bool
 	embedder   atomic.Value // EmbedderStatus, set by SetEmbedderHealth
 	voter      atomic.Value // VoterStatus, set by SetVoterStatus
+	scoped     atomic.Value // ScopedProjectionStatus, set by recovery wiring
 	Version    string
 }
 
@@ -76,6 +90,21 @@ func (h *HealthChecker) voterStatus() VoterStatus {
 		return v
 	}
 	return VoterStatus{}
+}
+
+// SetScopedProjectionStatus records the latest canonical projection rebuild.
+// Callers set Required only when canonical scoped envelopes actually exist, so
+// pre-v20 nodes and empty app-v20 scopes do not acquire a synthetic dependency.
+func (h *HealthChecker) SetScopedProjectionStatus(s ScopedProjectionStatus) {
+	s.Checked = true
+	h.scoped.Store(s)
+}
+
+func (h *HealthChecker) scopedProjectionStatus() ScopedProjectionStatus {
+	if v, ok := h.scoped.Load().(ScopedProjectionStatus); ok {
+		return v
+	}
+	return ScopedProjectionStatus{}
 }
 
 // SetPostgresHealth updates the PostgreSQL health status.
@@ -118,6 +147,7 @@ func (h *HealthChecker) ReadinessHandler(w http.ResponseWriter, r *http.Request)
 	pgOK := h.postgresOK.Load()
 	cmtOK := h.cometbftOK.Load()
 	emb := h.embedderStatus()
+	scoped := h.scopedProjectionStatus()
 
 	status := "ready"
 	httpStatus := http.StatusOK
@@ -125,6 +155,12 @@ func (h *HealthChecker) ReadinessHandler(w http.ResponseWriter, r *http.Request)
 	switch {
 	case !pgOK || !cmtOK:
 		// Core infrastructure down — genuinely not ready.
+		status = "not_ready"
+		httpStatus = http.StatusServiceUnavailable
+	case scoped.Required && (!scoped.Checked || !scoped.OK):
+		// Canonical scoped content exists but the local serving projection is
+		// absent, locked, or failed verification. Reporting ready here would let
+		// a state-synced replica silently serve an incomplete selected domain.
 		status = "not_ready"
 		httpStatus = http.StatusServiceUnavailable
 	case emb.Checked && emb.Semantic && !emb.OK:
@@ -143,10 +179,11 @@ func (h *HealthChecker) ReadinessHandler(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatus)
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"status":   status,
-		"postgres": pgOK,
-		"cometbft": cmtOK,
-		"embedder": emb,
+		"status":            status,
+		"postgres":          pgOK,
+		"cometbft":          cmtOK,
+		"embedder":          emb,
+		"scoped_projection": scoped,
 		// Informational voter/backlog block — never gates the status above
 		// (a voter-less node is legitimate; peers may vote memories through).
 		"voter": h.voterStatus(),

--- a/internal/metrics/health_test.go
+++ b/internal/metrics/health_test.go
@@ -155,3 +155,36 @@ func TestReadiness_EmbedderUnchecked_Ready(t *testing.T) {
 		t.Errorf("embedder block should report checked=false, got %v", body["embedder"])
 	}
 }
+
+func TestReadiness_ScopedProjectionRequiredFailsClosed(t *testing.T) {
+	h := NewHealthChecker()
+	h.SetPostgresHealth(true)
+	h.SetCometBFTHealth(true)
+
+	// Empty/pre-v20 nodes have no scoped serving dependency.
+	h.SetScopedProjectionStatus(ScopedProjectionStatus{Required: false, OK: true})
+	code, body := readiness(t, h, "")
+	if code != http.StatusOK || body["status"] != "ready" {
+		t.Fatalf("empty scoped projection must stay ready, got %d %v", code, body["status"])
+	}
+
+	// Once canonical envelopes exist, a locked or failed SQL projection is a
+	// hard readiness failure: serving an empty selected domain is not healthy.
+	h.SetScopedProjectionStatus(ScopedProjectionStatus{
+		Required: true, OK: false, Records: 4, Detail: "vault locked",
+	})
+	code, body = readiness(t, h, "")
+	if code != http.StatusServiceUnavailable || body["status"] != "not_ready" {
+		t.Fatalf("missing scoped projection must be 503, got %d %v", code, body["status"])
+	}
+	scoped, _ := body["scoped_projection"].(map[string]any)
+	if scoped == nil || scoped["checked"] != true || scoped["required"] != true || scoped["records"] != float64(4) {
+		t.Fatalf("scoped projection status missing or wrong: %v", body["scoped_projection"])
+	}
+
+	h.SetScopedProjectionStatus(ScopedProjectionStatus{Required: true, OK: true, Records: 4, Rebuilt: 4})
+	code, body = readiness(t, h, "")
+	if code != http.StatusOK || body["status"] != "ready" {
+		t.Fatalf("verified scoped projection must recover readiness, got %d %v", code, body["status"])
+	}
+}

--- a/internal/scope/ballot.go
+++ b/internal/scope/ballot.go
@@ -1,0 +1,161 @@
+package scope
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/bits"
+)
+
+// BallotState is the immutable-roster proposal lifecycle. The normal memory
+// status remains the public lifecycle source; this state lets recovery verify
+// that the pinned scope record reached the same terminal verdict.
+type BallotState byte
+
+const (
+	BallotPending BallotState = iota + 1
+	BallotCommitted
+	BallotDeprecated
+)
+
+// BallotMember is one active member copied from the accepted scope revision.
+// EffectiveWeight is the final integer weight for this ballot and never changes.
+type BallotMember struct {
+	ValidatorID     string
+	EffectiveWeight uint64
+}
+
+// Ballot is the pinned denominator for one scoped memory proposal.
+type Ballot struct {
+	MemoryID        string
+	ScopeID         string
+	ScopeRevision   uint64
+	SubmittedHeight int64
+	State           BallotState
+	Members         []BallotMember
+	TotalWeight     uint64
+}
+
+func EncodeBallot(ballot Ballot) ([]byte, error) {
+	if err := ValidateBallot(ballot); err != nil {
+		return nil, err
+	}
+	buf := []byte{SchemaV1}
+	buf = appendString(buf, ballot.MemoryID)
+	buf = appendString(buf, ballot.ScopeID)
+	buf = appendUint64(buf, ballot.ScopeRevision)
+	buf = appendInt64(buf, ballot.SubmittedHeight)
+	buf = append(buf, byte(ballot.State))
+	buf = appendUint32(buf, uint32(len(ballot.Members)))
+	for _, member := range ballot.Members {
+		buf = appendString(buf, member.ValidatorID)
+		buf = appendUint64(buf, member.EffectiveWeight)
+	}
+	buf = appendUint64(buf, ballot.TotalWeight)
+	return buf, nil
+}
+
+func DecodeBallot(data []byte) (Ballot, error) {
+	if len(data) == 0 || data[0] != SchemaV1 {
+		return Ballot{}, errors.New("unsupported or empty scope ballot schema")
+	}
+	off := 1
+	var ballot Ballot
+	var err error
+	if ballot.MemoryID, off, err = readString(data, off, maxIDBytes); err != nil {
+		return Ballot{}, fmt.Errorf("memory id: %w", err)
+	}
+	if ballot.ScopeID, off, err = readString(data, off, maxIDBytes); err != nil {
+		return Ballot{}, fmt.Errorf("scope id: %w", err)
+	}
+	if ballot.ScopeRevision, off, err = readUint64(data, off); err != nil {
+		return Ballot{}, fmt.Errorf("scope revision: %w", err)
+	}
+	if ballot.SubmittedHeight, off, err = readInt64(data, off); err != nil {
+		return Ballot{}, fmt.Errorf("submitted height: %w", err)
+	}
+	if off >= len(data) {
+		return Ballot{}, errors.New("ballot state: truncated")
+	}
+	ballot.State = BallotState(data[off])
+	off++
+	count, next, err := readUint32(data, off)
+	if err != nil {
+		return Ballot{}, fmt.Errorf("member count: %w", err)
+	}
+	off = next
+	if count == 0 || count > maxMembers {
+		return Ballot{}, fmt.Errorf("member count must be 1..%d", maxMembers)
+	}
+	ballot.Members = make([]BallotMember, 0, int(count))
+	for i := uint32(0); i < count; i++ {
+		var member BallotMember
+		if member.ValidatorID, off, err = readString(data, off, maxIDBytes); err != nil {
+			return Ballot{}, fmt.Errorf("member %d id: %w", i, err)
+		}
+		if member.EffectiveWeight, off, err = readUint64(data, off); err != nil {
+			return Ballot{}, fmt.Errorf("member %d weight: %w", i, err)
+		}
+		ballot.Members = append(ballot.Members, member)
+	}
+	if ballot.TotalWeight, off, err = readUint64(data, off); err != nil {
+		return Ballot{}, fmt.Errorf("total weight: %w", err)
+	}
+	if off != len(data) {
+		return Ballot{}, errors.New("scope ballot has trailing bytes")
+	}
+	if err := ValidateBallot(ballot); err != nil {
+		return Ballot{}, err
+	}
+	return ballot, nil
+}
+
+func ValidateBallot(ballot Ballot) error {
+	if err := validateID("memory id", ballot.MemoryID); err != nil {
+		return err
+	}
+	if err := validateID("scope id", ballot.ScopeID); err != nil {
+		return err
+	}
+	if ballot.ScopeRevision == 0 || ballot.SubmittedHeight <= 0 {
+		return errors.New("scope revision and submitted height must be positive")
+	}
+	if ballot.State != BallotPending && ballot.State != BallotCommitted && ballot.State != BallotDeprecated {
+		return fmt.Errorf("invalid ballot state %d", ballot.State)
+	}
+	if len(ballot.Members) == 0 || len(ballot.Members) > maxMembers {
+		return fmt.Errorf("member count must be 1..%d", maxMembers)
+	}
+	previous := ""
+	var total uint64
+	for i, member := range ballot.Members {
+		if err := validateID("ballot member", member.ValidatorID); err != nil {
+			return fmt.Errorf("member %d: %w", i, err)
+		}
+		if i > 0 && member.ValidatorID <= previous {
+			return errors.New("ballot members must be strictly bytewise sorted")
+		}
+		if member.EffectiveWeight == 0 {
+			return fmt.Errorf("member %d has zero effective weight", i)
+		}
+		if math.MaxUint64-total < member.EffectiveWeight {
+			return errors.New("effective weight total overflows uint64")
+		}
+		total += member.EffectiveWeight
+		previous = member.ValidatorID
+	}
+	if ballot.TotalWeight == 0 || ballot.TotalWeight != total {
+		return fmt.Errorf("total weight %d does not equal member sum %d", ballot.TotalWeight, total)
+	}
+	return nil
+}
+
+// HasStrictSupermajority evaluates accept/total > 2/3 without overflow.
+func HasStrictSupermajority(accept, total uint64) bool {
+	if total == 0 || accept > total {
+		return false
+	}
+	acceptHi, acceptLo := bits.Mul64(accept, 3)
+	totalHi, totalLo := bits.Mul64(total, 2)
+	return acceptHi > totalHi || (acceptHi == totalHi && acceptLo > totalLo)
+}

--- a/internal/scope/ballot_content_test.go
+++ b/internal/scope/ballot_content_test.go
@@ -1,6 +1,7 @@
 package scope
 
 import (
+	"bytes"
 	"math"
 	"testing"
 
@@ -98,4 +99,48 @@ func TestContentCodecRoundTripAndRejectsInvalidValues(t *testing.T) {
 	require.ErrorContains(t, err, "finite")
 	_, err = DecodeContent(append(encoded, 0))
 	require.ErrorContains(t, err, "trailing")
+}
+
+func FuzzDecodeBallot(f *testing.F) {
+	canonical, err := EncodeBallot(testBallot())
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(canonical)
+	f.Add([]byte("not a ballot"))
+	f.Fuzz(func(t *testing.T, input []byte) {
+		ballot, decodeErr := DecodeBallot(input)
+		if decodeErr != nil {
+			return
+		}
+		reencoded, encodeErr := EncodeBallot(ballot)
+		if encodeErr != nil {
+			t.Fatalf("decoded ballot failed validation on re-encode: %v", encodeErr)
+		}
+		if !bytes.Equal(reencoded, input) {
+			t.Fatal("accepted scope ballot has a second wire encoding")
+		}
+	})
+}
+
+func FuzzDecodeContent(f *testing.F) {
+	canonical, err := EncodeContent(testContent())
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(canonical)
+	f.Add([]byte("not scoped content"))
+	f.Fuzz(func(t *testing.T, input []byte) {
+		content, decodeErr := DecodeContent(input)
+		if decodeErr != nil {
+			return
+		}
+		reencoded, encodeErr := EncodeContent(content)
+		if encodeErr != nil {
+			t.Fatalf("decoded content failed validation on re-encode: %v", encodeErr)
+		}
+		if !bytes.Equal(reencoded, input) {
+			t.Fatal("accepted scoped content has a second wire encoding")
+		}
+	})
 }

--- a/internal/scope/ballot_content_test.go
+++ b/internal/scope/ballot_content_test.go
@@ -1,0 +1,101 @@
+package scope
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testBallot() Ballot {
+	return Ballot{
+		MemoryID:        "memory-a",
+		ScopeID:         "scope-a",
+		ScopeRevision:   2,
+		SubmittedHeight: 50,
+		State:           BallotPending,
+		Members: []BallotMember{
+			{ValidatorID: "validator-a", EffectiveWeight: 4},
+			{ValidatorID: "validator-b", EffectiveWeight: 3},
+		},
+		TotalWeight: 7,
+	}
+}
+
+func TestBallotCodecRoundTripAndStrictThreshold(t *testing.T) {
+	ballot := testBallot()
+	encoded, err := EncodeBallot(ballot)
+	require.NoError(t, err)
+	decoded, err := DecodeBallot(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, ballot, decoded)
+
+	assert.True(t, HasStrictSupermajority(3, 4), "three of four equal weights is strictly above two thirds")
+	assert.False(t, HasStrictSupermajority(2, 3), "exactly two thirds is not a strict supermajority")
+	assert.True(t, HasStrictSupermajority(math.MaxUint64-1, math.MaxUint64), "comparison must not overflow near uint64 max")
+	assert.False(t, HasStrictSupermajority(math.MaxUint64/2, math.MaxUint64))
+}
+
+func TestBallotCodecRejectsNonCanonicalAndMalformed(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*Ballot)
+	}{
+		{"unsorted", func(b *Ballot) { b.Members[0], b.Members[1] = b.Members[1], b.Members[0] }},
+		{"zero weight", func(b *Ballot) { b.Members[0].EffectiveWeight = 0 }},
+		{"wrong total", func(b *Ballot) { b.TotalWeight++ }},
+		{"zero revision", func(b *Ballot) { b.ScopeRevision = 0 }},
+		{"invalid state", func(b *Ballot) { b.State = 99 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ballot := testBallot()
+			tc.mutate(&ballot)
+			_, err := EncodeBallot(ballot)
+			require.Error(t, err)
+		})
+	}
+	encoded, err := EncodeBallot(testBallot())
+	require.NoError(t, err)
+	_, err = DecodeBallot(append(encoded, 0))
+	require.ErrorContains(t, err, "trailing")
+}
+
+func testContent() Content {
+	return Content{
+		MemoryID:          "memory-a",
+		ScopeID:           "scope-a",
+		ScopeRevision:     2,
+		SubmittingAgentID: "agent-a",
+		ContentHash:       make([]byte, 32),
+		MemoryType:        1,
+		Domain:            "research",
+		ConfidenceScore:   0.9,
+		Content:           "canonical recoverable content",
+		ParentHash:        "parent",
+		Classification:    2,
+		TaskStatus:        "planned",
+		SubmittedHeight:   50,
+		SubmittedUnix:     500,
+	}
+}
+
+func TestContentCodecRoundTripAndRejectsInvalidValues(t *testing.T) {
+	content := testContent()
+	encoded, err := EncodeContent(content)
+	require.NoError(t, err)
+	decoded, err := DecodeContent(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, content, decoded)
+
+	badHash := content
+	badHash.ContentHash = []byte("short")
+	_, err = EncodeContent(badHash)
+	require.ErrorContains(t, err, "32 bytes")
+	badConfidence := content
+	badConfidence.ConfidenceScore = math.NaN()
+	_, err = EncodeContent(badConfidence)
+	require.ErrorContains(t, err, "finite")
+	_, err = DecodeContent(append(encoded, 0))
+	require.ErrorContains(t, err, "trailing")
+}

--- a/internal/scope/codec.go
+++ b/internal/scope/codec.go
@@ -1,0 +1,343 @@
+// Package scope defines the deterministic, versioned on-chain record used by
+// v11.9 domain-scoped quorum. It deliberately has no store or ABCI dependency:
+// the same bytes can be validated by transaction handling, Badger persistence,
+// snapshot recovery, and tests before any caller is allowed to mutate state.
+package scope
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	// SchemaV1 is the leading byte on every v11.9 scope record. Future versions
+	// must add a new decoder rather than reinterpret these bytes.
+	SchemaV1 byte = 1
+
+	maxIDBytes     = 512
+	maxDomains     = 256
+	maxMembers     = 256
+	maxDomainBytes = 512
+)
+
+// State is the lifecycle state of a quorum scope.
+type State byte
+
+const (
+	StateActive State = iota + 1
+	StatePaused
+	StateRetired
+)
+
+// Domain is an explicit selected domain. V1 records only exact domains;
+// Subtree is retained in the wire shape for a later versioned extension but is
+// rejected by Validate until its semantics and collision rules are implemented.
+type Domain struct {
+	Name    string
+	Subtree bool
+}
+
+// Member is one pinned validator allocation in a scope roster. AssignedWeight
+// is deliberately an integer: a scope denominator must never depend on
+// architecture-sensitive floating-point arithmetic.
+type Member struct {
+	ValidatorID    string
+	AssignedWeight uint64
+	JoinedRevision uint64
+	Active         bool
+}
+
+// Record is the canonical v11.9 scope roster head. Domains and Members must be
+// strictly bytewise sorted by Name and ValidatorID respectively. Encode rejects
+// noncanonical caller input instead of sorting it silently.
+type Record struct {
+	ScopeID               string
+	Revision              uint64
+	State                 State
+	ControllerValidatorID string
+	CreatedHeight         int64
+	UpdatedHeight         int64
+	Domains               []Domain
+	Members               []Member
+}
+
+// Encode returns the one canonical V1 byte representation of r.
+func Encode(r Record) ([]byte, error) {
+	if err := Validate(r); err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, 0, 64+len(r.ScopeID)+len(r.ControllerValidatorID))
+	buf = append(buf, SchemaV1)
+	buf = appendString(buf, r.ScopeID)
+	buf = appendUint64(buf, r.Revision)
+	buf = append(buf, byte(r.State))
+	buf = appendString(buf, r.ControllerValidatorID)
+	buf = appendInt64(buf, r.CreatedHeight)
+	buf = appendInt64(buf, r.UpdatedHeight)
+	buf = appendUint32(buf, uint32(len(r.Domains)))
+	for _, d := range r.Domains {
+		buf = appendString(buf, d.Name)
+		if d.Subtree {
+			buf = append(buf, 1)
+		} else {
+			buf = append(buf, 0)
+		}
+	}
+	buf = appendUint32(buf, uint32(len(r.Members)))
+	for _, m := range r.Members {
+		buf = appendString(buf, m.ValidatorID)
+		buf = appendUint64(buf, m.AssignedWeight)
+		buf = appendUint64(buf, m.JoinedRevision)
+		if m.Active {
+			buf = append(buf, 1)
+		} else {
+			buf = append(buf, 0)
+		}
+	}
+	return buf, nil
+}
+
+// Decode validates and decodes one canonical V1 scope record. It rejects
+// unknown versions, oversized length prefixes, noncanonical ordering, and
+// trailing data; callers therefore cannot accept a second encoding for the
+// same logical roster.
+func Decode(data []byte) (Record, error) {
+	if len(data) == 0 {
+		return Record{}, errors.New("scope record is empty")
+	}
+	if data[0] != SchemaV1 {
+		return Record{}, fmt.Errorf("unsupported scope schema version %d", data[0])
+	}
+	off := 1
+	var err error
+	var r Record
+	if r.ScopeID, off, err = readString(data, off, maxIDBytes); err != nil {
+		return Record{}, fmt.Errorf("scope id: %w", err)
+	}
+	if r.Revision, off, err = readUint64(data, off); err != nil {
+		return Record{}, fmt.Errorf("revision: %w", err)
+	}
+	if off >= len(data) {
+		return Record{}, errors.New("state: truncated")
+	}
+	r.State = State(data[off])
+	off++
+	if r.ControllerValidatorID, off, err = readString(data, off, maxIDBytes); err != nil {
+		return Record{}, fmt.Errorf("controller validator: %w", err)
+	}
+	if r.CreatedHeight, off, err = readInt64(data, off); err != nil {
+		return Record{}, fmt.Errorf("created height: %w", err)
+	}
+	if r.UpdatedHeight, off, err = readInt64(data, off); err != nil {
+		return Record{}, fmt.Errorf("updated height: %w", err)
+	}
+
+	var count uint32
+	if count, off, err = readUint32(data, off); err != nil {
+		return Record{}, fmt.Errorf("domain count: %w", err)
+	}
+	if count > maxDomains {
+		return Record{}, fmt.Errorf("domain count %d exceeds %d", count, maxDomains)
+	}
+	r.Domains = make([]Domain, 0, int(count))
+	for i := uint32(0); i < count; i++ {
+		var d Domain
+		if d.Name, off, err = readString(data, off, maxDomainBytes); err != nil {
+			return Record{}, fmt.Errorf("domain %d: %w", i, err)
+		}
+		if off >= len(data) {
+			return Record{}, fmt.Errorf("domain %d subtree: truncated", i)
+		}
+		switch data[off] {
+		case 0:
+			d.Subtree = false
+		case 1:
+			d.Subtree = true
+		default:
+			return Record{}, fmt.Errorf("domain %d subtree flag is invalid", i)
+		}
+		off++
+		r.Domains = append(r.Domains, d)
+	}
+
+	if count, off, err = readUint32(data, off); err != nil {
+		return Record{}, fmt.Errorf("member count: %w", err)
+	}
+	if count > maxMembers {
+		return Record{}, fmt.Errorf("member count %d exceeds %d", count, maxMembers)
+	}
+	r.Members = make([]Member, 0, int(count))
+	for i := uint32(0); i < count; i++ {
+		var m Member
+		if m.ValidatorID, off, err = readString(data, off, maxIDBytes); err != nil {
+			return Record{}, fmt.Errorf("member %d id: %w", i, err)
+		}
+		if m.AssignedWeight, off, err = readUint64(data, off); err != nil {
+			return Record{}, fmt.Errorf("member %d weight: %w", i, err)
+		}
+		if m.JoinedRevision, off, err = readUint64(data, off); err != nil {
+			return Record{}, fmt.Errorf("member %d joined revision: %w", i, err)
+		}
+		if off >= len(data) {
+			return Record{}, fmt.Errorf("member %d active flag: truncated", i)
+		}
+		switch data[off] {
+		case 0:
+			m.Active = false
+		case 1:
+			m.Active = true
+		default:
+			return Record{}, fmt.Errorf("member %d active flag is invalid", i)
+		}
+		off++
+		r.Members = append(r.Members, m)
+	}
+	if off != len(data) {
+		return Record{}, errors.New("scope record has trailing bytes")
+	}
+	if err := Validate(r); err != nil {
+		return Record{}, err
+	}
+	return r, nil
+}
+
+// Validate checks the V1 safety and canonicalization invariants.
+func Validate(r Record) error {
+	if err := validateID("scope id", r.ScopeID); err != nil {
+		return err
+	}
+	// Scope IDs are exposed as one REST path segment. Rejecting '/' at the
+	// consensus codec boundary keeps the canonical identifier addressable on
+	// every operator surface instead of creating a valid on-chain scope that can
+	// only be discovered through the list endpoint.
+	if strings.ContainsRune(r.ScopeID, '/') {
+		return errors.New("scope id must not contain '/'")
+	}
+	if r.Revision == 0 {
+		return errors.New("revision must be non-zero")
+	}
+	if r.State != StateActive && r.State != StatePaused && r.State != StateRetired {
+		return fmt.Errorf("invalid scope state %d", r.State)
+	}
+	if err := validateID("controller validator", r.ControllerValidatorID); err != nil {
+		return err
+	}
+	if r.CreatedHeight < 0 || r.UpdatedHeight < r.CreatedHeight {
+		return errors.New("scope heights are invalid")
+	}
+	if len(r.Domains) == 0 || len(r.Domains) > maxDomains {
+		return fmt.Errorf("domain count must be 1..%d", maxDomains)
+	}
+	previous := ""
+	for i, d := range r.Domains {
+		if d.Subtree {
+			return fmt.Errorf("domain %d uses unsupported subtree scope", i)
+		}
+		if err := validateString("domain", d.Name, maxDomainBytes); err != nil {
+			return fmt.Errorf("domain %d: %w", i, err)
+		}
+		if i > 0 && d.Name <= previous {
+			return errors.New("domains must be strictly bytewise sorted")
+		}
+		previous = d.Name
+	}
+	if len(r.Members) == 0 || len(r.Members) > maxMembers {
+		return fmt.Errorf("member count must be 1..%d", maxMembers)
+	}
+	previous = ""
+	var total uint64
+	controllerActive := false
+	for i, m := range r.Members {
+		if err := validateID("member validator", m.ValidatorID); err != nil {
+			return fmt.Errorf("member %d: %w", i, err)
+		}
+		if i > 0 && m.ValidatorID <= previous {
+			return errors.New("members must be strictly bytewise sorted")
+		}
+		if m.AssignedWeight == 0 {
+			return fmt.Errorf("member %d has zero assigned weight", i)
+		}
+		if m.JoinedRevision == 0 || m.JoinedRevision > r.Revision {
+			return fmt.Errorf("member %d has invalid joined revision", i)
+		}
+		if math.MaxUint64-total < m.AssignedWeight {
+			return errors.New("assigned weight total overflows uint64")
+		}
+		total += m.AssignedWeight
+		if m.ValidatorID == r.ControllerValidatorID && m.Active {
+			controllerActive = true
+		}
+		previous = m.ValidatorID
+	}
+	if !controllerActive {
+		return errors.New("controller must be an active roster member")
+	}
+	return nil
+}
+
+func appendUint32(dst []byte, v uint32) []byte {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], v)
+	return append(dst, b[:]...)
+}
+
+func appendUint64(dst []byte, v uint64) []byte {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], v)
+	return append(dst, b[:]...)
+}
+
+func appendInt64(dst []byte, v int64) []byte { return appendUint64(dst, uint64(v)) }
+
+func appendString(dst []byte, s string) []byte {
+	dst = appendUint32(dst, uint32(len(s)))
+	return append(dst, s...)
+}
+
+func readUint32(data []byte, off int) (uint32, int, error) {
+	if off < 0 || len(data)-off < 4 {
+		return 0, off, errors.New("truncated uint32")
+	}
+	return binary.BigEndian.Uint32(data[off : off+4]), off + 4, nil
+}
+
+func readUint64(data []byte, off int) (uint64, int, error) {
+	if off < 0 || len(data)-off < 8 {
+		return 0, off, errors.New("truncated uint64")
+	}
+	return binary.BigEndian.Uint64(data[off : off+8]), off + 8, nil
+}
+
+func readInt64(data []byte, off int) (int64, int, error) {
+	v, next, err := readUint64(data, off)
+	return int64(v), next, err
+}
+
+func readString(data []byte, off, max int) (string, int, error) {
+	n, next, err := readUint32(data, off)
+	if err != nil {
+		return "", off, err
+	}
+	if n > uint32(max) || int(n) > len(data)-next {
+		return "", off, errors.New("invalid length-prefixed string")
+	}
+	s := string(data[next : next+int(n)])
+	if !utf8.ValidString(s) {
+		return "", off, errors.New("string is not valid UTF-8")
+	}
+	return s, next + int(n), nil
+}
+
+func validateID(label, value string) error { return validateString(label, value, maxIDBytes) }
+
+func validateString(label, value string, max int) error {
+	if value == "" || len(value) > max || !utf8.ValidString(value) {
+		return fmt.Errorf("%s is invalid", label)
+	}
+	return nil
+}

--- a/internal/scope/codec_test.go
+++ b/internal/scope/codec_test.go
@@ -1,0 +1,74 @@
+package scope
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validRecord() Record {
+	return Record{
+		ScopeID:               "audit-scope",
+		Revision:              3,
+		State:                 StateActive,
+		ControllerValidatorID: "validator-a",
+		CreatedHeight:         100,
+		UpdatedHeight:         140,
+		Domains:               []Domain{{Name: "audit"}, {Name: "research"}},
+		Members: []Member{
+			{ValidatorID: "validator-a", AssignedWeight: 4, JoinedRevision: 1, Active: true},
+			{ValidatorID: "validator-b", AssignedWeight: 3, JoinedRevision: 3, Active: true},
+		},
+	}
+}
+
+func TestRecordCodecRoundTripIsCanonical(t *testing.T) {
+	record := validRecord()
+	encoded, err := Encode(record)
+	require.NoError(t, err)
+	decoded, err := Decode(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, record, decoded)
+
+	encodedAgain, err := Encode(decoded)
+	require.NoError(t, err)
+	assert.Equal(t, encoded, encodedAgain, "a valid roster has exactly one wire form")
+}
+
+func TestRecordCodecRejectsNonCanonicalOrUnsafeInput(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Record)
+	}{
+		{"unsorted domains", func(r *Record) { r.Domains[0], r.Domains[1] = r.Domains[1], r.Domains[0] }},
+		{"duplicate member", func(r *Record) { r.Members[1].ValidatorID = r.Members[0].ValidatorID }},
+		{"zero weight", func(r *Record) { r.Members[0].AssignedWeight = 0 }},
+		{"inactive controller", func(r *Record) { r.Members[0].Active = false }},
+		{"subtree not enabled in v1", func(r *Record) { r.Domains[0].Subtree = true }},
+		{"joined after revision", func(r *Record) { r.Members[1].JoinedRevision = r.Revision + 1 }},
+		{"scope id is not one path segment", func(r *Record) { r.ScopeID = "org/research" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := validRecord()
+			tt.mutate(&r)
+			_, err := Encode(r)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestRecordCodecRejectsUnknownVersionAndTrailingBytes(t *testing.T) {
+	encoded, err := Encode(validRecord())
+	require.NoError(t, err)
+
+	unknown := append([]byte(nil), encoded...)
+	unknown[0] = 2
+	_, err = Decode(unknown)
+	assert.Error(t, err)
+
+	trailing := append(append([]byte(nil), encoded...), 0)
+	_, err = Decode(trailing)
+	assert.Error(t, err)
+}

--- a/internal/scope/codec_test.go
+++ b/internal/scope/codec_test.go
@@ -1,6 +1,7 @@
 package scope
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,4 +72,26 @@ func TestRecordCodecRejectsUnknownVersionAndTrailingBytes(t *testing.T) {
 	trailing := append(append([]byte(nil), encoded...), 0)
 	_, err = Decode(trailing)
 	assert.Error(t, err)
+}
+
+func FuzzDecodeRecord(f *testing.F) {
+	canonical, err := Encode(validRecord())
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(canonical)
+	f.Add([]byte("not a scope record"))
+	f.Fuzz(func(t *testing.T, input []byte) {
+		record, decodeErr := Decode(input)
+		if decodeErr != nil {
+			return
+		}
+		reencoded, encodeErr := Encode(record)
+		if encodeErr != nil {
+			t.Fatalf("decoded record failed validation on re-encode: %v", encodeErr)
+		}
+		if !bytes.Equal(reencoded, input) {
+			t.Fatal("accepted scope record has a second wire encoding")
+		}
+	})
 }

--- a/internal/scope/content.go
+++ b/internal/scope/content.go
@@ -1,0 +1,162 @@
+package scope
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"unicode/utf8"
+)
+
+const maxContentBytes = 1 << 20
+
+// Content is the canonical recoverable envelope for a scoped memory. It omits
+// embeddings and other rebuildable projections, but retains every field needed
+// to verify the normal memory hash and recreate the durable query projection.
+type Content struct {
+	MemoryID          string
+	ScopeID           string
+	ScopeRevision     uint64
+	SubmittingAgentID string
+	ContentHash       []byte
+	MemoryType        byte
+	Domain            string
+	ConfidenceScore   float64
+	Content           string
+	ParentHash        string
+	Classification    byte
+	TaskStatus        string
+	SubmittedHeight   int64
+	SubmittedUnix     int64
+}
+
+func EncodeContent(content Content) ([]byte, error) {
+	if err := ValidateContent(content); err != nil {
+		return nil, err
+	}
+	buf := []byte{SchemaV1}
+	buf = appendString(buf, content.MemoryID)
+	buf = appendString(buf, content.ScopeID)
+	buf = appendUint64(buf, content.ScopeRevision)
+	buf = appendString(buf, content.SubmittingAgentID)
+	buf = appendUint32(buf, uint32(len(content.ContentHash)))
+	buf = append(buf, content.ContentHash...)
+	buf = append(buf, content.MemoryType)
+	buf = appendString(buf, content.Domain)
+	buf = appendUint64(buf, math.Float64bits(content.ConfidenceScore))
+	buf = appendString(buf, content.Content)
+	buf = appendString(buf, content.ParentHash)
+	buf = append(buf, content.Classification)
+	buf = appendString(buf, content.TaskStatus)
+	buf = appendInt64(buf, content.SubmittedHeight)
+	buf = appendInt64(buf, content.SubmittedUnix)
+	return buf, nil
+}
+
+func DecodeContent(data []byte) (Content, error) {
+	if len(data) == 0 || data[0] != SchemaV1 {
+		return Content{}, errors.New("unsupported or empty scoped content schema")
+	}
+	off := 1
+	var content Content
+	var err error
+	if content.MemoryID, off, err = readString(data, off, maxIDBytes); err != nil {
+		return Content{}, fmt.Errorf("memory id: %w", err)
+	}
+	if content.ScopeID, off, err = readString(data, off, maxIDBytes); err != nil {
+		return Content{}, fmt.Errorf("scope id: %w", err)
+	}
+	if content.ScopeRevision, off, err = readUint64(data, off); err != nil {
+		return Content{}, fmt.Errorf("scope revision: %w", err)
+	}
+	if content.SubmittingAgentID, off, err = readString(data, off, maxIDBytes); err != nil {
+		return Content{}, fmt.Errorf("submitting agent: %w", err)
+	}
+	hashLen, next, err := readUint32(data, off)
+	if err != nil || hashLen != 32 || int(hashLen) > len(data)-next {
+		return Content{}, errors.New("content hash must be 32 bytes")
+	}
+	off = next
+	content.ContentHash = append([]byte(nil), data[off:off+int(hashLen)]...)
+	off += int(hashLen)
+	if off >= len(data) {
+		return Content{}, errors.New("memory type: truncated")
+	}
+	content.MemoryType = data[off]
+	off++
+	if content.Domain, off, err = readString(data, off, maxDomainBytes); err != nil {
+		return Content{}, fmt.Errorf("domain: %w", err)
+	}
+	confidenceBits, next, err := readUint64(data, off)
+	if err != nil {
+		return Content{}, fmt.Errorf("confidence: %w", err)
+	}
+	content.ConfidenceScore = math.Float64frombits(confidenceBits)
+	off = next
+	if content.Content, off, err = readString(data, off, maxContentBytes); err != nil {
+		return Content{}, fmt.Errorf("content: %w", err)
+	}
+	if content.ParentHash, off, err = readString(data, off, maxIDBytes); err != nil {
+		return Content{}, fmt.Errorf("parent hash: %w", err)
+	}
+	if off >= len(data) {
+		return Content{}, errors.New("classification: truncated")
+	}
+	content.Classification = data[off]
+	off++
+	if content.TaskStatus, off, err = readString(data, off, maxIDBytes); err != nil {
+		return Content{}, fmt.Errorf("task status: %w", err)
+	}
+	if content.SubmittedHeight, off, err = readInt64(data, off); err != nil {
+		return Content{}, fmt.Errorf("submitted height: %w", err)
+	}
+	if content.SubmittedUnix, off, err = readInt64(data, off); err != nil {
+		return Content{}, fmt.Errorf("submitted unix time: %w", err)
+	}
+	if off != len(data) {
+		return Content{}, errors.New("scoped content has trailing bytes")
+	}
+	if err := ValidateContent(content); err != nil {
+		return Content{}, err
+	}
+	return content, nil
+}
+
+func ValidateContent(content Content) error {
+	if err := validateID("memory id", content.MemoryID); err != nil {
+		return err
+	}
+	if err := validateID("scope id", content.ScopeID); err != nil {
+		return err
+	}
+	if content.ScopeRevision == 0 || content.SubmittedHeight <= 0 || content.SubmittedUnix <= 0 {
+		return errors.New("scope revision, submitted height, and submitted unix time must be positive")
+	}
+	if err := validateID("submitting agent", content.SubmittingAgentID); err != nil {
+		return err
+	}
+	if len(content.ContentHash) != 32 {
+		return errors.New("content hash must be 32 bytes")
+	}
+	if content.MemoryType < 1 || content.MemoryType > 4 {
+		return fmt.Errorf("invalid memory type %d", content.MemoryType)
+	}
+	if err := validateString("domain", content.Domain, maxDomainBytes); err != nil {
+		return err
+	}
+	if math.IsNaN(content.ConfidenceScore) || math.IsInf(content.ConfidenceScore, 0) || content.ConfidenceScore < 0 || content.ConfidenceScore > 1 {
+		return errors.New("confidence score must be finite and within 0..1")
+	}
+	if err := validateString("content", content.Content, maxContentBytes); err != nil {
+		return err
+	}
+	if len(content.ParentHash) > maxIDBytes || len(content.TaskStatus) > maxIDBytes {
+		return errors.New("parent hash or task status is oversized")
+	}
+	if (content.ParentHash != "" && !utf8.ValidString(content.ParentHash)) || (content.TaskStatus != "" && !utf8.ValidString(content.TaskStatus)) {
+		return errors.New("parent hash or task status is not valid UTF-8")
+	}
+	if content.Classification > 4 {
+		return fmt.Errorf("invalid classification %d", content.Classification)
+	}
+	return nil
+}

--- a/internal/scope/proposal.go
+++ b/internal/scope/proposal.go
@@ -1,0 +1,95 @@
+package scope
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// ProposalTemplate is the human-facing form of a ScopeRecordV1 governance
+// payload. Consensus-owned heights are deliberately absent. Domains and
+// members may arrive in any order; EncodeProposalTemplate makes their order
+// canonical before invoking the strict wire codec.
+type ProposalTemplate struct {
+	ScopeID               string           `json:"scope_id"`
+	Revision              uint64           `json:"revision"`
+	State                 string           `json:"state"`
+	ControllerValidatorID string           `json:"controller_validator_id"`
+	Domains               []string         `json:"domains"`
+	Members               []ProposalMember `json:"members"`
+}
+
+// ProposalMember is one guided roster entry. Active defaults to true when
+// omitted. JoinedRevision may be omitted only when creating revision 1; later
+// revisions must state the historical join revision explicitly so a client
+// cannot accidentally rewrite roster history.
+type ProposalMember struct {
+	ValidatorID    string `json:"validator_id"`
+	AssignedWeight uint64 `json:"assigned_weight"`
+	JoinedRevision uint64 `json:"joined_revision,omitempty"`
+	Active         *bool  `json:"active,omitempty"`
+}
+
+// EncodeProposalTemplate converts a guided JSON template into the canonical
+// binary payload consumed by app-v20 governance. It never mutates the input.
+func EncodeProposalTemplate(template ProposalTemplate) ([]byte, error) {
+	state, err := parseProposalState(template.State)
+	if err != nil {
+		return nil, err
+	}
+	if template.Revision == 0 {
+		return nil, errors.New("revision must be non-zero")
+	}
+
+	domains := make([]Domain, len(template.Domains))
+	for i, name := range template.Domains {
+		domains[i] = Domain{Name: name}
+	}
+	sort.Slice(domains, func(i, j int) bool { return domains[i].Name < domains[j].Name })
+
+	members := make([]Member, len(template.Members))
+	for i, input := range template.Members {
+		joinedRevision := input.JoinedRevision
+		if joinedRevision == 0 {
+			if template.Revision != 1 {
+				return nil, fmt.Errorf("member %q must specify joined_revision for revision %d", input.ValidatorID, template.Revision)
+			}
+			joinedRevision = 1
+		}
+		active := true
+		if input.Active != nil {
+			active = *input.Active
+		}
+		members[i] = Member{
+			ValidatorID:    input.ValidatorID,
+			AssignedWeight: input.AssignedWeight,
+			JoinedRevision: joinedRevision,
+			Active:         active,
+		}
+	}
+	sort.Slice(members, func(i, j int) bool { return members[i].ValidatorID < members[j].ValidatorID })
+
+	return Encode(Record{
+		ScopeID:               template.ScopeID,
+		Revision:              template.Revision,
+		State:                 state,
+		ControllerValidatorID: template.ControllerValidatorID,
+		CreatedHeight:         0,
+		UpdatedHeight:         0,
+		Domains:               domains,
+		Members:               members,
+	})
+}
+
+func parseProposalState(value string) (State, error) {
+	switch value {
+	case "active":
+		return StateActive, nil
+	case "paused":
+		return StatePaused, nil
+	case "retired":
+		return StateRetired, nil
+	default:
+		return 0, fmt.Errorf("state must be active, paused, or retired")
+	}
+}

--- a/internal/scope/proposal_test.go
+++ b/internal/scope/proposal_test.go
@@ -1,0 +1,83 @@
+package scope
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func boolPointer(value bool) *bool { return &value }
+
+func TestEncodeProposalTemplateCanonicalizesGuidedInput(t *testing.T) {
+	template := ProposalTemplate{
+		ScopeID:               "scope-research",
+		Revision:              1,
+		State:                 "active",
+		ControllerValidatorID: "validator-a",
+		Domains:               []string{"research.private", "research"},
+		Members: []ProposalMember{
+			{ValidatorID: "validator-b", AssignedWeight: 2},
+			{ValidatorID: "validator-a", AssignedWeight: 3},
+		},
+	}
+
+	encoded, err := EncodeProposalTemplate(template)
+	require.NoError(t, err)
+	record, err := Decode(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, []Domain{{Name: "research"}, {Name: "research.private"}}, record.Domains)
+	assert.Equal(t, "validator-a", record.Members[0].ValidatorID)
+	assert.Equal(t, uint64(1), record.Members[0].JoinedRevision)
+	assert.True(t, record.Members[0].Active)
+	assert.Equal(t, int64(0), record.CreatedHeight)
+	assert.Equal(t, int64(0), record.UpdatedHeight)
+	assert.Equal(t, "research.private", template.Domains[0], "builder must not mutate caller input")
+}
+
+func TestEncodeProposalTemplatePreservesExplicitInactiveMember(t *testing.T) {
+	template := ProposalTemplate{
+		ScopeID: "scope-research", Revision: 2, State: "paused",
+		ControllerValidatorID: "validator-a", Domains: []string{"research"},
+		Members: []ProposalMember{
+			{ValidatorID: "validator-a", AssignedWeight: 3, JoinedRevision: 1},
+			{ValidatorID: "validator-b", AssignedWeight: 2, JoinedRevision: 2, Active: boolPointer(false)},
+		},
+	}
+	encoded, err := EncodeProposalTemplate(template)
+	require.NoError(t, err)
+	record, err := Decode(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, StatePaused, record.State)
+	assert.False(t, record.Members[1].Active)
+}
+
+func TestEncodeProposalTemplateFailsClosed(t *testing.T) {
+	base := ProposalTemplate{
+		ScopeID: "scope-research", Revision: 1, State: "active",
+		ControllerValidatorID: "validator-a", Domains: []string{"research"},
+		Members: []ProposalMember{{ValidatorID: "validator-a", AssignedWeight: 1}},
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*ProposalTemplate)
+	}{
+		{"unknown state", func(v *ProposalTemplate) { v.State = "forming" }},
+		{"duplicate domain", func(v *ProposalTemplate) { v.Domains = append(v.Domains, "research") }},
+		{"duplicate member", func(v *ProposalTemplate) { v.Members = append(v.Members, v.Members[0]) }},
+		{"zero weight", func(v *ProposalTemplate) { v.Members[0].AssignedWeight = 0 }},
+		{"inactive controller", func(v *ProposalTemplate) { v.Members[0].Active = boolPointer(false) }},
+		{"missing historical join revision", func(v *ProposalTemplate) { v.Revision = 2 }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := base
+			input.Domains = append([]string(nil), base.Domains...)
+			input.Members = append([]ProposalMember(nil), base.Members...)
+			test.mutate(&input)
+			_, err := EncodeProposalTemplate(input)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -1,10 +1,12 @@
 // Package snapshot implements SAGE's local snapshot/restore substrate.
 //
 // A snapshot captures all three persistent layers (BadgerDB on-chain state,
-// SQLite mirror, CometBFT block+state+evidence dbs) plus enough config to
-// boot a fresh data directory against the same chain. The on-disk layout
-// mirrors the cosmos-sdk snapshots module convention so future ABCI
-// state-sync integration is additive.
+// SQLite mirror, CometBFT block+state+evidence dbs) plus enough private config
+// to boot a fresh data directory against the same chain. It is an operator-local
+// rollback bundle, not a network state-sync payload: it can contain node and
+// validator keys, vault material, local content, config, and a binary. Never
+// advertise or transmit this format through ABCI/P2P. Future ABCI state sync
+// requires a separate consensus-only, key-free format.
 //
 // Trigger plumbing (height/time/pre-upgrade) and the boot-time auto-restore
 // path live in separate files in this package; this file owns the Take

--- a/internal/statesync/activation.go
+++ b/internal/statesync/activation.go
@@ -1,0 +1,265 @@
+package statesync
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	activationJournalVersion  byte = 1
+	maxActivationNameBytes         = 255
+	activationJournalHeader        = 12 + 1 + 1 + 8 + sha256.Size + sha256.Size
+	maxActivationJournalBytes      = activationJournalHeader + 3*(2+maxActivationNameBytes)
+)
+
+var activationJournalMagic = [12]byte{'S', 'A', 'G', 'E', '-', 'A', 'C', 'T', 'I', 'V', 'E', 0}
+
+// ActivationPhase is the durable portion of the boot-only activation state
+// machine. Discovery and assembly are disposable staging work and need no
+// journal; these phases straddle live-directory and CometBFT persistence.
+type ActivationPhase byte
+
+const (
+	ActivationPrepared ActivationPhase = iota + 1
+	ActivationPendingComet
+	ActivationSealed
+)
+
+// ActivationJournal is the key-free recovery record for one verified state
+// sync activation. Directory fields are basenames beneath a caller-owned root,
+// never arbitrary paths. AppHash and MetadataHash are immutable SHA-256 values.
+type ActivationJournal struct {
+	Phase          ActivationPhase
+	Height         uint64
+	AppHash        []byte
+	MetadataHash   []byte
+	PreparedName   string
+	QuarantineName string
+	LiveName       string
+}
+
+// RecoveryAction tells startup which directory layout can be considered. The
+// caller must still verify the selected Badger database against CometBFT before
+// any rename or normal service startup.
+type RecoveryAction byte
+
+const (
+	RecoveryDiscardPrepared RecoveryAction = iota + 1
+	RecoveryRestoreQuarantine
+	RecoveryKeepActivated
+)
+
+func EncodeActivationJournal(journal ActivationJournal) ([]byte, error) {
+	if err := validateActivationJournal(journal); err != nil {
+		return nil, err
+	}
+	encoded := make([]byte, activationJournalHeader)
+	offset := 0
+	copy(encoded[offset:], activationJournalMagic[:])
+	offset += len(activationJournalMagic)
+	encoded[offset] = activationJournalVersion
+	offset++
+	encoded[offset] = byte(journal.Phase)
+	offset++
+	binary.BigEndian.PutUint64(encoded[offset:], journal.Height)
+	offset += 8
+	copy(encoded[offset:], journal.AppHash)
+	offset += sha256.Size
+	copy(encoded[offset:], journal.MetadataHash)
+	for _, name := range []string{journal.PreparedName, journal.QuarantineName, journal.LiveName} {
+		var length [2]byte
+		binary.BigEndian.PutUint16(length[:], uint16(len(name))) // #nosec G115 -- validateActivationJournal bounds to 255
+		encoded = append(encoded, length[:]...)
+		encoded = append(encoded, name...)
+	}
+	return encoded, nil
+}
+
+func DecodeActivationJournal(encoded []byte) (ActivationJournal, error) {
+	if len(encoded) < activationJournalHeader+6 || len(encoded) > maxActivationJournalBytes {
+		return ActivationJournal{}, errors.New("activation journal size is invalid")
+	}
+	offset := 0
+	if !bytes.Equal(encoded[:len(activationJournalMagic)], activationJournalMagic[:]) {
+		return ActivationJournal{}, errors.New("activation journal magic mismatch")
+	}
+	offset += len(activationJournalMagic)
+	if encoded[offset] != activationJournalVersion {
+		return ActivationJournal{}, fmt.Errorf("unsupported activation journal version %d", encoded[offset])
+	}
+	offset++
+	journal := ActivationJournal{Phase: ActivationPhase(encoded[offset])}
+	offset++
+	journal.Height = binary.BigEndian.Uint64(encoded[offset:])
+	offset += 8
+	journal.AppHash = append([]byte(nil), encoded[offset:offset+sha256.Size]...)
+	offset += sha256.Size
+	journal.MetadataHash = append([]byte(nil), encoded[offset:offset+sha256.Size]...)
+	offset += sha256.Size
+	names := []*string{&journal.PreparedName, &journal.QuarantineName, &journal.LiveName}
+	for _, target := range names {
+		if len(encoded)-offset < 2 {
+			return ActivationJournal{}, errors.New("activation journal name length is truncated")
+		}
+		length := int(binary.BigEndian.Uint16(encoded[offset:]))
+		offset += 2
+		if length == 0 || length > maxActivationNameBytes || len(encoded)-offset < length {
+			return ActivationJournal{}, errors.New("activation journal name is invalid")
+		}
+		*target = string(encoded[offset : offset+length])
+		offset += length
+	}
+	if offset != len(encoded) {
+		return ActivationJournal{}, errors.New("activation journal has trailing bytes")
+	}
+	if err := validateActivationJournal(journal); err != nil {
+		return ActivationJournal{}, err
+	}
+	return journal, nil
+}
+
+// WriteActivationJournal atomically replaces path with a canonical, fsynced
+// record. Temporary files live in the same directory so rename is atomic.
+func WriteActivationJournal(path string, journal ActivationJournal) error {
+	if path == "" {
+		return errors.New("activation journal path is empty")
+	}
+	encoded, err := EncodeActivationJournal(journal)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	info, err := os.Lstat(dir)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("activation journal parent must be an existing real directory")
+	}
+	tmp, err := os.CreateTemp(dir, ".activation-journal-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	ok := false
+	defer func() {
+		_ = tmp.Close()
+		if !ok {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(encoded); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	if err := syncDir(dir); err != nil {
+		return err
+	}
+	ok = true
+	return nil
+}
+
+func LoadActivationJournal(path string) (ActivationJournal, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return ActivationJournal{}, err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maxActivationJournalBytes {
+		return ActivationJournal{}, errors.New("activation journal must be a bounded regular file")
+	}
+	file, err := os.Open(path) //nolint:gosec // lstat-checked operator-owned path
+	if err != nil {
+		return ActivationJournal{}, err
+	}
+	defer func() { _ = file.Close() }()
+	encoded, err := io.ReadAll(io.LimitReader(file, maxActivationJournalBytes+1))
+	if err != nil {
+		return ActivationJournal{}, err
+	}
+	return DecodeActivationJournal(encoded)
+}
+
+// DecideActivationRecovery closes the app-ahead-of-Comet crash window without
+// touching disk. liveHeight/liveAppHash describe the currently named live
+// Badger directory. A restore decision still requires the caller to verify the
+// quarantined store against CometBFT before renaming it.
+func DecideActivationRecovery(journal ActivationJournal, cometHeight uint64, cometAppHash []byte, liveHeight uint64, liveAppHash []byte) (RecoveryAction, error) {
+	if err := validateActivationJournal(journal); err != nil {
+		return 0, err
+	}
+	if !validPersistedState(cometHeight, cometAppHash) || !validPersistedState(liveHeight, liveAppHash) {
+		return 0, errors.New("activation recovery state hash is invalid")
+	}
+
+	switch journal.Phase {
+	case ActivationPrepared:
+		if cometHeight != liveHeight || !bytes.Equal(cometAppHash, liveAppHash) {
+			return 0, errors.New("prepared activation live state does not match CometBFT")
+		}
+		return RecoveryDiscardPrepared, nil
+
+	case ActivationPendingComet:
+		if cometHeight < journal.Height {
+			return RecoveryRestoreQuarantine, nil
+		}
+		fallthrough
+
+	case ActivationSealed:
+		if cometHeight < journal.Height {
+			return 0, errors.New("sealed activation is ahead of CometBFT")
+		}
+		if cometHeight == journal.Height && !bytes.Equal(cometAppHash, journal.AppHash) {
+			return 0, errors.New("CometBFT snapshot AppHash does not match activation journal")
+		}
+		if liveHeight != cometHeight || !bytes.Equal(liveAppHash, cometAppHash) {
+			return 0, errors.New("activated Badger state does not match CometBFT")
+		}
+		return RecoveryKeepActivated, nil
+	default:
+		return 0, errors.New("activation journal phase is invalid")
+	}
+}
+
+func validateActivationJournal(journal ActivationJournal) error {
+	if journal.Phase != ActivationPrepared && journal.Phase != ActivationPendingComet && journal.Phase != ActivationSealed {
+		return errors.New("activation journal phase is invalid")
+	}
+	if journal.Height == 0 {
+		return errors.New("activation journal height must be positive")
+	}
+	if len(journal.AppHash) != sha256.Size || len(journal.MetadataHash) != sha256.Size {
+		return errors.New("activation journal hashes must be SHA-256 sized")
+	}
+	for _, name := range []string{journal.PreparedName, journal.QuarantineName, journal.LiveName} {
+		if len(name) == 0 || len(name) > maxActivationNameBytes || name == "." || name == ".." ||
+			filepath.Base(name) != name || strings.IndexByte(name, 0) >= 0 {
+			return errors.New("activation journal directory name is unsafe")
+		}
+	}
+	if journal.PreparedName == journal.QuarantineName || journal.PreparedName == journal.LiveName || journal.QuarantineName == journal.LiveName {
+		return errors.New("activation journal directory names must be distinct")
+	}
+	return nil
+}
+
+func validPersistedState(height uint64, appHash []byte) bool {
+	if height == 0 {
+		return len(appHash) == 0
+	}
+	return len(appHash) == sha256.Size
+}

--- a/internal/statesync/activation_test.go
+++ b/internal/statesync/activation_test.go
@@ -1,0 +1,119 @@
+package statesync
+
+import (
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func activationTestJournal() ActivationJournal {
+	appHash := sha256.Sum256([]byte("app"))
+	metadataHash := sha256.Sum256([]byte("metadata"))
+	return ActivationJournal{
+		Phase: ActivationPendingComet, Height: 42,
+		AppHash: appHash[:], MetadataHash: metadataHash[:],
+		PreparedName: "state-sync-prepared-42", QuarantineName: "badger-old-42", LiveName: "badger",
+	}
+}
+
+func TestActivationJournalCanonicalRoundTripAndAtomicWrite(t *testing.T) {
+	journal := activationTestJournal()
+	encoded, err := EncodeActivationJournal(journal)
+	require.NoError(t, err)
+	decoded, err := DecodeActivationJournal(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, journal, decoded)
+
+	path := filepath.Join(t.TempDir(), "activation.journal")
+	require.NoError(t, WriteActivationJournal(path, journal))
+	loaded, err := LoadActivationJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, journal, loaded)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	journal.Phase = ActivationSealed
+	require.NoError(t, WriteActivationJournal(path, journal))
+	loaded, err = LoadActivationJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, ActivationSealed, loaded.Phase)
+}
+
+func TestActivationJournalRejectsMalformedAndUnsafeInput(t *testing.T) {
+	journal := activationTestJournal()
+	bad := journal
+	bad.PreparedName = "../prepared"
+	_, err := EncodeActivationJournal(bad)
+	assert.ErrorContains(t, err, "unsafe")
+
+	encoded, err := EncodeActivationJournal(journal)
+	require.NoError(t, err)
+	_, err = DecodeActivationJournal(append(encoded, 0))
+	assert.ErrorContains(t, err, "trailing")
+	unknown := append([]byte(nil), encoded...)
+	unknown[len(activationJournalMagic)+1] = 99
+	_, err = DecodeActivationJournal(unknown)
+	assert.ErrorContains(t, err, "phase")
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	require.NoError(t, os.WriteFile(target, encoded, 0o600))
+	link := filepath.Join(dir, "journal-link")
+	require.NoError(t, os.Symlink(target, link))
+	_, err = LoadActivationJournal(link)
+	assert.ErrorContains(t, err, "regular file")
+}
+
+func TestDecideActivationRecovery(t *testing.T) {
+	journal := activationTestJournal()
+	oldHash := sha256.Sum256([]byte("old"))
+	newHash := append([]byte(nil), journal.AppHash...)
+	nextHash := sha256.Sum256([]byte("next"))
+
+	journal.Phase = ActivationPrepared
+	action, err := DecideActivationRecovery(journal, 40, oldHash[:], 40, oldHash[:])
+	require.NoError(t, err)
+	assert.Equal(t, RecoveryDiscardPrepared, action)
+
+	journal.Phase = ActivationPendingComet
+	action, err = DecideActivationRecovery(journal, 40, oldHash[:], 42, newHash)
+	require.NoError(t, err)
+	assert.Equal(t, RecoveryRestoreQuarantine, action)
+
+	action, err = DecideActivationRecovery(journal, 42, newHash, 42, newHash)
+	require.NoError(t, err)
+	assert.Equal(t, RecoveryKeepActivated, action)
+
+	action, err = DecideActivationRecovery(journal, 43, nextHash[:], 43, nextHash[:])
+	require.NoError(t, err)
+	assert.Equal(t, RecoveryKeepActivated, action, "later block catch-up may seal the already activated snapshot")
+
+	wrong := sha256.Sum256([]byte("wrong"))
+	_, err = DecideActivationRecovery(journal, 42, wrong[:], 42, wrong[:])
+	assert.ErrorContains(t, err, "journal")
+	_, err = DecideActivationRecovery(journal, 42, newHash, 41, oldHash[:])
+	assert.ErrorContains(t, err, "does not match")
+}
+
+func FuzzDecodeActivationJournal(f *testing.F) {
+	encoded, err := EncodeActivationJournal(activationTestJournal())
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(encoded)
+	f.Add([]byte("local snapshot manifest"))
+	f.Fuzz(func(t *testing.T, input []byte) {
+		journal, decodeErr := DecodeActivationJournal(input)
+		if decodeErr != nil {
+			return
+		}
+		canonical, encodeErr := EncodeActivationJournal(journal)
+		require.NoError(t, encodeErr)
+		assert.Equal(t, input, canonical)
+	})
+}

--- a/internal/statesync/assembler.go
+++ b/internal/statesync/assembler.go
@@ -1,0 +1,198 @@
+package statesync
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// Assembler persists verified chunks into a fresh staging directory. It never
+// opens or mutates the live Badger database; atomic database activation belongs
+// to the later ABCI integration gate.
+type Assembler struct {
+	mu       sync.Mutex
+	dir      string
+	metadata Metadata
+	received map[uint32]struct{}
+}
+
+// NewAssembler creates a fresh staging directory. Refusing an existing path
+// prevents an interrupted or attacker-controlled assembly from being silently
+// mixed with a newly offered snapshot.
+func NewAssembler(dir string, metadata Metadata) (*Assembler, error) {
+	if dir == "" {
+		return nil, errors.New("state sync staging directory is empty")
+	}
+	if err := validateMetadata(metadata); err != nil {
+		return nil, err
+	}
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create state sync staging directory: %w", err)
+	}
+	return &Assembler{dir: dir, metadata: metadata, received: make(map[uint32]struct{})}, nil
+}
+
+// AddChunk verifies index, canonical length, and the manifest hash before an
+// atomic write. Re-delivery of the exact chunk is idempotent.
+func (a *Assembler) AddChunk(index uint32, chunk []byte) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	expectedSize, err := expectedChunkSize(a.metadata, index)
+	if err != nil {
+		return err
+	}
+	if len(chunk) != expectedSize {
+		return fmt.Errorf("state sync chunk %d size %d, expected %d", index, len(chunk), expectedSize)
+	}
+	hash := sha256.Sum256(chunk)
+	if !bytes.Equal(hash[:], a.metadata.ChunkHashes[index]) {
+		return fmt.Errorf("state sync chunk %d hash mismatch", index)
+	}
+	if _, ok := a.received[index]; ok {
+		return nil
+	}
+	finalPath := filepath.Join(a.dir, chunkFilename(index))
+	if _, statErr := os.Stat(finalPath); statErr == nil {
+		return fmt.Errorf("state sync chunk %d exists outside assembler state", index)
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return statErr
+	}
+	tmp, err := os.CreateTemp(a.dir, ".chunk-part-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	ok := false
+	defer func() {
+		_ = tmp.Close()
+		if !ok {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(chunk); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		return err
+	}
+	if err := syncDir(a.dir); err != nil {
+		return err
+	}
+	ok = true
+	a.received[index] = struct{}{}
+	return nil
+}
+
+// Missing returns missing chunk indexes in canonical ascending order.
+func (a *Assembler) Missing() []uint32 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	missing := make([]uint32, 0, len(a.metadata.ChunkHashes)-len(a.received))
+	for i := range a.metadata.ChunkHashes {
+		index := uint32(i)
+		if _, ok := a.received[index]; !ok {
+			missing = append(missing, index)
+		}
+	}
+	return missing
+}
+
+// Assemble streams all verified chunks into a new file, verifies the complete
+// Badger backup hash and byte count, fsyncs, then atomically renames it. It
+// refuses to replace an existing output.
+func (a *Assembler) Assemble(outputPath string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.received) != len(a.metadata.ChunkHashes) {
+		return errors.New("state sync snapshot is incomplete")
+	}
+	if outputPath == "" {
+		return errors.New("state sync output path is empty")
+	}
+	if _, err := os.Stat(outputPath); err == nil {
+		return errors.New("state sync output already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	outputDir := filepath.Dir(outputPath)
+	if err := os.MkdirAll(outputDir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(outputDir, ".state-sync-backup-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	ok := false
+	defer func() {
+		_ = tmp.Close()
+		if !ok {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	whole := sha256.New()
+	written := uint64(0)
+	indexes := make([]int, len(a.metadata.ChunkHashes))
+	for i := range indexes {
+		indexes[i] = i
+	}
+	sort.Ints(indexes)
+	for _, index := range indexes {
+		chunkFile, err := os.Open(filepath.Join(a.dir, chunkFilename(uint32(index)))) //nolint:gosec // index is bounded metadata
+		if err != nil {
+			return err
+		}
+		count, copyErr := io.Copy(io.MultiWriter(tmp, whole), chunkFile)
+		closeErr := chunkFile.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		written += uint64(count) // #nosec G115 -- each chunk is bounded and positive
+	}
+	if written != a.metadata.BackupSize || !bytes.Equal(whole.Sum(nil), a.metadata.BackupHash) {
+		return errors.New("assembled state sync backup verification failed")
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, outputPath); err != nil {
+		return err
+	}
+	if err := syncDir(outputDir); err != nil {
+		return err
+	}
+	ok = true
+	return nil
+}
+
+func chunkFilename(index uint32) string { return fmt.Sprintf("chunk-%06d", index) }
+
+func syncDir(path string) error {
+	dir, err := os.Open(path) //nolint:gosec // caller-supplied staging/output directory
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return dir.Sync()
+}

--- a/internal/statesync/exporter.go
+++ b/internal/statesync/exporter.go
@@ -1,0 +1,362 @@
+package statesync
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	badger "github.com/dgraph-io/badger/v4"
+)
+
+const (
+	metadataFilename = "metadata.bin"
+	chunksDirname    = "chunks"
+)
+
+// BackupVerifier loads a staged Badger backup with the historical AppHash rule
+// appropriate to its height and returns the computed hash. Export requires this
+// callback so a racing/inconsistent backup is never advertised.
+type BackupVerifier func(context.Context, string) ([]byte, error)
+
+// Snapshot is a verified, network-safe export descriptor. Dir contains only
+// canonical public metadata and Badger backup chunks.
+type Snapshot struct {
+	Dir      string
+	Metadata Metadata
+	Encoded  []byte
+	Hash     []byte
+}
+
+// Export writes a bounded live Badger backup, verifies its AppHash, splits it
+// into hashed chunks, removes the monolithic staging file, and atomically
+// publishes a network-safe snapshot directory.
+func Export(ctx context.Context, db *badger.DB, root string, height uint64, appHash []byte, chunkSize uint32, verify BackupVerifier) (*Snapshot, error) {
+	if db == nil || root == "" || verify == nil {
+		return nil, errors.New("state sync export requires db, root, and verifier")
+	}
+	if height == 0 || len(appHash) != sha256.Size {
+		return nil, errors.New("state sync export requires positive height and SHA-256 AppHash")
+	}
+	if chunkSize < MinChunkSize || chunkSize > MaxChunkSize {
+		return nil, fmt.Errorf("state sync chunk size must be %d..%d bytes", MinChunkSize, MaxChunkSize)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, err
+	}
+	staging, err := os.MkdirTemp(root, fmt.Sprintf(".staging-%d-", height))
+	if err != nil {
+		return nil, err
+	}
+	published := false
+	defer func() {
+		if !published {
+			_ = os.RemoveAll(staging)
+		}
+	}()
+
+	backupPath := filepath.Join(staging, "badger.backup")
+	backupFile, err := os.OpenFile(backupPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	bounded := &boundedContextWriter{ctx: ctx, writer: backupFile, remaining: MaxSnapshotBytes}
+	_, backupErr := db.Backup(bounded, 0)
+	syncErr := backupFile.Sync()
+	closeErr := backupFile.Close()
+	if backupErr != nil {
+		return nil, fmt.Errorf("state sync badger backup: %w", backupErr)
+	}
+	if syncErr != nil {
+		return nil, syncErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	stat, err := os.Stat(backupPath)
+	if err != nil {
+		return nil, err
+	}
+	if stat.Size() <= 0 || uint64(stat.Size()) > MaxSnapshotBytes { // #nosec G115 -- positive size checked first
+		return nil, fmt.Errorf("state sync backup size %d outside 1..%d", stat.Size(), MaxSnapshotBytes)
+	}
+	computedAppHash, err := verify(ctx, backupPath)
+	if err != nil {
+		return nil, fmt.Errorf("verify state sync backup AppHash: %w", err)
+	}
+	if !bytes.Equal(computedAppHash, appHash) {
+		return nil, errors.New("state sync backup AppHash does not match committed AppHash")
+	}
+
+	chunksDir := filepath.Join(staging, chunksDirname)
+	if err := os.Mkdir(chunksDir, 0o700); err != nil {
+		return nil, err
+	}
+	input, err := os.Open(backupPath) //nolint:gosec // staging-owned path
+	if err != nil {
+		return nil, err
+	}
+	whole := sha256.New()
+	chunkHashes := make([][]byte, 0, (uint64(stat.Size())+uint64(chunkSize)-1)/uint64(chunkSize)) // #nosec G115 -- positive bounded size
+	buffer := make([]byte, int(chunkSize))
+	for index := uint32(0); ; index++ {
+		if err := ctx.Err(); err != nil {
+			_ = input.Close()
+			return nil, err
+		}
+		if index >= MaxChunks {
+			_ = input.Close()
+			return nil, fmt.Errorf("state sync export exceeds %d chunks", MaxChunks)
+		}
+		read, readErr := io.ReadFull(input, buffer)
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil && !errors.Is(readErr, io.ErrUnexpectedEOF) {
+			_ = input.Close()
+			return nil, readErr
+		}
+		chunk := buffer[:read]
+		_, _ = whole.Write(chunk)
+		hash := sha256.Sum256(chunk)
+		chunkHashes = append(chunkHashes, append([]byte(nil), hash[:]...))
+		if err := writeSyncedFile(filepath.Join(chunksDir, chunkFilename(index)), chunk); err != nil {
+			_ = input.Close()
+			return nil, err
+		}
+		if errors.Is(readErr, io.ErrUnexpectedEOF) {
+			break
+		}
+	}
+	if err := input.Close(); err != nil {
+		return nil, err
+	}
+	if len(chunkHashes) == 0 {
+		return nil, errors.New("state sync backup produced no chunks")
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return nil, err
+	}
+	metadata, encoded, snapshotHash, err := buildMetadataFromDigests(
+		height, appHash, uint64(stat.Size()), chunkSize, whole.Sum(nil), chunkHashes, // #nosec G115 -- positive bounded size
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeSyncedFile(filepath.Join(staging, metadataFilename), encoded); err != nil {
+		return nil, err
+	}
+	if err := syncDir(chunksDir); err != nil {
+		return nil, err
+	}
+	if err := syncDir(staging); err != nil {
+		return nil, err
+	}
+	finalDir := filepath.Join(root, fmt.Sprintf("%020d-%s", height, hex.EncodeToString(snapshotHash[:8])))
+	if _, err := os.Stat(finalDir); err == nil {
+		return nil, errors.New("state sync snapshot already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	if err := os.Rename(staging, finalDir); err != nil {
+		return nil, err
+	}
+	if err := syncDir(root); err != nil {
+		_ = os.RemoveAll(finalDir)
+		_ = syncDir(root)
+		return nil, err
+	}
+	published = true
+	return &Snapshot{Dir: finalDir, Metadata: metadata, Encoded: encoded, Hash: snapshotHash}, nil
+}
+
+// OpenSnapshot validates a published descriptor and the size/type of every
+// chunk. LoadChunk repeats the content hash immediately before bytes are served.
+func OpenSnapshot(dir string) (*Snapshot, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) != 2 {
+		return nil, errors.New("state sync snapshot directory contains unexpected entries")
+	}
+	entryTypes := make(map[string]os.FileMode, len(entries))
+	for _, entry := range entries {
+		entryTypes[entry.Name()] = entry.Type()
+	}
+	if _, ok := entryTypes[metadataFilename]; !ok {
+		return nil, errors.New("state sync snapshot metadata is missing")
+	}
+	if _, ok := entryTypes[chunksDirname]; !ok {
+		return nil, errors.New("state sync snapshot chunks directory is missing")
+	}
+	chunksInfo, err := os.Lstat(filepath.Join(dir, chunksDirname))
+	if err != nil || !chunksInfo.IsDir() || chunksInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("state sync chunks path is not a real directory")
+	}
+	metadataPath := filepath.Join(dir, metadataFilename)
+	if err := requireRegularFile(metadataPath); err != nil {
+		return nil, err
+	}
+	encoded, err := os.ReadFile(metadataPath) //nolint:gosec // caller-selected snapshot root
+	if err != nil {
+		return nil, err
+	}
+	metadata, err := DecodeMetadata(encoded)
+	if err != nil {
+		return nil, err
+	}
+	chunkEntries, err := os.ReadDir(filepath.Join(dir, chunksDirname))
+	if err != nil {
+		return nil, err
+	}
+	if len(chunkEntries) != len(metadata.ChunkHashes) {
+		return nil, errors.New("state sync chunks directory has unexpected entry count")
+	}
+	expectedNames := make(map[string]struct{}, len(metadata.ChunkHashes))
+	for index := range metadata.ChunkHashes {
+		expectedNames[chunkFilename(uint32(index))] = struct{}{}
+	}
+	for _, entry := range chunkEntries {
+		if _, ok := expectedNames[entry.Name()]; !ok {
+			return nil, fmt.Errorf("unexpected state sync chunk entry %q", entry.Name())
+		}
+	}
+	for index := range metadata.ChunkHashes {
+		path := filepath.Join(dir, chunksDirname, chunkFilename(uint32(index)))
+		if err := requireRegularFile(path); err != nil {
+			return nil, err
+		}
+		stat, err := os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+		expected, err := expectedChunkSize(metadata, uint32(index))
+		if err != nil || stat.Size() != int64(expected) {
+			return nil, fmt.Errorf("state sync chunk %d has invalid published size", index)
+		}
+	}
+	hash := sha256.Sum256(encoded)
+	return &Snapshot{Dir: dir, Metadata: metadata, Encoded: encoded, Hash: append([]byte(nil), hash[:]...)}, nil
+}
+
+// LoadChunk returns one verified chunk and refuses symlinks or post-publication
+// tampering.
+func (snapshot *Snapshot) LoadChunk(index uint32) ([]byte, error) {
+	if snapshot == nil {
+		return nil, errors.New("nil state sync snapshot")
+	}
+	expected, err := expectedChunkSize(snapshot.Metadata, index)
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(snapshot.Dir, chunksDirname, chunkFilename(index))
+	if err := requireRegularFile(path); err != nil {
+		return nil, err
+	}
+	chunk, err := os.ReadFile(path) //nolint:gosec // index is bounded metadata
+	if err != nil {
+		return nil, err
+	}
+	if len(chunk) != expected {
+		return nil, fmt.Errorf("state sync chunk %d size changed after publication", index)
+	}
+	hash := sha256.Sum256(chunk)
+	if !bytes.Equal(hash[:], snapshot.Metadata.ChunkHashes[index]) {
+		return nil, fmt.Errorf("state sync chunk %d hash changed after publication", index)
+	}
+	return chunk, nil
+}
+
+// ListSnapshots returns valid published snapshots newest-first. A malformed
+// directory fails the catalog closed instead of disappearing silently.
+func ListSnapshots(root string) ([]*Snapshot, error) {
+	entries, err := os.ReadDir(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	snapshots := make([]*Snapshot, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() || len(entry.Name()) > 0 && entry.Name()[0] == '.' {
+			continue
+		}
+		snapshot, err := OpenSnapshot(filepath.Join(root, entry.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("open state sync snapshot %q: %w", entry.Name(), err)
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	sort.Slice(snapshots, func(i, j int) bool {
+		if snapshots[i].Metadata.Height == snapshots[j].Metadata.Height {
+			return bytes.Compare(snapshots[i].Hash, snapshots[j].Hash) > 0
+		}
+		return snapshots[i].Metadata.Height > snapshots[j].Metadata.Height
+	})
+	return snapshots, nil
+}
+
+type boundedContextWriter struct {
+	ctx       context.Context
+	writer    io.Writer
+	remaining uint64
+}
+
+func (writer *boundedContextWriter) Write(data []byte) (int, error) {
+	if err := writer.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if uint64(len(data)) > writer.remaining {
+		return 0, fmt.Errorf("state sync backup exceeds %d bytes", MaxSnapshotBytes)
+	}
+	written, err := writer.writer.Write(data)
+	writer.remaining -= uint64(written) // #nosec G115 -- written never exceeds len(data)
+	return written, err
+}
+
+func writeSyncedFile(path string, data []byte) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	ok := false
+	defer func() {
+		_ = file.Close()
+		if !ok {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	ok = true
+	return nil
+}
+
+func requireRegularFile(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("state sync path is not a regular file: %s", path)
+	}
+	return nil
+}

--- a/internal/statesync/exporter.go
+++ b/internal/statesync/exporter.go
@@ -98,8 +98,8 @@ func Export(ctx context.Context, db *badger.DB, root string, height uint64, appH
 	}
 
 	chunksDir := filepath.Join(staging, chunksDirname)
-	if err := os.Mkdir(chunksDir, 0o700); err != nil {
-		return nil, err
+	if mkdirChunksErr := os.Mkdir(chunksDir, 0o700); mkdirChunksErr != nil {
+		return nil, mkdirChunksErr
 	}
 	input, err := os.Open(backupPath) //nolint:gosec // staging-owned path
 	if err != nil {
@@ -109,9 +109,9 @@ func Export(ctx context.Context, db *badger.DB, root string, height uint64, appH
 	chunkHashes := make([][]byte, 0, (uint64(stat.Size())+uint64(chunkSize)-1)/uint64(chunkSize)) // #nosec G115 -- positive bounded size
 	buffer := make([]byte, int(chunkSize))
 	for index := uint32(0); ; index++ {
-		if err := ctx.Err(); err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
 			_ = input.Close()
-			return nil, err
+			return nil, contextErr
 		}
 		if index >= MaxChunks {
 			_ = input.Close()
@@ -129,22 +129,22 @@ func Export(ctx context.Context, db *badger.DB, root string, height uint64, appH
 		_, _ = whole.Write(chunk)
 		hash := sha256.Sum256(chunk)
 		chunkHashes = append(chunkHashes, append([]byte(nil), hash[:]...))
-		if err := writeSyncedFile(filepath.Join(chunksDir, chunkFilename(index)), chunk); err != nil {
+		if writeChunkErr := writeSyncedFile(filepath.Join(chunksDir, chunkFilename(index)), chunk); writeChunkErr != nil {
 			_ = input.Close()
-			return nil, err
+			return nil, writeChunkErr
 		}
 		if errors.Is(readErr, io.ErrUnexpectedEOF) {
 			break
 		}
 	}
-	if err := input.Close(); err != nil {
-		return nil, err
+	if closeInputErr := input.Close(); closeInputErr != nil {
+		return nil, closeInputErr
 	}
 	if len(chunkHashes) == 0 {
 		return nil, errors.New("state sync backup produced no chunks")
 	}
-	if err := os.Remove(backupPath); err != nil {
-		return nil, err
+	if removeBackupErr := os.Remove(backupPath); removeBackupErr != nil {
+		return nil, removeBackupErr
 	}
 	metadata, encoded, snapshotHash, err := buildMetadataFromDigests(
 		height, appHash, uint64(stat.Size()), chunkSize, whole.Sum(nil), chunkHashes, // #nosec G115 -- positive bounded size
@@ -204,8 +204,8 @@ func OpenSnapshot(dir string) (*Snapshot, error) {
 		return nil, errors.New("state sync chunks path is not a real directory")
 	}
 	metadataPath := filepath.Join(dir, metadataFilename)
-	if err := requireRegularFile(metadataPath); err != nil {
-		return nil, err
+	if regularMetadataErr := requireRegularFile(metadataPath); regularMetadataErr != nil {
+		return nil, regularMetadataErr
 	}
 	encoded, err := os.ReadFile(metadataPath) //nolint:gosec // caller-selected snapshot root
 	if err != nil {
@@ -260,8 +260,8 @@ func (snapshot *Snapshot) LoadChunk(index uint32) ([]byte, error) {
 		return nil, err
 	}
 	path := filepath.Join(snapshot.Dir, chunksDirname, chunkFilename(index))
-	if err := requireRegularFile(path); err != nil {
-		return nil, err
+	if regularChunkErr := requireRegularFile(path); regularChunkErr != nil {
+		return nil, regularChunkErr
 	}
 	chunk, err := os.ReadFile(path) //nolint:gosec // index is bounded metadata
 	if err != nil {

--- a/internal/statesync/exporter_test.go
+++ b/internal/statesync/exporter_test.go
@@ -1,0 +1,147 @@
+package statesync
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+func narrowAppHashVerifier(t *testing.T) BackupVerifier {
+	t.Helper()
+	return func(_ context.Context, backupPath string) ([]byte, error) {
+		restoredPath := filepath.Join(t.TempDir(), "verify-badger")
+		db, err := badger.Open(badger.DefaultOptions(restoredPath).WithLogger(nil))
+		if err != nil {
+			return nil, err
+		}
+		file, err := os.Open(backupPath) //nolint:gosec // exporter-owned staging path
+		if err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+		if err := db.Load(file, 16); err != nil {
+			_ = file.Close()
+			_ = db.Close()
+			return nil, err
+		}
+		if err := file.Close(); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+		if err := db.Close(); err != nil {
+			return nil, err
+		}
+		restored, err := store.NewBadgerStore(restoredPath)
+		if err != nil {
+			return nil, err
+		}
+		hash, hashErr := restored.ComputeAppHashExcludingBookkeeping()
+		closeErr := restored.CloseBadger()
+		if hashErr != nil {
+			return nil, hashErr
+		}
+		return hash, closeErr
+	}
+}
+
+func TestExportCatalogAndLoadChunkContainOnlyConsensusState(t *testing.T) {
+	badgerPath := filepath.Join(t.TempDir(), "live-badger")
+	live, err := store.NewBadgerStore(badgerPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = live.CloseBadger() })
+	require.NoError(t, live.SetState("scope:export", bytes.Repeat([]byte("roster"), 20_000)))
+	require.NoError(t, live.SetState("scope-content:export", bytes.Repeat([]byte("selected"), 20_000)))
+	appHash, err := live.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+
+	root := filepath.Join(t.TempDir(), "network-snapshots")
+	exported, err := Export(context.Background(), live.DB(), root, 88, appHash, MinChunkSize, narrowAppHashVerifier(t))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(88), exported.Metadata.Height)
+	assert.Equal(t, appHash, exported.Metadata.AppHash)
+	entries, err := os.ReadDir(exported.Dir)
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	assert.ElementsMatch(t, []string{metadataFilename, chunksDirname}, names,
+		"network export must contain no SQLite, CometBFT db/config, keys, vault, or binary")
+
+	opened, err := OpenSnapshot(exported.Dir)
+	require.NoError(t, err)
+	assert.Equal(t, exported.Hash, opened.Hash)
+	var backup bytes.Buffer
+	for index := range opened.Metadata.ChunkHashes {
+		chunk, err := opened.LoadChunk(uint32(index))
+		require.NoError(t, err)
+		_, _ = backup.Write(chunk)
+	}
+	assert.Equal(t, opened.Metadata.BackupSize, uint64(backup.Len()))
+	backupHash := sha256.Sum256(backup.Bytes())
+	assert.Equal(t, opened.Metadata.BackupHash, backupHash[:])
+
+	catalog, err := ListSnapshots(root)
+	require.NoError(t, err)
+	require.Len(t, catalog, 1)
+	assert.Equal(t, opened.Hash, catalog[0].Hash)
+	require.NoError(t, os.WriteFile(filepath.Join(exported.Dir, "node_key.json"), []byte("must never travel"), 0o600))
+	_, err = OpenSnapshot(exported.Dir)
+	require.ErrorContains(t, err, "unexpected entries", "network catalogs reject private-file smuggling")
+}
+
+func TestExportRejectsWrongAppHashAndLoadDetectsTampering(t *testing.T) {
+	live, err := store.NewBadgerStore(filepath.Join(t.TempDir(), "live-badger"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = live.CloseBadger() })
+	require.NoError(t, live.SetState("scope:export", []byte("state")))
+	appHash, err := live.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	wrong := sha256.Sum256([]byte("wrong"))
+	root := filepath.Join(t.TempDir(), "network-snapshots")
+	_, err = Export(context.Background(), live.DB(), root, 1, wrong[:], MinChunkSize, narrowAppHashVerifier(t))
+	require.ErrorContains(t, err, "does not match")
+	catalog, err := ListSnapshots(root)
+	require.NoError(t, err)
+	assert.Empty(t, catalog, "failed export leaves no published snapshot")
+
+	exported, err := Export(context.Background(), live.DB(), root, 2, appHash, MinChunkSize, narrowAppHashVerifier(t))
+	require.NoError(t, err)
+	chunkPath := filepath.Join(exported.Dir, chunksDirname, chunkFilename(0))
+	chunk, err := os.ReadFile(chunkPath) //nolint:gosec // test-owned path
+	require.NoError(t, err)
+	chunk[0] ^= 0xff
+	require.NoError(t, os.WriteFile(chunkPath, chunk, 0o600))
+	_, err = exported.LoadChunk(0)
+	require.ErrorContains(t, err, "hash changed")
+	_, err = ListSnapshots(root)
+	require.NoError(t, err, "catalog checks type/size; LoadChunk performs just-in-time content verification")
+}
+
+func TestOpenSnapshotRejectsSymlinkChunk(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	metadata, encoded, _, chunks, _ := stateSyncFixture(t)
+	dir := filepath.Join(t.TempDir(), "snapshot")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, chunksDirname), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, metadataFilename), encoded, 0o600))
+	target := filepath.Join(t.TempDir(), "external")
+	require.NoError(t, os.WriteFile(target, chunks[0], 0o600))
+	require.NoError(t, os.Symlink(target, filepath.Join(dir, chunksDirname, chunkFilename(0))))
+	for index := 1; index < len(metadata.ChunkHashes); index++ {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, chunksDirname, chunkFilename(uint32(index))), chunks[index], 0o600))
+	}
+	_, err := OpenSnapshot(dir)
+	require.ErrorContains(t, err, "not a regular file")
+}

--- a/internal/statesync/exporter_test.go
+++ b/internal/statesync/exporter_test.go
@@ -29,17 +29,17 @@ func narrowAppHashVerifier(t *testing.T) BackupVerifier {
 			_ = db.Close()
 			return nil, err
 		}
-		if err := db.Load(file, 16); err != nil {
+		if loadErr := db.Load(file, 16); loadErr != nil {
 			_ = file.Close()
 			_ = db.Close()
-			return nil, err
+			return nil, loadErr
 		}
-		if err := file.Close(); err != nil {
+		if closeFileErr := file.Close(); closeFileErr != nil {
 			_ = db.Close()
-			return nil, err
+			return nil, closeFileErr
 		}
-		if err := db.Close(); err != nil {
-			return nil, err
+		if closeDBErr := db.Close(); closeDBErr != nil {
+			return nil, closeDBErr
 		}
 		restored, err := store.NewBadgerStore(restoredPath)
 		if err != nil {
@@ -83,8 +83,8 @@ func TestExportCatalogAndLoadChunkContainOnlyConsensusState(t *testing.T) {
 	assert.Equal(t, exported.Hash, opened.Hash)
 	var backup bytes.Buffer
 	for index := range opened.Metadata.ChunkHashes {
-		chunk, err := opened.LoadChunk(uint32(index))
-		require.NoError(t, err)
+		chunk, loadChunkErr := opened.LoadChunk(uint32(index))
+		require.NoError(t, loadChunkErr)
 		_, _ = backup.Write(chunk)
 	}
 	assert.Equal(t, opened.Metadata.BackupSize, uint64(backup.Len()))

--- a/internal/statesync/format.go
+++ b/internal/statesync/format.go
@@ -1,0 +1,238 @@
+// Package statesync defines SAGE's network-safe consensus snapshot substrate.
+//
+// This format contains only a chunked Badger backup plus canonical public
+// metadata. It is intentionally unrelated to internal/snapshot, whose local
+// rollback bundle can contain SQLite, CometBFT databases, validator/node keys,
+// vault material, configuration, and binaries and must never cross the network.
+package statesync
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+)
+
+const (
+	// Format is the CometBFT Snapshot.Format value for the first SAGE
+	// consensus-only snapshot format.
+	Format uint32 = 1
+
+	metadataVersion byte = 1
+	headerSize           = 12 + 1 + 8 + sha256.Size + 8 + 4 + 4 + sha256.Size
+
+	MinChunkSize     uint32 = 64 << 10
+	MaxChunkSize     uint32 = 8 << 20 // safely below CometBFT's 16 MB chunk channel
+	MaxChunks        uint32 = 512
+	MaxMetadata             = headerSize + int(MaxChunks)*sha256.Size
+	MaxSnapshotBytes        = uint64(MaxChunkSize) * uint64(MaxChunks)
+)
+
+var metadataMagic = [12]byte{'S', 'A', 'G', 'E', '-', 'S', 'T', 'S', 'Y', 'N', 'C', 0}
+
+// Metadata binds the trusted application height/hash to the exact Badger
+// backup byte stream and each independently verifiable transport chunk.
+type Metadata struct {
+	Height      uint64
+	AppHash     []byte
+	BackupSize  uint64
+	ChunkSize   uint32
+	BackupHash  []byte
+	ChunkHashes [][]byte
+}
+
+// BuildMetadata derives canonical metadata from an already chunked Badger
+// backup. Exporters should stream the live Badger backup to disk and pass its
+// bounded chunks here; this helper never accepts local rollback-bundle files.
+// chunkSize is the declared transport size, so a one-chunk backup may be
+// smaller than it while still using the standard minimum chunk size.
+func BuildMetadata(height uint64, appHash []byte, chunkSize uint32, chunks [][]byte) (Metadata, []byte, []byte, error) {
+	if height == 0 {
+		return Metadata{}, nil, nil, errors.New("state sync height must be positive")
+	}
+	if len(appHash) != sha256.Size {
+		return Metadata{}, nil, nil, fmt.Errorf("state sync app hash must be %d bytes", sha256.Size)
+	}
+	if len(chunks) == 0 || len(chunks) > int(MaxChunks) {
+		return Metadata{}, nil, nil, fmt.Errorf("state sync chunk count must be 1..%d", MaxChunks)
+	}
+	if chunkSize < MinChunkSize || chunkSize > MaxChunkSize {
+		return Metadata{}, nil, nil, fmt.Errorf("state sync chunk size must be %d..%d bytes", MinChunkSize, MaxChunkSize)
+	}
+	whole := sha256.New()
+	chunkHashes := make([][]byte, len(chunks))
+	var total uint64
+	for i, chunk := range chunks {
+		if len(chunk) == 0 || len(chunk) > int(chunkSize) || (i < len(chunks)-1 && len(chunk) != int(chunkSize)) {
+			return Metadata{}, nil, nil, fmt.Errorf("state sync chunk %d has non-canonical size %d", i, len(chunk))
+		}
+		if total > math.MaxUint64-uint64(len(chunk)) {
+			return Metadata{}, nil, nil, errors.New("state sync backup size overflow")
+		}
+		total += uint64(len(chunk))
+		_, _ = whole.Write(chunk)
+		hash := sha256.Sum256(chunk)
+		chunkHashes[i] = append([]byte(nil), hash[:]...)
+	}
+	backupHash := whole.Sum(nil)
+	return buildMetadataFromDigests(height, appHash, total, chunkSize, backupHash, chunkHashes)
+}
+
+func buildMetadataFromDigests(height uint64, appHash []byte, backupSize uint64, chunkSize uint32, backupHash []byte, chunkHashes [][]byte) (Metadata, []byte, []byte, error) {
+	metadata := Metadata{
+		Height: height, AppHash: append([]byte(nil), appHash...), BackupSize: backupSize,
+		ChunkSize: chunkSize, BackupHash: append([]byte(nil), backupHash...), ChunkHashes: make([][]byte, len(chunkHashes)),
+	}
+	for i, hash := range chunkHashes {
+		metadata.ChunkHashes[i] = append([]byte(nil), hash...)
+	}
+	encoded, err := EncodeMetadata(metadata)
+	if err != nil {
+		return Metadata{}, nil, nil, err
+	}
+	snapshotHash := sha256.Sum256(encoded)
+	return metadata, encoded, append([]byte(nil), snapshotHash[:]...), nil
+}
+
+// EncodeMetadata emits the one canonical wire encoding accepted by v1.
+func EncodeMetadata(metadata Metadata) ([]byte, error) {
+	if err := validateMetadata(metadata); err != nil {
+		return nil, err
+	}
+	encoded := make([]byte, headerSize+len(metadata.ChunkHashes)*sha256.Size)
+	offset := 0
+	copy(encoded[offset:], metadataMagic[:])
+	offset += len(metadataMagic)
+	encoded[offset] = metadataVersion
+	offset++
+	binary.BigEndian.PutUint64(encoded[offset:], metadata.Height)
+	offset += 8
+	copy(encoded[offset:], metadata.AppHash)
+	offset += sha256.Size
+	binary.BigEndian.PutUint64(encoded[offset:], metadata.BackupSize)
+	offset += 8
+	binary.BigEndian.PutUint32(encoded[offset:], metadata.ChunkSize)
+	offset += 4
+	binary.BigEndian.PutUint32(encoded[offset:], uint32(len(metadata.ChunkHashes)))
+	offset += 4
+	copy(encoded[offset:], metadata.BackupHash)
+	offset += sha256.Size
+	for _, hash := range metadata.ChunkHashes {
+		copy(encoded[offset:], hash)
+		offset += sha256.Size
+	}
+	return encoded, nil
+}
+
+// DecodeMetadata rejects unknown, oversized, non-canonical, and trailing-byte
+// encodings before allocating a chunk-hash table.
+func DecodeMetadata(encoded []byte) (Metadata, error) {
+	if len(encoded) < headerSize || len(encoded) > MaxMetadata {
+		return Metadata{}, fmt.Errorf("state sync metadata size %d is outside %d..%d", len(encoded), headerSize, MaxMetadata)
+	}
+	offset := 0
+	if !bytes.Equal(encoded[offset:offset+len(metadataMagic)], metadataMagic[:]) {
+		return Metadata{}, errors.New("state sync metadata magic mismatch")
+	}
+	offset += len(metadataMagic)
+	if encoded[offset] != metadataVersion {
+		return Metadata{}, fmt.Errorf("unsupported state sync metadata version %d", encoded[offset])
+	}
+	offset++
+	height := binary.BigEndian.Uint64(encoded[offset:])
+	offset += 8
+	appHash := append([]byte(nil), encoded[offset:offset+sha256.Size]...)
+	offset += sha256.Size
+	backupSize := binary.BigEndian.Uint64(encoded[offset:])
+	offset += 8
+	chunkSize := binary.BigEndian.Uint32(encoded[offset:])
+	offset += 4
+	chunkCount := binary.BigEndian.Uint32(encoded[offset:])
+	offset += 4
+	backupHash := append([]byte(nil), encoded[offset:offset+sha256.Size]...)
+	offset += sha256.Size
+	if chunkCount == 0 || chunkCount > MaxChunks {
+		return Metadata{}, fmt.Errorf("state sync chunk count %d is outside 1..%d", chunkCount, MaxChunks)
+	}
+	expectedLength := headerSize + int(chunkCount)*sha256.Size
+	if len(encoded) != expectedLength {
+		return Metadata{}, fmt.Errorf("state sync metadata length %d does not match canonical length %d", len(encoded), expectedLength)
+	}
+	chunkHashes := make([][]byte, int(chunkCount))
+	for i := range chunkHashes {
+		chunkHashes[i] = append([]byte(nil), encoded[offset:offset+sha256.Size]...)
+		offset += sha256.Size
+	}
+	metadata := Metadata{
+		Height: height, AppHash: appHash, BackupSize: backupSize, ChunkSize: chunkSize,
+		BackupHash: backupHash, ChunkHashes: chunkHashes,
+	}
+	if err := validateMetadata(metadata); err != nil {
+		return Metadata{}, err
+	}
+	return metadata, nil
+}
+
+// ValidateOffer binds untrusted ABCI snapshot metadata to CometBFT's trusted
+// height/AppHash and to Snapshot.Hash before any chunks are accepted.
+func ValidateOffer(format uint32, height uint64, chunks uint32, snapshotHash, encoded, trustedAppHash []byte) (Metadata, error) {
+	if format != Format {
+		return Metadata{}, fmt.Errorf("unsupported state sync format %d", format)
+	}
+	metadata, err := DecodeMetadata(encoded)
+	if err != nil {
+		return Metadata{}, err
+	}
+	wantSnapshotHash := sha256.Sum256(encoded)
+	if len(snapshotHash) != sha256.Size || !bytes.Equal(snapshotHash, wantSnapshotHash[:]) {
+		return Metadata{}, errors.New("state sync snapshot hash mismatch")
+	}
+	if metadata.Height != height || uint32(len(metadata.ChunkHashes)) != chunks {
+		return Metadata{}, errors.New("state sync snapshot fields disagree with metadata")
+	}
+	if len(trustedAppHash) != sha256.Size || !bytes.Equal(metadata.AppHash, trustedAppHash) {
+		return Metadata{}, errors.New("state sync metadata does not match trusted AppHash")
+	}
+	return metadata, nil
+}
+
+func validateMetadata(metadata Metadata) error {
+	if metadata.Height == 0 {
+		return errors.New("state sync height must be positive")
+	}
+	if len(metadata.AppHash) != sha256.Size || len(metadata.BackupHash) != sha256.Size {
+		return errors.New("state sync hashes must be SHA-256 sized")
+	}
+	if metadata.ChunkSize < MinChunkSize || metadata.ChunkSize > MaxChunkSize {
+		return fmt.Errorf("state sync chunk size %d is outside %d..%d", metadata.ChunkSize, MinChunkSize, MaxChunkSize)
+	}
+	count := uint64(len(metadata.ChunkHashes))
+	if count == 0 || count > uint64(MaxChunks) {
+		return fmt.Errorf("state sync chunk count %d is outside 1..%d", count, MaxChunks)
+	}
+	for i, hash := range metadata.ChunkHashes {
+		if len(hash) != sha256.Size {
+			return fmt.Errorf("state sync chunk hash %d is not SHA-256 sized", i)
+		}
+	}
+	maxSize := count * uint64(metadata.ChunkSize)
+	minSize := (count-1)*uint64(metadata.ChunkSize) + 1
+	if metadata.BackupSize < minSize || metadata.BackupSize > maxSize {
+		return fmt.Errorf("state sync backup size %d is inconsistent with %d chunks of %d", metadata.BackupSize, count, metadata.ChunkSize)
+	}
+	return nil
+}
+
+func expectedChunkSize(metadata Metadata, index uint32) (int, error) {
+	count := uint32(len(metadata.ChunkHashes))
+	if index >= count {
+		return 0, fmt.Errorf("state sync chunk index %d out of range", index)
+	}
+	if index < count-1 {
+		return int(metadata.ChunkSize), nil
+	}
+	last := metadata.BackupSize - uint64(count-1)*uint64(metadata.ChunkSize)
+	return int(last), nil
+}

--- a/internal/statesync/format_test.go
+++ b/internal/statesync/format_test.go
@@ -1,0 +1,186 @@
+package statesync
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+func stateSyncFixture(t *testing.T) (Metadata, []byte, []byte, [][]byte, []byte) {
+	t.Helper()
+	appHash := sha256.Sum256([]byte("trusted app hash"))
+	payload := bytes.Repeat([]byte("canonical-badger-backup"), 6_100)
+	chunks := make([][]byte, 0, 3)
+	for offset := 0; offset < len(payload); offset += int(MinChunkSize) {
+		end := offset + int(MinChunkSize)
+		if end > len(payload) {
+			end = len(payload)
+		}
+		chunks = append(chunks, append([]byte(nil), payload[offset:end]...))
+	}
+	metadata, encoded, snapshotHash, err := BuildMetadata(42, appHash[:], MinChunkSize, chunks)
+	require.NoError(t, err)
+	return metadata, encoded, snapshotHash, chunks, payload
+}
+
+func TestMetadataCanonicalRoundTripAndTrustedOffer(t *testing.T) {
+	metadata, encoded, snapshotHash, _, _ := stateSyncFixture(t)
+	decoded, err := DecodeMetadata(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, metadata, decoded)
+	reencoded, err := EncodeMetadata(decoded)
+	require.NoError(t, err)
+	assert.Equal(t, encoded, reencoded)
+
+	offered, err := ValidateOffer(Format, metadata.Height, uint32(len(metadata.ChunkHashes)), snapshotHash, encoded, metadata.AppHash)
+	require.NoError(t, err)
+	assert.Equal(t, metadata, offered)
+
+	_, err = ValidateOffer(Format+1, metadata.Height, uint32(len(metadata.ChunkHashes)), snapshotHash, encoded, metadata.AppHash)
+	require.ErrorContains(t, err, "unsupported")
+	wrongHash := sha256.Sum256([]byte("wrong trusted hash"))
+	_, err = ValidateOffer(Format, metadata.Height, uint32(len(metadata.ChunkHashes)), snapshotHash, encoded, wrongHash[:])
+	require.ErrorContains(t, err, "trusted AppHash")
+	_, err = ValidateOffer(Format, metadata.Height, uint32(len(metadata.ChunkHashes)), wrongHash[:], encoded, metadata.AppHash)
+	require.ErrorContains(t, err, "snapshot hash")
+}
+
+func TestMetadataRejectsLocalRollbackManifestAndMalformedInputs(t *testing.T) {
+	_, err := DecodeMetadata([]byte(`{"height":42,"chunks":[{"name":"config.tar.zst"}]}`))
+	require.Error(t, err, "the private local snapshot manifest is never a network format")
+
+	metadata, encoded, _, _, _ := stateSyncFixture(t)
+	_, err = DecodeMetadata(append(encoded, 0))
+	require.ErrorContains(t, err, "canonical length")
+	badVersion := append([]byte(nil), encoded...)
+	badVersion[len(metadataMagic)]++
+	_, err = DecodeMetadata(badVersion)
+	require.ErrorContains(t, err, "unsupported")
+	badCount := append([]byte(nil), encoded...)
+	countOffset := 12 + 1 + 8 + sha256.Size + 8 + 4
+	for i := 0; i < 4; i++ {
+		badCount[countOffset+i] = 0xff
+	}
+	_, err = DecodeMetadata(badCount)
+	require.ErrorContains(t, err, "chunk count")
+	metadata.BackupSize = 0
+	_, err = EncodeMetadata(metadata)
+	require.ErrorContains(t, err, "backup size")
+}
+
+func TestAssemblerOutOfOrderDuplicateCorruptionAndCompleteHash(t *testing.T) {
+	metadata, _, _, chunks, payload := stateSyncFixture(t)
+	staging := filepath.Join(t.TempDir(), "assembly")
+	assembler, err := NewAssembler(staging, metadata)
+	require.NoError(t, err)
+	assert.Equal(t, []uint32{0, 1, 2}, assembler.Missing())
+
+	require.NoError(t, assembler.AddChunk(2, chunks[2]))
+	require.NoError(t, assembler.AddChunk(0, chunks[0]))
+	require.NoError(t, assembler.AddChunk(0, chunks[0]), "exact chunk redelivery is idempotent")
+	corrupt := append([]byte(nil), chunks[1]...)
+	corrupt[0] ^= 0xff
+	require.ErrorContains(t, assembler.AddChunk(1, corrupt), "hash mismatch")
+	assert.Equal(t, []uint32{1}, assembler.Missing())
+	require.NoError(t, assembler.AddChunk(1, chunks[1]))
+	assert.Empty(t, assembler.Missing())
+
+	output := filepath.Join(t.TempDir(), "badger.backup")
+	require.NoError(t, assembler.Assemble(output))
+	got, err := os.ReadFile(output) //nolint:gosec // test-owned path
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+	require.ErrorContains(t, assembler.Assemble(output), "already exists")
+}
+
+func TestAssemblerRejectsIncompleteWrongSizeAndExistingStage(t *testing.T) {
+	metadata, _, _, chunks, _ := stateSyncFixture(t)
+	parent := t.TempDir()
+	staging := filepath.Join(parent, "assembly")
+	assembler, err := NewAssembler(staging, metadata)
+	require.NoError(t, err)
+	_, err = NewAssembler(staging, metadata)
+	require.Error(t, err, "existing staging state is never silently reused")
+	require.ErrorContains(t, assembler.AddChunk(0, chunks[0][:len(chunks[0])-1]), "size")
+	require.ErrorContains(t, assembler.AddChunk(uint32(len(chunks)), chunks[0]), "out of range")
+	require.ErrorContains(t, assembler.Assemble(filepath.Join(parent, "out")), "incomplete")
+}
+
+func TestConsensusOnlyFormatRoundTripsRealBadgerBackupAndAppHash(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "source-badger")
+	source, err := store.NewBadgerStore(sourcePath)
+	require.NoError(t, err)
+	require.NoError(t, source.SetState("scope:fixture", []byte("canonical scope state")))
+	require.NoError(t, source.SetState("scope-content:fixture", []byte("selected content only")))
+	appHash, err := source.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	var backup bytes.Buffer
+	_, err = source.DB().Backup(&backup, 0)
+	require.NoError(t, err)
+	require.NoError(t, source.CloseBadger())
+
+	payload := backup.Bytes()
+	chunks := make([][]byte, 0, (len(payload)+int(MinChunkSize)-1)/int(MinChunkSize))
+	for offset := 0; offset < len(payload); offset += int(MinChunkSize) {
+		end := offset + int(MinChunkSize)
+		if end > len(payload) {
+			end = len(payload)
+		}
+		chunks = append(chunks, append([]byte(nil), payload[offset:end]...))
+	}
+	metadata, encoded, snapshotHash, err := BuildMetadata(77, appHash, MinChunkSize, chunks)
+	require.NoError(t, err)
+	_, err = ValidateOffer(Format, 77, uint32(len(chunks)), snapshotHash, encoded, appHash)
+	require.NoError(t, err)
+
+	assembler, err := NewAssembler(filepath.Join(t.TempDir(), "stage"), metadata)
+	require.NoError(t, err)
+	for i := len(chunks) - 1; i >= 0; i-- {
+		require.NoError(t, assembler.AddChunk(uint32(i), chunks[i]))
+	}
+	assembledPath := filepath.Join(t.TempDir(), "badger.backup")
+	require.NoError(t, assembler.Assemble(assembledPath))
+
+	restoredPath := filepath.Join(t.TempDir(), "restored-badger")
+	db, err := badger.Open(badger.DefaultOptions(restoredPath).WithLogger(nil))
+	require.NoError(t, err)
+	backupFile, err := os.Open(assembledPath) //nolint:gosec // test-owned path
+	require.NoError(t, err)
+	require.NoError(t, db.Load(backupFile, 16))
+	require.NoError(t, backupFile.Close())
+	require.NoError(t, db.Close())
+	restored, err := store.NewBadgerStore(restoredPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = restored.CloseBadger() })
+	restoredHash, err := restored.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	assert.Equal(t, appHash, restoredHash)
+}
+
+func FuzzDecodeMetadata(f *testing.F) {
+	appHash := sha256.Sum256([]byte("seed"))
+	chunk := bytes.Repeat([]byte{0x42}, int(MinChunkSize))
+	_, encoded, _, err := BuildMetadata(1, appHash[:], MinChunkSize, [][]byte{chunk})
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(encoded)
+	f.Add([]byte(`{"height":1,"chunks":["private-local-bundle"]}`))
+	f.Fuzz(func(t *testing.T, input []byte) {
+		metadata, err := DecodeMetadata(input)
+		if err != nil {
+			return
+		}
+		reencoded, err := EncodeMetadata(metadata)
+		require.NoError(t, err)
+		require.Equal(t, input, reencoded)
+	})
+}

--- a/internal/store/badger.go
+++ b/internal/store/badger.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -85,6 +86,45 @@ func NewBadgerStore(path string) (*BadgerStore, error) {
 	}
 
 	return store, nil
+}
+
+// OpenBadgerStoreReadOnly opens an existing Badger database without running
+// constructor backfills or permitting writes. State-sync and snapshot
+// verification use this to recompute AppHash against the received bytes without
+// validation itself changing consensus state.
+func OpenBadgerStoreReadOnly(path string) (*BadgerStore, error) {
+	opts := badger.DefaultOptions(path).WithReadOnly(true)
+	opts.Logger = nil
+	db, err := badger.Open(opts)
+	if err != nil {
+		return nil, fmt.Errorf("open badger read-only: %w", err)
+	}
+	return &BadgerStore{db: db}, nil
+}
+
+// OpenBadgerStoreWithoutMigrations opens an existing Badger database writable
+// without running constructor backfills. It is reserved for a state-sync
+// database that has already been restored and verified read-only against a
+// trusted AppHash. Running NewBadgerStore on those bytes would be unsafe during
+// activation because a historical index backfill can change consensus state
+// after verification but before CometBFT performs its Info check.
+//
+// Ordinary boot and upgrade paths must continue to use NewBadgerStore.
+func OpenBadgerStoreWithoutMigrations(path string) (*BadgerStore, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect migration-free badger path: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("migration-free badger path must be a real directory")
+	}
+	opts := badger.DefaultOptions(path)
+	opts.Logger = nil
+	db, err := badger.Open(opts)
+	if err != nil {
+		return nil, fmt.Errorf("open badger without migrations: %w", err)
+	}
+	return &BadgerStore{db: db}, nil
 }
 
 // memoryKey returns the BadgerDB key for a memory's on-chain state.

--- a/internal/store/badger_multiorg_test.go
+++ b/internal/store/badger_multiorg_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"encoding/binary"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 	"time"
@@ -349,4 +351,45 @@ func TestNewBadgerStore_RunsOrgNameBackfill(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, orgs, 1, "store open must auto-backfill the org_name index")
 	assert.Equal(t, orgID, orgs[0].OrgID)
+}
+
+func TestOpenBadgerStoreWithoutMigrationsPreservesVerifiedBytes(t *testing.T) {
+	dir := t.TempDir()
+	const orgID = "0aaa11111111111111111111111111aa"
+	const admin = "admin0000000000000000000000000000000000000000000000000000000adm"
+
+	initial, err := NewBadgerStore(dir)
+	require.NoError(t, err)
+	require.NoError(t, writeLegacyOrg(initial, orgID, "levelup", "", admin, 9))
+	before, err := initial.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	require.NoError(t, initial.CloseBadger())
+
+	reopened, err := OpenBadgerStoreWithoutMigrations(dir)
+	require.NoError(t, err)
+	after, err := reopened.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "verified AppHash must not change merely because the activation handle opened writable")
+	orgs, err := reopened.ListOrgsByName("levelup")
+	require.NoError(t, err)
+	assert.Empty(t, orgs, "migration-free activation must not add a historical reverse index")
+	require.NoError(t, reopened.CloseBadger())
+
+	migrated, err := NewBadgerStore(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = migrated.CloseBadger() })
+	orgs, err = migrated.ListOrgsByName("levelup")
+	require.NoError(t, err)
+	require.Len(t, orgs, 1, "ordinary boot must retain its historical backfill behavior")
+}
+
+func TestOpenBadgerStoreWithoutMigrationsRequiresExistingRealDirectory(t *testing.T) {
+	_, err := OpenBadgerStoreWithoutMigrations(filepath.Join(t.TempDir(), "missing"))
+	assert.Error(t, err)
+
+	target := t.TempDir()
+	link := filepath.Join(t.TempDir(), "badger-link")
+	require.NoError(t, os.Symlink(target, link))
+	_, err = OpenBadgerStoreWithoutMigrations(link)
+	assert.ErrorContains(t, err, "real directory")
 }

--- a/internal/store/scope_state.go
+++ b/internal/store/scope_state.go
@@ -55,8 +55,7 @@ func (s *BadgerStore) SetScopeRecord(record scope.Record) error {
 		exactReplay := false
 		item, getErr := txn.Get(key)
 		if getErr == nil {
-			var decodeErr error
-			decodeErr = item.Value(func(value []byte) error {
+			decodeErr := item.Value(func(value []byte) error {
 				decoded, err := scope.Decode(value)
 				if err != nil {
 					return err

--- a/internal/store/scope_state.go
+++ b/internal/store/scope_state.go
@@ -1,0 +1,302 @@
+package store
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	badger "github.com/dgraph-io/badger/v4"
+
+	"github.com/l33tdawg/sage/internal/scope"
+)
+
+var (
+	ErrScopeRevision = errors.New("scope revision conflict")
+	ErrScopeRetired  = errors.New("scope is permanently retired")
+)
+
+// scopeRecordKey is AppHash-covered canonical v11.9 scope state. Scope records
+// are written only from deterministic ABCI execution once app-v20 is active.
+func scopeRecordKey(scopeID string) []byte { return []byte("state:scope:" + scopeID) }
+
+// scopeDomainKey maps one exact selected domain to its canonical scope. The
+// mapping makes scope lookup an O(1) on-chain read and allows the writer to
+// reject two active scopes claiming the same domain atomically.
+func scopeDomainKey(domain string) []byte { return []byte("state:scope-domain:" + domain) }
+
+// scopeRevisionKey is the immutable audit anchor for one accepted roster
+// revision. The fixed-width decimal suffix preserves revision order in prefix
+// scans while the complete scope ID remains part of the key.
+func scopeRevisionKey(scopeID string, revision uint64) []byte {
+	return []byte("state:scope-revision:" + scopeID + ":" + fmt.Sprintf("%020d", revision))
+}
+
+func scopeRevisionDigest(encoded []byte) []byte {
+	preimage := append([]byte("sage:scope-revision:v1\x00"), encoded...)
+	digest := sha256.Sum256(preimage)
+	return digest[:]
+}
+
+// SetScopeRecord creates or advances one canonical scope roster atomically.
+// Reapplying the exact same record is allowed for crash replay; a different
+// record at the same revision and every revision regression fail closed. Scope
+// domain mappings are replaced in the same Badger transaction, so no committed
+// state can point at a partially updated roster.
+func (s *BadgerStore) SetScopeRecord(record scope.Record) error {
+	encoded, err := scope.Encode(record)
+	if err != nil {
+		return fmt.Errorf("encode scope record: %w", err)
+	}
+
+	return s.db.Update(func(txn *badger.Txn) error {
+		key := scopeRecordKey(record.ScopeID)
+		var previous *scope.Record
+		exactReplay := false
+		item, getErr := txn.Get(key)
+		if getErr == nil {
+			var decodeErr error
+			decodeErr = item.Value(func(value []byte) error {
+				decoded, err := scope.Decode(value)
+				if err != nil {
+					return err
+				}
+				previous = &decoded
+				return nil
+			})
+			if decodeErr != nil {
+				return fmt.Errorf("decode existing scope %q: %w", record.ScopeID, decodeErr)
+			}
+		} else if !errors.Is(getErr, badger.ErrKeyNotFound) {
+			return getErr
+		}
+
+		if previous != nil {
+			switch {
+			case previous.State == scope.StateRetired && record.State != scope.StateRetired:
+				return ErrScopeRetired
+			case record.Revision < previous.Revision:
+				return fmt.Errorf("%w: %d < %d", ErrScopeRevision, record.Revision, previous.Revision)
+			case record.Revision == previous.Revision:
+				if err := item.Value(func(value []byte) error {
+					if bytes.Equal(value, encoded) {
+						exactReplay = true
+						return nil
+					}
+					return fmt.Errorf("%w: revision %d has different content", ErrScopeRevision, record.Revision)
+				}); err != nil {
+					return err
+				}
+			}
+		}
+		if exactReplay {
+			return setScopeRevisionAnchor(txn, record.ScopeID, record.Revision, encoded)
+		}
+
+		// Check all new domain claims before deleting any old mapping. A collision
+		// therefore leaves the previous complete record and mapping set intact.
+		for _, domain := range record.Domains {
+			mapped, err := getScopeDomainMapping(txn, domain.Name)
+			if err != nil {
+				return err
+			}
+			if mapped != "" && mapped != record.ScopeID {
+				return fmt.Errorf("domain %q is already bound to scope %q", domain.Name, mapped)
+			}
+		}
+
+		if previous != nil {
+			for _, oldDomain := range previous.Domains {
+				if !containsScopeDomain(record.Domains, oldDomain.Name) {
+					if err := txn.Delete(scopeDomainKey(oldDomain.Name)); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		if record.State != scope.StateRetired {
+			for _, domain := range record.Domains {
+				if err := txn.Set(scopeDomainKey(domain.Name), []byte(record.ScopeID)); err != nil {
+					return err
+				}
+			}
+		} else if previous != nil {
+			for _, oldDomain := range previous.Domains {
+				if err := txn.Delete(scopeDomainKey(oldDomain.Name)); err != nil {
+					return err
+				}
+			}
+		}
+		if err := setScopeRevisionAnchor(txn, record.ScopeID, record.Revision, encoded); err != nil {
+			return err
+		}
+		return txn.Set(key, encoded)
+	})
+}
+
+func setScopeRevisionAnchor(txn *badger.Txn, scopeID string, revision uint64, encoded []byte) error {
+	key := scopeRevisionKey(scopeID, revision)
+	want := scopeRevisionDigest(encoded)
+	item, err := txn.Get(key)
+	if err == nil {
+		return item.Value(func(value []byte) error {
+			if bytes.Equal(value, want) {
+				return nil
+			}
+			return fmt.Errorf("%w: revision %d audit anchor differs", ErrScopeRevision, revision)
+		})
+	}
+	if !errors.Is(err, badger.ErrKeyNotFound) {
+		return err
+	}
+	return txn.Set(key, want)
+}
+
+// GetScopeRecord returns one decoded canonical record, or (nil, nil) if it has
+// not been created. A malformed persisted value is an error; callers must not
+// treat corrupted consensus state as an absent scope.
+func (s *BadgerStore) GetScopeRecord(scopeID string) (*scope.Record, error) {
+	var record *scope.Record
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(scopeRecordKey(scopeID))
+		if err != nil {
+			return err
+		}
+		return item.Value(func(value []byte) error {
+			decoded, err := scope.Decode(value)
+			if err != nil {
+				return err
+			}
+			record = &decoded
+			return nil
+		})
+	})
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get scope record %q: %w", scopeID, err)
+	}
+	return record, nil
+}
+
+// ListScopeRecords returns every canonical scope head in bytewise scope-ID
+// order. It validates that each key agrees with the encoded record so operator
+// visibility never papers over corrupted consensus state.
+func (s *BadgerStore) ListScopeRecords() ([]scope.Record, error) {
+	prefix := []byte("state:scope:")
+	records := make([]scope.Record, 0)
+	err := s.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			scopeID := string(item.Key()[len(prefix):])
+			if err := item.Value(func(value []byte) error {
+				record, err := scope.Decode(value)
+				if err != nil {
+					return err
+				}
+				if record.ScopeID != scopeID {
+					return fmt.Errorf("scope key %q disagrees with record %q", scopeID, record.ScopeID)
+				}
+				records = append(records, record)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list scope records: %w", err)
+	}
+	return records, nil
+}
+
+// GetScopeRevisionHash returns the immutable domain-separated SHA-256 anchor
+// for one accepted revision, or nil when that revision has never existed.
+func (s *BadgerStore) GetScopeRevisionHash(scopeID string, revision uint64) ([]byte, error) {
+	var digest []byte
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(scopeRevisionKey(scopeID, revision))
+		if err != nil {
+			return err
+		}
+		return item.Value(func(value []byte) error {
+			digest = append([]byte(nil), value...)
+			return nil
+		})
+	})
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get scope revision %q/%d: %w", scopeID, revision, err)
+	}
+	if len(digest) != sha256.Size {
+		return nil, fmt.Errorf("scope revision %q/%d has invalid digest length %d", scopeID, revision, len(digest))
+	}
+	return digest, nil
+}
+
+// GetScopeForDomain returns the exact-domain scope mapping and record, or
+// (nil, nil) when no active/paused scope claims domain. Retired scopes remove
+// their mapping and therefore never accidentally turn an old domain back on.
+func (s *BadgerStore) GetScopeForDomain(domain string) (*scope.Record, error) {
+	var scopeID string
+	err := s.db.View(func(txn *badger.Txn) error {
+		mapped, err := getScopeDomainMapping(txn, domain)
+		if err != nil {
+			return err
+		}
+		scopeID = mapped
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get scope mapping for domain %q: %w", domain, err)
+	}
+	if scopeID == "" {
+		return nil, nil
+	}
+	record, err := s.GetScopeRecord(scopeID)
+	if err != nil {
+		return nil, err
+	}
+	if record == nil {
+		return nil, fmt.Errorf("scope mapping for domain %q points to missing scope %q", domain, scopeID)
+	}
+	return record, nil
+}
+
+func getScopeDomainMapping(txn *badger.Txn, domain string) (string, error) {
+	item, err := txn.Get(scopeDomainKey(domain))
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	var value string
+	if err := item.Value(func(raw []byte) error {
+		if len(raw) == 0 {
+			return errors.New("empty scope domain mapping")
+		}
+		value = string(raw)
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+func containsScopeDomain(domains []scope.Domain, target string) bool {
+	for _, domain := range domains {
+		if domain.Name == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/scope_state_test.go
+++ b/internal/store/scope_state_test.go
@@ -1,0 +1,119 @@
+package store
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/scope"
+)
+
+func testScopeRecord(revision uint64, domains ...string) scope.Record {
+	selected := make([]scope.Domain, 0, len(domains))
+	for _, domain := range domains {
+		selected = append(selected, scope.Domain{Name: domain})
+	}
+	return scope.Record{
+		ScopeID:               "scope-a",
+		Revision:              revision,
+		State:                 scope.StateActive,
+		ControllerValidatorID: "validator-a",
+		CreatedHeight:         10,
+		UpdatedHeight:         int64(10 + revision),
+		Domains:               selected,
+		Members: []scope.Member{
+			{ValidatorID: "validator-a", AssignedWeight: 4, JoinedRevision: 1, Active: true},
+			{ValidatorID: "validator-b", AssignedWeight: 3, JoinedRevision: 1, Active: true},
+		},
+	}
+}
+
+func TestScopeRecordStoreRoundTripReplayAndDomainReplacement(t *testing.T) {
+	bs := newTestBadger(t)
+	initial := testScopeRecord(1, "audit", "research")
+	require.NoError(t, bs.SetScopeRecord(initial))
+	require.NoError(t, bs.SetScopeRecord(initial), "exact crash replay is idempotent")
+
+	got, err := bs.GetScopeForDomain("audit")
+	require.NoError(t, err)
+	assert.Equal(t, initial, *got)
+	revision1, err := bs.GetScopeRevisionHash(initial.ScopeID, 1)
+	require.NoError(t, err)
+	require.Len(t, revision1, 32)
+
+	updated := testScopeRecord(2, "audit", "security")
+	require.NoError(t, bs.SetScopeRecord(updated))
+	old, err := bs.GetScopeForDomain("research")
+	require.NoError(t, err)
+	assert.Nil(t, old, "removed domain mapping must not survive a roster update")
+	newScope, err := bs.GetScopeForDomain("security")
+	require.NoError(t, err)
+	assert.Equal(t, updated, *newScope)
+	revision1After, err := bs.GetScopeRevisionHash(initial.ScopeID, 1)
+	require.NoError(t, err)
+	revision2, err := bs.GetScopeRevisionHash(initial.ScopeID, 2)
+	require.NoError(t, err)
+	assert.Equal(t, revision1, revision1After, "advancing the head cannot rewrite an older audit anchor")
+	require.Len(t, revision2, 32)
+	assert.NotEqual(t, revision1, revision2)
+}
+
+func TestScopeRecordStoreRejectsRevisionRewriteAndDomainCollisionAtomically(t *testing.T) {
+	bs := newTestBadger(t)
+	initial := testScopeRecord(1, "audit")
+	require.NoError(t, bs.SetScopeRecord(initial))
+
+	sameRevisionDifferent := initial
+	sameRevisionDifferent.UpdatedHeight++
+	err := bs.SetScopeRecord(sameRevisionDifferent)
+	require.ErrorIs(t, err, ErrScopeRevision)
+
+	lower := testScopeRecord(0, "audit")
+	err = bs.SetScopeRecord(lower)
+	require.Error(t, err)
+
+	other := testScopeRecord(1, "audit")
+	other.ScopeID = "scope-b"
+	err = bs.SetScopeRecord(other)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrScopeRevision), "collision is not confused with a revision replay")
+	missing, err := bs.GetScopeRecord("scope-b")
+	require.NoError(t, err)
+	assert.Nil(t, missing, "failed collision write must not leave a partial scope record")
+}
+
+func TestScopeRecordStoreRetirementRemovesDomainMapping(t *testing.T) {
+	bs := newTestBadger(t)
+	require.NoError(t, bs.SetScopeRecord(testScopeRecord(1, "audit")))
+	retired := testScopeRecord(2, "audit")
+	retired.State = scope.StateRetired
+	require.NoError(t, bs.SetScopeRecord(retired))
+
+	mapped, err := bs.GetScopeForDomain("audit")
+	require.NoError(t, err)
+	assert.Nil(t, mapped)
+	record, err := bs.GetScopeRecord("scope-a")
+	require.NoError(t, err)
+	assert.Equal(t, scope.StateRetired, record.State)
+
+	reactivate := testScopeRecord(3, "audit")
+	err = bs.SetScopeRecord(reactivate)
+	assert.ErrorIs(t, err, ErrScopeRetired)
+}
+
+func TestListScopeRecordsIsCanonicalAndSorted(t *testing.T) {
+	bs := newTestBadger(t)
+	second := testScopeRecord(1, "security")
+	second.ScopeID = "scope-z"
+	first := testScopeRecord(1, "audit")
+	first.ScopeID = "scope-a"
+	require.NoError(t, bs.SetScopeRecord(second))
+	require.NoError(t, bs.SetScopeRecord(first))
+
+	records, err := bs.ListScopeRecords()
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, []string{"scope-a", "scope-z"}, []string{records[0].ScopeID, records[1].ScopeID})
+}

--- a/internal/store/scoped_memory_state.go
+++ b/internal/store/scoped_memory_state.go
@@ -1,0 +1,396 @@
+package store
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	badger "github.com/dgraph-io/badger/v4"
+
+	"github.com/l33tdawg/sage/internal/scope"
+)
+
+var (
+	ErrScopeBallotConflict = errors.New("scope ballot conflict")
+	ErrScopeVoteExists     = errors.New("scoped vote already exists")
+)
+
+func scopeBallotKey(memoryID string) []byte   { return []byte("state:scope-proposal:" + memoryID) }
+func scopedContentKey(memoryID string) []byte { return []byte("state:scope-content:" + memoryID) }
+func scopedVoteHeightKey(memoryID, validatorID string) []byte {
+	return []byte("state:scope-vote-height:" + memoryID + ":" + validatorID)
+}
+
+// SetScopedMemorySubmission atomically creates the ordinary memory state and
+// its canonical v11.9 ballot/content mirrors. Every field is validated before
+// the transaction begins; an error leaves no partially scoped memory behind.
+func (s *BadgerStore) SetScopedMemorySubmission(ballot scope.Ballot, content scope.Content) error {
+	ballotBytes, err := scope.EncodeBallot(ballot)
+	if err != nil {
+		return fmt.Errorf("encode scope ballot: %w", err)
+	}
+	contentBytes, err := scope.EncodeContent(content)
+	if err != nil {
+		return fmt.Errorf("encode scoped content: %w", err)
+	}
+	if ballot.State != scope.BallotPending || ballot.MemoryID != content.MemoryID || ballot.ScopeID != content.ScopeID ||
+		ballot.ScopeRevision != content.ScopeRevision || ballot.SubmittedHeight != content.SubmittedHeight {
+		return errors.New("scope ballot and content identity do not match")
+	}
+
+	return s.db.Update(func(txn *badger.Txn) error {
+		if err := requireExactOrMissing(txn, scopeBallotKey(ballot.MemoryID), ballotBytes, ErrScopeBallotConflict); err != nil {
+			return err
+		}
+		if err := requireExactOrMissing(txn, scopedContentKey(content.MemoryID), contentBytes, ErrScopeBallotConflict); err != nil {
+			return err
+		}
+
+		// A still-proposed legacy record may be enrolled by a later app-v20
+		// re-submit only when its canonical hash is identical. Never overwrite a
+		// terminal verdict or change the content behind an existing memory ID.
+		if item, getErr := txn.Get(memoryKey(content.MemoryID)); getErr == nil {
+			if err := item.Value(func(value []byte) error {
+				hash, status, err := decodeMemoryEntry(value)
+				if err != nil {
+					return err
+				}
+				if status != "proposed" || !bytes.Equal(hash, content.ContentHash) {
+					return fmt.Errorf("%w: existing memory hash or status differs", ErrScopeBallotConflict)
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		} else if !errors.Is(getErr, badger.ErrKeyNotFound) {
+			return getErr
+		}
+
+		if err := requireExactOrMissing(txn, memoryDomainKey(content.MemoryID), []byte(content.Domain), ErrScopeBallotConflict); err != nil {
+			return err
+		}
+		if err := requireExactOrMissing(txn, memoryAuthorKey(content.MemoryID), []byte(content.SubmittingAgentID), ErrScopeBallotConflict); err != nil {
+			return err
+		}
+		if err := requireExactOrMissing(txn, memClassKey(content.MemoryID), []byte{content.Classification}, ErrScopeBallotConflict); err != nil {
+			return err
+		}
+
+		writes := []struct {
+			key   []byte
+			value []byte
+		}{
+			{memoryKey(content.MemoryID), encodeMemoryHashEntry(content.ContentHash, "proposed")},
+			{memoryDomainKey(content.MemoryID), []byte(content.Domain)},
+			{memoryAuthorKey(content.MemoryID), []byte(content.SubmittingAgentID)},
+			{memClassKey(content.MemoryID), []byte{content.Classification}},
+			{scopeBallotKey(ballot.MemoryID), ballotBytes},
+			{scopedContentKey(content.MemoryID), contentBytes},
+		}
+		for _, write := range writes {
+			if err := txn.Set(write.key, write.value); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func requireExactOrMissing(txn *badger.Txn, key, want []byte, conflict error) error {
+	item, err := txn.Get(key)
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return item.Value(func(value []byte) error {
+		if bytes.Equal(value, want) {
+			return nil
+		}
+		return conflict
+	})
+}
+
+func decodeMemoryEntry(value []byte) ([]byte, string, error) {
+	if len(value) < 4 {
+		return nil, "", errors.New("invalid memory hash entry")
+	}
+	hashLen := binary.BigEndian.Uint32(value[:4])
+	if uint64(hashLen)+4 > uint64(len(value)) {
+		return nil, "", errors.New("invalid memory hash entry")
+	}
+	hash := append([]byte(nil), value[4:4+int(hashLen)]...)
+	return hash, string(value[4+int(hashLen):]), nil
+}
+
+func (s *BadgerStore) GetScopeBallot(memoryID string) (*scope.Ballot, error) {
+	var ballot *scope.Ballot
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(scopeBallotKey(memoryID))
+		if err != nil {
+			return err
+		}
+		return item.Value(func(value []byte) error {
+			decoded, err := scope.DecodeBallot(value)
+			if err != nil {
+				return err
+			}
+			ballot = &decoded
+			return nil
+		})
+	})
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get scope ballot %q: %w", memoryID, err)
+	}
+	return ballot, nil
+}
+
+func (s *BadgerStore) GetScopedContent(memoryID string) (*scope.Content, error) {
+	var content *scope.Content
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(scopedContentKey(memoryID))
+		if err != nil {
+			return err
+		}
+		return item.Value(func(value []byte) error {
+			decoded, err := scope.DecodeContent(value)
+			if err != nil {
+				return err
+			}
+			content = &decoded
+			return nil
+		})
+	})
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get scoped content %q: %w", memoryID, err)
+	}
+	return content, nil
+}
+
+// ListScopedContents returns every canonical scoped envelope in bytewise
+// memory-ID order. Recovery uses this after snapshot/state sync to rebuild a
+// discarded local projection without consulting federation peers.
+func (s *BadgerStore) ListScopedContents() ([]scope.Content, error) {
+	prefix := []byte("state:scope-content:")
+	contents := make([]scope.Content, 0)
+	err := s.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			memoryID := string(item.Key()[len(prefix):])
+			if err := item.Value(func(value []byte) error {
+				content, err := scope.DecodeContent(value)
+				if err != nil {
+					return err
+				}
+				if content.MemoryID != memoryID {
+					return fmt.Errorf("scoped content key %q disagrees with envelope %q", memoryID, content.MemoryID)
+				}
+				contents = append(contents, content)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list scoped contents: %w", err)
+	}
+	return contents, nil
+}
+
+// SetScopedVote records one terminal member decision. Scoped votes are
+// immutable: retrying the exact decision at the same FinalizeBlock height is
+// idempotent, while changing either is rejected. Membership is checked against
+// the pinned ballot, not a live scope.
+func (s *BadgerStore) SetScopedVote(memoryID, validatorID, decision string, height int64) (bool, error) {
+	if decision != "accept" && decision != "reject" && decision != "abstain" {
+		return false, fmt.Errorf("invalid scoped vote decision %q", decision)
+	}
+	if height <= 0 {
+		return false, errors.New("scoped vote height must be positive")
+	}
+	inserted := false
+	err := s.db.Update(func(txn *badger.Txn) error {
+		item, err := txn.Get(scopeBallotKey(memoryID))
+		if err != nil {
+			return err
+		}
+		var ballot scope.Ballot
+		if err := item.Value(func(value []byte) error {
+			var decodeErr error
+			ballot, decodeErr = scope.DecodeBallot(value)
+			return decodeErr
+		}); err != nil {
+			return err
+		}
+		member := false
+		for _, candidate := range ballot.Members {
+			if candidate.ValidatorID == validatorID {
+				member = true
+				break
+			}
+		}
+		if !member {
+			return fmt.Errorf("validator %q is not a pinned scope member", validatorID)
+		}
+		voteKey := []byte("state:vote:" + memoryID + ":" + validatorID)
+		if existing, getErr := txn.Get(voteKey); getErr == nil {
+			return existing.Value(func(value []byte) error {
+				if string(value) != decision {
+					return ErrScopeVoteExists
+				}
+				heightItem, heightErr := txn.Get(scopedVoteHeightKey(memoryID, validatorID))
+				if heightErr != nil {
+					return ErrScopeVoteExists
+				}
+				return heightItem.Value(func(heightBytes []byte) error {
+					if len(heightBytes) != 8 || int64(binary.BigEndian.Uint64(heightBytes)) != height { // #nosec G115 -- consensus heights are positive int64 values
+						return ErrScopeVoteExists
+					}
+					return nil
+				})
+			})
+		} else if !errors.Is(getErr, badger.ErrKeyNotFound) {
+			return getErr
+		}
+		if ballot.State != scope.BallotPending {
+			return fmt.Errorf("scoped ballot is terminal: %d", ballot.State)
+		}
+		if err := txn.Set(voteKey, []byte(decision)); err != nil {
+			return err
+		}
+		heightBytes := make([]byte, 8)
+		binary.BigEndian.PutUint64(heightBytes, uint64(height)) // #nosec G115 -- height is validated positive
+		if err := txn.Set(scopedVoteHeightKey(memoryID, validatorID), heightBytes); err != nil {
+			return err
+		}
+		inserted = true
+		return nil
+	})
+	return inserted, err
+}
+
+// GetScopedVote returns a scoped member's immutable decision and the exact
+// FinalizeBlock height that first recorded it. The height binding lets crash
+// recovery distinguish replay of the same uncommitted block from a later
+// attempt to reuse an already-consumed nonce or vote.
+func (s *BadgerStore) GetScopedVote(memoryID, validatorID string) (decision string, height int64, ok bool, err error) {
+	voteKey := []byte("state:vote:" + memoryID + ":" + validatorID)
+	err = s.db.View(func(txn *badger.Txn) error {
+		voteItem, getErr := txn.Get(voteKey)
+		if getErr != nil {
+			return getErr
+		}
+		if valueErr := voteItem.Value(func(value []byte) error {
+			decision = string(value)
+			return nil
+		}); valueErr != nil {
+			return valueErr
+		}
+		heightItem, getErr := txn.Get(scopedVoteHeightKey(memoryID, validatorID))
+		if getErr != nil {
+			return getErr
+		}
+		return heightItem.Value(func(value []byte) error {
+			if len(value) != 8 {
+				return errors.New("invalid scoped vote height")
+			}
+			height = int64(binary.BigEndian.Uint64(value)) // #nosec G115 -- stored consensus height originated as int64
+			if height <= 0 {
+				return errors.New("invalid scoped vote height")
+			}
+			return nil
+		})
+	})
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return "", 0, false, nil
+	}
+	if err != nil {
+		return "", 0, false, fmt.Errorf("get scoped vote %q/%q: %w", memoryID, validatorID, err)
+	}
+	return decision, height, true, nil
+}
+
+// SetScopedMemoryVerdict atomically moves both the pinned ballot and ordinary
+// memory record to the same terminal state while preserving the content hash.
+func (s *BadgerStore) SetScopedMemoryVerdict(memoryID string, verdict scope.BallotState) error {
+	var status string
+	switch verdict {
+	case scope.BallotCommitted:
+		status = "committed"
+	case scope.BallotDeprecated:
+		status = "deprecated"
+	default:
+		return errors.New("scoped verdict must be committed or deprecated")
+	}
+	return s.db.Update(func(txn *badger.Txn) error {
+		ballotItem, err := txn.Get(scopeBallotKey(memoryID))
+		if err != nil {
+			return err
+		}
+		var ballot scope.Ballot
+		if err := ballotItem.Value(func(value []byte) error {
+			var decodeErr error
+			ballot, decodeErr = scope.DecodeBallot(value)
+			return decodeErr
+		}); err != nil {
+			return err
+		}
+		if ballot.State == verdict {
+			return nil
+		}
+		if ballot.State != scope.BallotPending {
+			return fmt.Errorf("scoped ballot already reached state %d", ballot.State)
+		}
+		contentItem, err := txn.Get(scopedContentKey(memoryID))
+		if err != nil {
+			return err
+		}
+		var content scope.Content
+		if err := contentItem.Value(func(value []byte) error {
+			var decodeErr error
+			content, decodeErr = scope.DecodeContent(value)
+			return decodeErr
+		}); err != nil {
+			return err
+		}
+		memoryItem, err := txn.Get(memoryKey(memoryID))
+		if err != nil {
+			return err
+		}
+		if err := memoryItem.Value(func(value []byte) error {
+			hash, current, decodeErr := decodeMemoryEntry(value)
+			if decodeErr != nil {
+				return decodeErr
+			}
+			if current != "proposed" || !bytes.Equal(hash, content.ContentHash) {
+				return errors.New("scoped content and ordinary memory state disagree")
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		ballot.State = verdict
+		encodedBallot, err := scope.EncodeBallot(ballot)
+		if err != nil {
+			return err
+		}
+		if err := txn.Set(scopeBallotKey(memoryID), encodedBallot); err != nil {
+			return err
+		}
+		return txn.Set(memoryKey(memoryID), encodeMemoryHashEntry(content.ContentHash, status))
+	})
+}

--- a/internal/store/scoped_memory_state.go
+++ b/internal/store/scoped_memory_state.go
@@ -342,12 +342,12 @@ func (s *BadgerStore) SetScopedMemoryVerdict(memoryID string, verdict scope.Ball
 			return err
 		}
 		var ballot scope.Ballot
-		if err := ballotItem.Value(func(value []byte) error {
+		if ballotValueErr := ballotItem.Value(func(value []byte) error {
 			var decodeErr error
 			ballot, decodeErr = scope.DecodeBallot(value)
 			return decodeErr
-		}); err != nil {
-			return err
+		}); ballotValueErr != nil {
+			return ballotValueErr
 		}
 		if ballot.State == verdict {
 			return nil
@@ -360,18 +360,18 @@ func (s *BadgerStore) SetScopedMemoryVerdict(memoryID string, verdict scope.Ball
 			return err
 		}
 		var content scope.Content
-		if err := contentItem.Value(func(value []byte) error {
+		if contentValueErr := contentItem.Value(func(value []byte) error {
 			var decodeErr error
 			content, decodeErr = scope.DecodeContent(value)
 			return decodeErr
-		}); err != nil {
-			return err
+		}); contentValueErr != nil {
+			return contentValueErr
 		}
 		memoryItem, err := txn.Get(memoryKey(memoryID))
 		if err != nil {
 			return err
 		}
-		if err := memoryItem.Value(func(value []byte) error {
+		if memoryValueErr := memoryItem.Value(func(value []byte) error {
 			hash, current, decodeErr := decodeMemoryEntry(value)
 			if decodeErr != nil {
 				return decodeErr
@@ -380,8 +380,8 @@ func (s *BadgerStore) SetScopedMemoryVerdict(memoryID string, verdict scope.Ball
 				return errors.New("scoped content and ordinary memory state disagree")
 			}
 			return nil
-		}); err != nil {
-			return err
+		}); memoryValueErr != nil {
+			return memoryValueErr
 		}
 		ballot.State = verdict
 		encodedBallot, err := scope.EncodeBallot(ballot)

--- a/internal/store/scoped_memory_state_test.go
+++ b/internal/store/scoped_memory_state_test.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/scope"
+)
+
+func scopedSubmissionFixture() (scope.Ballot, scope.Content) {
+	hash := sha256.Sum256([]byte("recover me"))
+	ballot := scope.Ballot{
+		MemoryID: "memory-a", ScopeID: "scope-a", ScopeRevision: 1,
+		SubmittedHeight: 10, State: scope.BallotPending,
+		Members: []scope.BallotMember{
+			{ValidatorID: "validator-a", EffectiveWeight: 1},
+			{ValidatorID: "validator-b", EffectiveWeight: 1},
+			{ValidatorID: "validator-c", EffectiveWeight: 1},
+			{ValidatorID: "validator-d", EffectiveWeight: 1},
+		},
+		TotalWeight: 4,
+	}
+	content := scope.Content{
+		MemoryID: "memory-a", ScopeID: "scope-a", ScopeRevision: 1,
+		SubmittingAgentID: "agent-a", ContentHash: hash[:], MemoryType: 1,
+		Domain: "research", ConfidenceScore: 0.9, Content: "recover me",
+		Classification: 2, SubmittedHeight: 10, SubmittedUnix: 100,
+	}
+	return ballot, content
+}
+
+func TestScopedMemorySubmissionIsAtomicAndReplaySafe(t *testing.T) {
+	bs := newTestBadger(t)
+	ballot, content := scopedSubmissionFixture()
+	require.NoError(t, bs.SetScopedMemorySubmission(ballot, content))
+	require.NoError(t, bs.SetScopedMemorySubmission(ballot, content), "exact crash replay is idempotent")
+
+	gotBallot, err := bs.GetScopeBallot(content.MemoryID)
+	require.NoError(t, err)
+	assert.Equal(t, ballot, *gotBallot)
+	gotContent, err := bs.GetScopedContent(content.MemoryID)
+	require.NoError(t, err)
+	assert.Equal(t, content, *gotContent)
+	hash, status, err := bs.GetMemoryHash(content.MemoryID)
+	require.NoError(t, err)
+	assert.Equal(t, content.ContentHash, hash)
+	assert.Equal(t, "proposed", status)
+	assert.Equal(t, content.Domain, mustMemoryDomain(t, bs, content.MemoryID))
+	assert.Equal(t, content.SubmittingAgentID, mustMemoryAuthor(t, bs, content.MemoryID))
+
+	conflict := content
+	conflict.Content = "different"
+	otherHash := sha256.Sum256([]byte(conflict.Content))
+	conflict.ContentHash = otherHash[:]
+	err = bs.SetScopedMemorySubmission(ballot, conflict)
+	require.ErrorIs(t, err, ErrScopeBallotConflict)
+	gotContent, err = bs.GetScopedContent(content.MemoryID)
+	require.NoError(t, err)
+	assert.Equal(t, content, *gotContent, "failed rewrite leaves the complete original state")
+}
+
+func TestScopedVoteAndVerdictPreservePinnedContentHash(t *testing.T) {
+	bs := newTestBadger(t)
+	ballot, content := scopedSubmissionFixture()
+	require.NoError(t, bs.SetScopedMemorySubmission(ballot, content))
+	inserted, err := bs.SetScopedVote(content.MemoryID, "validator-a", "accept", 11)
+	require.NoError(t, err)
+	assert.True(t, inserted)
+	inserted, err = bs.SetScopedVote(content.MemoryID, "validator-a", "accept", 11)
+	require.NoError(t, err)
+	assert.False(t, inserted, "exact vote replay is idempotent and cannot re-credit stats")
+	decision, height, ok, err := bs.GetScopedVote(content.MemoryID, "validator-a")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "accept", decision)
+	assert.Equal(t, int64(11), height)
+	_, err = bs.SetScopedVote(content.MemoryID, "validator-a", "accept", 12)
+	require.ErrorIs(t, err, ErrScopeVoteExists, "the same decision at another height is not an exact crash replay")
+	_, err = bs.SetScopedVote(content.MemoryID, "outsider", "accept", 11)
+	require.ErrorContains(t, err, "not a pinned scope member")
+	_, err = bs.SetScopedVote(content.MemoryID, "validator-a", "reject", 11)
+	require.ErrorIs(t, err, ErrScopeVoteExists)
+
+	require.NoError(t, bs.SetScopedMemoryVerdict(content.MemoryID, scope.BallotCommitted))
+	gotBallot, err := bs.GetScopeBallot(content.MemoryID)
+	require.NoError(t, err)
+	assert.Equal(t, scope.BallotCommitted, gotBallot.State)
+	hash, status, err := bs.GetMemoryHash(content.MemoryID)
+	require.NoError(t, err)
+	assert.Equal(t, content.ContentHash, hash, "terminal transition retains the recovery-verifiable hash")
+	assert.Equal(t, "committed", status)
+	err = bs.SetScopedMemoryVerdict(content.MemoryID, scope.BallotDeprecated)
+	require.ErrorContains(t, err, "already reached")
+}
+
+func mustMemoryDomain(t *testing.T, bs *BadgerStore, memoryID string) string {
+	t.Helper()
+	value, err := bs.GetMemoryDomain(memoryID)
+	require.NoError(t, err)
+	return value
+}
+
+func mustMemoryAuthor(t *testing.T, bs *BadgerStore, memoryID string) string {
+	t.Helper()
+	value, err := bs.GetMemoryAuthor(memoryID)
+	require.NoError(t, err)
+	return value
+}

--- a/internal/tx/types.go
+++ b/internal/tx/types.go
@@ -98,6 +98,10 @@ const (
 	// []MemoryDomainRepairEntry. Numerically matches governance.OpMemoryDomainRepair=6.
 	GovOpMemoryDomainRepair GovProposalOp = 6
 	GovOpSyncGroupAction    GovProposalOp = 7
+	// GovOpScopeAction (app-v20) numerically matches governance.OpScopeAction.
+	// GovPropose.Payload is the canonical versioned scope record template and
+	// TargetID must equal its ScopeID.
+	GovOpScopeAction GovProposalOp = 8
 )
 
 // VoteDecision represents a validator's vote on a proposed memory.
@@ -320,7 +324,8 @@ type MemoryReassign struct {
 	TargetAgentID string // agent receiving the memories
 }
 
-// GovPropose proposes a validator governance action (add, remove, update power).
+// GovPropose proposes a governance action. Legacy validator-set operations use
+// the scalar target fields; newer operations bind their exact body in Payload.
 type GovPropose struct {
 	Operation    GovProposalOp
 	TargetID     string // hex-encoded validator/agent ID
@@ -332,8 +337,9 @@ type GovPropose struct {
 	// legacy ops (1/2/3 — validator-set changes infer parameters from the
 	// existing scalar fields). For OpDomainReassign (4), Payload is the
 	// JSON-encoded DomainReassign body: {Domain, NewOwnerID, ParentDomain,
-	// OpenToShared}. The decoder treats the trailing length-prefix as
-	// optional so legacy bytes (no Payload) still round-trip cleanly.
+	// OpenToShared}. App-v20 OpScopeAction carries a canonical binary scope
+	// record template. The decoder treats the trailing length-prefix as optional
+	// so legacy bytes (no Payload) still round-trip cleanly.
 	Payload []byte
 }
 

--- a/scripts/cerebrum-shell.test.mjs
+++ b/scripts/cerebrum-shell.test.mjs
@@ -35,6 +35,12 @@ test('governance wizard builds structured canonical quorum scopes', () => {
         'the dashboard must submit structured scope JSON, not recreate the binary codec');
 });
 
+test('chain health recognizes app-v20 as the current consensus protocol', () => {
+    assert.match(appSource, /const appVerTone = appVer === '20'/);
+    assert.match(appSource, /Green when current \(20\)\./);
+    assert.doesNotMatch(appSource, /appVer === '15'/);
+});
+
 test('task board scrolls as one page instead of trapping wheel input in columns', () => {
     const tasksPage = cssSource.match(/\.tasks-page\s*\{([^}]*)\}/)?.[1] || '';
     const cards = cssSource.match(/\.kanban-cards\s*\{([^}]*)\}/)?.[1] || '';

--- a/scripts/cerebrum-shell.test.mjs
+++ b/scripts/cerebrum-shell.test.mjs
@@ -16,6 +16,25 @@ test('Access Controls is a first-class sidebar route', () => {
     assert.match(appSource, /accessMode \? 'access' : 'overview'/);
 });
 
+test('governance wizard builds structured canonical quorum scopes', () => {
+    const networkPage = appSource.slice(appSource.indexOf('function NetworkPage('), appSource.indexOf('function AddAgentWizard('));
+    assert.match(networkPage, /<option value="scope_action">Form or Revise Quorum Scope<\/option>/);
+    assert.match(networkPage, /proposal\.scope = \{/);
+    assert.match(networkPage, /controller_validator_id: govScopeController/);
+    assert.match(networkPage, /govScopeDomains\.split\(\/\[\\n,\]\//);
+    assert.match(networkPage, /assigned_weight: parseInt\(member\.weight, 10\)/);
+    assert.match(networkPage, /joined_revision: parseInt\(member\.joinedRevision, 10\)/);
+    assert.match(networkPage, /govScopeControllerMember/,
+        'the selected controller must also be an active selected roster member');
+    assert.match(networkPage, /govScopeValidatorOptions = govScopeValidators/,
+        'scope authority must come from the live CometBFT validator set, not ordinary agent rows');
+    assert.match(networkPage, /Number\.isSafeInteger\(weight\)/,
+        'the browser must not round canonical uint64 weights before submission');
+    assert.match(networkPage, /above two-thirds of this pinned integer weight/);
+    assert.doesNotMatch(networkPage, /btoa\(|payload.*scope_action/s,
+        'the dashboard must submit structured scope JSON, not recreate the binary codec');
+});
+
 test('task board scrolls as one page instead of trapping wheel input in columns', () => {
     const tasksPage = cssSource.match(/\.tasks-page\s*\{([^}]*)\}/)?.[1] || '';
     const cards = cssSource.match(/\.kanban-cards\s*\{([^}]*)\}/)?.[1] || '';

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -540,6 +540,41 @@ result = client.submit_domain_reassign(
 )
 ```
 
+App-v20 operators can inspect the canonical scope topology and immutable
+current-revision anchors without decoding Badger directly:
+
+```python
+scopes = client.list_scopes()
+for scope in scopes.scopes:
+    print(scope.scope_id, scope.state, scope.revision, scope.revision_hash)
+
+research = client.get_scope("research-quorum")
+print([(m.validator_id, m.assigned_weight) for m in research.members])
+```
+
+Create the first canonical scope without hand-encoding binary governance
+payloads:
+
+```python
+proposal = client.governance_propose_scope(
+    scope={
+        "scope_id": "research-quorum",
+        "revision": 1,
+        "state": "active",
+        "controller_validator_id": validator_id,
+        "domains": ["research"],
+        "members": [
+            {"validator_id": validator_id, "assigned_weight": 1},
+        ],
+    },
+    reason="form the research replica quorum",
+)
+```
+
+The server sorts domains and members canonically and supplies consensus-owned
+heights. For later revisions, include every member's historical
+`joined_revision`; `scope` and legacy binary `payload` cannot be combined.
+
 > **Code 50** (`shared domain not ownable`) surfaces as HTTP 403 with
 > `shared domain not ownable` in the error detail — see
 > `sage_sdk.exceptions` for the documented mapping.

--- a/sdk/python/src/sage_sdk/async_client.py
+++ b/sdk/python/src/sage_sdk/async_client.py
@@ -42,6 +42,9 @@ from sage_sdk.models import (
     PipeSendResponse,
     PreValidateResponse,
     ReinstateRequest,
+    ScopeActionTemplate,
+    ScopeListResponse,
+    ScopeRecord,
     TaskListResponse,
     TimelineResponse,
     VoteRequest,
@@ -804,13 +807,17 @@ class AsyncSageClient:
         target_pubkey: str | None = None,
         target_power: int | None = None,
         payload: dict | bytes | None = None,
+        scope: ScopeActionTemplate | dict[str, Any] | None = None,
     ) -> GovProposeResponse:
         """Submit a governance proposal.
 
         See :meth:`SageClient.governance_propose` for the full ``payload``
         contract — same encoding rules apply here (dict → JSON+base64,
-        bytes → base64, ``None`` → omitted).
+        bytes → base64, ``None`` → omitted). Guided app-v20 scope templates
+        use ``scope`` instead and are canonicalized by the server.
         """
+        if payload is not None and scope is not None:
+            raise ValueError("payload and scope are mutually exclusive")
         req = GovProposeRequest(
             operation=operation,
             target_id=target_id,
@@ -818,9 +825,24 @@ class AsyncSageClient:
             target_power=target_power,
             reason=reason,
             payload=_encode_gov_payload(payload),
+            scope=scope,
         )
         resp = await self._request("POST", "/v1/governance/propose", json=req.model_dump(exclude_none=True))
         return GovProposeResponse.model_validate(resp.json())
+
+    async def governance_propose_scope(
+        self,
+        scope: ScopeActionTemplate | dict[str, Any],
+        reason: str,
+    ) -> GovProposeResponse:
+        """Submit a guided canonical app-v20 scope_action proposal."""
+        template = ScopeActionTemplate.model_validate(scope)
+        return await self.governance_propose(
+            operation="scope_action",
+            target_id=template.scope_id,
+            reason=reason,
+            scope=template,
+        )
 
     async def governance_vote(self, proposal_id: str, decision: str) -> GovVoteResponse:
         """Vote on an active governance proposal."""
@@ -833,6 +855,18 @@ class AsyncSageClient:
         req = GovCancelRequest(proposal_id=proposal_id)
         resp = await self._request("POST", "/v1/governance/cancel", json=req.model_dump())
         return GovCancelResponse.model_validate(resp.json())
+
+    async def list_scopes(self) -> ScopeListResponse:
+        """List canonical v11.9 quorum scopes (operator/admin only)."""
+        resp = await self._request("GET", "/v1/scopes")
+        return ScopeListResponse.model_validate(resp.json())
+
+    async def get_scope(self, scope_id: str) -> ScopeRecord:
+        """Read one canonical v11.9 quorum scope (operator/admin only)."""
+        from urllib.parse import quote
+
+        resp = await self._request("GET", f"/v1/scopes/{quote(scope_id, safe='')}")
+        return ScopeRecord.model_validate(resp.json())
 
     async def governance_proposals(self, status: str | None = None) -> GovProposalListResponse:
         """List governance proposals, optionally filtered by status."""

--- a/sdk/python/src/sage_sdk/client.py
+++ b/sdk/python/src/sage_sdk/client.py
@@ -41,6 +41,9 @@ from sage_sdk.models import (
     PipeSendResponse,
     PreValidateResponse,
     ReinstateRequest,
+    ScopeActionTemplate,
+    ScopeListResponse,
+    ScopeRecord,
     TaskListResponse,
     TimelineResponse,
     VoteRequest,
@@ -926,12 +929,14 @@ class SageClient:
         target_pubkey: str | None = None,
         target_power: int | None = None,
         payload: dict | bytes | None = None,
+        scope: ScopeActionTemplate | dict[str, Any] | None = None,
     ) -> GovProposeResponse:
         """Submit a governance proposal.
 
         Supports validator-set operations (``add_validator``,
         ``remove_validator``, ``update_power``) and access-control recovery
-        (``domain_reassign``, v8.0+).
+        (``domain_reassign``, v8.0+) plus canonical app-v20 scope decisions
+        (``scope_action`` with a guided ``scope`` template).
 
         ``payload`` carries an optional structured body for operations that
         need one — e.g. ``domain_reassign`` expects a JSON-encoded
@@ -941,7 +946,13 @@ class SageClient:
             wire as ``payload``.
           - ``bytes``: base64-encoded directly.
           - ``None``: the ``payload`` field is omitted from the request.
+
+        ``scope`` is the preferred app-v20 surface. The server converts it to
+        canonical ScopeRecordV1 bytes; it is mutually exclusive with
+        ``payload``.
         """
+        if payload is not None and scope is not None:
+            raise ValueError("payload and scope are mutually exclusive")
         req = GovProposeRequest(
             operation=operation,
             target_id=target_id,
@@ -949,9 +960,24 @@ class SageClient:
             target_power=target_power,
             reason=reason,
             payload=_encode_gov_payload(payload),
+            scope=scope,
         )
         resp = self._request("POST", "/v1/governance/propose", json=req.model_dump(exclude_none=True))
         return GovProposeResponse.model_validate(resp.json())
+
+    def governance_propose_scope(
+        self,
+        scope: ScopeActionTemplate | dict[str, Any],
+        reason: str,
+    ) -> GovProposeResponse:
+        """Submit a guided canonical app-v20 scope_action proposal."""
+        template = ScopeActionTemplate.model_validate(scope)
+        return self.governance_propose(
+            operation="scope_action",
+            target_id=template.scope_id,
+            reason=reason,
+            scope=template,
+        )
 
     def governance_vote(self, proposal_id: str, decision: str) -> GovVoteResponse:
         """Vote on an active governance proposal."""
@@ -964,6 +990,18 @@ class SageClient:
         req = GovCancelRequest(proposal_id=proposal_id)
         resp = self._request("POST", "/v1/governance/cancel", json=req.model_dump())
         return GovCancelResponse.model_validate(resp.json())
+
+    def list_scopes(self) -> ScopeListResponse:
+        """List canonical v11.9 quorum scopes (operator/admin only)."""
+        resp = self._request("GET", "/v1/scopes")
+        return ScopeListResponse.model_validate(resp.json())
+
+    def get_scope(self, scope_id: str) -> ScopeRecord:
+        """Read one canonical v11.9 quorum scope (operator/admin only)."""
+        from urllib.parse import quote
+
+        resp = self._request("GET", f"/v1/scopes/{quote(scope_id, safe='')}")
+        return ScopeRecord.model_validate(resp.json())
 
     def governance_proposals(self, status: str | None = None) -> GovProposalListResponse:
         """List governance proposals, optionally filtered by status."""

--- a/sdk/python/src/sage_sdk/models.py
+++ b/sdk/python/src/sage_sdk/models.py
@@ -426,8 +426,28 @@ class DeptMemberInfo(BaseModel):
 
 # --- Governance Models ---
 
+class ScopeActionMember(BaseModel):
+    """One member in a guided app-v20 scope governance template."""
+
+    validator_id: str
+    assigned_weight: int
+    joined_revision: int | None = None
+    active: bool = True
+
+
+class ScopeActionTemplate(BaseModel):
+    """Human-facing scope template; the server creates canonical wire bytes."""
+
+    scope_id: str
+    revision: int
+    state: str
+    controller_validator_id: str
+    domains: list[str]
+    members: list[ScopeActionMember]
+
+
 class GovProposeRequest(BaseModel):
-    operation: str  # "add_validator", "remove_validator", "update_power", "domain_reassign"
+    operation: str  # validator ops, "domain_reassign", "memory_domain_repair", or "scope_action"
     target_id: str
     target_pubkey: str | None = None
     target_power: int | None = None
@@ -436,6 +456,9 @@ class GovProposeRequest(BaseModel):
     # structured body (e.g. ``domain_reassign`` carries the JSON-encoded
     # DomainReassignRequest). None omits the field from the on-wire request.
     payload: str | None = None
+    # Guided scope_action input. Mutually exclusive with payload; the server
+    # sorts it canonically and materializes consensus-owned heights later.
+    scope: ScopeActionTemplate | None = None
 
 
 class GovProposeResponse(BaseModel):
@@ -456,6 +479,35 @@ class GovVoteResponse(BaseModel):
 
 class GovCancelRequest(BaseModel):
     proposal_id: str
+
+
+class ScopeDomain(BaseModel):
+    name: str
+    subtree: bool = False
+
+
+class ScopeMember(BaseModel):
+    validator_id: str
+    assigned_weight: int
+    joined_revision: int
+    active: bool
+
+
+class ScopeRecord(BaseModel):
+    scope_id: str
+    revision: int
+    revision_hash: str
+    state: str
+    controller_validator_id: str
+    created_height: int
+    updated_height: int
+    domains: list[ScopeDomain]
+    members: list[ScopeMember]
+
+
+class ScopeListResponse(BaseModel):
+    scopes: list[ScopeRecord]
+    count: int
 
 
 class GovCancelResponse(BaseModel):

--- a/sdk/python/tests/test_async_client.py
+++ b/sdk/python/tests/test_async_client.py
@@ -88,3 +88,66 @@ async def test_reinstate(async_client, mock_api):
     result = await async_client.reinstate(memory_id, reason="false alarm")
     assert result["status"] == "committed"
     assert route.calls.last.request.read() == b'{"reason":"false alarm"}'
+
+
+@pytest.mark.asyncio
+async def test_scope_read_surface(async_client, mock_api):
+    record = {
+        "scope_id": "scope-a",
+        "revision": 2,
+        "revision_hash": "ab" * 32,
+        "state": "active",
+        "controller_validator_id": "validator-a",
+        "created_height": 10,
+        "updated_height": 20,
+        "domains": [{"name": "research", "subtree": False}],
+        "members": [{
+            "validator_id": "validator-a",
+            "assigned_weight": 7,
+            "joined_revision": 1,
+            "active": True,
+        }],
+    }
+    mock_api.get("/v1/scopes").mock(
+        return_value=httpx.Response(200, json={"scopes": [record], "count": 1})
+    )
+    mock_api.get("/v1/scopes/scope-a").mock(
+        return_value=httpx.Response(200, json=record)
+    )
+    # The client must keep a valid scope ID within one URL path segment.
+    escaped = mock_api.get("/v1/scopes/scope%20a").mock(
+        return_value=httpx.Response(200, json={**record, "scope_id": "scope a"})
+    )
+
+    listed = await async_client.list_scopes()
+    assert listed.scopes[0].domains[0].name == "research"
+    assert (await async_client.get_scope("scope-a")).state == "active"
+    assert (await async_client.get_scope("scope a")).scope_id == "scope a"
+    assert escaped.called
+
+
+@pytest.mark.asyncio
+async def test_governance_propose_scope_uses_guided_template(async_client, mock_api):
+    import json
+
+    route = mock_api.post("/v1/governance/propose").mock(
+        return_value=httpx.Response(200, json={
+            "proposal_id": "proposal-1", "tx_hash": "tx-1", "status": "voting",
+        })
+    )
+    result = await async_client.governance_propose_scope(
+        scope={
+            "scope_id": "scope-a",
+            "revision": 1,
+            "state": "active",
+            "controller_validator_id": "validator-a",
+            "domains": ["research"],
+            "members": [{"validator_id": "validator-a", "assigned_weight": 1}],
+        },
+        reason="form research quorum",
+    )
+    body = json.loads(route.calls.last.request.read())
+    assert result.tx_hash == "tx-1"
+    assert body["target_id"] == "scope-a"
+    assert body["scope"]["domains"] == ["research"]
+    assert "payload" not in body

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -238,3 +238,84 @@ def test_context_manager(agent_identity, mock_api):
     )
     with SageClient(base_url=BASE_URL, identity=agent_identity) as client:
         pass  # Just verify context manager works
+
+
+def test_scope_read_surface(client, mock_api):
+    record = {
+        "scope_id": "scope-a",
+        "revision": 2,
+        "revision_hash": "ab" * 32,
+        "state": "active",
+        "controller_validator_id": "validator-a",
+        "created_height": 10,
+        "updated_height": 20,
+        "domains": [{"name": "research", "subtree": False}],
+        "members": [{
+            "validator_id": "validator-a",
+            "assigned_weight": 7,
+            "joined_revision": 1,
+            "active": True,
+        }],
+    }
+    mock_api.get("/v1/scopes").mock(
+        return_value=httpx.Response(200, json={"scopes": [record], "count": 1})
+    )
+    mock_api.get("/v1/scopes/scope-a").mock(
+        return_value=httpx.Response(200, json=record)
+    )
+    # The client must keep a valid scope ID within one URL path segment.
+    escaped = mock_api.get("/v1/scopes/scope%20a").mock(
+        return_value=httpx.Response(200, json={**record, "scope_id": "scope a"})
+    )
+
+    listed = client.list_scopes()
+    assert listed.count == 1
+    assert listed.scopes[0].members[0].assigned_weight == 7
+    assert client.get_scope("scope-a").revision_hash == "ab" * 32
+    assert client.get_scope("scope a").scope_id == "scope a"
+    assert escaped.called
+
+
+def test_governance_propose_scope_uses_guided_template(client, mock_api):
+    import json
+
+    route = mock_api.post("/v1/governance/propose").mock(
+        return_value=httpx.Response(200, json={
+            "proposal_id": "proposal-1", "tx_hash": "tx-1", "status": "voting",
+        })
+    )
+    result = client.governance_propose_scope(
+        scope={
+            "scope_id": "scope-a",
+            "revision": 1,
+            "state": "active",
+            "controller_validator_id": "validator-a",
+            "domains": ["research"],
+            "members": [{"validator_id": "validator-a", "assigned_weight": 1}],
+        },
+        reason="form research quorum",
+    )
+    body = json.loads(route.calls.last.request.read())
+    assert result.proposal_id == "proposal-1"
+    assert body["operation"] == "scope_action"
+    assert body["target_id"] == "scope-a"
+    assert body["scope"]["members"][0]["active"] is True
+    assert "payload" not in body
+
+
+def test_governance_propose_rejects_scope_and_payload(client):
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        client.governance_propose(
+            operation="scope_action",
+            target_id="scope-a",
+            reason="ambiguous",
+            payload=b"raw",
+            scope={
+                "scope_id": "scope-a",
+                "revision": 1,
+                "state": "active",
+                "controller_validator_id": "validator-a",
+                "domains": ["research"],
+                "members": [{"validator_id": "validator-a", "assigned_weight": 1}],
+            },
+        )

--- a/web/governance_handler.go
+++ b/web/governance_handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/l33tdawg/sage/internal/governance"
+	"github.com/l33tdawg/sage/internal/scope"
 	"github.com/l33tdawg/sage/internal/store"
 	"github.com/l33tdawg/sage/internal/tx"
 )
@@ -134,12 +136,14 @@ func (h *DashboardHandler) handleDashboardGovPropose(w http.ResponseWriter, r *h
 	}
 
 	var req struct {
-		Operation    string `json:"operation"`
-		TargetID     string `json:"target_id"`
-		TargetPubkey string `json:"target_pubkey,omitempty"`
-		TargetPower  int64  `json:"target_power,omitempty"`
-		ExpiryBlocks int64  `json:"expiry_blocks,omitempty"`
-		Reason       string `json:"reason"`
+		Operation    string                  `json:"operation"`
+		TargetID     string                  `json:"target_id"`
+		TargetPubkey string                  `json:"target_pubkey,omitempty"`
+		TargetPower  int64                   `json:"target_power,omitempty"`
+		ExpiryBlocks int64                   `json:"expiry_blocks,omitempty"`
+		Reason       string                  `json:"reason"`
+		Payload      string                  `json:"payload,omitempty"`
+		Scope        *scope.ProposalTemplate `json:"scope,omitempty"`
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := decodeJSONBody(r, &req); err != nil {
@@ -148,11 +152,7 @@ func (h *DashboardHandler) handleDashboardGovPropose(w http.ResponseWriter, r *h
 	}
 
 	if req.Operation == "" {
-		writeError(w, http.StatusBadRequest, "operation is required (add_validator, remove_validator, update_power)")
-		return
-	}
-	if req.TargetID == "" {
-		writeError(w, http.StatusBadRequest, "target_id is required")
+		writeError(w, http.StatusBadRequest, "operation is required (add_validator, remove_validator, update_power, sync_group_action, scope_action)")
 		return
 	}
 	if req.Reason == "" {
@@ -165,6 +165,10 @@ func (h *DashboardHandler) handleDashboardGovPropose(w http.ResponseWriter, r *h
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if op == tx.GovOpScopeAction && (h.AppV20ActiveFn == nil || !h.AppV20ActiveFn()) {
+		writeError(w, http.StatusConflict, "scope_action requires app-v20 activation")
+		return
+	}
 
 	var pubKeyBytes []byte
 	if req.TargetPubkey != "" {
@@ -173,6 +177,12 @@ func (h *DashboardHandler) handleDashboardGovPropose(w http.ResponseWriter, r *h
 			writeError(w, http.StatusBadRequest, "target_pubkey must be valid hex")
 			return
 		}
+	}
+	var payloadBytes []byte
+	req.TargetID, payloadBytes, err = resolveDashboardGovProposalPayload(op, req.TargetID, req.Payload, req.Scope)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	proposeTx := &tx.ParsedTx{
@@ -186,6 +196,7 @@ func (h *DashboardHandler) handleDashboardGovPropose(w http.ResponseWriter, r *h
 			TargetPower:  req.TargetPower,
 			ExpiryBlocks: req.ExpiryBlocks,
 			Reason:       req.Reason,
+			Payload:      payloadBytes,
 		},
 	}
 
@@ -222,6 +233,43 @@ func (h *DashboardHandler) handleDashboardGovPropose(w http.ResponseWriter, r *h
 		"status":  "submitted",
 		"message": "Governance proposal submitted for consensus.",
 	})
+}
+
+func resolveDashboardGovProposalPayload(op tx.GovProposalOp, targetID, rawPayload string, template *scope.ProposalTemplate) (string, []byte, error) {
+	if template != nil {
+		if op != tx.GovOpScopeAction {
+			return "", nil, fmt.Errorf("scope is only valid for scope_action")
+		}
+		if rawPayload != "" {
+			return "", nil, fmt.Errorf("payload and scope are mutually exclusive")
+		}
+		encoded, err := scope.EncodeProposalTemplate(*template)
+		if err != nil {
+			return "", nil, fmt.Errorf("scope: %w", err)
+		}
+		if targetID == "" {
+			targetID = template.ScopeID
+		} else if targetID != template.ScopeID {
+			return "", nil, fmt.Errorf("target_id %q does not match scope_id %q", targetID, template.ScopeID)
+		}
+		return targetID, encoded, nil
+	}
+
+	var payload []byte
+	if rawPayload != "" {
+		decoded, err := base64.StdEncoding.DecodeString(rawPayload)
+		if err != nil {
+			return "", nil, fmt.Errorf("payload must be valid base64")
+		}
+		payload = decoded
+	}
+	if targetID == "" {
+		return "", nil, fmt.Errorf("target_id is required")
+	}
+	if op == tx.GovOpScopeAction && len(payload) == 0 {
+		return "", nil, fmt.Errorf("scope_action requires either payload or scope")
+	}
+	return targetID, payload, nil
 }
 
 // handleDashboardGovVote handles POST /v1/dashboard/governance/vote.
@@ -314,8 +362,10 @@ func parseDashboardGovOp(s string) (tx.GovProposalOp, error) {
 		return tx.GovOpUpdatePower, nil
 	case "sync_group_action":
 		return tx.GovOpSyncGroupAction, nil
+	case "scope_action":
+		return tx.GovOpScopeAction, nil
 	default:
-		return 0, fmt.Errorf("operation must be one of: add_validator, remove_validator, update_power, sync_group_action")
+		return 0, fmt.Errorf("operation must be one of: add_validator, remove_validator, update_power, sync_group_action, scope_action")
 	}
 }
 

--- a/web/governance_scope_test.go
+++ b/web/governance_scope_test.go
@@ -1,0 +1,42 @@
+package web
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/scope"
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+func TestResolveDashboardGovProposalPayloadBuildsCanonicalScope(t *testing.T) {
+	template := &scope.ProposalTemplate{
+		ScopeID: "scope-a", Revision: 1, State: "active",
+		ControllerValidatorID: "validator-a",
+		Domains:               []string{"research.private", "research"},
+		Members: []scope.ProposalMember{
+			{ValidatorID: "validator-b", AssignedWeight: 1},
+			{ValidatorID: "validator-a", AssignedWeight: 2},
+		},
+	}
+	targetID, payload, err := resolveDashboardGovProposalPayload(tx.GovOpScopeAction, "", "", template)
+	require.NoError(t, err)
+	assert.Equal(t, "scope-a", targetID)
+	record, err := scope.Decode(payload)
+	require.NoError(t, err)
+	assert.Equal(t, []scope.Domain{{Name: "research"}, {Name: "research.private"}}, record.Domains)
+}
+
+func TestResolveDashboardGovProposalPayloadRejectsAmbiguity(t *testing.T) {
+	template := &scope.ProposalTemplate{
+		ScopeID: "scope-a", Revision: 1, State: "active",
+		ControllerValidatorID: "validator-a", Domains: []string{"research"},
+		Members: []scope.ProposalMember{{ValidatorID: "validator-a", AssignedWeight: 1}},
+	}
+	_, _, err := resolveDashboardGovProposalPayload(tx.GovOpScopeAction, "scope-a", base64.StdEncoding.EncodeToString([]byte("raw")), template)
+	assert.ErrorContains(t, err, "mutually exclusive")
+	_, _, err = resolveDashboardGovProposalPayload(tx.GovOpScopeAction, "scope-b", "", template)
+	assert.ErrorContains(t, err, "does not match")
+}

--- a/web/handler.go
+++ b/web/handler.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -102,6 +103,10 @@ type DashboardHandler struct {
 	// production node cancels and joins these before closing stores; nil keeps
 	// the lightweight test/embed behavior.
 	RunBackground func(func(context.Context))
+	// ScopedProjectionRebuildFn replays AppHash-covered v11.9 content into the
+	// local serving projection after a locked vault becomes writable. nil keeps
+	// pre-v11.9 embeddings/tests unchanged.
+	ScopedProjectionRebuildFn func(context.Context) (int, error)
 
 	// graphCache memoises the expensive /memory/graph response with a
 	// stale-while-revalidate policy: the first load computes synchronously, every
@@ -234,6 +239,9 @@ type DashboardHandler struct {
 	// deny. Nil (unwired) or false leaves the pre-fork explicit-allowlist behavior,
 	// so a chain that has not activated app-v19 reads exactly as before.
 	AppV19ActiveFn func() bool
+	// AppV20ActiveFn reports whether a newly broadcast scope_action can execute
+	// under app-v20. nil/false keeps the dashboard construction path disabled.
+	AppV20ActiveFn func() bool
 	// StrictRBAC, when true, opts the operator out of the app-v19 default-read
 	// flip: even with app-v19 active, a non-admin agent is confined to its explicit
 	// DomainAccess allowlist. Sourced from cfg.RBAC.Strict; default false = local
@@ -365,6 +373,15 @@ func (h *DashboardHandler) runBackground(fn func(context.Context)) {
 		return
 	}
 	go fn(context.Background()) //nolint:gosec // embedded/test handler has no lifecycle owner
+}
+
+func (h *DashboardHandler) startPostUnlockRepairs() {
+	h.runBackground(func(ctx context.Context) {
+		if h.ScopedProjectionRebuildFn != nil {
+			_, _ = h.ScopedProjectionRebuildFn(ctx)
+		}
+		_, _ = h.StartEmbeddingRepairIfNeeded(ctx)
+	})
 }
 
 // handlePreValidate runs the per-node validation checks (dedup, quality,
@@ -1026,7 +1043,7 @@ func (h *DashboardHandler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	// A transient MCP embed failure may have preserved observations without
 	// vectors while the vault was locked. Repair them now that plaintext is
 	// available instead of leaving a manual setup banner behind.
-	h.runBackground(func(ctx context.Context) { _, _ = h.StartEmbeddingRepairIfNeeded(ctx) })
+	h.startPostUnlockRepairs()
 
 	// Create session
 	token := generateToken()
@@ -2753,7 +2770,11 @@ func (h *DashboardHandler) handleChainValidators(w http.ResponseWriter, r *http.
 
 	cometClient := &http.Client{Timeout: 2 * time.Second}
 	type cometVal struct {
-		Address          string `json:"address"`
+		Address string `json:"address"`
+		PubKey  struct {
+			Type  string `json:"type"`
+			Value string `json:"value"`
+		} `json:"pub_key"`
 		VotingPower      string `json:"voting_power"`
 		ProposerPriority string `json:"proposer_priority"`
 	}
@@ -2805,11 +2826,21 @@ func (h *DashboardHandler) handleChainValidators(w http.ResponseWriter, r *http.
 	var totalVP int64
 	validators := make([]map[string]any, 0, len(collected))
 	for _, v := range collected {
+		pubKeyBytes, decodeErr := base64.StdEncoding.DecodeString(v.PubKey.Value)
+		if decodeErr != nil || len(pubKeyBytes) != ed25519.PublicKeySize {
+			fail("validator set contains an invalid Ed25519 public key")
+			return
+		}
 		if vp, perr := strconv.ParseInt(v.VotingPower, 10, 64); perr == nil {
 			totalVP += vp
 		}
 		validators = append(validators, map[string]any{
-			"address":           v.Address,
+			"address": v.Address,
+			// Scope governance and vote transactions identify a validator by
+			// lowercase hex(Ed25519 public key), not by CometBFT's 20-byte
+			// address and not necessarily by the local dashboard agent ID.
+			"agent_id":          auth.PublicKeyToAgentID(ed25519.PublicKey(pubKeyBytes)),
+			"pub_key":           v.PubKey,
 			"voting_power":      v.VotingPower,
 			"proposer_priority": v.ProposerPriority,
 		})

--- a/web/handler_chain_validators_test.go
+++ b/web/handler_chain_validators_test.go
@@ -1,0 +1,59 @@
+package web
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChainValidatorsReturnsCanonicalScopeIdentity(t *testing.T) {
+	pubKey := bytes.Repeat([]byte{0x42}, 32)
+	rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/validators", r.URL.Path)
+		assert.Equal(t, "100", r.URL.Query().Get("per_page"))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{
+				"total": "1",
+				"validators": []map[string]any{{
+					"address": "COMET-ADDRESS",
+					"pub_key": map[string]string{
+						"type":  "tendermint/PubKeyEd25519",
+						"value": base64.StdEncoding.EncodeToString(pubKey),
+					},
+					"voting_power":      "7",
+					"proposer_priority": "0",
+				}},
+			},
+		})
+	}))
+	defer rpc.Close()
+
+	handler := &DashboardHandler{CometBFTRPC: rpc.URL}
+	rr := httptest.NewRecorder()
+	handler.handleChainValidators(rr, httptest.NewRequest(http.MethodGet, "/v1/dashboard/chain/validators", nil))
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var body struct {
+		Count      int `json:"count"`
+		Validators []struct {
+			Address string `json:"address"`
+			AgentID string `json:"agent_id"`
+			PubKey  struct {
+				Value string `json:"value"`
+			} `json:"pub_key"`
+		} `json:"validators"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	require.Equal(t, 1, body.Count)
+	require.Len(t, body.Validators, 1)
+	assert.Equal(t, "COMET-ADDRESS", body.Validators[0].Address)
+	assert.Equal(t, hex.EncodeToString(pubKey), body.Validators[0].AgentID)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(pubKey), body.Validators[0].PubKey.Value)
+}

--- a/web/handler_ledger.go
+++ b/web/handler_ledger.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -258,7 +257,7 @@ func (h *DashboardHandler) handleRecoverLedger(w http.ResponseWriter, r *http.Re
 		vs.SetVault(v)
 	}
 	h.VaultLocked.Store(false)
-	h.runBackground(func(ctx context.Context) { _, _ = h.StartEmbeddingRepairIfNeeded(ctx) })
+	h.startPostUnlockRepairs()
 
 	writeJSONResp(w, http.StatusOK, map[string]any{
 		"ok":      true,

--- a/web/handler_ledger_test.go
+++ b/web/handler_ledger_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -59,6 +60,28 @@ func TestHandleEnableLedger(t *testing.T) {
 	assert.Equal(t, true, resp["ok"])
 	assert.NotEmpty(t, resp["recovery_key"])
 	assert.True(t, h.Encrypted.Load())
+}
+
+func TestVaultLoginTriggersScopedProjectionRecovery(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.VaultKeyPath = filepath.Join(t.TempDir(), "vault.key")
+	h.RunBackground = func(fn func(context.Context)) { fn(context.Background()) }
+	called := 0
+	h.ScopedProjectionRebuildFn = func(context.Context) (int, error) {
+		called++
+		return 3, nil
+	}
+	r := testRouter(h)
+
+	body, _ := json.Marshal(map[string]string{"passphrase": "test-pass-123"})
+	req := httptest.NewRequest("POST", "/v1/dashboard/settings/ledger/enable", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	_ = loginAfterEnable(t, r, "test-pass-123")
+	assert.Equal(t, 1, called, "unlock must retry the canonical scoped projection before readiness can recover")
 }
 
 func TestHandleEnableLedger_MissingPassphrase(t *testing.T) {

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -7340,6 +7340,12 @@ function NetworkPage({ sse, accessMode = false }) {
     const [govNewTarget, setGovNewTarget] = useState('');
     const [govNewPower, setGovNewPower] = useState('10');
     const [govNewReason, setGovNewReason] = useState('');
+    const [govScopeRevision, setGovScopeRevision] = useState('1');
+    const [govScopeState, setGovScopeState] = useState('active');
+    const [govScopeController, setGovScopeController] = useState('');
+    const [govScopeDomains, setGovScopeDomains] = useState('');
+    const [govScopeMembers, setGovScopeMembers] = useState({});
+    const [govScopeValidators, setGovScopeValidators] = useState([]);
     const [currentHeight, setCurrentHeight] = useState(0);
     const govPollRef = useRef(null);
 
@@ -7349,6 +7355,15 @@ function NetworkPage({ sse, accessMode = false }) {
             setAgents(data.agents || []);
         } catch (e) { console.error(e); }
         finally { setLoading(false); }
+    }, []);
+
+    const loadScopeValidators = useCallback(async () => {
+        try {
+            const data = await fetchValidators();
+            setGovScopeValidators(Array.isArray(data?.validators) ? data.validators.filter(v => v.agent_id) : []);
+        } catch (e) {
+            setGovScopeValidators([]);
+        }
     }, []);
 
     const loadUnregistered = useCallback(async () => {
@@ -7370,6 +7385,7 @@ function NetworkPage({ sse, accessMode = false }) {
 
     useEffect(() => {
         loadAgents();
+        loadScopeValidators();
         loadUnregistered();
         loadGovProposals();
         fetchStats().then(data => {
@@ -7415,25 +7431,27 @@ function NetworkPage({ sse, accessMode = false }) {
                     // If proposal is no longer voting, refresh the full list
                     if (base.status !== 'voting') {
                         loadGovProposals();
+                        loadScopeValidators();
                     }
                 }
                 if (health?.chain?.block_height) setCurrentHeight(Number(health.chain.block_height));
             } catch (e) { /* ignore polling errors */ }
         }, 3000);
         return () => { if (govPollRef.current) { clearInterval(govPollRef.current); govPollRef.current = null; } };
-    }, [activeProposal?.proposal_id, loadGovProposals]);
+    }, [activeProposal?.proposal_id, loadGovProposals, loadScopeValidators]);
 
     // SSE governance events — auto-refresh on governance activity
     useEffect(() => {
         if (!sse) return;
         const unsub = sse.on('governance', () => {
             loadGovProposals();
+            loadScopeValidators();
             fetchHealth().then(h => {
                 if (h?.chain?.block_height) setCurrentHeight(Number(h.chain.block_height));
             }).catch(() => {});
         });
         return unsub;
-    }, [sse, loadGovProposals]);
+    }, [sse, loadGovProposals, loadScopeValidators]);
 
     // Redeploy polling
     const startRedeployPoll = useCallback(() => {
@@ -7653,6 +7671,25 @@ function NetworkPage({ sse, accessMode = false }) {
             if (govNewOp === 'add_validator' || govNewOp === 'update_power') {
                 proposal.target_power = parseInt(govNewPower, 10) || 10;
             }
+            if (govNewOp === 'scope_action') {
+                const revision = parseInt(govScopeRevision, 10);
+                proposal.target_id = govNewTarget.trim();
+                proposal.scope = {
+                    scope_id: govNewTarget.trim(),
+                    revision,
+                    state: govScopeState,
+                    controller_validator_id: govScopeController,
+                    domains: govScopeDomains.split(/[\n,]/).map(v => v.trim()).filter(Boolean),
+                    members: Object.entries(govScopeMembers)
+                        .filter(([, member]) => member.selected)
+                        .map(([validatorId, member]) => ({
+                            validator_id: validatorId,
+                            assigned_weight: parseInt(member.weight, 10),
+                            joined_revision: parseInt(member.joinedRevision, 10),
+                            active: member.active !== false,
+                        })),
+                };
+            }
             const res = await submitGovProposal(proposal);
             if (res.error) { showToast(res.error, 'error'); }
             else {
@@ -7662,19 +7699,38 @@ function NetworkPage({ sse, accessMode = false }) {
                 setGovNewTarget('');
                 setGovNewPower('10');
                 setGovNewReason('');
+                setGovScopeRevision('1');
+                setGovScopeState('active');
+                setGovScopeController('');
+                setGovScopeDomains('');
+                setGovScopeMembers({});
             }
             loadGovProposals();
         } catch (e) { showToast('Proposal failed: ' + e.message, 'error'); }
         setGovSubmitting(false);
-    }, [govNewOp, govNewTarget, govNewPower, govNewReason, loadGovProposals]);
+    }, [govNewOp, govNewTarget, govNewPower, govNewReason, govScopeRevision, govScopeState, govScopeController, govScopeDomains, govScopeMembers, loadGovProposals]);
+
+    const updateGovScopeMember = useCallback((validatorId, patch) => {
+        setGovScopeMembers(current => ({
+            ...current,
+            [validatorId]: {
+                selected: false,
+                weight: '1',
+                joinedRevision: govScopeRevision || '1',
+                active: true,
+                ...(current[validatorId] || {}),
+                ...patch,
+            },
+        }));
+    }, [govScopeRevision]);
 
     // Governance helpers
     const govOpLabel = (op) => {
-        const labels = { add_validator: 'Add Validator', remove_validator: 'Remove Validator', update_power: 'Update Power' };
+        const labels = { add_validator: 'Add Validator', remove_validator: 'Remove Validator', update_power: 'Update Power', scope_action: 'Quorum Scope' };
         return labels[op] || op;
     };
     const govOpIcon = (op) => {
-        const icons = { add_validator: '+', remove_validator: '-', update_power: '~' };
+        const icons = { add_validator: '+', remove_validator: '-', update_power: '~', scope_action: 'Q' };
         return icons[op] || '?';
     };
     const resolveAgentName = (agentId) => {
@@ -7686,6 +7742,43 @@ function NetworkPage({ sse, accessMode = false }) {
         return html`<span class="gov-status-badge gov-status-${status}">${status.charAt(0).toUpperCase() + status.slice(1)}</span>`;
     };
     const pastProposals = govProposals.filter(p => p.status !== 'voting');
+    const canonicalValidatorPubkeyID = (raw) => {
+        const value = String(raw || '').trim();
+        if (/^[0-9a-fA-F]{64}$/.test(value)) return value.toLowerCase();
+        try {
+            const decoded = atob(value);
+            if (decoded.length !== 32) return '';
+            return Array.from(decoded, ch => ch.charCodeAt(0).toString(16).padStart(2, '0')).join('');
+        } catch (_) {
+            return '';
+        }
+    };
+    const govScopeValidatorOptions = govScopeValidators.map(validator => {
+        const validatorID = validator.agent_id;
+        const agent = agents.find(candidate =>
+            candidate.agent_id === validatorID || canonicalValidatorPubkeyID(candidate.validator_pubkey) === validatorID
+        );
+        return {
+            validatorID,
+            name: agent?.name || validatorID.slice(0, 16) + '...',
+            role: agent?.role || 'validator',
+            votingPower: validator.voting_power,
+        };
+    });
+    const govScopeDomainList = govScopeDomains.split(/[\n,]/).map(v => v.trim()).filter(Boolean);
+    const govScopeSelectedMembers = Object.entries(govScopeMembers).filter(([, member]) => member.selected);
+    const govScopeControllerMember = govScopeSelectedMembers.find(([validatorId, member]) => validatorId === govScopeController && member.active !== false);
+    const govScopeRevisionNumber = Number(govScopeRevision);
+    const govScopeValid = govNewOp !== 'scope_action' || (
+        Number.isSafeInteger(govScopeRevisionNumber) && govScopeRevisionNumber > 0 &&
+        (govScopeRevisionNumber !== 1 || govScopeState === 'active') &&
+        !!govScopeController && govScopeDomainList.length > 0 && govScopeSelectedMembers.length > 0 && !!govScopeControllerMember &&
+        govScopeSelectedMembers.every(([, member]) => {
+            const weight = Number(member.weight);
+            const joinedRevision = Number(member.joinedRevision);
+            return Number.isSafeInteger(weight) && weight > 0 && Number.isSafeInteger(joinedRevision) && joinedRevision > 0 && joinedRevision <= govScopeRevisionNumber;
+        })
+    );
 
     if (loading) return html`<div class="network-page"><p style="color:var(--text-muted);text-align:center;padding:40px;">Loading agents...</p></div>`;
 
@@ -7789,7 +7882,7 @@ function NetworkPage({ sse, accessMode = false }) {
 
             ${showGovModal && html`
                 <div class="wizard-overlay" onClick=${e => { if (e.target === e.currentTarget) setShowGovModal(false); }}>
-                    <div class="wizard-modal" style="max-width:520px;">
+                    <div class="wizard-modal" style=${`max-width:${govNewOp === 'scope_action' ? '760px' : '520px'};`}>
                         <div class="wizard-header">
                             <h2>New Governance Proposal</h2>
                             <button class="detail-close" onClick=${() => setShowGovModal(false)}>×</button>
@@ -7801,17 +7894,74 @@ function NetworkPage({ sse, accessMode = false }) {
                                     <option value="add_validator">Add Validator</option>
                                     <option value="remove_validator">Remove Validator</option>
                                     <option value="update_power">Update Power</option>
+                                    <option value="scope_action">Form or Revise Quorum Scope</option>
                                 </select>
                             </div>
-                            <div class="wizard-field">
-                                <label>Target Agent</label>
-                                <select class="wizard-select" value=${govNewTarget} onChange=${e => setGovNewTarget(e.target.value)}>
-                                    <option value="">Select agent...</option>
-                                    ${agents.filter(a => a.status !== 'removed').map(a => html`
-                                        <option value=${a.agent_id}>${a.name} (${a.role})</option>
-                                    `)}
-                                </select>
-                            </div>
+                            ${govNewOp === 'scope_action' ? html`
+                                <div class="wizard-field">
+                                    <label>Scope ID</label>
+                                    <input class="wizard-input" placeholder="research-quorum" value=${govNewTarget} onInput=${e => setGovNewTarget(e.target.value)} />
+                                </div>
+                                <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;">
+                                    <div class="wizard-field">
+                                        <label>Revision</label>
+                                        <input class="wizard-input" type="number" min="1" value=${govScopeRevision} onInput=${e => setGovScopeRevision(e.target.value)} />
+                                    </div>
+                                    <div class="wizard-field">
+                                        <label>Lifecycle</label>
+                                        <select class="wizard-select" value=${govScopeState} onChange=${e => setGovScopeState(e.target.value)}>
+                                            <option value="active">Active</option>
+                                            <option value="paused">Paused</option>
+                                            <option value="retired">Retired</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="wizard-field">
+                                    <label>Controller Validator</label>
+                                    <select class="wizard-select" value=${govScopeController} onChange=${e => setGovScopeController(e.target.value)}>
+                                        <option value="">Select controller...</option>
+                                        ${govScopeValidatorOptions.map(validator => html`
+                                            <option value=${validator.validatorID}>${validator.name} (${validator.role}, power ${validator.votingPower})</option>
+                                        `)}
+                                    </select>
+                                </div>
+                                <div class="wizard-field">
+                                    <label>Exact Domains</label>
+                                    <textarea class="wizard-textarea" placeholder=${allDomains.length ? `Comma-separated, e.g. ${allDomains.slice(0, 2).join(', ')}` : 'Comma-separated registered domains'} value=${govScopeDomains} onInput=${e => setGovScopeDomains(e.target.value)} />
+                                    <div style="font-size:11px;color:var(--text-muted);margin-top:5px;">Only existing on-chain domains are accepted. V1 does not include future subdomains automatically.</div>
+                                </div>
+                                <div class="wizard-field">
+                                    <label>Weighted Validator Roster</label>
+                                    <div style="border:1px solid var(--border);border-radius:10px;max-height:220px;overflow:auto;padding:8px;">
+                                        ${govScopeValidatorOptions.map(validator => {
+                                            const member = govScopeMembers[validator.validatorID] || { selected: false, weight: '1', joinedRevision: govScopeRevision || '1', active: true };
+                                            return html`<div style="padding:8px;border-bottom:1px solid var(--border);">
+                                                <label style="display:flex;align-items:center;gap:8px;cursor:pointer;">
+                                                    <input type="checkbox" checked=${member.selected} onChange=${e => updateGovScopeMember(validator.validatorID, { selected: e.target.checked })} />
+                                                    <span style="flex:1;min-width:0;">${validator.name}<div class="mono" style="font-size:10px;color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;">${validator.validatorID}</div></span>
+                                                </label>
+                                                ${member.selected && html`<div style="display:grid;grid-template-columns:1fr 1fr auto;gap:8px;align-items:end;margin-top:8px;padding-left:24px;">
+                                                    <label style="font-size:11px;color:var(--text-muted);">Weight<input class="wizard-input" type="number" min="1" value=${member.weight} onInput=${e => updateGovScopeMember(validator.validatorID, { weight: e.target.value })} /></label>
+                                                    <label style="font-size:11px;color:var(--text-muted);">Joined revision<input class="wizard-input" type="number" min="1" max=${govScopeRevision || '1'} value=${member.joinedRevision} onInput=${e => updateGovScopeMember(validator.validatorID, { joinedRevision: e.target.value })} /></label>
+                                                    <label style="font-size:11px;color:var(--text-muted);padding-bottom:10px;"><input type="checkbox" checked=${member.active !== false} onChange=${e => updateGovScopeMember(validator.validatorID, { active: e.target.checked })} /> Active</label>
+                                                </div>`}
+                                            </div>`;
+                                        })}
+                                        ${govScopeValidatorOptions.length === 0 && html`<div style="padding:12px;color:var(--text-muted);font-size:12px;">No active validators are available from the chain.</div>`}
+                                    </div>
+                                    <div style="font-size:11px;color:var(--text-muted);margin-top:5px;">The controller must be selected and active. A memory commits only above two-thirds of this pinned integer weight.</div>
+                                </div>
+                            ` : html`
+                                <div class="wizard-field">
+                                    <label>Target Agent</label>
+                                    <select class="wizard-select" value=${govNewTarget} onChange=${e => setGovNewTarget(e.target.value)}>
+                                        <option value="">Select agent...</option>
+                                        ${agents.filter(a => a.status !== 'removed').map(a => html`
+                                            <option value=${a.agent_id}>${a.name} (${a.role})</option>
+                                        `)}
+                                    </select>
+                                </div>
+                            `}
                             ${(govNewOp === 'add_validator' || govNewOp === 'update_power') && html`
                                 <div class="wizard-field">
                                     <label>Voting Power</label>
@@ -7825,7 +7975,7 @@ function NetworkPage({ sse, accessMode = false }) {
                         </div>
                         <div class="wizard-footer">
                             <button class="btn" onClick=${() => setShowGovModal(false)}>Cancel</button>
-                            <button class="btn btn-primary" onClick=${handleGovSubmit} disabled=${govSubmitting || !govNewTarget || !govNewReason.trim()}>
+                            <button class="btn btn-primary" onClick=${handleGovSubmit} disabled=${govSubmitting || !govNewTarget.trim() || !govNewReason.trim() || !govScopeValid}>
                                 ${govSubmitting ? 'Submitting...' : 'Submit Proposal'}
                             </button>
                         </div>

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -10674,8 +10674,10 @@ function OverviewPage({ sse }) {
     const appVerNum = parseInt(appVer, 10);
     // "0"/empty/unparseable -> neutral: a fresh or un-upgraded chain may not
     // report a consensus app version yet, so do not cry "behind" (amber) on it.
-    // Only a real version below 15 is genuinely behind.
-    const appVerTone = appVer === '15' ? 'healthy' : (appVerNum > 0 && appVerNum < 15 ? 'degraded' : 'neutral');
+    // Only a real version below the v11 baseline is genuinely behind. During a
+    // rolling app-v20 activation the intermediate fork rungs remain neutral;
+    // the current protocol turns green only once the v11.9 gate is active.
+    const appVerTone = appVer === '20' ? 'healthy' : (appVerNum > 0 && appVerNum < 15 ? 'degraded' : 'neutral');
     const appVerShown = (appVer && appVer !== '0') ? ('v' + appVer) : '--';
     const mempoolTxs = (chain && chain.mempool_txs != null) ? Number(chain.mempool_txs) : null;
     const mempoolHot = mempoolTxs != null && !isNaN(mempoolTxs) && mempoolTxs > 50;
@@ -10700,7 +10702,7 @@ function OverviewPage({ sse }) {
         tile(chain ? Number(chain.block_height || 0).toLocaleString() : '--', 'Block height', { color: '#10b981', title: 'Total blocks committed to the chain.' }),
         tile(fmtAge(blockElapsed), 'Last block age', { title: 'Time since the last committed block.', sub: chainIdle ? 'idle - not a stall' : '' }),
         tile(chain ? (chain.catching_up ? 'Catching up' : 'In sync') : '--', 'Sync state', { small: true, color: chain ? (chain.catching_up ? '#f59e0b' : '#10b981') : undefined }),
-        tile(appVerShown, 'App version', { small: true, color: appVerTone === 'healthy' ? '#10b981' : (appVerTone === 'degraded' ? '#f59e0b' : undefined), title: 'CometBFT app protocol version. Green when current (15).' }),
+        tile(appVerShown, 'App version', { small: true, color: appVerTone === 'healthy' ? '#10b981' : (appVerTone === 'degraded' ? '#f59e0b' : undefined), title: 'CometBFT app protocol version. Green when current (20).' }),
         tile(chainIdle ? 'Idle' : (blockRate ? blockRate.toFixed(1) + 's' : '--'), 'Block rate', { small: chainIdle, title: 'Seconds per block, derived client-side from height deltas.' }),
         tile(uptimeDisplay, 'Node uptime', { small: true, title: 'Time since this node process started.' }),
         tile(chain && chain.mempool_txs != null ? chain.mempool_txs : '--', 'Pending transactions', { color: mempoolHot ? '#f59e0b' : undefined, title: 'Unconfirmed transactions waiting in the mempool. Amber above 50 signals a backlog.' }),


### PR DESCRIPTION
## Summary

- add the dormant `app-v20` fork gate and canonical one-chain quorum-scope state
- govern scope create/update/pause/retire operations through exact on-chain records
- pin integer member weights per scoped memory and require a strict greater-than-two-thirds application quorum
- mirror scoped content in AppHash-covered Badger state and rebuild the serving projection fail-closed
- prove ordered offline catch-up, local snapshot recovery, and exact FinalizeBlock/Commit crash replay
- add bounded consensus-only state-sync format, assembly/export verification, preparation, and activation-journal primitives
- expose guided scope formation and operator visibility through REST, MCP/CEREBRUM, dashboard, OpenAPI, and Python SDK

## Safety boundary

This PR does **not** merge independent SAGE chains and does not create internet transport. v11.6 supplies libp2p internet reachability; v11.6-v11.8 authenticate synchronization between independent chains; app-v20 adds selected-domain canonical quorum replication inside one existing CometBFT validator chain.

ABCI `ListSnapshots`, `OfferSnapshot`, `LoadSnapshotChunk`, and `ApplySnapshotChunk` remain deliberately disabled. The existing full local rollback snapshot is never a network payload. Endpoint activation remains gated on whole-application bundle switching, crash-recoverable directory activation, reciprocal validator-only P2P authorization, and multiprocess kill-point/partition tests documented in `docs/v11.9-state-sync-activation.md`.

This is a foundation PR, not the v11.9 release/version bump.

## Verification

- `go test ./... -count=1 -race`
- `go vet ./...`
- exact pinned `golangci-lint v2.12.2`: 0 issues
- `go build ./cmd/amid`
- `cd natter && go test ./... -count=1 -race`
- Python SDK: 114 passed
- frontend static suite: 21 passed
- scope record/ballot/content fuzz campaigns: approximately 890k generated cases, no failures
- OpenAPI YAML parse and `git diff --check`
- GitHub CI: lint, root+natter race, frontend, Python, build, Docker, CodeQL, and four-validator Byzantine chain all green on final head `3454d7a`

## Audit fixes included

- The first dashboard wizard draft sourced scope members from ordinary agent rows. Scope authority requires the live CometBFT validator identity, and the local dashboard agent ID can differ from the validator key. The chain-validator response now exposes canonical `hex(Ed25519 pubkey)` IDs, and CEREBRUM builds its selectable controller/roster exclusively from that live set while consensus independently re-verifies every member.
- CEREBRUM now recognizes app-v20 as the current protocol after the governed upgrade ladder completes.
- Canonical round-trip fuzz invariants now cover scope records, ballots, and scoped content, closing the codec-fuzz test gap in the release plan.

## Remaining v11.9 release gates found by the audit

- User tags are currently attached after consensus only on the receiving SQLite node. Before release, normalized tags must be action-bound, carried in the post-v20 transaction, stored in the AppHash-covered scoped envelope, and restored with the serving projection.
- Removing a CometBFT validator currently can leave an affected scope labeled active while later scoped submissions fail closed. Before release, validator removal needs a scope revision/pause interlock, pending-ballot drain visibility, and reconfiguration tests.
- Network state sync still needs the accepted `BootStateSyncRuntime`/whole-bundle activation design, verified quarantine/live directory transaction and pre-handshake recovery, reciprocal validator-only P2P join authorization, endpoint wiring, kill-point coverage, and real multiprocess state-sync/partition/reconfiguration chaos.
- Release metadata/version surfaces remain at 11.8.5 intentionally and must move together only when all release gates pass.
