### PR TITLE
v11.9: canonical scoped tags and validator removal drains

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -283,12 +283,17 @@ components:
             For task-type memories: planned, in_progress, done, or dropped.
         tags:
           type: array
+          maxItems: 32
           items:
             type: string
           description: >-
-            Optional user-defined labels attached after consensus commit.
-            Stored as node-local metadata (not part of the on-chain tx);
-            queryable via `tags` on /v1/memory/query and /v1/memory/search.
+            Optional user-defined labels, each at most 128 UTF-8 bytes. Above
+            app-v20 the node trims no values: it rejects empty/padded/oversized
+            tags, then sorts and deduplicates them into the signed transaction.
+            For scoped domains they are also AppHash-covered canonical content
+            and survive projection rebuild. Ordinary-domain tags remain
+            node-local serving metadata. Queryable via `tags` on
+            /v1/memory/query and /v1/memory/search.
         provider:
           type: string
           description: Stored off-chain only; not on-chain.
@@ -333,8 +338,8 @@ components:
             type: string
           description: >-
             Optional filter — when non-empty, restricts results to memories
-            tagged with ANY of the listed values (OR semantics). SQLite-only;
-            ignored on PostgresStore.
+            tagged with ANY of the listed values (OR semantics). Supported by
+            both SQLiteStore and PostgresStore.
 
     MemorySearchRequest:
       type: object
@@ -939,7 +944,7 @@ components:
 
     ScopeMember:
       type: object
-      required: [validator_id, assigned_weight, joined_revision, active]
+      required: [validator_id, assigned_weight, joined_revision, active, pending_ballot_count, validator_removal_blocked]
       properties:
         validator_id:
           type: string
@@ -951,10 +956,35 @@ components:
           format: uint64
         active:
           type: boolean
+        pending_ballot_count:
+          type: integer
+          minimum: 0
+          description: Pending ballots whose pinned roster includes this validator.
+        validator_removal_blocked:
+          type: boolean
+          description: True while active scope membership or a pinned pending ballot prevents safe CometBFT validator removal.
+
+    ScopeDrain:
+      type: object
+      required: [pending_ballot_count, pending_memory_ids, blocking_validator_ids]
+      properties:
+        pending_ballot_count:
+          type: integer
+          minimum: 0
+        pending_memory_ids:
+          type: array
+          items:
+            type: string
+          description: Pending scoped memories in canonical memory-ID order.
+        blocking_validator_ids:
+          type: array
+          items:
+            type: string
+          description: Validators blocked from CometBFT removal by this scope head or its pinned ballots.
 
     ScopeRecord:
       type: object
-      required: [scope_id, revision, revision_hash, state, controller_validator_id, created_height, updated_height, domains, members]
+      required: [scope_id, revision, revision_hash, state, controller_validator_id, created_height, updated_height, domains, members, drain]
       properties:
         scope_id:
           type: string
@@ -984,6 +1014,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ScopeMember"
+        drain:
+          $ref: "#/components/schemas/ScopeDrain"
 
     ScopeListResponse:
       type: object
@@ -3344,12 +3376,12 @@ paths:
   /v1/scopes:
     get:
       operationId: listScopes
-      summary: List canonical v11.9 quorum scopes (operator/admin only).
+      summary: List canonical v11.9 quorum scopes and removal drain state (operator/admin only).
       tags:
         - Governance
       responses:
         "200":
-          description: Canonical scope heads in scope-ID order.
+          description: Canonical scope heads, pending ballot drains, and validator-removal blockers in scope-ID order.
           content:
             application/json:
               schema:
@@ -3364,7 +3396,7 @@ paths:
   /v1/scopes/{scope_id}:
     get:
       operationId: getScope
-      summary: Read one canonical v11.9 quorum scope (operator/admin only).
+      summary: Read one canonical v11.9 quorum scope and removal drain state (operator/admin only).
       tags:
         - Governance
       parameters:
@@ -3375,7 +3407,7 @@ paths:
             type: string
       responses:
         "200":
-          description: Canonical scope head and immutable current-revision anchor.
+          description: Canonical scope head, immutable current-revision anchor, pending ballot drain, and validator-removal blockers.
           content:
             application/json:
               schema:

--- a/api/rest/handlers_test.go
+++ b/api/rest/handlers_test.go
@@ -611,6 +611,59 @@ func TestSubmitMemory_AttachesTagsAfterCommit(t *testing.T) {
 	assert.Equal(t, []string{"project-x", "follow-up"}, tags)
 }
 
+func TestSubmitMemory_AppV20CarriesCanonicalTagsInSignedTransaction(t *testing.T) {
+	var captured string
+	var capturedURI string
+	cometMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/broadcast_tx_commit" {
+			capturedURI = r.RequestURI
+			captured = strings.TrimPrefix(r.URL.Query().Get("tx"), "0x")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": map[string]any{
+			"check_tx": map[string]any{"code": 0}, "tx_result": map[string]any{"code": 0},
+			"hash": "V20TAGS", "height": "2",
+		}})
+	}))
+	defer cometMock.Close()
+
+	srv, memStore, _ := newTestServer(t, cometMock.URL)
+	srv.SetPostV20ForNextTxAccessor(func() bool { return true })
+	body := []byte(`{"content":"scoped tags","memory_type":"fact","domain_tag":"research","confidence_score":0.9,"tags":["zeta","alpha","alpha"]}`)
+	req, _ := signedRequest(t, http.MethodPost, "/v1/memory/submit", body)
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+
+	raw, err := hex.DecodeString(captured)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw, "captured Comet transaction is empty: request_uri=%q", capturedURI)
+	parsed, err := tx.DecodeTx(raw)
+	require.NoError(t, err, "captured_len=%d captured_prefix=%q", len(raw), captured[:min(len(captured), 24)])
+	require.NoError(t, tx.ActivateMemorySubmitTags(parsed))
+	assert.Equal(t, []string{"alpha", "zeta"}, parsed.MemorySubmit.Tags)
+	valid, err := tx.VerifyTx(parsed)
+	require.NoError(t, err)
+	assert.True(t, valid)
+
+	var response SubmitMemoryResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.Equal(t, []string{"alpha", "zeta"}, memStore.setTagsCalls[response.MemoryID])
+}
+
+func TestSubmitMemory_AppV20RejectsInvalidTagsBeforeBroadcast(t *testing.T) {
+	broadcast := false
+	cometMock := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { broadcast = true }))
+	defer cometMock.Close()
+	srv, _, _ := newTestServer(t, cometMock.URL)
+	srv.SetPostV20ForNextTxAccessor(func() bool { return true })
+	body := []byte(`{"content":"bad tags","memory_type":"fact","domain_tag":"research","confidence_score":0.9,"tags":[" padded "]}`)
+	req, _ := signedRequest(t, http.MethodPost, "/v1/memory/submit", body)
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.False(t, broadcast)
+}
+
 func TestSubmitMemory_NoTags_SkipsSetTags(t *testing.T) {
 	// When the client submits without a tags field, the handler must not
 	// call SetTags at all (would clear any existing tags otherwise).

--- a/api/rest/memory_handler.go
+++ b/api/rest/memory_handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/l33tdawg/sage/internal/memory"
 	"github.com/l33tdawg/sage/internal/metrics"
 	"github.com/l33tdawg/sage/internal/store"
+	memorytags "github.com/l33tdawg/sage/internal/tags"
 	"github.com/l33tdawg/sage/internal/tx"
 )
 
@@ -39,9 +40,9 @@ type SubmitMemoryRequest struct {
 	ParentHash       string                   `json:"parent_hash,omitempty"`
 	TaskStatus       string                   `json:"task_status,omitempty"`
 	LinkedMemories   []string                 `json:"linked_memories,omitempty"`
-	// Tags are user-defined labels attached after consensus commit. They're
-	// node-local metadata (not part of the on-chain tx), queryable via the
-	// `tags` filter on /v1/memory/query and /v1/memory/search.
+	// Tags remain node-local for ordinary domains. Above app-v20 they are also
+	// carried canonically by the transaction so scoped domains can recover the
+	// same query projection on every validator and after state sync.
 	Tags []string `json:"tags,omitempty"`
 }
 
@@ -64,7 +65,7 @@ type QueryMemoryRequest struct {
 	TopK          int       `json:"top_k,omitempty"`
 	Cursor        string    `json:"cursor,omitempty"`
 	// Tags, when non-empty, restricts results to memories tagged with ANY
-	// of the listed values (OR semantics). SQLite-only.
+	// of the listed values (OR semantics) on both supported SQL backends.
 	Tags []string `json:"tags,omitempty"`
 	// Federated opts this recall into the v11 cross-network proxy: results
 	// from every active cross_fed peer are merged in (read-only, stamped with
@@ -480,6 +481,15 @@ func (s *Server) handleSubmitMemory(w http.ResponseWriter, r *http.Request) {
 	// into INTERNAL on the wire, which then triggered the per-record
 	// classification gate in handleQueryMemory for every cross-agent read.
 	classification := req.Classification
+	var consensusTags []string
+	if s.isPostV20ForNextTx() {
+		consensusTags, err = memorytags.Normalize(req.Tags)
+		if err != nil {
+			writeProblem(w, http.StatusBadRequest, "Invalid tags", err.Error())
+			return
+		}
+		req.Tags = consensusTags
+	}
 
 	submitTx := &tx.ParsedTx{
 		Type:      tx.TxTypeMemorySubmit,
@@ -496,6 +506,7 @@ func (s *Server) handleSubmitMemory(w http.ResponseWriter, r *http.Request) {
 			ParentHash:      req.ParentHash,
 			Classification:  tx.ClearanceLevel(classification), // #nosec G115 -- validated small int
 			TaskStatus:      req.TaskStatus,
+			Tags:            consensusTags,
 		},
 	}
 
@@ -564,18 +575,20 @@ func (s *Server) handleSubmitMemory(w http.ResponseWriter, r *http.Request) {
 
 	metrics.MemoriesTotal.WithLabelValues(req.MemoryType, req.DomainTag, string(memory.StatusProposed)).Inc()
 
-	// Attach user-defined tags after the block is committed. Tags are
-	// non-consensus metadata (node-local), so we set them via the store
-	// rather than folding them into the tx. broadcastTxCommit has already
-	// returned after Commit flushed the memory, so SetTags will find it.
+	// Materialize user-defined tags after the block is committed. Above app-v20
+	// scoped tags are also carried by the signed transaction, mirrored in
+	// AppHash-covered scoped content, and flushed during Commit. This call is an
+	// idempotent serving-projection fallback for scoped records and remains the
+	// node-local source for ordinary unscoped domains. broadcastTxCommit has
+	// already returned after Commit flushed the memory, so SetTags will find it.
 	//
 	// Use a fresh short-timeout context rather than r.Context() — the
 	// client may have disconnected (SIGKILL, network drop) between
 	// broadcastTxCommit completing and here, and with r.Context() every
 	// interrupted submit leaves an untagged orphan row that the next
 	// idempotency run re-proposes as a duplicate. The commit has already
-	// landed on-chain; tag attachment is a node-local finalisation step
-	// and must not depend on the HTTP request staying alive.
+	// landed on-chain; projection finalisation must not depend on the HTTP
+	// request staying alive.
 	tagCtx, tagCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer tagCancel()
 

--- a/api/rest/scope_handler.go
+++ b/api/rest/scope_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"github.com/go-chi/chi/v5"
 
@@ -18,10 +19,18 @@ type scopeDomainResponse struct {
 }
 
 type scopeMemberResponse struct {
-	ValidatorID    string `json:"validator_id"`
-	AssignedWeight uint64 `json:"assigned_weight"`
-	JoinedRevision uint64 `json:"joined_revision"`
-	Active         bool   `json:"active"`
+	ValidatorID             string `json:"validator_id"`
+	AssignedWeight          uint64 `json:"assigned_weight"`
+	JoinedRevision          uint64 `json:"joined_revision"`
+	Active                  bool   `json:"active"`
+	PendingBallotCount      int    `json:"pending_ballot_count"`
+	ValidatorRemovalBlocked bool   `json:"validator_removal_blocked"`
+}
+
+type scopeDrainResponse struct {
+	PendingBallotCount   int      `json:"pending_ballot_count"`
+	PendingMemoryIDs     []string `json:"pending_memory_ids"`
+	BlockingValidatorIDs []string `json:"blocking_validator_ids"`
 }
 
 type scopeRecordResponse struct {
@@ -34,6 +43,7 @@ type scopeRecordResponse struct {
 	UpdatedHeight         int64                 `json:"updated_height"`
 	Domains               []scopeDomainResponse `json:"domains"`
 	Members               []scopeMemberResponse `json:"members"`
+	Drain                 scopeDrainResponse    `json:"drain"`
 }
 
 func (s *Server) handleListScopes(w http.ResponseWriter, r *http.Request) {
@@ -50,9 +60,14 @@ func (s *Server) handleListScopes(w http.ResponseWriter, r *http.Request) {
 		writeProblem(w, http.StatusInternalServerError, "Scope state invalid", err.Error())
 		return
 	}
+	pending, err := s.badgerStore.ListPendingScopeBallots()
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "Scope state invalid", err.Error())
+		return
+	}
 	views := make([]scopeRecordResponse, 0, len(records))
 	for i := range records {
-		view, err := s.scopeRecordView(&records[i])
+		view, err := s.scopeRecordViewWithBallots(&records[i], pending)
 		if err != nil {
 			writeProblem(w, http.StatusInternalServerError, "Scope state invalid", err.Error())
 			return
@@ -94,6 +109,14 @@ func (s *Server) scopeReadAuthorized(r *http.Request) bool {
 }
 
 func (s *Server) scopeRecordView(record *scope.Record) (scopeRecordResponse, error) {
+	pending, err := s.badgerStore.ListPendingScopeBallots()
+	if err != nil {
+		return scopeRecordResponse{}, err
+	}
+	return s.scopeRecordViewWithBallots(record, pending)
+}
+
+func (s *Server) scopeRecordViewWithBallots(record *scope.Record, pending []scope.Ballot) (scopeRecordResponse, error) {
 	digest, err := s.badgerStore.GetScopeRevisionHash(record.ScopeID, record.Revision)
 	if err != nil {
 		return scopeRecordResponse{}, err
@@ -105,18 +128,45 @@ func (s *Server) scopeRecordView(record *scope.Record) (scopeRecordResponse, err
 	for _, domain := range record.Domains {
 		domains = append(domains, scopeDomainResponse{Name: domain.Name, Subtree: domain.Subtree})
 	}
+	pendingByValidator := make(map[string]int)
+	pendingMemoryIDs := make([]string, 0)
+	blockingValidators := make(map[string]struct{})
+	for _, ballot := range pending {
+		if ballot.ScopeID != record.ScopeID {
+			continue
+		}
+		pendingMemoryIDs = append(pendingMemoryIDs, ballot.MemoryID)
+		for _, member := range ballot.Members {
+			pendingByValidator[member.ValidatorID]++
+			blockingValidators[member.ValidatorID] = struct{}{}
+		}
+	}
 	members := make([]scopeMemberResponse, 0, len(record.Members))
 	for _, member := range record.Members {
+		if record.State != scope.StateRetired && member.Active {
+			blockingValidators[member.ValidatorID] = struct{}{}
+		}
 		members = append(members, scopeMemberResponse{
 			ValidatorID: member.ValidatorID, AssignedWeight: member.AssignedWeight,
 			JoinedRevision: member.JoinedRevision, Active: member.Active,
+			PendingBallotCount:      pendingByValidator[member.ValidatorID],
+			ValidatorRemovalBlocked: (record.State != scope.StateRetired && member.Active) || pendingByValidator[member.ValidatorID] > 0,
 		})
 	}
+	blockingValidatorIDs := make([]string, 0, len(blockingValidators))
+	for validatorID := range blockingValidators {
+		blockingValidatorIDs = append(blockingValidatorIDs, validatorID)
+	}
+	sort.Strings(blockingValidatorIDs)
 	return scopeRecordResponse{
 		ScopeID: record.ScopeID, Revision: record.Revision, RevisionHash: hex.EncodeToString(digest),
 		State: scopeStateString(record.State), ControllerValidatorID: record.ControllerValidatorID,
 		CreatedHeight: record.CreatedHeight, UpdatedHeight: record.UpdatedHeight,
 		Domains: domains, Members: members,
+		Drain: scopeDrainResponse{
+			PendingBallotCount: len(pendingMemoryIDs), PendingMemoryIDs: pendingMemoryIDs,
+			BlockingValidatorIDs: blockingValidatorIDs,
+		},
 	}, nil
 }
 

--- a/api/rest/scope_handler_test.go
+++ b/api/rest/scope_handler_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -39,6 +40,16 @@ func TestScopeReadSurfaceIsCanonicalAndOperatorOnly(t *testing.T) {
 		Members: []scope.Member{{ValidatorID: "validator-a", AssignedWeight: 7, JoinedRevision: 1, Active: true}},
 	}
 	require.NoError(t, bs.SetScopeRecord(record))
+	contentHash := sha256.Sum256([]byte("pending scoped memory"))
+	require.NoError(t, bs.SetScopedMemorySubmission(scope.Ballot{
+		MemoryID: "memory-a", ScopeID: "scope-a", ScopeRevision: 1, SubmittedHeight: 11,
+		State:   scope.BallotPending,
+		Members: []scope.BallotMember{{ValidatorID: "validator-a", EffectiveWeight: 7}}, TotalWeight: 7,
+	}, scope.Content{
+		MemoryID: "memory-a", ScopeID: "scope-a", ScopeRevision: 1, SubmittingAgentID: "agent-a",
+		ContentHash: contentHash[:], MemoryType: 1, Domain: "research", ConfidenceScore: 0.9,
+		Content: "pending scoped memory", SubmittedHeight: 11, SubmittedUnix: 100,
+	}))
 	server := &Server{badgerStore: bs, nodeOperatorID: "operator", logger: zerolog.Nop()}
 
 	rr := httptest.NewRecorder()
@@ -55,6 +66,11 @@ func TestScopeReadSurfaceIsCanonicalAndOperatorOnly(t *testing.T) {
 	assert.Equal(t, "active", listed.Scopes[0].State)
 	assert.Len(t, listed.Scopes[0].RevisionHash, 64)
 	assert.Equal(t, uint64(7), listed.Scopes[0].Members[0].AssignedWeight)
+	assert.True(t, listed.Scopes[0].Members[0].ValidatorRemovalBlocked)
+	assert.Equal(t, 1, listed.Scopes[0].Members[0].PendingBallotCount)
+	assert.Equal(t, 1, listed.Scopes[0].Drain.PendingBallotCount)
+	assert.Equal(t, []string{"memory-a"}, listed.Scopes[0].Drain.PendingMemoryIDs)
+	assert.Equal(t, []string{"validator-a"}, listed.Scopes[0].Drain.BlockingValidatorIDs)
 
 	rr = httptest.NewRecorder()
 	scopeReadRouter(server, "operator").ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/scopes/scope-a", nil))

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -1086,14 +1086,15 @@ func runServe() (rerr error) {
 		logger.Warn().Msg("no chain_id in genesis/config — federation transport disabled")
 	} else {
 		fedMgr = federation.NewManager(federation.Config{
-			LocalChainID: cfg.ChainID,
-			NetworkName:  sanitizeNetworkName(cfg.NetworkName),
-			CertsDir:     certsDir,
-			CometRPC:     cometRPC,
-			AgentKey:     fedAgentKey,
-			Badger:       badgerStore,
-			MemStore:     sqliteStore,
-			Logger:       logger,
+			LocalChainID:     cfg.ChainID,
+			NetworkName:      sanitizeNetworkName(cfg.NetworkName),
+			CertsDir:         certsDir,
+			CometRPC:         cometRPC,
+			AgentKey:         fedAgentKey,
+			Badger:           badgerStore,
+			MemStore:         sqliteStore,
+			PostV20ForNextTx: app.IsAppV20ActiveForNextTx,
+			Logger:           logger,
 		})
 		restServer.SetFederation(fedMgr)
 		// The dashboard drives the guided JOIN wizards (cookie-authed) by calling

--- a/deploy/init.sql
+++ b/deploy/init.sql
@@ -46,6 +46,13 @@ CREATE TABLE memory_links (
 );
 CREATE INDEX idx_memory_links_target ON memory_links(target_id);
 
+CREATE TABLE memory_tags (
+    memory_id UUID NOT NULL REFERENCES memories(memory_id) ON DELETE CASCADE,
+    tag       TEXT NOT NULL,
+    PRIMARY KEY (memory_id, tag)
+);
+CREATE INDEX idx_memory_tags_tag ON memory_tags(tag);
+
 -- ============================================================
 -- 2. knowledge_triples
 -- ============================================================

--- a/docs/reference/concepts/memory-lifecycle.md
+++ b/docs/reference/concepts/memory-lifecycle.md
@@ -125,7 +125,7 @@ In that one-strike path there is no separate voting round: the challenged memory
 | Access grants / domain owners  | BadgerDB (on-chain) | Keys `grant:<domain>:<agentID>`, `domain:<name>`. Written via tx, not REST-only.             |
 | Full content, embedding vector  | PostgreSQL (off-chain) | Written in `Commit`; node-local until replicated by PostgreSQL shared service.              |
 | Corroborations                  | PostgreSQL (off-chain) | Written in `Commit`. Count read at query time for confidence computation.                    |
-| **Tags**                        | **SQLite only (node-local)** | `SetTags`/`GetTags` are **no-ops on PostgresStore** (`store/postgres.go:1383-1395`). Tags exist only in personal (SQLite) mode deployments and are never on-chain. The `QueryOptions.Tags` field is explicitly noted: "any-match filter on user-defined tags (SQLite-only)" (`store/store.go:89`). |
+| **Tags**                        | SQLite/Postgres serving projection; app-v20 scoped copy in BadgerDB | Both SQL backends implement `SetTags`/`GetTags` and OR-filtered recall. Above app-v20 tags are bounded, sorted, and deduplicated in the signed `MemorySubmit`; for a scoped domain they are also stored in the AppHash-covered canonical envelope and restored with the projection. Ordinary-domain tags remain node-local serving metadata. |
 | Embedding vector (supplementary) | Process-local SupplementaryCache → PostgreSQL | Staged in-process pre-broadcast; only the receiving node has it in cache. |
 | Knowledge triples               | PostgreSQL (off-chain) | Staged via SupplementaryCache, flushed in Commit.                                            |
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -154,7 +154,7 @@ Submits a BFT memory proposal. The proposal enters consensus; status transitions
 - `confidence`: `0.0–1.0`
 - `embedding`: precomputed vector (768-dim for nomic-embed-text). Omit to let the server embed on-chain (requires Ollama on the node).
 - `knowledge_triples`: structured subject/predicate/object triples; `object_` field has alias `object` on the wire (source: `models.py:47`).
-- `tags`: node-local labels, not part of the on-chain tx. Queryable via `query(tags=...)`.
+- `tags`: up to 32 labels of 128 UTF-8 bytes each, queryable via `query(tags=...)`. Above app-v20 they are normalized into the signed transaction; scoped-domain tags are also AppHash-covered and restored during projection rebuild. Ordinary-domain tags remain node-local.
 - `classification`: per-record clearance level. When omitted, the field is excluded from the wire payload via `model_dump(exclude_none=True)` and the server stores the memory as PUBLIC (0) (source: `client.py:192`, `models.py:81`).
 
 **Classification levels:**
@@ -1084,7 +1084,8 @@ list_scopes() -> ScopeListResponse
 ```
 
 `GET /v1/scopes`. Node-operator/admin only. Returns canonical v11.9 scope
-heads, exact domain allowlists, assigned integer weights, and revision anchors.
+heads, exact domain allowlists, assigned integer weights, revision anchors,
+pending-ballot drains, and validator-removal blockers.
 
 ---
 
@@ -1095,7 +1096,8 @@ get_scope(scope_id: str) -> ScopeRecord
 ```
 
 `GET /v1/scopes/{scope_id}`. Node-operator/admin only. The clients URL-escape
-the canonical single-segment scope ID.
+the canonical single-segment scope ID. `ScopeRecord.drain` lists pending memory
+IDs and every validator that must not yet be removed from CometBFT.
 
 ---
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -55,7 +55,7 @@ Submit a memory for BFT consensus. Blocks until `broadcast_tx_commit` returns (F
 | `knowledge_triples` | []KnowledgeTriple | no | `{subject, predicate, object}` triples |
 | `parent_hash` | string | no | SHA-256 hex of parent memory for lineage |
 | `task_status` | string | no | For `task` type: `planned`, `in_progress`, `done`, `dropped` |
-| `tags` | []string | no | Node-local labels attached post-commit; OR-filter on query/search |
+| `tags` | []string | no | Up to 32 labels of 128 UTF-8 bytes each. Above app-v20 they are sorted/deduplicated into the signed tx; scoped-domain tags are also AppHash-covered and projection-recoverable. Ordinary-domain tags remain node-local. OR-filter on query/search. |
 | `provider` | string | no | Stored off-chain only; not on-chain |
 
 **Classification values** (`internal/tx/types.go:84-90`):
@@ -124,7 +124,7 @@ Vector similarity search. Requires a precomputed embedding.
 | `status_filter` | string | no | `proposed`, `validated`, `committed`, `challenged`, `deprecated` |
 | `top_k` | int | no | Max results; default 10 |
 | `cursor` | string | no | Opaque pagination cursor from previous response |
-| `tags` | []string | no | OR-filter by tag; SQLite only, ignored on Postgres |
+| `tags` | []string | no | OR-filter by tag on both SQLite and Postgres |
 
 **Response** (HTTP 200):
 
@@ -992,7 +992,10 @@ List canonical v11.9 scope heads in bytewise scope-ID order. Read-only and
 restricted to the node operator or an administrator because the response
 contains validator topology. Each record includes its current domain-separated
 SHA-256 `revision_hash`, exact domain allowlist, pinned integer weights, state,
-and materialized consensus heights.
+materialized consensus heights, pending scoped ballots, and validator-removal
+blockers. `drain.blocking_validator_ids` is the operator's fail-closed checklist:
+a validator cannot be removed from CometBFT until it has left every non-retired
+scope and every ballot whose pinned roster contains it is terminal.
 
 **Response** (HTTP 200): `{"scopes": [...], "count": 1}`
 

--- a/docs/v11.9-PLAN.md
+++ b/docs/v11.9-PLAN.md
@@ -15,14 +15,14 @@ recovery decision logic, and a writable no-migration verified-store opener, but
 no directory switch or runtime delegation. Guided canonical scope formation is
 now available through REST, MCP/CEREBRUM, the dashboard, and both Python
 clients. The dashboard derives its roster from the live CometBFT validator
-set's canonical Ed25519 identities rather than ordinary agent rows. The current
-REST submit path still attaches user tags after consensus only on the receiving
-SQLite node; binding normalized tags into the app-v20 transaction/action proof,
-canonical scoped envelope, and projection rebuild is therefore an explicit
-pre-release gate. Validator removal also still lacks the app-v20 scope
-interlock and operator drain visibility: the consensus path fails later scoped
-submissions closed when a removed validator remains in the roster, but the
-scope head still appears active. Remaining release work includes real
+set's canonical Ed25519 identities rather than ordinary agent rows. Above
+app-v20, bounded normalized tags are carried in the signed transaction and
+delegated-action proof; scoped-domain tags are also AppHash-covered in the
+canonical envelope, rebuilt into either SQL backend, and preserved by incoming
+federation admission. Validator-removal proposals are now rejected both at
+admission and immediately before execution while the validator remains active
+in a non-retired scope or any pending ballot pins it. REST, MCP, SDK, and the
+dashboard expose the exact drain blockers. Remaining release work includes real
 multi-process partition/chaos proof and reconfiguration stress. This document
 is not a claim that v11.8 synchronization groups already provide BFT or that
 v11.9 is released.
@@ -77,10 +77,14 @@ domain. Therefore v11.9 adds a **canonical scoped-content mirror** in Badger.
 For a scope-selected memory the delivered envelope contains id, content, type,
 domain, classification, confidence, timestamps, author, and content hash. It is
 written only by the deterministic app-v20 FinalizeBlock path and is covered by
-AppHash. User tags are still node-local post-commit metadata in the current
-submit path; the release must add canonical normalized tags to the signed
-post-v20 transaction and this envelope so projection recovery does not silently
-drop them.
+AppHash. Above app-v20, the submitter signs one backward-compatible extension
+containing at most 32 tags of 128 UTF-8 bytes each. The REST and federation
+paths reject padded/invalid values, sort bytewise, and deduplicate before
+signing. The extension remains dormant during pre-v20 decode/replay; after the
+fork the app activates and validates it at the deterministic block boundary.
+Scoped envelopes include the canonical list, so projection rebuild cannot
+silently drop it. Untagged and every historical pre-v20 transaction retain
+their prior bytes and behavior.
 
 The selected implementation model is therefore:
 
@@ -375,16 +379,17 @@ The release is not ready until all of the following pass:
    cannot alter an existing ballot's pinned denominator.
 6. A nonmember, a removed member, an unrelated validator, stale revision, and
    domain collision all fail closed. Removing a CometBFT validator that remains
-   active in a scope must be rejected until a governance-approved scope
-   revision/pause is in place, with pending ballots surfaced as a drain
-   requirement; a misleading active-but-unusable scope is not release-ready.
+   active in a non-retired scope is rejected until a governance-approved scope
+   revision removes it; pause alone does not drain membership. Every pending
+   ballot that pins the validator must also become terminal. The app-v20
+   interlock rechecks both conditions at proposal admission and execution, and
+   operator surfaces expose the exact drain requirement.
 7. Ordered offline replay and verified local snapshot restore rebuild selected
    scoped content and serving indexes, verify query results and hashes, and prove
    that an unselected domain receives no canonical scoped envelope. Canonically
-   normalized tags must be action-bound, AppHash-covered, and restored with the
-   projection; the current node-local post-commit tag path does not satisfy this
-   gate. The other integration proofs exist; real multi-process execution
-   remains required.
+   normalized scoped tags are action-bound, AppHash-covered, and restored with
+   the projection on SQLite and Postgres. The integration proofs exist; real
+   multi-process execution remains required.
 8. The separate network-safe snapshot format/export/preparation path passes canonical codec,
    malformed/oversized, out-of-order/chunk-retry, wrong-AppHash, local-manifest
    rejection, complete-backup hash, extra/private-file and symlink rejection,
@@ -414,8 +419,8 @@ The release is not ready until all of the following pass:
    The network-safe format, assembler, verified exporter/catalog, and read-only
    receiver preparation gate are implemented; authorized ABCI serving, atomic
    activation/rebinding, multi-process chaos, and release hardening remain.
-   Canonical post-v20 tag binding and recovery also remain before the scoped
-   envelope is complete.
+   Canonical post-v20 tag binding/recovery and the validator-removal drain
+   interlock are implemented and covered by deterministic integration tests.
    Guided canonical formation is available through REST, MCP/CEREBRUM, the
    dashboard, and both Python SDK clients without hand-encoding binary scope
    records. CEREBRUM's selectable roster is the live chain validator set, and

--- a/internal/abci/agent_proof.go
+++ b/internal/abci/agent_proof.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/l33tdawg/sage/internal/store"
+	memorytags "github.com/l33tdawg/sage/internal/tags"
 	"github.com/l33tdawg/sage/internal/tx"
 )
 
@@ -35,7 +36,7 @@ type signedAgentRequest struct {
 // agent, consensus must independently prove that the signed HTTP request maps
 // to this exact type-specific payload. Same-key node-originated transactions
 // are already bound by the outer transaction signature and nonce.
-func (app *SageApp) enforceDelegatedAgentProof(parsedTx *tx.ParsedTx, consensusTime time.Time, claim bool) error {
+func (app *SageApp) enforceDelegatedAgentProof(parsedTx *tx.ParsedTx, consensusTime time.Time, claim bool, bindMemoryTags bool) error {
 	if !txUsesAgentIdentity(parsedTx.Type) || bytes.Equal(parsedTx.PublicKey, parsedTx.AgentPubKey) {
 		return nil
 	}
@@ -62,7 +63,7 @@ func (app *SageApp) enforceDelegatedAgentProof(parsedTx *tx.ParsedTx, consensusT
 	if err != nil {
 		return err
 	}
-	if bindErr := app.verifySignedAgentAction(parsedTx, agentID, req); bindErr != nil {
+	if bindErr := app.verifySignedAgentAction(parsedTx, agentID, req, bindMemoryTags); bindErr != nil {
 		return fmt.Errorf("delegated agent action mismatch: %w", bindErr)
 	}
 
@@ -297,7 +298,7 @@ func compareAgentPayload(actual, expected *tx.ParsedTx) error {
 // embedding/timestamp posture must be tightened, it has to be a NEW forward-only fork
 // that changes behaviour only ABOVE its own activation height, never a retroactive
 // re-strictification. Guarded by TestReplayGuardDelegatedMemorySubmitAcceptedBelowAppV19.
-func (app *SageApp) verifySignedAgentAction(actual *tx.ParsedTx, agentID string, req signedAgentRequest) error { //nolint:gocyclo,maintidx // exhaustive protocol routing is intentionally centralized
+func (app *SageApp) verifySignedAgentAction(actual *tx.ParsedTx, agentID string, req signedAgentRequest, bindMemoryTags bool) error { //nolint:gocyclo,maintidx // exhaustive protocol routing is intentionally centralized
 	expected := &tx.ParsedTx{Type: actual.Type}
 
 	switch actual.Type {
@@ -314,6 +315,7 @@ func (app *SageApp) verifySignedAgentAction(actual *tx.ParsedTx, agentID string,
 			Embedding       []float32 `json:"embedding,omitempty"`
 			ParentHash      string    `json:"parent_hash,omitempty"`
 			TaskStatus      string    `json:"task_status,omitempty"`
+			Tags            []string  `json:"tags,omitempty"`
 		}
 		if err := decodeSignedJSON(req.body, &body, false); err != nil {
 			return err
@@ -332,6 +334,13 @@ func (app *SageApp) verifySignedAgentAction(actual *tx.ParsedTx, agentID string,
 			return fmt.Errorf("memory submit has an invalid node-generated embedding hash")
 		}
 		contentHash := sha256.Sum256([]byte(body.Content))
+		var canonicalTags []string
+		if bindMemoryTags {
+			canonicalTags, err = memorytags.Normalize(body.Tags)
+			if err != nil {
+				return fmt.Errorf("signed memory tags fail the REST contract: %w", err)
+			}
+		}
 		expected.MemorySubmit = &tx.MemorySubmit{
 			MemoryID:    actual.MemorySubmit.MemoryID,
 			ContentHash: contentHash[:],
@@ -350,6 +359,7 @@ func (app *SageApp) verifySignedAgentAction(actual *tx.ParsedTx, agentID string,
 			ParentHash:      body.ParentHash,
 			Classification:  tx.ClearanceLevel(body.Classification), // #nosec G115 -- range checked above
 			TaskStatus:      body.TaskStatus,
+			Tags:            canonicalTags,
 		}
 
 	case tx.TxTypeMemoryChallenge:

--- a/internal/abci/agent_proof_routes_test.go
+++ b/internal/abci/agent_proof_routes_test.go
@@ -215,7 +215,7 @@ func TestAppV17DelegatedRESTRouteMatrix(t *testing.T) { //nolint:maintidx // pro
 		t.Run(tc.name, func(t *testing.T) {
 			req, err := parseSignedAgentRequest(tc.request)
 			require.NoError(t, err)
-			require.NoError(t, app.verifySignedAgentAction(tc.parsed, agent.id, req))
+			require.NoError(t, app.verifySignedAgentAction(tc.parsed, agent.id, req, false))
 		})
 	}
 }
@@ -238,10 +238,31 @@ func TestAppV17DelegatedMemorySubmitAllowsNodeRegeneratedEmbedding(t *testing.T)
 		DomainTag: "sage-mcp-reliability", ConfidenceScore: 0.8,
 		Content: "a longer turn observation",
 	}}
-	require.NoError(t, app.verifySignedAgentAction(actual, "delegated-agent", req))
+	require.NoError(t, app.verifySignedAgentAction(actual, "delegated-agent", req, false))
 
 	actual.MemorySubmit.EmbeddingHash = []byte("not-a-sha256")
-	require.ErrorContains(t, app.verifySignedAgentAction(actual, "delegated-agent", req), "invalid node-generated embedding hash")
+	require.ErrorContains(t, app.verifySignedAgentAction(actual, "delegated-agent", req, false), "invalid node-generated embedding hash")
+}
+
+func TestAppV20DelegatedMemorySubmitBindsCanonicalTags(t *testing.T) {
+	app := setupTestApp(t)
+	content := "scoped tagged memory"
+	contentHash := sha256.Sum256([]byte(content))
+	request := canonicalAgentRequest(t, "POST", "/v1/memory/submit", map[string]any{
+		"content": content, "memory_type": "fact", "domain_tag": "research",
+		"confidence_score": 0.9, "tags": []string{"zeta", "alpha", "alpha"},
+	})
+	req, err := parseSignedAgentRequest(request)
+	require.NoError(t, err)
+	actual := &tx.ParsedTx{Type: tx.TxTypeMemorySubmit, MemorySubmit: &tx.MemorySubmit{
+		MemoryID: "00000000-0000-4000-8000-000000000000", ContentHash: contentHash[:],
+		MemoryType: tx.MemoryTypeFact, DomainTag: "research", ConfidenceScore: 0.9,
+		Content: content, Tags: []string{"alpha", "zeta"},
+	}}
+	require.NoError(t, app.verifySignedAgentAction(actual, "delegated-agent", req, true))
+
+	actual.MemorySubmit.Tags = []string{"alpha", "other"}
+	require.ErrorContains(t, app.verifySignedAgentAction(actual, "delegated-agent", req, true), "differs")
 }
 
 func TestAppV17DelegatedNonRESTRoutesFailClosed(t *testing.T) {
@@ -256,7 +277,7 @@ func TestAppV17DelegatedNonRESTRoutesFailClosed(t *testing.T) {
 		{Type: tx.TxTypeUpgradeRevert, UpgradeRevert: &tx.UpgradeRevert{Name: "app-v17", TargetAppVersion: 16}},
 	} {
 		t.Run(fmt.Sprintf("type-%d", parsed.Type), func(t *testing.T) {
-			require.ErrorContains(t, app.verifySignedAgentAction(parsed, "agent", req), "no delegated REST action")
+			require.ErrorContains(t, app.verifySignedAgentAction(parsed, "agent", req, false), "no delegated REST action")
 		})
 	}
 }

--- a/internal/abci/agent_proof_test.go
+++ b/internal/abci/agent_proof_test.go
@@ -185,7 +185,7 @@ func TestReplayGuardDelegatedMemorySubmitAcceptedBelowAppV19(t *testing.T) {
 	require.NoError(t, tx.SignTx(parsed, node.priv))
 
 	// Consensus-path enforcement (claim=true), app-v19 dormant, MUST accept.
-	require.NoError(t, app.enforceDelegatedAgentProof(parsed, blockTime, true),
+	require.NoError(t, app.enforceDelegatedAgentProof(parsed, blockTime, true, false),
 		"delegated memory-submit with a node-regenerated embedding + future-dated proof must stay ACCEPTED below app-v19; gating the relaxation would replay-fork every v11.7.6/7 chain")
 }
 

--- a/internal/abci/app.go
+++ b/internal/abci/app.go
@@ -26,6 +26,7 @@ import (
 	"github.com/l33tdawg/sage/internal/poe"
 	"github.com/l33tdawg/sage/internal/scope"
 	"github.com/l33tdawg/sage/internal/store"
+	memorytags "github.com/l33tdawg/sage/internal/tags"
 	"github.com/l33tdawg/sage/internal/tx"
 	"github.com/l33tdawg/sage/internal/validator"
 
@@ -34,8 +35,13 @@ import (
 
 // pendingWrite represents a PostgreSQL write buffered until Commit.
 type pendingWrite struct {
-	writeType string // "memory", "triples", "challenge", "vote", "corroborate", "epoch_score", "validator_score", "status_update", "access_grant", "access_request", "access_revoke", "access_log", "domain_register", "access_request_status", "org_register", "org_member", "org_member_remove", "org_member_clearance", "federation", "federation_approve", "federation_revoke", "mem_classification", "dept_register", "dept_member", "dept_member_remove", "agent_register", "agent_update", "agent_permission"
+	writeType string // "memory", "memory_tags", "triples", "challenge", "vote", "corroborate", "epoch_score", "validator_score", "status_update", "access_grant", "access_request", "access_revoke", "access_log", "domain_register", "access_request_status", "org_register", "org_member", "org_member_remove", "org_member_clearance", "federation", "federation_approve", "federation_revoke", "mem_classification", "dept_register", "dept_member", "dept_member_remove", "agent_register", "agent_update", "agent_permission"
 	data      interface{}
+}
+
+type memoryTagsData struct {
+	MemoryID string
+	Tags     []string
 }
 
 // statusUpdate carries the fields needed to update a memory's status in PostgreSQL.
@@ -2303,6 +2309,12 @@ func (app *SageApp) CheckTx(_ context.Context, req *abcitypes.RequestCheckTx) (*
 	if err != nil {
 		return &abcitypes.ResponseCheckTx{Code: 1, Log: fmt.Sprintf("decode error: %v", err)}, nil
 	}
+	postAppV20 := app.IsAppV20ActiveForNextTx()
+	if postAppV20 {
+		if tagErr := tx.ActivateMemorySubmitTags(parsedTx); tagErr != nil {
+			return &abcitypes.ResponseCheckTx{Code: 1, Log: fmt.Sprintf("decode app-v20 extension: %v", tagErr)}, nil
+		}
+	}
 
 	// Verify Ed25519 signature
 	valid, err := tx.VerifyTx(parsedTx)
@@ -2377,7 +2389,7 @@ func (app *SageApp) CheckTx(_ context.Context, req *abcitypes.RequestCheckTx) (*
 	// time is acceptable in CheckTx (which is not consensus); FinalizeBlock
 	// repeats the check against req.Time and atomically consumes the proof.
 	if app.IsAppV17ActiveForNextTx() {
-		if proofErr := app.enforceDelegatedAgentProof(parsedTx, time.Now(), false); proofErr != nil {
+		if proofErr := app.enforceDelegatedAgentProof(parsedTx, time.Now(), false, postAppV20); proofErr != nil {
 			metrics.TxRejectedTotal.WithLabelValues("agent_proof_binding").Inc()
 			return &abcitypes.ResponseCheckTx{Code: 109, Log: fmt.Sprintf("agent proof rejected: %v", proofErr)}, nil
 		}
@@ -2403,6 +2415,13 @@ func (app *SageApp) FinalizeBlock(_ context.Context, req *abcitypes.RequestFinal
 		if err != nil {
 			txResults[i] = &abcitypes.ExecTxResult{Code: 1, Log: err.Error()}
 			continue
+		}
+		postAppV20 := app.postAppV20Fork(req.Height)
+		if postAppV20 {
+			if err := tx.ActivateMemorySubmitTags(parsedTx); err != nil {
+				txResults[i] = &abcitypes.ExecTxResult{Code: 1, Log: "invalid app-v20 transaction extension"}
+				continue
+			}
 		}
 
 		// app-v15 (v11): reject non-canonical tx encodings. DecodeTx tolerates
@@ -2760,7 +2779,7 @@ func (app *SageApp) processTx(parsedTx *tx.ParsedTx, height int64, blockTime tim
 	// state. Same-key node-originated transactions are already action-bound by
 	// the outer signature and app-v9 nonce and bypass this delegated-only gate.
 	if app.postAppV17Rules(height) {
-		if proofErr := app.enforceDelegatedAgentProof(parsedTx, blockTime, true); proofErr != nil {
+		if proofErr := app.enforceDelegatedAgentProof(parsedTx, blockTime, true, app.postAppV20Fork(height)); proofErr != nil {
 			metrics.TxRejectedTotal.WithLabelValues("agent_proof_binding_consensus").Inc()
 			return &abcitypes.ExecTxResult{Code: 109, Log: fmt.Sprintf("agent proof rejected: %v", proofErr)}
 		}
@@ -2982,6 +3001,11 @@ func (app *SageApp) processMemorySubmit(parsedTx *tx.ParsedTx, height int64, blo
 	submit := parsedTx.MemorySubmit
 	if submit == nil {
 		return &abcitypes.ExecTxResult{Code: 11, Log: "missing memory submit payload"}
+	}
+	if app.postAppV20Fork(height) {
+		if err := memorytags.ValidateCanonical(submit.Tags); err != nil {
+			return &abcitypes.ExecTxResult{Code: 19, Log: "memory tags are not canonical: " + err.Error()}
+		}
 	}
 
 	// Verify agent identity on-chain via embedded Ed25519 proof.
@@ -3229,6 +3253,12 @@ func (app *SageApp) processMemorySubmit(parsedTx *tx.ParsedTx, height int64, blo
 
 	// Memory must be inserted before triples (FK constraint: knowledge_triples.memory_id → memories).
 	app.pendingWrites = append(app.pendingWrites, pendingWrite{writeType: "memory", data: record})
+	if scopedSubmission && len(submit.Tags) > 0 {
+		app.pendingWrites = append(app.pendingWrites, pendingWrite{writeType: "memory_tags", data: &memoryTagsData{
+			MemoryID: memoryID,
+			Tags:     append([]string(nil), submit.Tags...),
+		}})
+	}
 
 	if len(suppTriples) > 0 {
 		app.pendingWrites = append(app.pendingWrites, pendingWrite{
@@ -6312,6 +6342,10 @@ func (app *SageApp) flushPendingWrites(ctx context.Context, s store.OffchainStor
 			if record, ok := pw.data.(*memory.MemoryRecord); ok {
 				err = s.InsertMemory(ctx, record)
 			}
+		case "memory_tags":
+			if tags, ok := pw.data.(*memoryTagsData); ok {
+				err = s.SetTags(ctx, tags.MemoryID, tags.Tags)
+			}
 		case "triples":
 			if td, ok := pw.data.(*triplesData); ok {
 				err = s.InsertTriples(ctx, td.MemoryID, td.Triples)
@@ -6682,6 +6716,11 @@ func (app *SageApp) processGovPropose(parsedTx *tx.ParsedTx, height int64, _ tim
 	if app.postAppV20Fork(height) && op == governance.OpScopeAction {
 		if _, scopeErr := app.prepareScopeProposal(gp.TargetID, gp.TargetPubKey, gp.TargetPower, gp.Payload, proposerID, height, false); scopeErr != nil {
 			return &abcitypes.ExecTxResult{Code: 72, Log: "governance propose: invalid OpScopeAction: " + scopeErr.Error()}
+		}
+	}
+	if app.postAppV20Fork(height) && op == governance.OpRemoveValidator {
+		if drainErr := app.requireScopeValidatorRemovalReady(gp.TargetID); drainErr != nil {
+			return &abcitypes.ExecTxResult{Code: 72, Log: "governance propose: validator removal blocked: " + drainErr.Error()}
 		}
 	}
 
@@ -7539,6 +7578,11 @@ func (app *SageApp) applyGovernanceProposal(proposal *governance.ProposalState, 
 		return &abcitypes.ValidatorUpdate{PubKey: protoKey, Power: proposal.TargetPower}, nil
 
 	case governance.OpRemoveValidator:
+		if app.postAppV20Fork(height) {
+			if err := app.requireScopeValidatorRemovalReady(proposal.TargetID); err != nil {
+				return nil, fmt.Errorf("validator removal blocked at execution: %w", err)
+			}
+		}
 		if err := app.validators.RemoveValidator(proposal.TargetID); err != nil {
 			return nil, fmt.Errorf("remove validator: %w", err)
 		}
@@ -7579,6 +7623,24 @@ func (app *SageApp) applyGovernanceProposal(proposal *governance.ProposalState, 
 	default:
 		return nil, fmt.Errorf("unknown governance operation: %d", proposal.Operation)
 	}
+}
+
+func (app *SageApp) requireScopeValidatorRemovalReady(validatorID string) error {
+	drain, err := app.badgerStore.GetScopeValidatorDrain(validatorID)
+	if err != nil {
+		return err
+	}
+	if drain.Ready() {
+		return nil
+	}
+	parts := make([]string, 0, 2)
+	if len(drain.ActiveScopeIDs) > 0 {
+		parts = append(parts, "active scope memberships ["+strings.Join(drain.ActiveScopeIDs, ",")+"]")
+	}
+	if len(drain.PendingMemoryIDs) > 0 {
+		parts = append(parts, "pending scoped ballots ["+strings.Join(drain.PendingMemoryIDs, ",")+"]")
+	}
+	return fmt.Errorf("validator %q still has %s; update or retire its scopes and resolve every pinned ballot before removal", validatorID, strings.Join(parts, " and "))
 }
 
 // applyMemoryDomainRepair executes an OpMemoryDomainRepair (app-v16) proposal: it

--- a/internal/abci/appv20_scoped_memory_test.go
+++ b/internal/abci/appv20_scoped_memory_test.go
@@ -87,6 +87,7 @@ func TestAppV20ScopedBallotPinsRosterAcrossScopeUpdate(t *testing.T) {
 	record := installScopeForValidators(t, app, "scope-research", domain, 1, scope.StateActive, validators[:4])
 
 	submit := makeMemorySubmitTx(t, validators[0], domain, "pinned canonical memory")
+	submit.MemorySubmit.Tags = []string{"alpha", "research"}
 	result := app.processMemorySubmit(submit, 2, time.Unix(2, 0))
 	require.Zero(t, result.Code, result.Log)
 	memoryID := string(result.Data)
@@ -101,6 +102,15 @@ func TestAppV20ScopedBallotPinsRosterAcrossScopeUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, content)
 	assert.Equal(t, submit.MemorySubmit.Content, content.Content)
+	assert.Equal(t, submit.MemorySubmit.Tags, content.Tags)
+	require.Condition(t, func() bool {
+		for _, write := range app.pendingWrites {
+			if write.writeType == "memory_tags" {
+				return true
+			}
+		}
+		return false
+	}, "scoped submission must project canonical tags during Commit")
 
 	assert.Equal(t, uint32(13), scopedVote(t, app, validators[4], memoryID, tx.VoteDecisionAccept, 3), "current-chain outsider is not a scoped ballot member")
 	require.Zero(t, scopedVote(t, app, validators[0], memoryID, tx.VoteDecisionAccept, 4))
@@ -288,6 +298,7 @@ func TestAppV20ScopedProjectionRebuildFromCanonicalBadger(t *testing.T) {
 	app, validators, domain := setupScopedMemoryApp(t, 1)
 	installScopeForValidators(t, app, "scope-recovery", domain, 1, scope.StateActive, validators)
 	submit := makeMemorySubmitTx(t, validators[0], domain, "recoverable after projection loss")
+	submit.MemorySubmit.Tags = []string{"alpha", "recoverable"}
 	result := app.processMemorySubmit(submit, 2, time.Unix(200, 0))
 	require.Zero(t, result.Code, result.Log)
 	memoryID := string(result.Data)
@@ -304,6 +315,7 @@ func TestAppV20ScopedProjectionRebuildFromCanonicalBadger(t *testing.T) {
 		DomainTag: "other", ConfidenceScore: 0.1, Status: memory.StatusProposed,
 		CreatedAt: time.Unix(1, 0),
 	}))
+	require.NoError(t, projection.SetTags(context.Background(), memoryID, []string{"poisoned"}))
 	app.offchainStore = projection
 	rebuilt, err := app.RebuildScopedProjection(context.Background())
 	require.NoError(t, err)
@@ -323,6 +335,9 @@ func TestAppV20ScopedProjectionRebuildFromCanonicalBadger(t *testing.T) {
 	classification, err := projection.GetMemoryClassificationLocal(context.Background(), memoryID)
 	require.NoError(t, err)
 	assert.Equal(t, int(submit.MemorySubmit.Classification), classification)
+	projectedTags, err := projection.GetTags(context.Background(), memoryID)
+	require.NoError(t, err)
+	assert.Equal(t, submit.MemorySubmit.Tags, projectedTags)
 
 	challenge := app.processMemoryChallenge(makeMemoryChallengeTx(t, validators[0], memoryID, "retire bad knowledge"), 4, time.Unix(400, 0))
 	require.Zero(t, challenge.Code, challenge.Log)

--- a/internal/abci/governance_test.go
+++ b/internal/abci/governance_test.go
@@ -3,7 +3,9 @@ package abci
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/hex"
+	"sort"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/l33tdawg/sage/internal/governance" // ensure governance package compiles with tests
+	"github.com/l33tdawg/sage/internal/scope"
 	"github.com/l33tdawg/sage/internal/tx"
 	"github.com/l33tdawg/sage/internal/validator"
 )
@@ -248,6 +251,84 @@ func TestGov_RemoveValidator(t *testing.T) {
 
 	_, exists := app.validators.GetValidator(val3.id)
 	assert.False(t, exists, "val3 should be removed from set")
+}
+
+func TestGovAppV20RemovalInterlockChecksProposalAndExecution(t *testing.T) {
+	setupThree := func(t *testing.T) (*SageApp, agentKey, agentKey, agentKey) {
+		t.Helper()
+		app, admin := setupGovTestApp(t)
+		app.appV20AppliedHeight = 1
+		val2, val3 := newAgentKey(t), newAgentKey(t)
+		registerAgent(t, app, val2, "validator-2", "admin")
+		registerAgent(t, app, val3, "validator-3", "admin")
+		for _, candidate := range []agentKey{val2, val3} {
+			require.NoError(t, app.validators.AddValidator(&validator.ValidatorInfo{ID: candidate.id, PublicKey: candidate.pub, Power: 10}))
+		}
+		require.NoError(t, app.badgerStore.SaveValidators(map[string]int64{admin.id: 10, val2.id: 10, val3.id: 10}))
+		return app, admin, val2, val3
+	}
+	installActiveScope := func(t *testing.T, app *SageApp, members ...agentKey) {
+		t.Helper()
+		sort.Slice(members, func(i, j int) bool { return members[i].id < members[j].id })
+		scopeMembers := make([]scope.Member, 0, len(members))
+		for _, member := range members {
+			scopeMembers = append(scopeMembers, scope.Member{ValidatorID: member.id, AssignedWeight: 1, JoinedRevision: 1, Active: true})
+		}
+		require.NoError(t, app.badgerStore.SetScopeRecord(scope.Record{
+			ScopeID: "scope-removal", Revision: 1, State: scope.StateActive,
+			ControllerValidatorID: members[0].id, CreatedHeight: 1, UpdatedHeight: 2,
+			Domains: []scope.Domain{{Name: "research"}}, Members: scopeMembers,
+		}))
+	}
+
+	t.Run("proposal admission", func(t *testing.T) {
+		app, admin, val2, val3 := setupThree(t)
+		installActiveScope(t, app, admin, val2, val3)
+		resp := finalizeBlock(t, app, 2, makeGovProposeTx(t, admin, tx.GovOpRemoveValidator, val3.id, val3.pub, 0, "remove scoped validator", 1))
+		require.Len(t, resp.TxResults, 1)
+		assert.Equal(t, uint32(72), resp.TxResults[0].Code)
+		assert.Contains(t, resp.TxResults[0].Log, "active scope memberships")
+		assert.Empty(t, resp.ValidatorUpdates)
+	})
+
+	t.Run("pinned ballot after roster exit", func(t *testing.T) {
+		app, admin, _, val3 := setupThree(t)
+		hash := sha256.Sum256([]byte("pending removal dependency"))
+		require.NoError(t, app.badgerStore.SetScopedMemorySubmission(scope.Ballot{
+			MemoryID: "pending-removal", ScopeID: "old-scope", ScopeRevision: 1, SubmittedHeight: 2,
+			State: scope.BallotPending, Members: []scope.BallotMember{
+				{ValidatorID: val3.id, EffectiveWeight: 1},
+			}, TotalWeight: 1,
+		}, scope.Content{
+			MemoryID: "pending-removal", ScopeID: "old-scope", ScopeRevision: 1,
+			SubmittingAgentID: admin.id, ContentHash: hash[:], MemoryType: 1,
+			Domain: "research", ConfidenceScore: 0.9, Content: "pending removal dependency",
+			SubmittedHeight: 2, SubmittedUnix: 100,
+		}))
+		resp := finalizeBlock(t, app, 3, makeGovProposeTx(t, admin, tx.GovOpRemoveValidator, val3.id, val3.pub, 0, "wait for pinned ballot", 1))
+		require.Len(t, resp.TxResults, 1)
+		assert.Equal(t, uint32(72), resp.TxResults[0].Code)
+		assert.Contains(t, resp.TxResults[0].Log, "pending scoped ballots [pending-removal]")
+		assert.NotContains(t, resp.TxResults[0].Log, "active scope memberships")
+	})
+
+	t.Run("execution recheck", func(t *testing.T) {
+		app, admin, val2, val3 := setupThree(t)
+		resp := finalizeBlock(t, app, 2, makeGovProposeTx(t, admin, tx.GovOpRemoveValidator, val3.id, val3.pub, 0, "remove after vote", 1))
+		require.Zero(t, resp.TxResults[0].Code, resp.TxResults[0].Log)
+		proposal, err := app.govEngine.GetActiveProposal()
+		require.NoError(t, err)
+		require.NotNil(t, proposal)
+
+		// A new scope dependency appearing during the governance voting window
+		// must make execution fail closed even though proposal admission passed.
+		installActiveScope(t, app, admin, val2, val3)
+		resp = finalizeBlock(t, app, 12, makeGovVoteTx(t, val2, proposal.ProposalID, tx.VoteDecisionAccept, 1))
+		require.Zero(t, resp.TxResults[0].Code, resp.TxResults[0].Log)
+		assert.Empty(t, resp.ValidatorUpdates)
+		_, stillPresent := app.validators.GetValidator(val3.id)
+		assert.True(t, stillPresent)
+	})
 }
 
 func TestGov_ProposalExpiry(t *testing.T) {

--- a/internal/abci/scoped_memory.go
+++ b/internal/abci/scoped_memory.go
@@ -85,6 +85,7 @@ func (app *SageApp) setScopedMemorySubmission(submit *tx.MemorySubmit, memoryID,
 		ParentHash:        submit.ParentHash,
 		Classification:    byte(submit.Classification),
 		TaskStatus:        submit.TaskStatus,
+		Tags:              append([]string(nil), submit.Tags...),
 		SubmittedHeight:   height,
 		SubmittedUnix:     blockTime.Unix(),
 	}
@@ -135,6 +136,7 @@ func (app *SageApp) replayScopedFinalizeTx(parsedTx *tx.ParsedTx, height int64, 
 			content.MemoryType != byte(submit.MemoryType) ||
 			content.Classification != byte(submit.Classification) ||
 			content.TaskStatus != submit.TaskStatus ||
+			!equalStrings(content.Tags, submit.Tags) ||
 			math.Float64bits(content.ConfidenceScore) != math.Float64bits(submit.ConfidenceScore) ||
 			!bytes.Equal(content.ContentHash, effectiveHash) ||
 			content.ParentHash != submit.ParentHash {
@@ -168,6 +170,11 @@ func (app *SageApp) replayScopedFinalizeTx(parsedTx *tx.ParsedTx, height int64, 
 				MemoryID: memoryID, Classification: store.ClearanceLevel(content.Classification),
 			}},
 		)
+		if len(content.Tags) > 0 {
+			app.pendingWrites = append(app.pendingWrites, pendingWrite{writeType: "memory_tags", data: &memoryTagsData{
+				MemoryID: memoryID, Tags: append([]string(nil), content.Tags...),
+			}})
+		}
 		return &abcitypes.ExecTxResult{
 			Code: 0, Data: []byte(memoryID), Log: fmt.Sprintf("memory %s submitted", memoryID),
 		}, true
@@ -204,6 +211,18 @@ func (app *SageApp) replayScopedFinalizeTx(parsedTx *tx.ParsedTx, height int64, 
 	}
 
 	return nil, false
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func scopeBallotHasMember(ballot scope.Ballot, validatorID string) bool {

--- a/internal/abci/scoped_recovery.go
+++ b/internal/abci/scoped_recovery.go
@@ -52,9 +52,16 @@ func (app *SageApp) RebuildScopedProjection(ctx context.Context) (int, error) {
 			if err := projection.UpdateMemoryClassification(ctx, content.MemoryID, store.ClearanceLevel(content.Classification)); err != nil {
 				return fmt.Errorf("classification projection: %w", err)
 			}
+			if err := projection.SetTags(ctx, content.MemoryID, content.Tags); err != nil {
+				return fmt.Errorf("tag projection: %w", err)
+			}
 			projected, err := projection.GetMemory(ctx, content.MemoryID)
 			if err != nil || !recoveredProjectionMatches(projected, record) {
 				return errors.New("projection verification failed")
+			}
+			projectedTags, err := projection.GetTags(ctx, content.MemoryID)
+			if err != nil || !equalStrings(projectedTags, content.Tags) {
+				return errors.New("tag projection verification failed")
 			}
 			return nil
 		}); err != nil {

--- a/internal/federation/manager.go
+++ b/internal/federation/manager.go
@@ -48,20 +48,25 @@ type Config struct {
 	Badger *store.BadgerStore
 	// MemStore serves the actual memory content for peer queries.
 	MemStore store.MemoryStore
-	Logger   zerolog.Logger
+	// PostV20ForNextTx gates the backward-compatible MemorySubmit tag extension.
+	// It must remain absent before activation because older validators reproduce
+	// the historical payload without that extension when checking signatures.
+	PostV20ForNextTx func() bool
+	Logger           zerolog.Logger
 }
 
 // Manager is the off-consensus federation transport: trust resolution,
 // the mTLS listener's handlers, the outbound client, and receipt exchange.
 type Manager struct {
-	localChainID string
-	certsDir     string
-	cometRPC     string
-	agentKey     ed25519.PrivateKey
-	agentPub     ed25519.PublicKey
-	badger       *store.BadgerStore
-	memStore     store.MemoryStore
-	logger       zerolog.Logger
+	localChainID     string
+	certsDir         string
+	cometRPC         string
+	agentKey         ed25519.PrivateKey
+	agentPub         ed25519.PublicKey
+	badger           *store.BadgerStore
+	memStore         store.MemoryStore
+	postV20ForNextTx func() bool
+	logger           zerolog.Logger
 
 	// peerDialFn is the optional v11.6 connectivity seam. It may handle a
 	// remote chain via a libp2p stream; handled=false preserves the original
@@ -291,21 +296,22 @@ func (m *Manager) JoinStore() *JoinStore { return m.joins }
 func NewManager(cfg Config) *Manager {
 	pub, _ := cfg.AgentKey.Public().(ed25519.PublicKey)
 	m := &Manager{
-		localChainID: cfg.LocalChainID,
-		networkName:  cfg.NetworkName,
-		certsDir:     cfg.CertsDir,
-		cometRPC:     cfg.CometRPC,
-		agentKey:     cfg.AgentKey,
-		agentPub:     pub,
-		badger:       cfg.Badger,
-		memStore:     cfg.MemStore,
-		logger:       cfg.Logger.With().Str("component", "federation").Logger(),
-		seenSigs:     make(map[string]map[string]int64),
-		caCache:      make(map[string]*x509.Certificate),
-		broadcastSem: make(chan struct{}, maxConcurrentReceiptBroadcasts),
-		seedCache:    make(map[string][][]byte),
-		joins:        NewJoinStore(),
-		guestDrafts:  make(map[string]*guestDraft),
+		localChainID:     cfg.LocalChainID,
+		networkName:      cfg.NetworkName,
+		certsDir:         cfg.CertsDir,
+		cometRPC:         cfg.CometRPC,
+		agentKey:         cfg.AgentKey,
+		agentPub:         pub,
+		badger:           cfg.Badger,
+		memStore:         cfg.MemStore,
+		postV20ForNextTx: cfg.PostV20ForNextTx,
+		logger:           cfg.Logger.With().Str("component", "federation").Logger(),
+		seenSigs:         make(map[string]map[string]int64),
+		caCache:          make(map[string]*x509.Certificate),
+		broadcastSem:     make(chan struct{}, maxConcurrentReceiptBroadcasts),
+		seedCache:        make(map[string][][]byte),
+		joins:            NewJoinStore(),
+		guestDrafts:      make(map[string]*guestDraft),
 	}
 	// Production governance proof is read from the durable consensus state. Tests
 	// may replace the seam, but production never defaults to a permissive stub.

--- a/internal/federation/sync_server.go
+++ b/internal/federation/sync_server.go
@@ -740,6 +740,9 @@ func (m *Manager) buildSyncSubmitTx(localID string, item *SyncItem) ([]byte, err
 		AgentBodyHash:  bodyHash[:],
 		AgentTimestamp: ts,
 	}
+	if m.postV20ForNextTx != nil && m.postV20ForNextTx() {
+		ptx.MemorySubmit.Tags = append([]string(nil), item.Tags...)
+	}
 	if err := tx.SignTx(ptx, m.agentKey); err != nil {
 		return nil, fmt.Errorf("sign sync submit tx: %w", err)
 	}

--- a/internal/federation/sync_server_test.go
+++ b/internal/federation/sync_server_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/l33tdawg/sage/internal/memory"
 	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/tx"
 )
 
 // scriptedComet serves the CometBFT broadcast_tx_commit JSON shape. Each call pops
@@ -118,6 +119,29 @@ func syncItem(originID, domain, content string) SyncItem {
 		Content:        content,
 		ContentHash:    hex.EncodeToString(sum[:]),
 	}
+}
+
+func TestBuildSyncSubmitTxCarriesTagsOnlyAfterAppV20(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	m := &Manager{agentKey: priv, agentPub: pub}
+	item := syncItem("tagged", "research", "federated scoped content")
+	item.Tags = []string{"alpha", "zeta"}
+
+	preFork, err := m.buildSyncSubmitTx("00000000-0000-4000-8000-000000000000", &item)
+	require.NoError(t, err)
+	parsed, err := tx.DecodeTx(preFork)
+	require.NoError(t, err)
+	require.NoError(t, tx.ActivateMemorySubmitTags(parsed))
+	assert.Empty(t, parsed.MemorySubmit.Tags)
+
+	m.postV20ForNextTx = func() bool { return true }
+	postFork, err := m.buildSyncSubmitTx("00000000-0000-4000-8000-000000000000", &item)
+	require.NoError(t, err)
+	parsed, err = tx.DecodeTx(postFork)
+	require.NoError(t, err)
+	require.NoError(t, tx.ActivateMemorySubmitTags(parsed))
+	assert.Equal(t, item.Tags, parsed.MemorySubmit.Tags)
 }
 
 func TestSyncPushGateOrder(t *testing.T) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -352,7 +352,7 @@ func (s *Server) registerTools() map[string]Tool {
 		},
 		"sage_scope_list": {
 			Name:        "sage_scope_list",
-			Description: "List canonical app-v20 quorum scopes, their exact domain allowlists, pinned integer weights, lifecycle state, and revision audit anchors. Requires node-operator or admin access.",
+			Description: "List canonical app-v20 quorum scopes, exact domains, pinned weights, revision anchors, pending-ballot drain state, and validator-removal blockers. Requires node-operator or admin access.",
 			InputSchema: map[string]any{
 				"type":       "object",
 				"properties": map[string]any{},
@@ -361,7 +361,7 @@ func (s *Server) registerTools() map[string]Tool {
 		},
 		"sage_scope_get": {
 			Name:        "sage_scope_get",
-			Description: "Read one canonical app-v20 quorum scope by exact scope ID. Requires node-operator or admin access.",
+			Description: "Read one canonical app-v20 quorum scope and its pending-ballot/validator-removal drain state by exact scope ID. Requires node-operator or admin access.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/internal/scope/ballot_content_test.go
+++ b/internal/scope/ballot_content_test.go
@@ -83,6 +83,7 @@ func testContent() Content {
 
 func TestContentCodecRoundTripAndRejectsInvalidValues(t *testing.T) {
 	content := testContent()
+	content.Tags = []string{"alpha", "zeta"}
 	encoded, err := EncodeContent(content)
 	require.NoError(t, err)
 	decoded, err := DecodeContent(encoded)
@@ -99,6 +100,21 @@ func TestContentCodecRoundTripAndRejectsInvalidValues(t *testing.T) {
 	require.ErrorContains(t, err, "finite")
 	_, err = DecodeContent(append(encoded, 0))
 	require.ErrorContains(t, err, "trailing")
+
+	nonCanonicalTags := content
+	nonCanonicalTags.Tags = []string{"zeta", "alpha"}
+	_, err = EncodeContent(nonCanonicalTags)
+	require.ErrorContains(t, err, "canonical")
+
+	legacyUntagged := testContent()
+	legacyBytes, err := EncodeContent(legacyUntagged)
+	require.NoError(t, err)
+	legacyRoundTrip, err := DecodeContent(legacyBytes)
+	require.NoError(t, err)
+	assert.Empty(t, legacyRoundTrip.Tags)
+	reencodedLegacy, err := EncodeContent(legacyRoundTrip)
+	require.NoError(t, err)
+	assert.Equal(t, legacyBytes, reencodedLegacy)
 }
 
 func FuzzDecodeBallot(f *testing.F) {

--- a/internal/scope/content.go
+++ b/internal/scope/content.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math"
 	"unicode/utf8"
+
+	memorytags "github.com/l33tdawg/sage/internal/tags"
 )
 
 const maxContentBytes = 1 << 20
@@ -25,6 +27,7 @@ type Content struct {
 	ParentHash        string
 	Classification    byte
 	TaskStatus        string
+	Tags              []string
 	SubmittedHeight   int64
 	SubmittedUnix     int64
 }
@@ -49,8 +52,17 @@ func EncodeContent(content Content) ([]byte, error) {
 	buf = appendString(buf, content.TaskStatus)
 	buf = appendInt64(buf, content.SubmittedHeight)
 	buf = appendInt64(buf, content.SubmittedUnix)
+	if len(content.Tags) > 0 {
+		buf = append(buf, scopedContentTagsMarker...)
+		buf = appendUint32(buf, uint32(len(content.Tags))) // #nosec G115 -- bounded by tags.MaxCount
+		for _, tag := range content.Tags {
+			buf = appendString(buf, tag)
+		}
+	}
 	return buf, nil
 }
+
+var scopedContentTagsMarker = []byte("SAGE-CONTENT-TAGS-V1\x00")
 
 func DecodeContent(data []byte) (Content, error) {
 	if len(data) == 0 || data[0] != SchemaV1 {
@@ -112,6 +124,26 @@ func DecodeContent(data []byte) (Content, error) {
 	if content.SubmittedUnix, off, err = readInt64(data, off); err != nil {
 		return Content{}, fmt.Errorf("submitted unix time: %w", err)
 	}
+	if off < len(data) {
+		if len(data)-off < len(scopedContentTagsMarker) || string(data[off:off+len(scopedContentTagsMarker)]) != string(scopedContentTagsMarker) {
+			return Content{}, errors.New("scoped content has invalid trailing bytes")
+		}
+		off += len(scopedContentTagsMarker)
+		count, next, countErr := readUint32(data, off)
+		if countErr != nil || count == 0 || count > memorytags.MaxCount {
+			return Content{}, errors.New("scoped content has invalid tag count")
+		}
+		off = next
+		content.Tags = make([]string, 0, int(count))
+		for i := uint32(0); i < count; i++ {
+			tag, tagNext, tagErr := readString(data, off, memorytags.MaxBytes)
+			if tagErr != nil {
+				return Content{}, fmt.Errorf("tag %d: %w", i, tagErr)
+			}
+			content.Tags = append(content.Tags, tag)
+			off = tagNext
+		}
+	}
 	if off != len(data) {
 		return Content{}, errors.New("scoped content has trailing bytes")
 	}
@@ -157,6 +189,9 @@ func ValidateContent(content Content) error {
 	}
 	if content.Classification > 4 {
 		return fmt.Errorf("invalid classification %d", content.Classification)
+	}
+	if err := memorytags.ValidateCanonical(content.Tags); err != nil {
+		return fmt.Errorf("tags: %w", err)
 	}
 	return nil
 }

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -296,6 +296,16 @@ func (s *PostgresStore) ensureMemoriesSchema(ctx context.Context) error {
 			`CREATE INDEX IF NOT EXISTS idx_memories_embedding_provider ON memories (embedding_provider)`); err != nil {
 			return fmt.Errorf("index memories.embedding_provider: %w", err)
 		}
+		if _, err := ps.db.Exec(ctx, `CREATE TABLE IF NOT EXISTS memory_tags (
+			memory_id UUID NOT NULL REFERENCES memories(memory_id) ON DELETE CASCADE,
+			tag TEXT NOT NULL,
+			PRIMARY KEY (memory_id, tag)
+		)`); err != nil {
+			return fmt.Errorf("migrate memory_tags: %w", err)
+		}
+		if _, err := ps.db.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_memory_tags_tag ON memory_tags(tag)`); err != nil {
+			return fmt.Errorf("index memory_tags.tag: %w", err)
+		}
 		for _, stmt := range postgresTaskAssignmentSchema {
 			if _, err := ps.db.Exec(ctx, stmt); err != nil {
 				return fmt.Errorf("migrate task assignment schema: %w", err)
@@ -553,8 +563,15 @@ func (s *PostgresStore) QuerySimilar(ctx context.Context, embedding []float32, o
 		}
 		query += " AND submitting_agent IN (" + strings.Join(placeholders, ",") + ")"
 	}
-	// opts.Tags is ignored on PostgresStore — tags are a SQLite-only feature
-	// (PostgresStore.SetTags is a no-op, so no tagged memories can exist).
+	if len(opts.Tags) > 0 {
+		placeholders := make([]string, len(opts.Tags))
+		for i, tag := range opts.Tags {
+			placeholders[i] = fmt.Sprintf("$%d", argIdx)
+			args = append(args, tag)
+			argIdx++
+		}
+		query += " AND EXISTS (SELECT 1 FROM memory_tags mt WHERE mt.memory_id = memories.memory_id AND mt.tag IN (" + strings.Join(placeholders, ",") + "))"
+	}
 
 	scanLimit := opts.TopK
 	if opts.DecayFloor > 0 {
@@ -1368,6 +1385,13 @@ func (s *PostgresStore) ListMemories(ctx context.Context, opts ListOptions) ([]*
 		query += filter
 		countQuery += filter
 	}
+	if opts.Tag != "" {
+		filter := fmt.Sprintf(" AND EXISTS (SELECT 1 FROM memory_tags mt WHERE mt.memory_id = memories.memory_id AND mt.tag = $%d)", argIdx)
+		query += filter
+		countQuery += filter
+		args = append(args, opts.Tag)
+		argIdx++
+	}
 
 	switch opts.Sort {
 	case "oldest":
@@ -2033,26 +2057,79 @@ func (s *PostgresStore) GetAllTasks(ctx context.Context, domain string, limit in
 	return records, rows.Err()
 }
 
-// ---- Tag operations (stubs — Postgres uses enterprise deployment, tags are SQLite/personal) ----
+// ---- Tag operations ----
 
-func (s *PostgresStore) SetTags(_ context.Context, _ string, _ []string) error {
-	return nil
+func (s *PostgresStore) SetTags(ctx context.Context, memoryID string, tags []string) error {
+	return s.RunInTx(ctx, func(tx OffchainStore) error {
+		ps := tx.(*PostgresStore)
+		if _, err := ps.db.Exec(ctx, `DELETE FROM memory_tags WHERE memory_id = $1`, memoryID); err != nil {
+			return fmt.Errorf("clear tags: %w", err)
+		}
+		for _, tag := range tags {
+			if _, err := ps.db.Exec(ctx, `INSERT INTO memory_tags (memory_id, tag) VALUES ($1, $2) ON CONFLICT DO NOTHING`, memoryID, tag); err != nil {
+				return fmt.Errorf("insert tag %q: %w", tag, err)
+			}
+		}
+		return nil
+	})
 }
 
-func (s *PostgresStore) GetTags(_ context.Context, _ string) ([]string, error) {
-	return nil, nil
+func (s *PostgresStore) GetTags(ctx context.Context, memoryID string) ([]string, error) {
+	rows, err := s.db.Query(ctx, `SELECT tag FROM memory_tags WHERE memory_id = $1 ORDER BY tag`, memoryID)
+	if err != nil {
+		return nil, fmt.Errorf("query tags: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var tag string
+		if err := rows.Scan(&tag); err != nil {
+			return nil, fmt.Errorf("scan tag: %w", err)
+		}
+		out = append(out, tag)
+	}
+	return out, rows.Err()
 }
 
-func (s *PostgresStore) GetTagsBatch(_ context.Context, _ []string) (map[string][]string, error) {
-	return map[string][]string{}, nil
+func (s *PostgresStore) GetTagsBatch(ctx context.Context, memoryIDs []string) (map[string][]string, error) {
+	out := make(map[string][]string, len(memoryIDs))
+	if len(memoryIDs) == 0 {
+		return out, nil
+	}
+	rows, err := s.db.Query(ctx, `SELECT memory_id, tag FROM memory_tags WHERE memory_id = ANY($1) ORDER BY memory_id, tag`, memoryIDs)
+	if err != nil {
+		return nil, fmt.Errorf("query tags batch: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var memoryID, tag string
+		if err := rows.Scan(&memoryID, &tag); err != nil {
+			return nil, fmt.Errorf("scan tag: %w", err)
+		}
+		out[memoryID] = append(out[memoryID], tag)
+	}
+	return out, rows.Err()
 }
 
-func (s *PostgresStore) ListAllTags(_ context.Context) ([]TagCount, error) {
-	return nil, nil
+func (s *PostgresStore) ListAllTags(ctx context.Context) ([]TagCount, error) {
+	rows, err := s.db.Query(ctx, `SELECT tag, COUNT(*) FROM memory_tags GROUP BY tag ORDER BY COUNT(*) DESC, tag ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list tags: %w", err)
+	}
+	defer rows.Close()
+	var out []TagCount
+	for rows.Next() {
+		var item TagCount
+		if err := rows.Scan(&item.Tag, &item.Count); err != nil {
+			return nil, fmt.Errorf("scan tag count: %w", err)
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
 }
 
-func (s *PostgresStore) ListMemoriesByTag(_ context.Context, _ string, _, _ int) ([]*memory.MemoryRecord, int, error) {
-	return nil, 0, nil
+func (s *PostgresStore) ListMemoriesByTag(ctx context.Context, tag string, limit, offset int) ([]*memory.MemoryRecord, int, error) {
+	return s.ListMemories(ctx, ListOptions{Tag: tag, Limit: limit, Offset: offset})
 }
 
 func (s *PostgresStore) FindByContentHash(_ context.Context, _ string) (bool, error) {

--- a/internal/store/postgres_tasks_unit_test.go
+++ b/internal/store/postgres_tasks_unit_test.go
@@ -121,6 +121,13 @@ func TestPostgresEnsureMemoriesSchemaRepairsTaskStatusAndClassification(t *testi
 		WillReturnResult(pgxmock.NewResult("ALTER TABLE", 0))
 	mock.ExpectExec(regexp.QuoteMeta(`CREATE INDEX IF NOT EXISTS idx_memories_embedding_provider ON memories (embedding_provider)`)).
 		WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
+	mock.ExpectExec(regexp.QuoteMeta(`CREATE TABLE IF NOT EXISTS memory_tags (
+			memory_id UUID NOT NULL REFERENCES memories(memory_id) ON DELETE CASCADE,
+			tag TEXT NOT NULL,
+			PRIMARY KEY (memory_id, tag)
+		)`)).WillReturnResult(pgxmock.NewResult("CREATE TABLE", 0))
+	mock.ExpectExec(regexp.QuoteMeta(`CREATE INDEX IF NOT EXISTS idx_memory_tags_tag ON memory_tags(tag)`)).
+		WillReturnResult(pgxmock.NewResult("CREATE INDEX", 0))
 	for _, stmt := range postgresTaskAssignmentSchema {
 		mock.ExpectExec(regexp.QuoteMeta(stmt)).WillReturnResult(pgxmock.NewResult("DDL", 0))
 	}
@@ -134,6 +141,30 @@ func TestPostgresEnsureMemoriesSchemaRepairsTaskStatusAndClassification(t *testi
 		WillReturnResult(pgxmock.NewResult("INSERT", 0))
 
 	require.NoError(t, store.ensureMemoriesSchema(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPostgresTagProjectionUsesCanonicalTable(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	t.Cleanup(mock.Close)
+	store := &PostgresStore{db: mock}
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM memory_tags WHERE memory_id = $1`)).
+		WithArgs("00000000-0000-4000-8000-000000000000").
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+	for _, tag := range []string{"alpha", "zeta"} {
+		mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO memory_tags (memory_id, tag) VALUES ($1, $2) ON CONFLICT DO NOTHING`)).
+			WithArgs("00000000-0000-4000-8000-000000000000", tag).
+			WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	}
+	require.NoError(t, store.SetTags(context.Background(), "00000000-0000-4000-8000-000000000000", []string{"alpha", "zeta"}))
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT tag FROM memory_tags WHERE memory_id = $1 ORDER BY tag`)).
+		WithArgs("00000000-0000-4000-8000-000000000000").
+		WillReturnRows(pgxmock.NewRows([]string{"tag"}).AddRow("alpha").AddRow("zeta"))
+	got, err := store.GetTags(context.Background(), "00000000-0000-4000-8000-000000000000")
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "zeta"}, got)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/store/scoped_memory_state.go
+++ b/internal/store/scoped_memory_state.go
@@ -16,6 +16,21 @@ var (
 	ErrScopeVoteExists     = errors.New("scoped vote already exists")
 )
 
+// ScopeValidatorDrain is the deterministic set of canonical dependencies that
+// must be cleared before a CometBFT validator can be removed. ActiveScopeIDs
+// includes active members of active or paused scopes. PendingMemoryIDs includes
+// every still-pending pinned ballot that names the validator, even if it has
+// already voted; v11.9 requires the ballot itself to reach a terminal state.
+type ScopeValidatorDrain struct {
+	ValidatorID      string
+	ActiveScopeIDs   []string
+	PendingMemoryIDs []string
+}
+
+func (d ScopeValidatorDrain) Ready() bool {
+	return len(d.ActiveScopeIDs) == 0 && len(d.PendingMemoryIDs) == 0
+}
+
 func scopeBallotKey(memoryID string) []byte   { return []byte("state:scope-proposal:" + memoryID) }
 func scopedContentKey(memoryID string) []byte { return []byte("state:scope-content:" + memoryID) }
 func scopedVoteHeightKey(memoryID, validatorID string) []byte {
@@ -209,6 +224,123 @@ func (s *BadgerStore) ListScopedContents() ([]scope.Content, error) {
 		return nil, fmt.Errorf("list scoped contents: %w", err)
 	}
 	return contents, nil
+}
+
+// ListPendingScopeBallots returns all pending ballots in bytewise memory-ID
+// order for operator drain visibility. Terminal ballots are deliberately
+// omitted: they no longer depend on the live Comet validator set.
+func (s *BadgerStore) ListPendingScopeBallots() ([]scope.Ballot, error) {
+	prefix := []byte("state:scope-proposal:")
+	ballots := make([]scope.Ballot, 0)
+	err := s.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			memoryID := string(item.Key()[len(prefix):])
+			if err := item.Value(func(value []byte) error {
+				ballot, err := scope.DecodeBallot(value)
+				if err != nil {
+					return err
+				}
+				if ballot.MemoryID != memoryID {
+					return fmt.Errorf("scope ballot key %q disagrees with ballot %q", memoryID, ballot.MemoryID)
+				}
+				if ballot.State == scope.BallotPending {
+					ballots = append(ballots, ballot)
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list pending scope ballots: %w", err)
+	}
+	return ballots, nil
+}
+
+// GetScopeValidatorDrain atomically scans current scope heads and pending
+// pinned ballots. Governance calls it at both proposal admission and execution
+// so a scope created, resumed, or submitted into during the voting window
+// cannot race a validator out of the Comet set.
+func (s *BadgerStore) GetScopeValidatorDrain(validatorID string) (ScopeValidatorDrain, error) {
+	drain := ScopeValidatorDrain{ValidatorID: validatorID}
+	if validatorID == "" {
+		return drain, errors.New("validator id is required for scope drain")
+	}
+	err := s.db.View(func(txn *badger.Txn) error {
+		scopePrefix := []byte("state:scope:")
+		scopeOpts := badger.DefaultIteratorOptions
+		scopeOpts.Prefix = scopePrefix
+		scopeIt := txn.NewIterator(scopeOpts)
+		defer scopeIt.Close()
+		for scopeIt.Seek(scopePrefix); scopeIt.ValidForPrefix(scopePrefix); scopeIt.Next() {
+			item := scopeIt.Item()
+			scopeID := string(item.Key()[len(scopePrefix):])
+			if err := item.Value(func(value []byte) error {
+				record, err := scope.Decode(value)
+				if err != nil {
+					return err
+				}
+				if record.ScopeID != scopeID {
+					return fmt.Errorf("scope key %q disagrees with record %q", scopeID, record.ScopeID)
+				}
+				if record.State == scope.StateRetired {
+					return nil
+				}
+				for _, member := range record.Members {
+					if member.ValidatorID == validatorID && member.Active {
+						drain.ActiveScopeIDs = append(drain.ActiveScopeIDs, scopeID)
+						break
+					}
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+
+		ballotPrefix := []byte("state:scope-proposal:")
+		ballotOpts := badger.DefaultIteratorOptions
+		ballotOpts.Prefix = ballotPrefix
+		ballotIt := txn.NewIterator(ballotOpts)
+		defer ballotIt.Close()
+		for ballotIt.Seek(ballotPrefix); ballotIt.ValidForPrefix(ballotPrefix); ballotIt.Next() {
+			item := ballotIt.Item()
+			memoryID := string(item.Key()[len(ballotPrefix):])
+			if err := item.Value(func(value []byte) error {
+				ballot, err := scope.DecodeBallot(value)
+				if err != nil {
+					return err
+				}
+				if ballot.MemoryID != memoryID {
+					return fmt.Errorf("scope ballot key %q disagrees with ballot %q", memoryID, ballot.MemoryID)
+				}
+				if ballot.State != scope.BallotPending {
+					return nil
+				}
+				for _, member := range ballot.Members {
+					if member.ValidatorID == validatorID {
+						drain.PendingMemoryIDs = append(drain.PendingMemoryIDs, memoryID)
+						break
+					}
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return drain, fmt.Errorf("scope drain for validator %q: %w", validatorID, err)
+	}
+	return drain, nil
 }
 
 // SetScopedVote records one terminal member decision. Scoped votes are

--- a/internal/store/scoped_memory_state_test.go
+++ b/internal/store/scoped_memory_state_test.go
@@ -96,6 +96,41 @@ func TestScopedVoteAndVerdictPreservePinnedContentHash(t *testing.T) {
 	require.ErrorContains(t, err, "already reached")
 }
 
+func TestScopeValidatorDrainRequiresRosterExitAndTerminalBallots(t *testing.T) {
+	bs := newTestBadger(t)
+	record := testScopeRecord(1, "research")
+	require.NoError(t, bs.SetScopeRecord(record))
+	ballot, content := scopedSubmissionFixture()
+	content.ScopeID = record.ScopeID
+	ballot.ScopeID = record.ScopeID
+	require.NoError(t, bs.SetScopedMemorySubmission(ballot, content))
+
+	drain, err := bs.GetScopeValidatorDrain("validator-a")
+	require.NoError(t, err)
+	assert.False(t, drain.Ready())
+	assert.Equal(t, []string{"scope-a"}, drain.ActiveScopeIDs)
+	assert.Equal(t, []string{"memory-a"}, drain.PendingMemoryIDs)
+	pending, err := bs.ListPendingScopeBallots()
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "memory-a", pending[0].MemoryID)
+
+	updated := testScopeRecord(2, "research")
+	updated.ControllerValidatorID = "validator-b"
+	updated.Members = []scope.Member{{ValidatorID: "validator-b", AssignedWeight: 3, JoinedRevision: 1, Active: true}}
+	require.NoError(t, bs.SetScopeRecord(updated))
+	drain, err = bs.GetScopeValidatorDrain("validator-a")
+	require.NoError(t, err)
+	assert.Empty(t, drain.ActiveScopeIDs)
+	assert.Equal(t, []string{"memory-a"}, drain.PendingMemoryIDs)
+	assert.False(t, drain.Ready(), "leaving the current roster cannot discard an older ballot's pinned dependency")
+
+	require.NoError(t, bs.SetScopedMemoryVerdict(content.MemoryID, scope.BallotCommitted))
+	drain, err = bs.GetScopeValidatorDrain("validator-a")
+	require.NoError(t, err)
+	assert.True(t, drain.Ready())
+}
+
 func mustMemoryDomain(t *testing.T, bs *BadgerStore, memoryID string) string {
 	t.Helper()
 	value, err := bs.GetMemoryDomain(memoryID)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -4335,6 +4335,20 @@ func (s *SQLiteStore) TakeAgentNotifications(ctx context.Context, agentID string
 
 // SetTags replaces all tags on a memory with the given set.
 func (s *SQLiteStore) SetTags(ctx context.Context, memoryID string, tags []string) error {
+	// Commit and scoped recovery already run inside RunInTx. Reuse that
+	// transaction directly; attempting beginTxLocked on a tx-scoped store would
+	// dereference the intentionally-nil s.db and would also break atomicity.
+	if s.db == nil {
+		if _, err := s.conn.ExecContext(ctx, `DELETE FROM memory_tags WHERE memory_id = ?`, memoryID); err != nil {
+			return fmt.Errorf("clear tags: %w", err)
+		}
+		for _, tag := range tags {
+			if _, err := s.conn.ExecContext(ctx, `INSERT OR IGNORE INTO memory_tags (memory_id, tag) VALUES (?, ?)`, memoryID, tag); err != nil {
+				return fmt.Errorf("insert tag %q: %w", tag, err)
+			}
+		}
+		return nil
+	}
 	tx, unlock, err := s.beginTxLocked(ctx)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1204,6 +1204,29 @@ func TestSetTags_ConcurrentWithInserts(t *testing.T) {
 	}
 }
 
+func TestSetTagsParticipatesInOuterTransaction(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	record := testMemory("atomic-tags", "agent1", "atomic content", "research")
+	require.NoError(t, s.InsertMemory(ctx, record))
+
+	err := s.RunInTx(ctx, func(tx OffchainStore) error {
+		require.NoError(t, tx.SetTags(ctx, record.MemoryID, []string{"alpha", "zeta"}))
+		return fmt.Errorf("force rollback")
+	})
+	require.ErrorContains(t, err, "force rollback")
+	got, err := s.GetTags(ctx, record.MemoryID)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	require.NoError(t, s.RunInTx(ctx, func(tx OffchainStore) error {
+		return tx.SetTags(ctx, record.MemoryID, []string{"alpha", "zeta"})
+	}))
+	got, err = s.GetTags(ctx, record.MemoryID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "zeta"}, got)
+}
+
 // TestSearchByText_VaultActiveErrors confirms the v6.6.10 fix: when the store
 // has an attached vault (content encrypted at rest), SearchByText must return
 // the canonical "text search unavailable: content is vault-encrypted" error

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -99,7 +99,7 @@ type QueryOptions struct {
 	DecayFloor       float64   `json:"-"`
 	DecayNow         time.Time `json:"-"`
 	SubmittingAgents []string  `json:"submitting_agents,omitempty"` // RBAC: restrict to these agent IDs
-	Tags             []string  `json:"tags,omitempty"`              // any-match filter on user-defined tags (SQLite-only)
+	Tags             []string  `json:"tags,omitempty"`              // any-match filter on user-defined tags
 	CreatedFrom      string    `json:"created_from,omitempty"`      // ISO-8601 lower bound on created_at (inclusive)
 	CreatedTo        string    `json:"created_to,omitempty"`        // ISO-8601 upper bound on created_at (inclusive)
 }

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -1,0 +1,65 @@
+// Package tags defines the canonical representation of user-authored memory
+// tags shared by REST, federation, the transaction codec, and app-v20 scoped
+// consensus state.
+package tags
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	MaxCount = 32
+	MaxBytes = 128
+)
+
+// Normalize validates, sorts, and deduplicates tags. Empty input is represented
+// as nil so there is one canonical in-memory value and one wire encoding.
+func Normalize(values []string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	if len(values) > MaxCount {
+		return nil, fmt.Errorf("tags exceed %d entries", MaxCount)
+	}
+	canonical := append([]string(nil), values...)
+	for _, value := range canonical {
+		if value == "" || value != strings.TrimSpace(value) {
+			return nil, errors.New("tag is empty or padded")
+		}
+		if !utf8.ValidString(value) {
+			return nil, errors.New("tag is not valid UTF-8")
+		}
+		if len(value) > MaxBytes {
+			return nil, fmt.Errorf("tag exceeds %d bytes", MaxBytes)
+		}
+	}
+	sort.Strings(canonical)
+	out := canonical[:0]
+	for _, value := range canonical {
+		if len(out) == 0 || out[len(out)-1] != value {
+			out = append(out, value)
+		}
+	}
+	return out, nil
+}
+
+// ValidateCanonical rejects any representation Normalize would change.
+func ValidateCanonical(values []string) error {
+	canonical, err := Normalize(values)
+	if err != nil {
+		return err
+	}
+	if len(canonical) != len(values) {
+		return errors.New("tags contain duplicates")
+	}
+	for i := range canonical {
+		if canonical[i] != values[i] {
+			return errors.New("tags are not in canonical byte order")
+		}
+	}
+	return nil
+}

--- a/internal/tags/tags_test.go
+++ b/internal/tags/tags_test.go
@@ -1,0 +1,34 @@
+package tags
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalize(t *testing.T) {
+	got, err := Normalize([]string{"zeta", "alpha", "alpha"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "zeta"}, got)
+
+	for name, values := range map[string][]string{
+		"empty":     {""},
+		"padded":    {" alpha"},
+		"oversized": {strings.Repeat("a", MaxBytes+1)},
+		"too many":  make([]string, MaxCount+1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := Normalize(values)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestValidateCanonical(t *testing.T) {
+	require.NoError(t, ValidateCanonical(nil))
+	require.NoError(t, ValidateCanonical([]string{"alpha", "zeta"}))
+	require.Error(t, ValidateCanonical([]string{"zeta", "alpha"}))
+	require.Error(t, ValidateCanonical([]string{"alpha", "alpha"}))
+}

--- a/internal/tx/codec.go
+++ b/internal/tx/codec.go
@@ -1,6 +1,7 @@
 package tx
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/binary"
@@ -8,6 +9,8 @@ import (
 	"fmt"
 	"math"
 	"time"
+
+	memorytags "github.com/l33tdawg/sage/internal/tags"
 )
 
 // Wire format: [1-byte type][payload][64-byte signature][32-byte pubkey][8-byte nonce][8-byte unix-nano timestamp]
@@ -705,8 +708,14 @@ func encodeMemorySubmit(s *MemorySubmit) []byte {
 	buf = appendBytes(buf, []byte(s.ParentHash))
 	buf = append(buf, byte(s.Classification))
 	buf = appendBytes(buf, []byte(s.TaskStatus))
+	if len(s.Tags) > 0 {
+		buf = append(buf, memorySubmitTagsMarker...)
+		buf = appendStringSlice(buf, s.Tags)
+	}
 	return buf
 }
+
+var memorySubmitTagsMarker = []byte("SAGE-MEM-TAGS-V1\x00")
 
 func decodeMemorySubmit(data []byte) (*MemorySubmit, error) {
 	s := &MemorySubmit{}
@@ -769,13 +778,52 @@ func decodeMemorySubmit(data []byte) (*MemorySubmit, error) {
 
 	// TaskStatus: backward compatible — empty string if absent
 	if off < len(data) {
-		b, _, err = readBytes(data, off)
+		var next int
+		b, next, err = readBytes(data, off)
 		if err == nil {
 			s.TaskStatus = string(b)
+			off = next
+			if off < len(data) {
+				s.tagExtension = append([]byte(nil), data[off:]...)
+			}
 		}
 	}
 
 	return s, nil
+}
+
+// ActivateMemorySubmitTags interprets the app-v20 tag extension after the
+// caller has established that the deterministic fork is active. Keeping this
+// out of DecodeTx preserves pre-v20 replay: legacy decoders ignored every byte
+// after TaskStatus, including arbitrary historical trailing data.
+func ActivateMemorySubmitTags(parsed *ParsedTx) error {
+	if parsed == nil || parsed.Type != TxTypeMemorySubmit || parsed.MemorySubmit == nil {
+		return nil
+	}
+	submit := parsed.MemorySubmit
+	if len(submit.tagExtension) == 0 {
+		return memorytags.ValidateCanonical(submit.Tags)
+	}
+	if !bytes.HasPrefix(submit.tagExtension, memorySubmitTagsMarker) {
+		return fmt.Errorf("%w: invalid memory tag extension", ErrInvalidTxData)
+	}
+	countOffset := len(memorySubmitTagsMarker)
+	if len(submit.tagExtension)-countOffset < 4 {
+		return fmt.Errorf("%w: malformed memory tag extension", ErrInvalidTxData)
+	}
+	count := binary.BigEndian.Uint32(submit.tagExtension[countOffset : countOffset+4])
+	if count == 0 || count > memorytags.MaxCount {
+		return fmt.Errorf("%w: invalid memory tag count", ErrInvalidTxData)
+	}
+	values, off, err := readStringSlice(submit.tagExtension, len(memorySubmitTagsMarker))
+	if err != nil || off != len(submit.tagExtension) {
+		return fmt.Errorf("%w: malformed memory tag extension", ErrInvalidTxData)
+	}
+	if err := memorytags.ValidateCanonical(values); err != nil {
+		return fmt.Errorf("%w: non-canonical memory tags: %v", ErrInvalidTxData, err)
+	}
+	submit.Tags = values
+	return nil
 }
 
 // --- CoCommit (v11 / app-v15) ---

--- a/internal/tx/codec_test.go
+++ b/internal/tx/codec_test.go
@@ -3,11 +3,14 @@ package tx
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	memorytags "github.com/l33tdawg/sage/internal/tags"
 )
 
 func testKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
@@ -208,6 +211,51 @@ func TestVerifyTxTampered(t *testing.T) {
 	valid, err := VerifyTx(tx)
 	require.NoError(t, err)
 	assert.False(t, valid)
+}
+
+func TestMemorySubmitTagsRemainDormantUntilAppV20Activation(t *testing.T) {
+	_, priv := testKeypair(t)
+	tagged := sampleSubmitTx()
+	tagged.MemorySubmit.Tags = []string{"alpha", "zeta"}
+	require.NoError(t, SignTx(tagged, priv))
+	raw, err := EncodeTx(tagged)
+	require.NoError(t, err)
+
+	decoded, err := DecodeTx(raw)
+	require.NoError(t, err)
+	assert.Nil(t, decoded.MemorySubmit.Tags, "DecodeTx alone must preserve pre-v20 semantics")
+	preActivation, err := EncodeTx(decoded)
+	require.NoError(t, err)
+	assert.NotEqual(t, raw, preActivation, "a pre-v20 canonicality check rejects the dormant extension exactly as an older binary does")
+	valid, err := VerifyTx(decoded)
+	require.NoError(t, err)
+	assert.False(t, valid, "the extension cannot become unsigned metadata before activation")
+
+	require.NoError(t, ActivateMemorySubmitTags(decoded))
+	assert.Equal(t, []string{"alpha", "zeta"}, decoded.MemorySubmit.Tags)
+	canonical, err := EncodeTx(decoded)
+	require.NoError(t, err)
+	assert.Equal(t, raw, canonical)
+	valid, err = VerifyTx(decoded)
+	require.NoError(t, err)
+	assert.True(t, valid)
+}
+
+func TestMemorySubmitTagActivationRejectsNonCanonicalExtension(t *testing.T) {
+	parsed := sampleSubmitTx()
+	parsed.MemorySubmit.Tags = []string{"zeta", "alpha"}
+	require.ErrorContains(t, ActivateMemorySubmitTags(parsed), "canonical")
+
+	parsed.MemorySubmit.Tags = nil
+	parsed.MemorySubmit.tagExtension = append(append([]byte(nil), memorySubmitTagsMarker...), appendStringSlice(nil, []string{"alpha", "alpha"})...)
+	require.ErrorContains(t, ActivateMemorySubmitTags(parsed), "canonical")
+
+	tooMany := make([]string, memorytags.MaxCount+1)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("tag-%02d", i)
+	}
+	parsed.MemorySubmit.tagExtension = append(append([]byte(nil), memorySubmitTagsMarker...), appendStringSlice(nil, tooMany)...)
+	require.ErrorContains(t, ActivateMemorySubmitTags(parsed), "tag count")
 }
 
 func TestDecodeInvalidBytes(t *testing.T) {

--- a/internal/tx/types.go
+++ b/internal/tx/types.go
@@ -146,6 +146,13 @@ type MemorySubmit struct {
 	ParentHash      string
 	Classification  ClearanceLevel // Defaults to ClearanceInternal (1)
 	TaskStatus      string         // For task memories: planned, in_progress, done, dropped
+	// Tags is a canonical (sorted, unique, bounded) app-v20 extension. It is
+	// encoded only when non-empty, so every historical MemorySubmit retains its
+	// exact bytes. DecodeTx keeps the extension dormant until the caller knows
+	// the deterministic fork height and calls ActivateMemorySubmitTags.
+	Tags []string
+
+	tagExtension []byte
 }
 
 // MemoryVote records a validator's vote on a proposed memory.

--- a/sdk/python/src/sage_sdk/async_client.py
+++ b/sdk/python/src/sage_sdk/async_client.py
@@ -132,9 +132,11 @@ class AsyncSageClient:
     ) -> MemorySubmitResponse:
         """Submit a new memory proposal.
 
-        tags: optional user-defined labels attached after consensus commit.
-        Stored as node-local metadata (not part of the on-chain tx) and
-        queryable via the `tags` argument on :meth:`query`.
+        tags: optional user-defined labels queryable via the `tags` argument
+        on :meth:`query`. Above app-v20 they are normalized into the signed
+        transaction; scoped-domain tags are also AppHash-covered and restored
+        with the canonical scoped projection. Ordinary-domain tags remain
+        node-local serving metadata.
 
         classification: per-record clearance level 0-4 (PUBLIC, INTERNAL,
         CONFIDENTIAL, SECRET, TOP SECRET). When omitted the server stores

--- a/sdk/python/src/sage_sdk/client.py
+++ b/sdk/python/src/sage_sdk/client.py
@@ -173,9 +173,11 @@ class SageClient:
     ) -> MemorySubmitResponse:
         """Submit a new memory proposal.
 
-        tags: optional user-defined labels attached after consensus commit.
-        Stored as node-local metadata (not part of the on-chain tx) and
-        queryable via the `tags` argument on :meth:`query`.
+        tags: optional user-defined labels queryable via the `tags` argument
+        on :meth:`query`. Above app-v20 they are normalized into the signed
+        transaction; scoped-domain tags are also AppHash-covered and restored
+        with the canonical scoped projection. Ordinary-domain tags remain
+        node-local serving metadata.
 
         classification: per-record clearance level 0-4 (PUBLIC, INTERNAL,
         CONFIDENTIAL, SECRET, TOP SECRET). When omitted the server stores

--- a/sdk/python/src/sage_sdk/models.py
+++ b/sdk/python/src/sage_sdk/models.py
@@ -491,6 +491,14 @@ class ScopeMember(BaseModel):
     assigned_weight: int
     joined_revision: int
     active: bool
+    pending_ballot_count: int = 0
+    validator_removal_blocked: bool = False
+
+
+class ScopeDrain(BaseModel):
+    pending_ballot_count: int = 0
+    pending_memory_ids: list[str] = Field(default_factory=list)
+    blocking_validator_ids: list[str] = Field(default_factory=list)
 
 
 class ScopeRecord(BaseModel):
@@ -503,6 +511,7 @@ class ScopeRecord(BaseModel):
     updated_height: int
     domains: list[ScopeDomain]
     members: list[ScopeMember]
+    drain: ScopeDrain = Field(default_factory=ScopeDrain)
 
 
 class ScopeListResponse(BaseModel):

--- a/sdk/python/tests/test_async_client.py
+++ b/sdk/python/tests/test_async_client.py
@@ -107,6 +107,11 @@ async def test_scope_read_surface(async_client, mock_api):
             "joined_revision": 1,
             "active": True,
         }],
+        "drain": {
+            "pending_ballot_count": 1,
+            "pending_memory_ids": ["memory-a"],
+            "blocking_validator_ids": ["validator-a"],
+        },
     }
     mock_api.get("/v1/scopes").mock(
         return_value=httpx.Response(200, json={"scopes": [record], "count": 1})
@@ -121,6 +126,7 @@ async def test_scope_read_surface(async_client, mock_api):
 
     listed = await async_client.list_scopes()
     assert listed.scopes[0].domains[0].name == "research"
+    assert listed.scopes[0].drain.blocking_validator_ids == ["validator-a"]
     assert (await async_client.get_scope("scope-a")).state == "active"
     assert (await async_client.get_scope("scope a")).scope_id == "scope a"
     assert escaped.called

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -256,6 +256,11 @@ def test_scope_read_surface(client, mock_api):
             "joined_revision": 1,
             "active": True,
         }],
+        "drain": {
+            "pending_ballot_count": 1,
+            "pending_memory_ids": ["memory-a"],
+            "blocking_validator_ids": ["validator-a"],
+        },
     }
     mock_api.get("/v1/scopes").mock(
         return_value=httpx.Response(200, json={"scopes": [record], "count": 1})
@@ -271,6 +276,7 @@ def test_scope_read_surface(client, mock_api):
     listed = client.list_scopes()
     assert listed.count == 1
     assert listed.scopes[0].members[0].assigned_weight == 7
+    assert listed.scopes[0].drain.pending_memory_ids == ["memory-a"]
     assert client.get_scope("scope-a").revision_hash == "ab" * 32
     assert client.get_scope("scope a").scope_id == "scope a"
     assert escaped.called

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -83,6 +83,12 @@ export async function fetchValidators() {
     return res.json();
 }
 
+export async function fetchScopes() {
+	const res = await fetch(`${API_BASE}/v1/scopes`);
+	if (!res.ok) throw new Error('scopes fetch failed');
+	return res.json();
+}
+
 export async function fetchMcpConfig() {
     const res = await fetch(`${API_BASE}/v1/mcp-config`);
     if (!res.ok) throw new Error('mcp-config fetch failed');

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1,6 +1,6 @@
 // CEREBRUM — Your SAGE Brain
 import { SSEClient } from './sse.js';
-import { fetchStats, fetchGraph, fetchMemories, deleteMemory, updateMemory, fetchHealth, fetchValidators, fetchMcpConfig, checkAuth, login, recoverVault, lockSession, importMemories, importPreview, importConfirm, fetchCleanupSettings, saveCleanupSettings, runCleanup, fetchAgents, fetchAgent, createAgent, updateAgent, removeAgent, downloadBundle, fetchTemplates, fetchRedeployStatus, startRedeploy, createPairingCode, rotateAgentKey, fetchBootInstructions, saveBootInstructions, fetchLedgerStatus, enableLedger, changeLedgerPassphrase, disableLedger, fetchTags, fetchMemoryTags, setMemoryTags, fetchAutostart, setAutostart, checkForUpdate, applyUpdate, restartServer, fetchReranker, saveReranker, testReranker, detectReranker, fetchOnboarding, saveOnboarding,
+import { fetchStats, fetchGraph, fetchMemories, deleteMemory, updateMemory, fetchHealth, fetchValidators, fetchScopes, fetchMcpConfig, checkAuth, login, recoverVault, lockSession, importMemories, importPreview, importConfirm, fetchCleanupSettings, saveCleanupSettings, runCleanup, fetchAgents, fetchAgent, createAgent, updateAgent, removeAgent, downloadBundle, fetchTemplates, fetchRedeployStatus, startRedeploy, createPairingCode, rotateAgentKey, fetchBootInstructions, saveBootInstructions, fetchLedgerStatus, enableLedger, changeLedgerPassphrase, disableLedger, fetchTags, fetchMemoryTags, setMemoryTags, fetchAutostart, setAutostart, checkForUpdate, applyUpdate, restartServer, fetchReranker, saveReranker, testReranker, detectReranker, fetchOnboarding, saveOnboarding,
 rerankerSetupStatus, rerankerSetupDownload, rerankerSetupStart, rerankerSetupStop, rerankerSetupInstallEngine, fetchTasks, updateTaskStatus, createTask, assignTask, fetchUnregisteredAgents, mergeAgent, fetchRecallSettings, saveRecallSettings, fetchAgentDomains, reassignDomainOwnership, bulkUpdateMemories, fetchMemoryMode, saveMemoryMode, fetchPipeline, fetchPipelineStats, sendPipelineNote, fetchGovProposals, fetchGovProposalDetail, submitGovProposal, submitGovVote, wizardCheckCloudflared, wizardInstallCloudflared, wizardStartLogin, wizardLoginStatus, wizardCreateTunnel, wizardMintToken, connectProvider, connectRemoteUrl, fetchUpdateStatus, selectEmbeddingProvider,
 embeddingsStatus, checkOllamaEmbed, installOllamaRuntime, startOllamaRuntime, pullEmbedModel, reembedMemories, reembedProgress, enableSemanticEmbeddings,
 deprecateUnreadable, getRecoveryKey, recoverOrphansPreview, recoverOrphans,
@@ -7345,7 +7345,8 @@ function NetworkPage({ sse, accessMode = false }) {
     const [govScopeController, setGovScopeController] = useState('');
     const [govScopeDomains, setGovScopeDomains] = useState('');
     const [govScopeMembers, setGovScopeMembers] = useState({});
-    const [govScopeValidators, setGovScopeValidators] = useState([]);
+	const [govScopeValidators, setGovScopeValidators] = useState([]);
+	const [govScopes, setGovScopes] = useState([]);
     const [currentHeight, setCurrentHeight] = useState(0);
     const govPollRef = useRef(null);
 
@@ -7357,14 +7358,23 @@ function NetworkPage({ sse, accessMode = false }) {
         finally { setLoading(false); }
     }, []);
 
-    const loadScopeValidators = useCallback(async () => {
+	const loadScopeValidators = useCallback(async () => {
         try {
             const data = await fetchValidators();
             setGovScopeValidators(Array.isArray(data?.validators) ? data.validators.filter(v => v.agent_id) : []);
         } catch (e) {
             setGovScopeValidators([]);
         }
-    }, []);
+	}, []);
+
+	const loadGovScopes = useCallback(async () => {
+		try {
+			const data = await fetchScopes();
+			setGovScopes(Array.isArray(data?.scopes) ? data.scopes : []);
+		} catch (e) {
+			setGovScopes([]);
+		}
+	}, []);
 
     const loadUnregistered = useCallback(async () => {
         try {
@@ -7385,7 +7395,8 @@ function NetworkPage({ sse, accessMode = false }) {
 
     useEffect(() => {
         loadAgents();
-        loadScopeValidators();
+		loadScopeValidators();
+		loadGovScopes();
         loadUnregistered();
         loadGovProposals();
         fetchStats().then(data => {
@@ -7395,7 +7406,7 @@ function NetworkPage({ sse, accessMode = false }) {
         fetchHealth().then(h => {
             if (h?.chain?.block_height) setCurrentHeight(Number(h.chain.block_height));
         }).catch(() => {});
-    }, []);
+	}, []);
 
     // Poll active proposal detail + block height every 3s while one is active
     useEffect(() => {
@@ -7431,27 +7442,29 @@ function NetworkPage({ sse, accessMode = false }) {
                     // If proposal is no longer voting, refresh the full list
                     if (base.status !== 'voting') {
                         loadGovProposals();
-                        loadScopeValidators();
+						loadScopeValidators();
+						loadGovScopes();
                     }
                 }
                 if (health?.chain?.block_height) setCurrentHeight(Number(health.chain.block_height));
             } catch (e) { /* ignore polling errors */ }
         }, 3000);
         return () => { if (govPollRef.current) { clearInterval(govPollRef.current); govPollRef.current = null; } };
-    }, [activeProposal?.proposal_id, loadGovProposals, loadScopeValidators]);
+	}, [activeProposal?.proposal_id, loadGovProposals, loadScopeValidators, loadGovScopes]);
 
     // SSE governance events — auto-refresh on governance activity
     useEffect(() => {
         if (!sse) return;
         const unsub = sse.on('governance', () => {
             loadGovProposals();
-            loadScopeValidators();
+			loadScopeValidators();
+			loadGovScopes();
             fetchHealth().then(h => {
                 if (h?.chain?.block_height) setCurrentHeight(Number(h.chain.block_height));
             }).catch(() => {});
         });
         return unsub;
-    }, [sse, loadGovProposals, loadScopeValidators]);
+	}, [sse, loadGovProposals, loadScopeValidators, loadGovScopes]);
 
     // Redeploy polling
     const startRedeployPoll = useCallback(() => {
@@ -7769,7 +7782,7 @@ function NetworkPage({ sse, accessMode = false }) {
     const govScopeSelectedMembers = Object.entries(govScopeMembers).filter(([, member]) => member.selected);
     const govScopeControllerMember = govScopeSelectedMembers.find(([validatorId, member]) => validatorId === govScopeController && member.active !== false);
     const govScopeRevisionNumber = Number(govScopeRevision);
-    const govScopeValid = govNewOp !== 'scope_action' || (
+	const govScopeValid = govNewOp !== 'scope_action' || (
         Number.isSafeInteger(govScopeRevisionNumber) && govScopeRevisionNumber > 0 &&
         (govScopeRevisionNumber !== 1 || govScopeState === 'active') &&
         !!govScopeController && govScopeDomainList.length > 0 && govScopeSelectedMembers.length > 0 && !!govScopeControllerMember &&
@@ -7778,7 +7791,11 @@ function NetworkPage({ sse, accessMode = false }) {
             const joinedRevision = Number(member.joinedRevision);
             return Number.isSafeInteger(weight) && weight > 0 && Number.isSafeInteger(joinedRevision) && joinedRevision > 0 && joinedRevision <= govScopeRevisionNumber;
         })
-    );
+	);
+	const govRemovalBlockingScopes = govNewOp === 'remove_validator' && govNewTarget
+		? govScopes.filter(scope => (scope?.drain?.blocking_validator_ids || []).includes(govNewTarget))
+		: [];
+	const govRemovalValid = govNewOp !== 'remove_validator' || govRemovalBlockingScopes.length === 0;
 
     if (loading) return html`<div class="network-page"><p style="color:var(--text-muted);text-align:center;padding:40px;">Loading agents...</p></div>`;
 
@@ -7793,11 +7810,27 @@ function NetworkPage({ sse, accessMode = false }) {
                     : html`<div><h2>Agents <${HelpTip} text="Manage the agents on your own SAGE node. Each agent is a separate participant in BFT consensus with its own permissions. Click any agent to expand its details and access. (To connect your whole node to ANOTHER SAGE, use Federation.)" /><${PageHelp} section="network" label="Agents guide" /></h2><div class="network-header-sub">${agents.length} agent${agents.length !== 1 ? 's' : ''} on this node</div></div>`}
             </div>
 
-            <div class="gov-section">
+			<div class="gov-section">
                 <div class="gov-section-header">
                     <h3>Governance <${HelpTip} text="Validator governance allows network participants to propose and vote on changes to the validator set. Proposals require 2/3 quorum to pass." /></h3>
                     ${!activeProposal && html`<button class="gov-new-btn" onClick=${() => setShowGovModal(true)}>+ New Proposal</button>`}
-                </div>
+				</div>
+
+				${govScopes.length > 0 && html`
+					<div style="display:grid;gap:8px;margin:10px 0 14px;">
+						${govScopes.map(scope => html`
+							<div style="border:1px solid var(--border);border-radius:10px;padding:10px 12px;background:var(--surface);">
+								<div style="display:flex;justify-content:space-between;gap:12px;align-items:center;">
+									<div><strong>${scope.scope_id}</strong> <span style="color:var(--text-muted);font-size:11px;">rev ${scope.revision} · ${scope.state}</span></div>
+									${scope.drain?.pending_ballot_count > 0
+										? html`<span style="color:var(--warning);font-size:11px;font-weight:600;">Draining ${scope.drain.pending_ballot_count} ballot${scope.drain.pending_ballot_count === 1 ? '' : 's'}</span>`
+										: html`<span style="color:var(--text-muted);font-size:11px;">No pending ballots</span>`}
+								</div>
+								<div style="color:var(--text-muted);font-size:11px;margin-top:5px;">${(scope.domains || []).map(domain => domain.name).join(', ')} · ${(scope.drain?.blocking_validator_ids || []).length} validator removal blocker${(scope.drain?.blocking_validator_ids || []).length === 1 ? '' : 's'}</div>
+							</div>
+						`)}
+					</div>
+				`}
 
                 ${activeProposal ? html`
                     <div class="gov-proposal-card active">
@@ -7962,12 +7995,17 @@ function NetworkPage({ sse, accessMode = false }) {
                                     </select>
                                 </div>
                             `}
-                            ${(govNewOp === 'add_validator' || govNewOp === 'update_power') && html`
+							${(govNewOp === 'add_validator' || govNewOp === 'update_power') && html`
                                 <div class="wizard-field">
                                     <label>Voting Power</label>
                                     <input class="wizard-input" type="number" min="1" max="100" value=${govNewPower} onInput=${e => setGovNewPower(e.target.value)} />
                                 </div>
-                            `}
+							`}
+							${govNewOp === 'remove_validator' && govRemovalBlockingScopes.length > 0 && html`
+								<div style="border:1px solid var(--danger);border-radius:10px;padding:10px 12px;color:var(--danger);font-size:12px;margin-bottom:12px;">
+									Removal is blocked by ${govRemovalBlockingScopes.map(scope => scope.scope_id).join(', ')}. Revise or retire those scopes and let every pending scoped ballot finish first.
+								</div>
+							`}
                             <div class="wizard-field">
                                 <label>Reason</label>
                                 <textarea class="wizard-textarea" placeholder="Why is this change needed?" value=${govNewReason} onInput=${e => setGovNewReason(e.target.value)} />
@@ -7975,7 +8013,7 @@ function NetworkPage({ sse, accessMode = false }) {
                         </div>
                         <div class="wizard-footer">
                             <button class="btn" onClick=${() => setShowGovModal(false)}>Cancel</button>
-                            <button class="btn btn-primary" onClick=${handleGovSubmit} disabled=${govSubmitting || !govNewTarget.trim() || !govNewReason.trim() || !govScopeValid}>
+							<button class="btn btn-primary" onClick=${handleGovSubmit} disabled=${govSubmitting || !govNewTarget.trim() || !govNewReason.trim() || !govScopeValid || !govRemovalValid}>
                                 ${govSubmitting ? 'Submitting...' : 'Submit Proposal'}
                             </button>
                         </div>


### PR DESCRIPTION
## Outcome

Completes two v11.9 release-blocking foundation gaps for domain-scoped quorum state.

- Carries bounded, normalized tags through the dormant app-v20 MemorySubmit extension, delegated action binding, canonical scoped content, federation admission, and SQLite/Postgres projection recovery.
- Preserves historical replay by activating the extension only at the deterministic app-v20 boundary; untagged and pre-v20 bytes remain unchanged.
- Blocks CometBFT validator removal at proposal admission and execution while any non-retired scope membership or pinned pending ballot remains.
- Exposes exact drain blockers through REST/OpenAPI, MCP, Python SDK, and CEREBRUM.

## Verification

- Full Go root suite with race detector
- golangci-lint v2.12.2: 0 issues
- Go vet and production amid build
- Frontend static/test suite: 21 passed
- Python SDK: 114 passed
- OpenAPI YAML parse and diff checks

## Release boundary

This advances v11.9 quorum replication inside one consensus chain. It does not claim independent internet chains have become one BFT validator set. Atomic live network state-sync activation/rebinding, join authorization, and real multi-process partition/chaos and reconfiguration stress remain release gates.