### PR TITLE
feat(statesync): add crash-safe boot activation foundation

### DIFF
--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -646,8 +646,20 @@ func runServe() (rerr error) {
 		}
 	}
 
-	// Create the node controller — manages CometBFT lifecycle for redeployment
-	nodeCtrl := NewSageNodeController(cometCfg, app, pv, nodeKey, cmtLogger, logger, cfg.DataDir)
+	// CometBFT receives only the boot runtime, never a raw SageApp pointer. The
+	// runtime is dormant for now: normal ABCI calls delegate to this complete
+	// bundle while network state-sync endpoints remain empty/reject/abort.
+	consensusBundle, err := sageabci.NewConsensusBundle(ctx, app)
+	if err != nil {
+		return fmt.Errorf("create consensus bundle: %w", err)
+	}
+	bootRuntime, err := sageabci.NewBootStateSyncRuntime(consensusBundle)
+	if err != nil {
+		return fmt.Errorf("create boot state-sync runtime: %w", err)
+	}
+
+	// Create the node controller — manages CometBFT lifecycle for redeployment.
+	nodeCtrl := NewSageNodeController(cometCfg, bootRuntime, pv, nodeKey, cmtLogger, logger, cfg.DataDir)
 
 	if err := nodeCtrl.StartChain(); err != nil {
 		return fmt.Errorf("start CometBFT: %w", err)

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -49,6 +49,7 @@ import (
 	sagep2p "github.com/l33tdawg/sage/internal/p2p"
 	"github.com/l33tdawg/sage/internal/rerankd"
 	"github.com/l33tdawg/sage/internal/snapshot"
+	"github.com/l33tdawg/sage/internal/statesync"
 	"github.com/l33tdawg/sage/internal/store"
 	"github.com/l33tdawg/sage/internal/tlsca"
 	"github.com/l33tdawg/sage/internal/tunnelclientd"
@@ -103,10 +104,20 @@ func runServe() (rerr error) {
 	badgerPath := filepath.Join(cfg.DataDir, "badger")
 	sqlitePath := filepath.Join(cfg.DataDir, "sage.db")
 
-	for _, dir := range []string{cfg.DataDir, cometHome, badgerPath} {
+	// Do not create the canonical Badger directory until activation recovery has
+	// inspected the crash layout. A missing live directory can be intentional.
+	for _, dir := range []string{cfg.DataDir, cometHome} {
 		if mkErr := os.MkdirAll(dir, 0700); mkErr != nil {
 			return fmt.Errorf("create dir %s: %w", dir, mkErr)
 		}
+	}
+	if action, found, recoveryErr := recoverPendingStateSyncActivation(context.Background(), cfg.DataDir, cometHome, badgerPath); recoveryErr != nil {
+		return fmt.Errorf("recover state sync activation before ABCI handshake: %w", recoveryErr)
+	} else if found {
+		logger.Warn().Str("action", stateSyncRecoveryActionName(action)).Msg("recovered interrupted state sync activation before opening Badger")
+	}
+	if mkErr := os.MkdirAll(badgerPath, 0700); mkErr != nil {
+		return fmt.Errorf("create dir %s: %w", badgerPath, mkErr)
 	}
 	pidPath := filepath.Join(SageHome(), "sage.pid")
 	pidValue := strconv.Itoa(os.Getpid())
@@ -380,9 +391,12 @@ func runServe() (rerr error) {
 	if err != nil {
 		return fmt.Errorf("open BadgerDB: %w", err)
 	}
+	badgerOwnedByRuntime := false
 	defer func() {
 		stopWorkers()
-		_ = badgerStore.CloseBadger()
+		if !badgerOwnedByRuntime {
+			_ = badgerStore.CloseBadger()
+		}
 	}()
 
 	// Seed the replay-nonce allocator from the chain's committed nonces. The
@@ -407,10 +421,6 @@ func runServe() (rerr error) {
 		return fmt.Errorf("create SAGE app: %w", err)
 	}
 	app.Version = version
-	defer func() {
-		stopWorkers()
-		_ = app.Close()
-	}()
 
 	// v11.9 recovery: Badger is the canonical scoped-content source after
 	// snapshot/state sync; SQLite is only the serving projection. Verify and
@@ -649,7 +659,7 @@ func runServe() (rerr error) {
 	// CometBFT receives only the boot runtime, never a raw SageApp pointer. The
 	// runtime is dormant for now: normal ABCI calls delegate to this complete
 	// bundle while network state-sync endpoints remain empty/reject/abort.
-	consensusBundle, err := sageabci.NewConsensusBundle(ctx, app)
+	consensusBundle, err := sageabci.NewConsensusBundleWithCleanup(ctx, app, app.CloseConsensusState)
 	if err != nil {
 		return fmt.Errorf("create consensus bundle: %w", err)
 	}
@@ -657,6 +667,13 @@ func runServe() (rerr error) {
 	if err != nil {
 		return fmt.Errorf("create boot state-sync runtime: %w", err)
 	}
+	badgerOwnedByRuntime = true
+	defer func() {
+		stopWorkers()
+		if closeErr := bootRuntime.Close(); closeErr != nil {
+			logger.Error().Err(closeErr).Msg("close active consensus bundle")
+		}
+	}()
 
 	// Create the node controller — manages CometBFT lifecycle for redeployment.
 	nodeCtrl := NewSageNodeController(cometCfg, bootRuntime, pv, nodeKey, cmtLogger, logger, cfg.DataDir)
@@ -1699,6 +1716,19 @@ func runServe() (rerr error) {
 		return errCoordinatedRestart
 	}
 	return nil
+}
+
+func stateSyncRecoveryActionName(action statesync.RecoveryAction) string {
+	switch action {
+	case statesync.RecoveryDiscardPrepared:
+		return "discard_prepared"
+	case statesync.RecoveryRestoreQuarantine:
+		return "restore_quarantine"
+	case statesync.RecoveryKeepActivated:
+		return "keep_activated"
+	default:
+		return "unknown"
+	}
 }
 
 func confirmPendingUpdateAfterReady(ctx context.Context, baseURL, bootID, execPath string) error {

--- a/cmd/sage-gui/node_controller.go
+++ b/cmd/sage-gui/node_controller.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	abcitypes "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/config"
 	cmtcrypto "github.com/cometbft/cometbft/crypto/ed25519"
 	cmtlog "github.com/cometbft/cometbft/libs/log"
@@ -18,7 +19,6 @@ import (
 	cmttime "github.com/cometbft/cometbft/types/time"
 	"github.com/rs/zerolog"
 
-	sageabci "github.com/l33tdawg/sage/internal/abci"
 	"github.com/l33tdawg/sage/internal/orchestrator"
 )
 
@@ -29,7 +29,7 @@ type SageNodeController struct {
 	mu        sync.Mutex
 	cometNode *node.Node
 	cometCfg  *config.Config
-	app       *sageabci.SageApp
+	app       abcitypes.Application
 	pv        *privval.FilePV
 	nodeKey   *p2p.NodeKey
 	cmtLogger cmtlog.Logger
@@ -44,7 +44,7 @@ var _ orchestrator.NodeController = (*SageNodeController)(nil)
 // NewSageNodeController creates a new node controller.
 func NewSageNodeController(
 	cometCfg *config.Config,
-	app *sageabci.SageApp,
+	app abcitypes.Application,
 	pv *privval.FilePV,
 	nodeKey *p2p.NodeKey,
 	cmtLogger cmtlog.Logger,

--- a/cmd/sage-gui/state_sync_boot.go
+++ b/cmd/sage-gui/state_sync_boot.go
@@ -1,13 +1,23 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/cometbft/cometbft/config"
 	cmtstate "github.com/cometbft/cometbft/state"
+
+	sageabci "github.com/l33tdawg/sage/internal/abci"
+	"github.com/l33tdawg/sage/internal/statesync"
 )
+
+const stateSyncActivationJournalName = "state-sync-activation.journal"
+
+type persistedCometStateReader func(*config.Config) (uint64, []byte, error)
 
 // readPersistedCometState reads the state DB before node.NewNode starts and
 // before the ABCI handshake can compare CometBFT with SAGE. State-sync journal
@@ -34,14 +44,69 @@ func readPersistedCometStateWithProvider(cfg *config.Config, provider config.DBP
 	if closeErr != nil {
 		return 0, nil, fmt.Errorf("close CometBFT state DB: %w", closeErr)
 	}
-	if state.IsEmpty() || state.LastBlockHeight == 0 {
-		if state.LastBlockHeight < 0 || len(state.AppHash) != 0 {
+	if state.LastBlockHeight == 0 {
+		if len(state.AppHash) != 0 {
 			return 0, nil, errors.New("empty CometBFT state has an invalid height or AppHash")
 		}
 		return 0, nil, nil
 	}
-	if state.LastBlockHeight < 0 || len(state.AppHash) != sha256.Size {
+	if state.IsEmpty() || state.LastBlockHeight < 0 || len(state.AppHash) != sha256.Size {
 		return 0, nil, errors.New("persisted CometBFT state has an invalid height or AppHash")
 	}
 	return uint64(state.LastBlockHeight), append([]byte(nil), state.AppHash...), nil // #nosec G115 -- positive int64 checked above
+}
+
+// recoverPendingStateSyncActivation runs before startup creates or opens the
+// canonical Badger directory. In particular, MkdirAll(badger) must not run
+// first: after a crash between live->quarantine and prepared->live, recreating
+// an empty live directory would turn a recoverable layout into an ambiguous one.
+func recoverPendingStateSyncActivation(ctx context.Context, dataDir, cometHome, badgerPath string) (statesync.RecoveryAction, bool, error) {
+	return recoverPendingStateSyncActivationWith(
+		ctx,
+		dataDir,
+		cometHome,
+		badgerPath,
+		readPersistedCometState,
+		func(path string) (uint64, []byte, error) {
+			return sageabci.InspectStateSyncRecoveryDirectory(ctx, path)
+		},
+	)
+}
+
+func recoverPendingStateSyncActivationWith(
+	ctx context.Context,
+	dataDir, cometHome, badgerPath string,
+	readComet persistedCometStateReader,
+	inspect statesync.ActivationDirectoryInspector,
+) (statesync.RecoveryAction, bool, error) {
+	if dataDir == "" || cometHome == "" || badgerPath == "" || readComet == nil || inspect == nil {
+		return 0, false, errors.New("state sync recovery paths, Comet reader, and directory inspector are required")
+	}
+	if contextErr := ctx.Err(); contextErr != nil {
+		return 0, false, contextErr
+	}
+	journalPath := filepath.Join(dataDir, stateSyncActivationJournalName)
+	if _, err := os.Lstat(journalPath); errors.Is(err, os.ErrNotExist) {
+		return 0, false, nil
+	} else if err != nil {
+		return 0, true, fmt.Errorf("inspect state sync activation journal: %w", err)
+	}
+	journal, err := statesync.LoadActivationJournal(journalPath)
+	if err != nil {
+		return 0, true, err
+	}
+	if journal.LiveName != filepath.Base(badgerPath) || filepath.Dir(badgerPath) != dataDir {
+		return 0, true, errors.New("state sync activation journal does not target the canonical Badger directory")
+	}
+	cometCfg := config.DefaultConfig()
+	cometCfg.SetRoot(cometHome)
+	cometHeight, cometAppHash, err := readComet(cometCfg)
+	if err != nil {
+		return 0, true, err
+	}
+	action, err := statesync.RecoverActivationDirectories(dataDir, journalPath, cometHeight, cometAppHash, inspect)
+	if err != nil {
+		return 0, true, err
+	}
+	return action, true, nil
 }

--- a/cmd/sage-gui/state_sync_boot.go
+++ b/cmd/sage-gui/state_sync_boot.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	"github.com/cometbft/cometbft/config"
+	cmtstate "github.com/cometbft/cometbft/state"
+)
+
+// readPersistedCometState reads the state DB before node.NewNode starts and
+// before the ABCI handshake can compare CometBFT with SAGE. State-sync journal
+// recovery uses this narrow seam to avoid booting an app whose Badger height is
+// ahead of CometBFT after a crash between directory activation and Comet's own
+// state persistence.
+func readPersistedCometState(cfg *config.Config) (uint64, []byte, error) {
+	return readPersistedCometStateWithProvider(cfg, config.DefaultDBProvider)
+}
+
+func readPersistedCometStateWithProvider(cfg *config.Config, provider config.DBProvider) (uint64, []byte, error) {
+	if cfg == nil || provider == nil {
+		return 0, nil, errors.New("CometBFT config and DB provider are required")
+	}
+	db, err := provider(&config.DBContext{ID: "state", Config: cfg})
+	if err != nil {
+		return 0, nil, fmt.Errorf("open CometBFT state DB: %w", err)
+	}
+	state, loadErr := cmtstate.NewStore(db, cmtstate.StoreOptions{}).Load()
+	closeErr := db.Close()
+	if loadErr != nil {
+		return 0, nil, fmt.Errorf("load CometBFT state DB: %w", loadErr)
+	}
+	if closeErr != nil {
+		return 0, nil, fmt.Errorf("close CometBFT state DB: %w", closeErr)
+	}
+	if state.IsEmpty() || state.LastBlockHeight == 0 {
+		if state.LastBlockHeight < 0 || len(state.AppHash) != 0 {
+			return 0, nil, errors.New("empty CometBFT state has an invalid height or AppHash")
+		}
+		return 0, nil, nil
+	}
+	if state.LastBlockHeight < 0 || len(state.AppHash) != sha256.Size {
+		return 0, nil, errors.New("persisted CometBFT state has an invalid height or AppHash")
+	}
+	return uint64(state.LastBlockHeight), append([]byte(nil), state.AppHash...), nil // #nosec G115 -- positive int64 checked above
+}

--- a/cmd/sage-gui/state_sync_boot_test.go
+++ b/cmd/sage-gui/state_sync_boot_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"crypto/sha256"
+	"testing"
+	"time"
+
+	"github.com/cometbft/cometbft/config"
+	cmtcrypto "github.com/cometbft/cometbft/crypto/ed25519"
+	cmtstate "github.com/cometbft/cometbft/state"
+	cmttypes "github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stateSyncCometConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	cfg.SetRoot(t.TempDir())
+	cfg.DBBackend = "goleveldb"
+	cfg.DBPath = "data"
+	return cfg
+}
+
+func savePersistedCometState(t *testing.T, cfg *config.Config, height int64, appHash []byte) {
+	t.Helper()
+	db, err := config.DefaultDBProvider(&config.DBContext{ID: "state", Config: cfg})
+	require.NoError(t, err)
+	pubKey := cmtcrypto.GenPrivKey().PubKey()
+	genesis := &cmttypes.GenesisDoc{
+		GenesisTime:     time.Unix(1, 0).UTC(),
+		ChainID:         "state-sync-test",
+		InitialHeight:   1,
+		ConsensusParams: cmttypes.DefaultConsensusParams(),
+		Validators: []cmttypes.GenesisValidator{{
+			Address: pubKey.Address(), PubKey: pubKey, Power: 10, Name: "validator-a",
+		}},
+	}
+	state, err := cmtstate.MakeGenesisState(genesis)
+	require.NoError(t, err)
+	state.LastBlockHeight = height
+	state.AppHash = append([]byte(nil), appHash...)
+	if height > 0 {
+		state.LastValidators = state.Validators.Copy()
+	}
+	require.NoError(t, cmtstate.NewStore(db, cmtstate.StoreOptions{}).Save(state))
+	require.NoError(t, db.Close())
+}
+
+func TestReadPersistedCometStateBeforeHandshake(t *testing.T) {
+	cfg := stateSyncCometConfig(t)
+	want := sha256.Sum256([]byte("persisted app hash"))
+	savePersistedCometState(t, cfg, 42, want[:])
+
+	height, appHash, err := readPersistedCometState(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), height)
+	assert.Equal(t, want[:], appHash)
+
+	appHash[0] ^= 0xff
+	heightAgain, hashAgain, err := readPersistedCometState(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), heightAgain)
+	assert.Equal(t, want[:], hashAgain, "callers receive a private AppHash copy")
+}
+
+func TestReadPersistedCometStateHandlesFreshAndInvalidDatabases(t *testing.T) {
+	fresh := stateSyncCometConfig(t)
+	height, appHash, err := readPersistedCometState(fresh)
+	require.NoError(t, err)
+	assert.Zero(t, height)
+	assert.Nil(t, appHash)
+
+	invalid := stateSyncCometConfig(t)
+	savePersistedCometState(t, invalid, 9, []byte("short"))
+	_, _, err = readPersistedCometState(invalid)
+	require.ErrorContains(t, err, "invalid height or AppHash")
+
+	_, _, err = readPersistedCometState(nil)
+	require.ErrorContains(t, err, "required")
+}

--- a/cmd/sage-gui/state_sync_boot_test.go
+++ b/cmd/sage-gui/state_sync_boot_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
+	"encoding/binary"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,6 +15,8 @@ import (
 	cmttypes "github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/statesync"
 )
 
 func stateSyncCometConfig(t *testing.T) *config.Config {
@@ -78,4 +84,88 @@ func TestReadPersistedCometStateHandlesFreshAndInvalidDatabases(t *testing.T) {
 
 	_, _, err = readPersistedCometState(nil)
 	require.ErrorContains(t, err, "required")
+
+	emptyButPositive := stateSyncCometConfig(t)
+	db, err := config.DefaultDBProvider(&config.DBContext{ID: "state", Config: emptyButPositive})
+	require.NoError(t, err)
+	badHash := sha256.Sum256([]byte("empty positive state"))
+	inconsistent := cmtstate.State{LastBlockHeight: 9, AppHash: badHash[:]}
+	require.NoError(t, cmtstate.NewStore(db, cmtstate.StoreOptions{}).Save(inconsistent))
+	require.NoError(t, db.Close())
+	_, _, err = readPersistedCometState(emptyButPositive)
+	require.Error(t, err, "an internally empty positive-height Comet state must fail closed")
+}
+
+func writeBootRecoveryTestState(t *testing.T, path string, height uint64, appHash []byte) {
+	t.Helper()
+	require.NoError(t, os.Mkdir(path, 0o700))
+	encoded := make([]byte, 8+len(appHash))
+	binary.BigEndian.PutUint64(encoded, height)
+	copy(encoded[8:], appHash)
+	require.NoError(t, os.WriteFile(filepath.Join(path, "state"), encoded, 0o600))
+}
+
+func inspectBootRecoveryTestState(path string) (uint64, []byte, error) {
+	encoded, err := os.ReadFile(filepath.Join(path, "state")) //nolint:gosec // test-owned path
+	if err != nil {
+		return 0, nil, err
+	}
+	if len(encoded) < 8 {
+		return 0, nil, os.ErrInvalid
+	}
+	return binary.BigEndian.Uint64(encoded), append([]byte(nil), encoded[8:]...), nil
+}
+
+func TestRecoverPendingStateSyncActivationRunsBeforeLiveDirectoryCreation(t *testing.T) {
+	dataDir := t.TempDir()
+	cometHome := filepath.Join(dataDir, "cometbft")
+	require.NoError(t, os.Mkdir(cometHome, 0o700))
+	oldHash := sha256.Sum256([]byte("old state"))
+	newHash := sha256.Sum256([]byte("new state"))
+	metadataHash := sha256.Sum256([]byte("metadata"))
+	journal := statesync.ActivationJournal{
+		Phase: statesync.ActivationPrepared, Height: 42, AppHash: newHash[:], MetadataHash: metadataHash[:],
+		PreparedName: "state-sync-prepared-42", QuarantineName: "badger-old-42", LiveName: "badger",
+	}
+	journalPath := filepath.Join(dataDir, stateSyncActivationJournalName)
+	require.NoError(t, statesync.WriteActivationJournal(journalPath, journal))
+	writeBootRecoveryTestState(t, filepath.Join(dataDir, journal.PreparedName), journal.Height, newHash[:])
+	writeBootRecoveryTestState(t, filepath.Join(dataDir, journal.QuarantineName), 40, oldHash[:])
+	badgerPath := filepath.Join(dataDir, journal.LiveName)
+	assert.NoDirExists(t, badgerPath, "precondition models a crash after live was quarantined")
+
+	action, found, err := recoverPendingStateSyncActivationWith(
+		context.Background(), dataDir, cometHome, badgerPath,
+		func(*config.Config) (uint64, []byte, error) { return 40, oldHash[:], nil },
+		inspectBootRecoveryTestState,
+	)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, statesync.RecoveryRestoreQuarantine, action)
+	height, appHash, err := inspectBootRecoveryTestState(badgerPath)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(40), height)
+	assert.Equal(t, oldHash[:], appHash)
+	assert.NoDirExists(t, filepath.Join(dataDir, journal.PreparedName))
+	assert.NoDirExists(t, filepath.Join(dataDir, journal.QuarantineName))
+	assert.NoFileExists(t, journalPath)
+}
+
+func TestRecoverPendingStateSyncActivationNoJournalAndCanonicalTarget(t *testing.T) {
+	dataDir := t.TempDir()
+	cometHome := filepath.Join(dataDir, "cometbft")
+	require.NoError(t, os.Mkdir(cometHome, 0o700))
+	readCalled := false
+	action, found, err := recoverPendingStateSyncActivationWith(
+		context.Background(), dataDir, cometHome, filepath.Join(dataDir, "badger"),
+		func(*config.Config) (uint64, []byte, error) {
+			readCalled = true
+			return 0, nil, nil
+		},
+		inspectBootRecoveryTestState,
+	)
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Zero(t, action)
+	assert.False(t, readCalled, "Comet DB stays untouched when no recovery journal exists")
 }

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,9 @@
-<!-- Reconciled through SAGE v11.7.0. -->
+<!-- Core document reconciled through SAGE v11.7.0; the v11.9 quorum/state-sync section is code-verified through the 2026-07 foundation branch. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against code at SAGE v11.7.0.
+Verified against code at SAGE v11.7.0, with the v11.9 quorum/state-sync section
+updated against the 2026-07 foundation implementation.
 
 ## Overview
 
@@ -288,8 +289,8 @@ content plus classification from Badger
 (`internal/abci/appv20_recovery_integration_test.go:152-285`). Network state sync
 is not yet enabled: CometBFT receives a dormant boot runtime that advertises no
 snapshots, rejects offers, returns no chunks, and aborts apply
-(`internal/abci/boot_state_sync_runtime.go:163-182`,
-`cmd/sage-gui/node.go:649-662`). A future enabled network path must therefore use
+(`internal/abci/boot_state_sync_runtime.go`, `cmd/sage-gui/node.go`). A future
+enabled network path must therefore use
 the separate consensus-only, key-free format described below.
 
 Crash replay is height-bound rather than a nonce bypass. Scoped votes store the
@@ -314,7 +315,7 @@ encodings, wrong trusted hashes, interrupted/incomplete assembly, and a real
 Badger backup/load with an identical AppHash (`internal/statesync/format_test.go`).
 The ABCI endpoints stay disabled even though these format proofs pass.
 
-The producer and receiver foundations are also dormant. Export makes a bounded
+The network producer and receiver endpoints are also dormant. Export makes a bounded
 live Badger backup, requires an app-v20 reload verifier to match the committed
 AppHash, atomically publishes only metadata/chunks, rejects extra files and
 symlinks, and hashes a chunk again immediately before read
@@ -341,8 +342,11 @@ Delivered foundations include the canonical/fsynced journal and recovery
 decision (`internal/statesync/activation.go`), guarded directory executor,
 writable no-migration opener (`internal/store/badger.go:105-128`), and dormant
 complete-bundle runtime with read/write leases
-(`internal/abci/boot_state_sync_runtime.go`). Ordinary services are not yet
-delayed behind runtime sealing, and no network receiver is armed.
+(`internal/abci/boot_state_sync_runtime.go`). Startup now resolves any durable
+activation journal against persisted Comet state before creating/opening the
+canonical Badger directory (`cmd/sage-gui/state_sync_boot.go`). Ordinary
+services are not yet delayed behind runtime sealing, and no network receiver is
+armed.
 
 Scope proposals no longer require operators or agents to hand-encode that
 binary record. REST/dashboard accept a structured `scope` template, MCP exposes

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -286,10 +286,11 @@ configuration, and a binary, so it must never be sent over ABCI/P2P
 bundle, deletes SQLite, recomputes AppHash, reloads app-v20, and rebuilds scoped
 content plus classification from Badger
 (`internal/abci/appv20_recovery_integration_test.go:152-285`). Network state sync
-is not yet implemented: the ABCI app advertises no snapshots, rejects offers,
-returns no chunks, and aborts apply (`internal/abci/app.go:6547-6566`). A future
-enabled network path must therefore use the separate dormant consensus-only,
-key-free format described below.
+is not yet enabled: CometBFT receives a dormant boot runtime that advertises no
+snapshots, rejects offers, returns no chunks, and aborts apply
+(`internal/abci/boot_state_sync_runtime.go:163-182`,
+`cmd/sage-gui/node.go:649-662`). A future enabled network path must therefore use
+the separate consensus-only, key-free format described below.
 
 Crash replay is height-bound rather than a nonce bypass. Scoped votes store the
 immutable first decision and its FinalizeBlock height atomically; only an exact
@@ -323,21 +324,25 @@ mutate consensus state, requires exact persisted height plus active app-v20,
 recomputes the narrow AppHash, validates all canonical scoped state, and removes
 the stage on failure (`internal/store/badger.go`,
 `internal/abci/scoped_state_sync.go:19-139`,
-`internal/abci/scoped_recovery.go:73-114`). No code swaps that directory into a
-live application yet, so `ListSnapshots` still advertises none.
+`internal/abci/scoped_recovery.go:73-114`). A guarded boot-only executor can now
+journal and rename a prepared directory while verifying restart decisions
+against persisted Comet state (`internal/statesync/activation_directories.go`),
+but no endpoint invokes it or publishes its result into a serving process, so
+`ListSnapshots` still advertises none.
 
 The accepted activation design deliberately avoids changing `BadgerStore.db`
 inside a serving process. It replaces the whole ABCI application bundle during
 boot, journals the filesystem/Comet persistence crash window, delays REST,
 dashboard, projection, snapshot-scheduler, and worker construction until the
 runtime is sealed, and requires an authenticated validator-only P2P allowlist.
-This is design work, not enabled behavior; the detailed gates are in
+This remains disabled behavior; the detailed gates are in
 [`../../v11.9-state-sync-activation.md`](../../v11.9-state-sync-activation.md).
-The first non-activating pieces are code: a bounded canonical/fsynced journal
-and pure Comet-vs-live recovery decision (`internal/statesync/activation.go`),
-plus a writable no-migration opener that preserves the already verified
-AppHash (`internal/store/badger.go:105-128`). No function performs the live
-directory rename yet.
+Delivered foundations include the canonical/fsynced journal and recovery
+decision (`internal/statesync/activation.go`), guarded directory executor,
+writable no-migration opener (`internal/store/badger.go:105-128`), and dormant
+complete-bundle runtime with read/write leases
+(`internal/abci/boot_state_sync_runtime.go`). Ordinary services are not yet
+delayed behind runtime sealing, and no network receiver is armed.
 
 Scope proposals no longer require operators or agents to hand-encode that
 binary record. REST/dashboard accept a structured `scope` template, MCP exposes

--- a/docs/v11.9-PLAN.md
+++ b/docs/v11.9-PLAN.md
@@ -11,10 +11,12 @@ assembler, AppHash-checked Badger-only exporter/catalog, and read-only receiver
 preparation gate now exist. The ABCI endpoints remain disabled until atomic
 live-store activation/rebinding and join authorization are proven. The accepted
 boot-only activation design now has a canonical fsynced journal, fail-closed
-recovery decision logic, and a writable no-migration verified-store opener, but
-no directory switch or runtime delegation. Guided canonical scope formation is
-now available through REST, MCP/CEREBRUM, the dashboard, and both Python
-clients. The dashboard derives its roster from the live CometBFT validator
+recovery decision logic, guarded directory switching, pre-handshake startup
+recovery, a writable no-migration verified-store opener, and dormant complete-
+bundle runtime delegation. Network endpoints and bundle publication remain
+disabled. Guided canonical scope formation is now available through REST,
+MCP/CEREBRUM, the dashboard, and both Python clients. The dashboard derives its
+roster from the live CometBFT validator
 set's canonical Ed25519 identities rather than ordinary agent rows. Above
 app-v20, bounded normalized tags are carried in the signed transaction and
 delegated-action proof; scoped-domain tags are also AppHash-covered in the

--- a/docs/v11.9-state-sync-activation.md
+++ b/docs/v11.9-state-sync-activation.md
@@ -5,13 +5,15 @@ activation journal, pure recovery decision logic, writable no-migration Badger
 opener, pre-handshake persisted Comet height/AppHash reader, and verified
 quarantine/live directory executor are implemented. CometBFT now receives the
 dormant `BootStateSyncRuntime` and delegates normal ABCI calls through bundle
-read leases; endpoint implementations remain disabled.
+read leases; startup resolves any activation journal against persisted Comet
+state before it creates or opens `badger/`. Endpoint implementations remain
+disabled.
 
 This document closes the architectural question between SAGE's verified
 consensus-only snapshot receiver and CometBFT's ABCI state-sync endpoints. It
 does not enable those endpoints. The existing fail-closed stubs remain the
 correct production behavior until every acceptance test in section 9 passes
-(`internal/abci/app.go:6563-6582`).
+(`internal/abci/boot_state_sync_runtime.go`).
 
 ## 1. Boundary
 
@@ -34,7 +36,8 @@ Delivered substrate:
   fail-closed catalog/chunk loading.
 - `internal/abci/scoped_state_sync.go` — fresh-directory restore, exact height,
   app-v20 audit, narrow AppHash, stored AppHash, and canonical scoped-state
-  verification without activation.
+  verification plus a read-only recovery inspector for fresh, older, and
+  post-app-v20 live directories.
 - `internal/statesync/activation.go` and
   `internal/statesync/activation_directories.go` — bounded canonical activation
   journal, atomic fsynced journal replacement, guarded quarantine/live renames,
@@ -43,6 +46,9 @@ Delivered substrate:
   handle or start ordinary services.
 - `internal/store/badger.go:105-128` — writable open of an existing verified
   state-sync database without constructor migrations/backfills.
+- `cmd/sage-gui/state_sync_boot.go` — persisted Comet state reader and startup
+  journal recovery invoked before the canonical Badger directory is created or
+  opened.
 
 ## 2. Why a live Badger rename is rejected
 
@@ -85,7 +91,7 @@ ConsensusBundle
 ├── ValidatorSet
 ├── GovernanceEngine
 ├── AppState / fork caches
-└── expected height + AppHash
+└── expected height + AppHash + app version
 ```
 
 All normal ABCI methods take a short runtime read lease and delegate to the
@@ -94,10 +100,13 @@ by the old `SageApp`, so the final chunk can replace the complete bundle without
 closing an object that is still executing its own method.
 
 The delivered runtime is deliberately dormant. It captures and validates the
-bundle's `Info` height/AppHash, enforces a strict one-shot phase graph, holds an
+bundle's `Info` height/AppHash/app version, enforces a strict one-shot phase
+graph, rejects lower-height and same-height conflicting replacements, holds an
 exclusive lease across complete-bundle activation, validates the replacement
 against the trusted snapshot, and refuses to delegate any state-sync endpoint
-to `SageApp` (`internal/abci/boot_state_sync_runtime.go`).
+to `SageApp` (`internal/abci/boot_state_sync_runtime.go`). Bundle cleanup owns
+only consensus Badger state; the shared off-chain projection remains
+process-owned across replacement.
 
 The runtime accepts activation only in a one-shot boot phase. Once CometBFT has
 persisted the synchronized state and the runtime is sealed, `OfferSnapshot`
@@ -221,6 +230,12 @@ The receiver also checks every `ApplySnapshotChunk.sender` against the approved
 provider set and returns it in `reject_senders` on mismatch. This is defence in
 depth; it does not replace connection-level serving authorization.
 
+The current validator transport is raw CometBFT TCP, not SAGE's independent-
+chain libp2p federation relay. Internet validators therefore require mutually
+routable addresses, operator-managed VPN reachability, or explicit port
+forwarding. Supporting home validators without any of those is a separate
+consensus-transport/tunnel design and is not delivered or implied by v11.9.
+
 ## 7. Readiness and serving
 
 `/ready` remains false from discovery through activation and projection rebuild.
@@ -281,11 +296,12 @@ empty/reject/abort behavior.
 ## 10. Implementation order
 
 1. **Delivered substrate:** writable no-backfill store opener, canonical
-   journal, verified quarantine/live directory executor, restart recovery, and
-   pre-handshake Comet state reader.
+   journal, verified quarantine/live directory executor, and startup recovery
+   against pre-handshake persisted Comet state before `badger/` is opened.
 2. **Delivered dormant:** `BootStateSyncRuntime`, strict one-shot phases,
-   complete-bundle leases, trusted replacement checks, and fail-closed endpoint
-   ownership; feature configuration remains off.
+   complete-bundle leases, height/hash/app-version replacement and sealing
+   checks, consensus-only cleanup ownership, and fail-closed endpoints; feature
+   configuration remains off.
 3. **Next:** move projection/snapshot/REST/dashboard/worker construction behind
    runtime sealing and add fail-closed startup health reporting.
 4. Add reciprocal validator-node allowlist/join-ticket configuration and tests.

--- a/docs/v11.9-state-sync-activation.md
+++ b/docs/v11.9-state-sync-activation.md
@@ -1,9 +1,9 @@
 # v11.9 State-Sync Activation and Join Authorization
 
 **Status:** accepted implementation design. The canonical fsynced activation
-journal, pure recovery decision logic, and writable no-migration Badger opener
-are implemented; directory switching, runtime delegation, and endpoints remain
-disabled.
+journal, pure recovery decision logic, writable no-migration Badger opener, and
+pre-handshake persisted Comet height/AppHash reader are implemented; directory
+switching, runtime delegation, and endpoints remain disabled.
 
 This document closes the architectural question between SAGE's verified
 consensus-only snapshot receiver and CometBFT's ABCI state-sync endpoints. It
@@ -268,8 +268,8 @@ empty/reject/abort behavior.
 ## 10. Implementation order
 
 1. **Partially delivered:** writable no-backfill store opener, canonical journal,
-   and pure recovery decision. Finish the verified quarantine/live directory
-   executor and pre-handshake Comet state reader.
+   pure recovery decision, and pre-handshake Comet state reader. Finish the
+   verified quarantine/live directory executor.
 2. Introduce `BootStateSyncRuntime` with bundle leases and dormant endpoint
    implementations; keep feature configuration off.
 3. Move projection/snapshot/REST/dashboard/worker construction behind runtime

--- a/docs/v11.9-state-sync-activation.md
+++ b/docs/v11.9-state-sync-activation.md
@@ -3,8 +3,9 @@
 **Status:** accepted design under implementation. The canonical fsynced
 activation journal, pure recovery decision logic, writable no-migration Badger
 opener, pre-handshake persisted Comet height/AppHash reader, and verified
-quarantine/live directory executor are implemented; runtime delegation and
-endpoints remain disabled.
+quarantine/live directory executor are implemented. CometBFT now receives the
+dormant `BootStateSyncRuntime` and delegates normal ABCI calls through bundle
+read leases; endpoint implementations remain disabled.
 
 This document closes the architectural question between SAGE's verified
 consensus-only snapshot receiver and CometBFT's ABCI state-sync endpoints. It
@@ -51,8 +52,10 @@ starts:
 - `SageApp` owns a concrete `*store.BadgerStore`, validator set, governance
   engine bound to that store, and cached app state
   (`internal/abci/app.go:248-255`, `internal/abci/app.go:1833-1851`).
-- the local CometBFT client is created against one concrete `*SageApp`
-  (`cmd/sage-gui/node_controller.go:111-119`).
+- the local CometBFT client now receives a `BootStateSyncRuntime` through the
+  ABCI application interface (`cmd/sage-gui/node_controller.go:28-56`,
+  `cmd/sage-gui/node_controller.go:111-120`), but ordinary services still retain
+  the initial concrete app/store graph;
 - the nonce allocator, projection rebuilder, local snapshot scheduler, upgrade
   watchdog, REST server, and dashboard all capture the original store or raw
   `*badger.DB` handle (`cmd/sage-gui/node.go:388-448`,
@@ -72,8 +75,8 @@ store inside an already serving `SageApp`.
 
 ## 3. Chosen runtime ownership model
 
-Introduce one `BootStateSyncRuntime` implementing the CometBFT ABCI application
-interface. The runtime owns exactly one immutable bundle:
+`BootStateSyncRuntime` now implements the CometBFT ABCI application interface
+and owns exactly one immutable bundle reference:
 
 ```text
 ConsensusBundle
@@ -89,6 +92,12 @@ All normal ABCI methods take a short runtime read lease and delegate to the
 current bundle. State-sync methods are implemented by the runtime itself, not
 by the old `SageApp`, so the final chunk can replace the complete bundle without
 closing an object that is still executing its own method.
+
+The delivered runtime is deliberately dormant. It captures and validates the
+bundle's `Info` height/AppHash, enforces a strict one-shot phase graph, holds an
+exclusive lease across complete-bundle activation, validates the replacement
+against the trusted snapshot, and refuses to delegate any state-sync endpoint
+to `SageApp` (`internal/abci/boot_state_sync_runtime.go`).
 
 The runtime accepts activation only in a one-shot boot phase. Once CometBFT has
 persisted the synchronized state and the runtime is sealed, `OfferSnapshot`
@@ -274,10 +283,11 @@ empty/reject/abort behavior.
 1. **Delivered substrate:** writable no-backfill store opener, canonical
    journal, verified quarantine/live directory executor, restart recovery, and
    pre-handshake Comet state reader.
-2. **Next:** introduce `BootStateSyncRuntime` with bundle leases and dormant endpoint
-   implementations; keep feature configuration off.
-3. Move projection/snapshot/REST/dashboard/worker construction behind runtime
-   sealing and add fail-closed startup health reporting.
+2. **Delivered dormant:** `BootStateSyncRuntime`, strict one-shot phases,
+   complete-bundle leases, trusted replacement checks, and fail-closed endpoint
+   ownership; feature configuration remains off.
+3. **Next:** move projection/snapshot/REST/dashboard/worker construction behind
+   runtime sealing and add fail-closed startup health reporting.
 4. Add reciprocal validator-node allowlist/join-ticket configuration and tests.
 5. Add kill-point and real multi-process harnesses.
 6. Enable snapshot serving first on an explicitly opted-in validator; enable

--- a/docs/v11.9-state-sync-activation.md
+++ b/docs/v11.9-state-sync-activation.md
@@ -1,9 +1,10 @@
 # v11.9 State-Sync Activation and Join Authorization
 
-**Status:** accepted implementation design. The canonical fsynced activation
-journal, pure recovery decision logic, writable no-migration Badger opener, and
-pre-handshake persisted Comet height/AppHash reader are implemented; directory
-switching, runtime delegation, and endpoints remain disabled.
+**Status:** accepted design under implementation. The canonical fsynced
+activation journal, pure recovery decision logic, writable no-migration Badger
+opener, pre-handshake persisted Comet height/AppHash reader, and verified
+quarantine/live directory executor are implemented; runtime delegation and
+endpoints remain disabled.
 
 This document closes the architectural question between SAGE's verified
 consensus-only snapshot receiver and CometBFT's ABCI state-sync endpoints. It
@@ -33,9 +34,12 @@ Delivered substrate:
 - `internal/abci/scoped_state_sync.go` — fresh-directory restore, exact height,
   app-v20 audit, narrow AppHash, stored AppHash, and canonical scoped-state
   verification without activation.
-- `internal/statesync/activation.go` — bounded canonical activation journal,
-  atomic fsynced journal replacement, symlink/path rejection, and fail-closed
-  Comet-vs-live recovery decisions. It does not rename a database.
+- `internal/statesync/activation.go` and
+  `internal/statesync/activation_directories.go` — bounded canonical activation
+  journal, atomic fsynced journal replacement, guarded quarantine/live renames,
+  verification callbacks, symlink/path rejection, and fail-closed restart
+  recovery against persisted Comet state. They do not publish a live database
+  handle or start ordinary services.
 - `internal/store/badger.go:105-128` — writable open of an existing verified
   state-sync database without constructor migrations/backfills.
 
@@ -267,10 +271,10 @@ empty/reject/abort behavior.
 
 ## 10. Implementation order
 
-1. **Partially delivered:** writable no-backfill store opener, canonical journal,
-   pure recovery decision, and pre-handshake Comet state reader. Finish the
-   verified quarantine/live directory executor.
-2. Introduce `BootStateSyncRuntime` with bundle leases and dormant endpoint
+1. **Delivered substrate:** writable no-backfill store opener, canonical
+   journal, verified quarantine/live directory executor, restart recovery, and
+   pre-handshake Comet state reader.
+2. **Next:** introduce `BootStateSyncRuntime` with bundle leases and dormant endpoint
    implementations; keep feature configuration off.
 3. Move projection/snapshot/REST/dashboard/worker construction behind runtime
    sealing and add fail-closed startup health reporting.

--- a/internal/abci/app.go
+++ b/internal/abci/app.go
@@ -6628,10 +6628,17 @@ func (app *SageApp) VerifyVoteExtension(_ context.Context, req *abcitypes.Reques
 
 // Close cleans up resources.
 func (app *SageApp) Close() error {
-	if err := app.badgerStore.CloseBadger(); err != nil {
+	if err := app.CloseConsensusState(); err != nil {
 		return err
 	}
 	return app.offchainStore.Close()
+}
+
+// CloseConsensusState closes only bundle-owned consensus storage. Boot state
+// sync uses this while replacing a complete SageApp graph; the off-chain
+// projection is process-owned and must remain open for the replacement bundle.
+func (app *SageApp) CloseConsensusState() error {
+	return app.badgerStore.CloseBadger()
 }
 
 // GetOffchainStore returns the off-chain store for REST handlers.

--- a/internal/abci/boot_state_sync_runtime.go
+++ b/internal/abci/boot_state_sync_runtime.go
@@ -29,31 +29,44 @@ const (
 // graph and the state it reported when constructed. Replacing the application,
 // store, validator set, governance engine, or caches separately is forbidden.
 type ConsensusBundle struct {
-	application    abcitypes.Application
-	expectedHeight int64
-	expectedHash   []byte
+	application        abcitypes.Application
+	expectedHeight     int64
+	expectedHash       []byte
+	expectedAppVersion uint64
+	cleanup            func() error
+	closeOnce          sync.Once
+	closeErr           error
 }
 
 // NewConsensusBundle captures the application's current Info state. Callers
 // must finish constructing the complete SageApp graph before wrapping it.
 func NewConsensusBundle(ctx context.Context, application abcitypes.Application) (*ConsensusBundle, error) {
+	return NewConsensusBundleWithCleanup(ctx, application, nil)
+}
+
+// NewConsensusBundleWithCleanup attaches a consensus-only cleanup callback.
+// It must never close a process-owned off-chain projection shared with the
+// replacement bundle.
+func NewConsensusBundleWithCleanup(ctx context.Context, application abcitypes.Application, cleanup func() error) (*ConsensusBundle, error) {
 	if application == nil {
-		return nil, errors.New("consensus bundle application is required")
+		return nil, cleanupFailedConsensusBundle(cleanup, errors.New("consensus bundle application is required"))
 	}
 	info, err := application.Info(ctx, &abcitypes.RequestInfo{})
 	if err != nil {
-		return nil, fmt.Errorf("read consensus bundle state: %w", err)
+		return nil, cleanupFailedConsensusBundle(cleanup, fmt.Errorf("read consensus bundle state: %w", err))
 	}
 	if info == nil {
-		return nil, errors.New("consensus bundle Info response is nil")
+		return nil, cleanupFailedConsensusBundle(cleanup, errors.New("consensus bundle Info response is nil"))
 	}
-	if err := validateBundleState(info.LastBlockHeight, info.LastBlockAppHash); err != nil {
-		return nil, err
+	if err := validateBundleState(info.LastBlockHeight, info.LastBlockAppHash, info.AppVersion); err != nil {
+		return nil, cleanupFailedConsensusBundle(cleanup, err)
 	}
 	return &ConsensusBundle{
-		application:    application,
-		expectedHeight: info.LastBlockHeight,
-		expectedHash:   append([]byte(nil), info.LastBlockAppHash...),
+		application:        application,
+		expectedHeight:     info.LastBlockHeight,
+		expectedHash:       append([]byte(nil), info.LastBlockAppHash...),
+		expectedAppVersion: info.AppVersion,
+		cleanup:            cleanup,
 	}, nil
 }
 
@@ -63,6 +76,29 @@ func (b *ConsensusBundle) ExpectedState() (int64, []byte) {
 		return 0, nil
 	}
 	return b.expectedHeight, append([]byte(nil), b.expectedHash...)
+}
+
+// ExpectedAppVersion returns the app protocol version captured with Info.
+func (b *ConsensusBundle) ExpectedAppVersion() uint64 {
+	if b == nil {
+		return 0
+	}
+	return b.expectedAppVersion
+}
+
+// Close releases the complete application graph at most once when it exposes
+// a Close method. Candidate bundles are closed automatically if activation
+// rejects them; the active bundle is closed by BootStateSyncRuntime.Close.
+func (b *ConsensusBundle) Close() error {
+	if b == nil {
+		return nil
+	}
+	b.closeOnce.Do(func() {
+		if b.cleanup != nil {
+			b.closeErr = b.cleanup()
+		}
+	})
+	return b.closeErr
 }
 
 // BootStateSyncRuntime owns the only application reference given to CometBFT.
@@ -98,6 +134,20 @@ func (r *BootStateSyncRuntime) ExpectedState() (int64, []byte) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.bundle.ExpectedState()
+}
+
+// ExpectedAppVersion returns the active bundle's construction-time app version.
+func (r *BootStateSyncRuntime) ExpectedAppVersion() uint64 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.ExpectedAppVersion()
+}
+
+// Close waits for delegated calls and releases the active complete bundle.
+func (r *BootStateSyncRuntime) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.bundle.Close()
 }
 
 func (r *BootStateSyncRuntime) Info(ctx context.Context, req *abcitypes.RequestInfo) (*abcitypes.ResponseInfo, error) {
@@ -197,34 +247,52 @@ func (r *BootStateSyncRuntime) transitionBootStateSync(next BootStateSyncPhase) 
 // activatePreparedBundle executes activation while holding the exclusive
 // runtime lease and publishes the replacement only if it reports the trusted
 // snapshot state. Any error permanently fails state sync for this process.
-func (r *BootStateSyncRuntime) activatePreparedBundle(expectedHeight int64, expectedHash []byte, activate func(current *ConsensusBundle) (*ConsensusBundle, error)) error {
-	if activate == nil {
-		return errors.New("consensus bundle activator is required")
-	}
-	if err := validateBundleState(expectedHeight, expectedHash); err != nil {
-		return err
-	}
+func (r *BootStateSyncRuntime) activatePreparedBundle(expectedHeight int64, expectedHash []byte, expectedAppVersion uint64, activate func(current *ConsensusBundle) (*ConsensusBundle, error)) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.phase != BootStateSyncPrepared {
 		return fmt.Errorf("consensus bundle activation requires prepared phase, got %d", r.phase)
 	}
-	next, err := activate(r.bundle)
-	if err != nil {
+	if activate == nil {
+		r.phase = BootStateSyncFailed
+		return errors.New("consensus bundle activator is required")
+	}
+	if err := validateBundleState(expectedHeight, expectedHash, expectedAppVersion); err != nil {
 		r.phase = BootStateSyncFailed
 		return err
 	}
-	if next == r.bundle {
+	if expectedAppVersion != 20 {
+		r.phase = BootStateSyncFailed
+		return errors.New("state sync activation requires app version 20")
+	}
+	if expectedHeight < r.bundle.expectedHeight ||
+		(expectedHeight == r.bundle.expectedHeight && !bytes.Equal(expectedHash, r.bundle.expectedHash)) ||
+		expectedAppVersion < r.bundle.expectedAppVersion ||
+		(expectedHeight == r.bundle.expectedHeight && expectedAppVersion != r.bundle.expectedAppVersion) {
+		r.phase = BootStateSyncFailed
+		return errors.New("trusted snapshot would regress or fork the current consensus bundle")
+	}
+	current := r.bundle
+	next, err := activate(current)
+	if err != nil {
+		r.phase = BootStateSyncFailed
+		return closeRejectedConsensusBundle(next, err)
+	}
+	if next == current {
 		r.phase = BootStateSyncFailed
 		return errors.New("consensus bundle activation did not replace the bundle")
 	}
 	if err := validateConsensusBundle(next); err != nil {
 		r.phase = BootStateSyncFailed
-		return err
+		return closeRejectedConsensusBundle(next, err)
 	}
-	if next.expectedHeight != expectedHeight || !bytes.Equal(next.expectedHash, expectedHash) {
+	if next.expectedHeight != expectedHeight || !bytes.Equal(next.expectedHash, expectedHash) || next.expectedAppVersion != expectedAppVersion {
 		r.phase = BootStateSyncFailed
-		return errors.New("replacement consensus bundle does not match trusted snapshot state")
+		return closeRejectedConsensusBundle(next, errors.New("replacement consensus bundle does not match trusted snapshot state and app version"))
+	}
+	if err := current.Close(); err != nil {
+		r.phase = BootStateSyncFailed
+		return closeRejectedConsensusBundle(next, fmt.Errorf("close replaced consensus bundle: %w", err))
 	}
 	r.bundle = next
 	r.phase = BootStateSyncPendingComet
@@ -233,21 +301,29 @@ func (r *BootStateSyncRuntime) activatePreparedBundle(expectedHeight int64, expe
 
 // sealActivatedBundle verifies CometBFT and the live application agree after
 // bootstrap before allowing boot to proceed to ordinary services.
-func (r *BootStateSyncRuntime) sealActivatedBundle(ctx context.Context, cometHeight int64, cometAppHash []byte) error {
-	if err := validateBundleState(cometHeight, cometAppHash); err != nil {
-		return err
-	}
+func (r *BootStateSyncRuntime) sealActivatedBundle(ctx context.Context, cometHeight int64, cometAppHash []byte, cometAppVersion uint64) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.phase != BootStateSyncPendingComet {
 		return fmt.Errorf("consensus bundle sealing requires pending-Comet phase, got %d", r.phase)
+	}
+	if err := validateBundleState(cometHeight, cometAppHash, cometAppVersion); err != nil {
+		r.phase = BootStateSyncFailed
+		return err
+	}
+	if cometHeight < r.bundle.expectedHeight ||
+		(cometHeight == r.bundle.expectedHeight && !bytes.Equal(cometAppHash, r.bundle.expectedHash)) ||
+		cometAppVersion < r.bundle.expectedAppVersion ||
+		(cometHeight == r.bundle.expectedHeight && cometAppVersion != r.bundle.expectedAppVersion) {
+		r.phase = BootStateSyncFailed
+		return errors.New("persisted CometBFT state is below or conflicts with the activated snapshot")
 	}
 	info, err := r.bundle.application.Info(ctx, &abcitypes.RequestInfo{})
 	if err != nil {
 		r.phase = BootStateSyncFailed
 		return fmt.Errorf("read activated consensus bundle state: %w", err)
 	}
-	if info == nil || info.LastBlockHeight != cometHeight || !bytes.Equal(info.LastBlockAppHash, cometAppHash) {
+	if info == nil || info.LastBlockHeight != cometHeight || !bytes.Equal(info.LastBlockAppHash, cometAppHash) || info.AppVersion != cometAppVersion {
 		r.phase = BootStateSyncFailed
 		return errors.New("activated consensus bundle does not match persisted CometBFT state")
 	}
@@ -275,10 +351,13 @@ func validateConsensusBundle(bundle *ConsensusBundle) error {
 	if bundle == nil || bundle.application == nil {
 		return errors.New("consensus bundle application is required")
 	}
-	return validateBundleState(bundle.expectedHeight, bundle.expectedHash)
+	return validateBundleState(bundle.expectedHeight, bundle.expectedHash, bundle.expectedAppVersion)
 }
 
-func validateBundleState(height int64, appHash []byte) error {
+func validateBundleState(height int64, appHash []byte, appVersion uint64) error {
+	if appVersion == 0 {
+		return errors.New("consensus bundle app version must be positive")
+	}
 	if height < 0 {
 		return errors.New("consensus bundle height cannot be negative")
 	}
@@ -292,4 +371,24 @@ func validateBundleState(height int64, appHash []byte) error {
 		return errors.New("consensus bundle AppHash must be SHA-256 sized")
 	}
 	return nil
+}
+
+func closeRejectedConsensusBundle(bundle *ConsensusBundle, cause error) error {
+	if bundle == nil {
+		return cause
+	}
+	if closeErr := bundle.Close(); closeErr != nil {
+		return errors.Join(cause, fmt.Errorf("close rejected consensus bundle: %w", closeErr))
+	}
+	return cause
+}
+
+func cleanupFailedConsensusBundle(cleanup func() error, cause error) error {
+	if cleanup == nil {
+		return cause
+	}
+	if cleanupErr := cleanup(); cleanupErr != nil {
+		return errors.Join(cause, fmt.Errorf("cleanup failed consensus bundle construction: %w", cleanupErr))
+	}
+	return cause
 }

--- a/internal/abci/boot_state_sync_runtime.go
+++ b/internal/abci/boot_state_sync_runtime.go
@@ -1,0 +1,295 @@
+package abci
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sync"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+)
+
+// BootStateSyncPhase is the process-local portion of the one-shot boot state
+// sync lifecycle. Durable directory phases live in statesync.ActivationJournal.
+type BootStateSyncPhase byte
+
+const (
+	BootStateSyncDisabled BootStateSyncPhase = iota
+	BootStateSyncDiscovering
+	BootStateSyncAssembling
+	BootStateSyncPrepared
+	BootStateSyncPendingComet
+	BootStateSyncSealed
+	BootStateSyncFailed
+)
+
+// ConsensusBundle is an immutable reference to one complete ABCI application
+// graph and the state it reported when constructed. Replacing the application,
+// store, validator set, governance engine, or caches separately is forbidden.
+type ConsensusBundle struct {
+	application    abcitypes.Application
+	expectedHeight int64
+	expectedHash   []byte
+}
+
+// NewConsensusBundle captures the application's current Info state. Callers
+// must finish constructing the complete SageApp graph before wrapping it.
+func NewConsensusBundle(ctx context.Context, application abcitypes.Application) (*ConsensusBundle, error) {
+	if application == nil {
+		return nil, errors.New("consensus bundle application is required")
+	}
+	info, err := application.Info(ctx, &abcitypes.RequestInfo{})
+	if err != nil {
+		return nil, fmt.Errorf("read consensus bundle state: %w", err)
+	}
+	if info == nil {
+		return nil, errors.New("consensus bundle Info response is nil")
+	}
+	if err := validateBundleState(info.LastBlockHeight, info.LastBlockAppHash); err != nil {
+		return nil, err
+	}
+	return &ConsensusBundle{
+		application:    application,
+		expectedHeight: info.LastBlockHeight,
+		expectedHash:   append([]byte(nil), info.LastBlockAppHash...),
+	}, nil
+}
+
+// ExpectedState returns a private copy of the bundle's construction-time state.
+func (b *ConsensusBundle) ExpectedState() (int64, []byte) {
+	if b == nil {
+		return 0, nil
+	}
+	return b.expectedHeight, append([]byte(nil), b.expectedHash...)
+}
+
+// BootStateSyncRuntime owns the only application reference given to CometBFT.
+// Normal ABCI calls hold a read lease for their full duration. The final state
+// sync activation holds the write lease, so it cannot close or replace a
+// bundle while any delegated call is still using it.
+type BootStateSyncRuntime struct {
+	mu     sync.RWMutex
+	bundle *ConsensusBundle
+	phase  BootStateSyncPhase
+}
+
+var _ abcitypes.Application = (*BootStateSyncRuntime)(nil)
+
+// NewBootStateSyncRuntime creates a dormant runtime. State-sync endpoints stay
+// empty/reject/abort until a later release gate explicitly arms a receiver.
+func NewBootStateSyncRuntime(bundle *ConsensusBundle) (*BootStateSyncRuntime, error) {
+	if err := validateConsensusBundle(bundle); err != nil {
+		return nil, err
+	}
+	return &BootStateSyncRuntime{bundle: bundle, phase: BootStateSyncDisabled}, nil
+}
+
+// Phase reports the current process-local boot state-sync phase.
+func (r *BootStateSyncRuntime) Phase() BootStateSyncPhase {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.phase
+}
+
+// ExpectedState returns the active bundle's construction-time state.
+func (r *BootStateSyncRuntime) ExpectedState() (int64, []byte) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.ExpectedState()
+}
+
+func (r *BootStateSyncRuntime) Info(ctx context.Context, req *abcitypes.RequestInfo) (*abcitypes.ResponseInfo, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.application.Info(ctx, req)
+}
+
+func (r *BootStateSyncRuntime) Query(ctx context.Context, req *abcitypes.RequestQuery) (*abcitypes.ResponseQuery, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.application.Query(ctx, req)
+}
+
+func (r *BootStateSyncRuntime) CheckTx(ctx context.Context, req *abcitypes.RequestCheckTx) (*abcitypes.ResponseCheckTx, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.application.CheckTx(ctx, req)
+}
+
+func (r *BootStateSyncRuntime) InitChain(ctx context.Context, req *abcitypes.RequestInitChain) (*abcitypes.ResponseInitChain, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.application.InitChain(ctx, req)
+}
+
+func (r *BootStateSyncRuntime) PrepareProposal(ctx context.Context, req *abcitypes.RequestPrepareProposal) (*abcitypes.ResponsePrepareProposal, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.application.PrepareProposal(ctx, req)
+}
+
+func (r *BootStateSyncRuntime) ProcessProposal(ctx context.Context, req *abcitypes.RequestProcessProposal) (*abcitypes.ResponseProcessProposal, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.application.ProcessProposal(ctx, req)
+}
+
+func (r *BootStateSyncRuntime) FinalizeBlock(ctx context.Context, req *abcitypes.RequestFinalizeBlock) (*abcitypes.ResponseFinalizeBlock, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.application.FinalizeBlock(ctx, req)
+}
+
+func (r *BootStateSyncRuntime) ExtendVote(ctx context.Context, req *abcitypes.RequestExtendVote) (*abcitypes.ResponseExtendVote, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.application.ExtendVote(ctx, req)
+}
+
+func (r *BootStateSyncRuntime) VerifyVoteExtension(ctx context.Context, req *abcitypes.RequestVerifyVoteExtension) (*abcitypes.ResponseVerifyVoteExtension, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.application.VerifyVoteExtension(ctx, req)
+}
+
+func (r *BootStateSyncRuntime) Commit(ctx context.Context, req *abcitypes.RequestCommit) (*abcitypes.ResponseCommit, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.bundle.application.Commit(ctx, req)
+}
+
+// ListSnapshots remains dormant here instead of delegating to SageApp. The
+// runtime will eventually enforce the validator-only serving profile.
+func (r *BootStateSyncRuntime) ListSnapshots(context.Context, *abcitypes.RequestListSnapshots) (*abcitypes.ResponseListSnapshots, error) {
+	return &abcitypes.ResponseListSnapshots{}, nil
+}
+
+// OfferSnapshot remains fail-closed until boot receiving is explicitly armed.
+func (r *BootStateSyncRuntime) OfferSnapshot(context.Context, *abcitypes.RequestOfferSnapshot) (*abcitypes.ResponseOfferSnapshot, error) {
+	return &abcitypes.ResponseOfferSnapshot{Result: abcitypes.ResponseOfferSnapshot_REJECT}, nil
+}
+
+// LoadSnapshotChunk never delegates to the local rollback snapshot machinery.
+func (r *BootStateSyncRuntime) LoadSnapshotChunk(context.Context, *abcitypes.RequestLoadSnapshotChunk) (*abcitypes.ResponseLoadSnapshotChunk, error) {
+	return &abcitypes.ResponseLoadSnapshotChunk{}, nil
+}
+
+// ApplySnapshotChunk remains fail-closed until the full receiver is armed.
+func (r *BootStateSyncRuntime) ApplySnapshotChunk(context.Context, *abcitypes.RequestApplySnapshotChunk) (*abcitypes.ResponseApplySnapshotChunk, error) {
+	return &abcitypes.ResponseApplySnapshotChunk{Result: abcitypes.ResponseApplySnapshotChunk_ABORT}, nil
+}
+
+// transitionBootStateSync advances the strict one-shot in-memory lifecycle.
+// Endpoint code lives in this package and must use this gate rather than
+// assigning phase directly.
+func (r *BootStateSyncRuntime) transitionBootStateSync(next BootStateSyncPhase) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !validBootStateSyncTransition(r.phase, next) {
+		return fmt.Errorf("invalid boot state-sync transition %d -> %d", r.phase, next)
+	}
+	r.phase = next
+	return nil
+}
+
+// activatePreparedBundle executes activation while holding the exclusive
+// runtime lease and publishes the replacement only if it reports the trusted
+// snapshot state. Any error permanently fails state sync for this process.
+func (r *BootStateSyncRuntime) activatePreparedBundle(expectedHeight int64, expectedHash []byte, activate func(current *ConsensusBundle) (*ConsensusBundle, error)) error {
+	if activate == nil {
+		return errors.New("consensus bundle activator is required")
+	}
+	if err := validateBundleState(expectedHeight, expectedHash); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.phase != BootStateSyncPrepared {
+		return fmt.Errorf("consensus bundle activation requires prepared phase, got %d", r.phase)
+	}
+	next, err := activate(r.bundle)
+	if err != nil {
+		r.phase = BootStateSyncFailed
+		return err
+	}
+	if next == r.bundle {
+		r.phase = BootStateSyncFailed
+		return errors.New("consensus bundle activation did not replace the bundle")
+	}
+	if err := validateConsensusBundle(next); err != nil {
+		r.phase = BootStateSyncFailed
+		return err
+	}
+	if next.expectedHeight != expectedHeight || !bytes.Equal(next.expectedHash, expectedHash) {
+		r.phase = BootStateSyncFailed
+		return errors.New("replacement consensus bundle does not match trusted snapshot state")
+	}
+	r.bundle = next
+	r.phase = BootStateSyncPendingComet
+	return nil
+}
+
+// sealActivatedBundle verifies CometBFT and the live application agree after
+// bootstrap before allowing boot to proceed to ordinary services.
+func (r *BootStateSyncRuntime) sealActivatedBundle(ctx context.Context, cometHeight int64, cometAppHash []byte) error {
+	if err := validateBundleState(cometHeight, cometAppHash); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.phase != BootStateSyncPendingComet {
+		return fmt.Errorf("consensus bundle sealing requires pending-Comet phase, got %d", r.phase)
+	}
+	info, err := r.bundle.application.Info(ctx, &abcitypes.RequestInfo{})
+	if err != nil {
+		r.phase = BootStateSyncFailed
+		return fmt.Errorf("read activated consensus bundle state: %w", err)
+	}
+	if info == nil || info.LastBlockHeight != cometHeight || !bytes.Equal(info.LastBlockAppHash, cometAppHash) {
+		r.phase = BootStateSyncFailed
+		return errors.New("activated consensus bundle does not match persisted CometBFT state")
+	}
+	r.phase = BootStateSyncSealed
+	return nil
+}
+
+func validBootStateSyncTransition(current, next BootStateSyncPhase) bool {
+	if next == BootStateSyncFailed {
+		return current != BootStateSyncSealed && current != BootStateSyncFailed
+	}
+	switch current {
+	case BootStateSyncDisabled:
+		return next == BootStateSyncDiscovering
+	case BootStateSyncDiscovering:
+		return next == BootStateSyncAssembling
+	case BootStateSyncAssembling:
+		return next == BootStateSyncPrepared
+	default:
+		return false
+	}
+}
+
+func validateConsensusBundle(bundle *ConsensusBundle) error {
+	if bundle == nil || bundle.application == nil {
+		return errors.New("consensus bundle application is required")
+	}
+	return validateBundleState(bundle.expectedHeight, bundle.expectedHash)
+}
+
+func validateBundleState(height int64, appHash []byte) error {
+	if height < 0 {
+		return errors.New("consensus bundle height cannot be negative")
+	}
+	if height == 0 {
+		if len(appHash) != 0 {
+			return errors.New("fresh consensus bundle must have an empty AppHash")
+		}
+		return nil
+	}
+	if len(appHash) != sha256.Size {
+		return errors.New("consensus bundle AppHash must be SHA-256 sized")
+	}
+	return nil
+}

--- a/internal/abci/boot_state_sync_runtime_test.go
+++ b/internal/abci/boot_state_sync_runtime_test.go
@@ -1,0 +1,190 @@
+package abci
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type bootRuntimeTestApp struct {
+	abcitypes.BaseApplication
+	height         int64
+	appHash        []byte
+	queryValue     []byte
+	queryEntered   chan struct{}
+	queryRelease   chan struct{}
+	stateSyncCalls atomic.Int32
+	infoErr        error
+}
+
+func (a *bootRuntimeTestApp) Info(context.Context, *abcitypes.RequestInfo) (*abcitypes.ResponseInfo, error) {
+	if a.infoErr != nil {
+		return nil, a.infoErr
+	}
+	return &abcitypes.ResponseInfo{LastBlockHeight: a.height, LastBlockAppHash: append([]byte(nil), a.appHash...)}, nil
+}
+
+func (a *bootRuntimeTestApp) Query(context.Context, *abcitypes.RequestQuery) (*abcitypes.ResponseQuery, error) {
+	if a.queryEntered != nil {
+		close(a.queryEntered)
+		<-a.queryRelease
+	}
+	return &abcitypes.ResponseQuery{Value: append([]byte(nil), a.queryValue...)}, nil
+}
+
+func (a *bootRuntimeTestApp) ListSnapshots(context.Context, *abcitypes.RequestListSnapshots) (*abcitypes.ResponseListSnapshots, error) {
+	a.stateSyncCalls.Add(1)
+	return &abcitypes.ResponseListSnapshots{Snapshots: []*abcitypes.Snapshot{{Height: 99}}}, nil
+}
+
+func (a *bootRuntimeTestApp) OfferSnapshot(context.Context, *abcitypes.RequestOfferSnapshot) (*abcitypes.ResponseOfferSnapshot, error) {
+	a.stateSyncCalls.Add(1)
+	return &abcitypes.ResponseOfferSnapshot{Result: abcitypes.ResponseOfferSnapshot_ACCEPT}, nil
+}
+
+func (a *bootRuntimeTestApp) LoadSnapshotChunk(context.Context, *abcitypes.RequestLoadSnapshotChunk) (*abcitypes.ResponseLoadSnapshotChunk, error) {
+	a.stateSyncCalls.Add(1)
+	return &abcitypes.ResponseLoadSnapshotChunk{Chunk: []byte("private rollback data")}, nil
+}
+
+func (a *bootRuntimeTestApp) ApplySnapshotChunk(context.Context, *abcitypes.RequestApplySnapshotChunk) (*abcitypes.ResponseApplySnapshotChunk, error) {
+	a.stateSyncCalls.Add(1)
+	return &abcitypes.ResponseApplySnapshotChunk{Result: abcitypes.ResponseApplySnapshotChunk_ACCEPT}, nil
+}
+
+func newBootRuntimeTestBundle(t *testing.T, app *bootRuntimeTestApp) *ConsensusBundle {
+	t.Helper()
+	bundle, err := NewConsensusBundle(context.Background(), app)
+	require.NoError(t, err)
+	return bundle
+}
+
+func newBootRuntimeTestRuntime(t *testing.T, app *bootRuntimeTestApp) *BootStateSyncRuntime {
+	t.Helper()
+	runtime, err := NewBootStateSyncRuntime(newBootRuntimeTestBundle(t, app))
+	require.NoError(t, err)
+	return runtime
+}
+
+func TestBootStateSyncRuntimeDelegatesNormalABCI(t *testing.T) {
+	hash := sha256.Sum256([]byte("state"))
+	app := &bootRuntimeTestApp{height: 7, appHash: hash[:], queryValue: []byte("old bundle")}
+	runtime := newBootRuntimeTestRuntime(t, app)
+
+	response, err := runtime.Query(context.Background(), &abcitypes.RequestQuery{Path: "/status"})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("old bundle"), response.Value)
+	info, err := runtime.Info(context.Background(), &abcitypes.RequestInfo{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), info.LastBlockHeight)
+	assert.Equal(t, BootStateSyncDisabled, runtime.Phase())
+	height, copiedHash := runtime.ExpectedState()
+	assert.Equal(t, int64(7), height)
+	assert.Equal(t, hash[:], copiedHash)
+	copiedHash[0] ^= 0xff
+	_, freshHash := runtime.ExpectedState()
+	assert.Equal(t, hash[:], freshHash)
+}
+
+func TestBootStateSyncRuntimeOwnsDormantStateSyncEndpoints(t *testing.T) {
+	runtime := newBootRuntimeTestRuntime(t, &bootRuntimeTestApp{})
+
+	listed, err := runtime.ListSnapshots(context.Background(), &abcitypes.RequestListSnapshots{})
+	require.NoError(t, err)
+	assert.Empty(t, listed.Snapshots)
+	offered, err := runtime.OfferSnapshot(context.Background(), &abcitypes.RequestOfferSnapshot{})
+	require.NoError(t, err)
+	assert.Equal(t, abcitypes.ResponseOfferSnapshot_REJECT, offered.Result)
+	loaded, err := runtime.LoadSnapshotChunk(context.Background(), &abcitypes.RequestLoadSnapshotChunk{})
+	require.NoError(t, err)
+	assert.Empty(t, loaded.Chunk)
+	applied, err := runtime.ApplySnapshotChunk(context.Background(), &abcitypes.RequestApplySnapshotChunk{})
+	require.NoError(t, err)
+	assert.Equal(t, abcitypes.ResponseApplySnapshotChunk_ABORT, applied.Result)
+	assert.Zero(t, runtime.bundle.application.(*bootRuntimeTestApp).stateSyncCalls.Load(), "private SageApp snapshot methods must never be delegated")
+}
+
+func TestBootStateSyncRuntimeReplacementWaitsForReaders(t *testing.T) {
+	oldHash := sha256.Sum256([]byte("old"))
+	oldApp := &bootRuntimeTestApp{
+		height: 40, appHash: oldHash[:], queryValue: []byte("old bundle"),
+		queryEntered: make(chan struct{}), queryRelease: make(chan struct{}),
+	}
+	runtime := newBootRuntimeTestRuntime(t, oldApp)
+	require.NoError(t, runtime.transitionBootStateSync(BootStateSyncDiscovering))
+	require.NoError(t, runtime.transitionBootStateSync(BootStateSyncAssembling))
+	require.NoError(t, runtime.transitionBootStateSync(BootStateSyncPrepared))
+
+	queryDone := make(chan *abcitypes.ResponseQuery, 1)
+	go func() {
+		response, _ := runtime.Query(context.Background(), &abcitypes.RequestQuery{})
+		queryDone <- response
+	}()
+	<-oldApp.queryEntered
+
+	newHash := sha256.Sum256([]byte("new"))
+	newApp := &bootRuntimeTestApp{height: 42, appHash: newHash[:], queryValue: []byte("new bundle")}
+	activationStarted := make(chan struct{})
+	activationDone := make(chan error, 1)
+	go func() {
+		activationDone <- runtime.activatePreparedBundle(42, newHash[:], func(current *ConsensusBundle) (*ConsensusBundle, error) {
+			close(activationStarted)
+			assert.Same(t, oldApp, current.application)
+			return NewConsensusBundle(context.Background(), newApp)
+		})
+	}()
+
+	select {
+	case <-activationStarted:
+		t.Fatal("bundle activation acquired its write lease while a delegated query was active")
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(oldApp.queryRelease)
+	oldResponse := <-queryDone
+	assert.Equal(t, []byte("old bundle"), oldResponse.Value)
+	require.NoError(t, <-activationDone)
+	assert.Equal(t, BootStateSyncPendingComet, runtime.Phase())
+
+	newResponse, err := runtime.Query(context.Background(), &abcitypes.RequestQuery{})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new bundle"), newResponse.Value)
+	require.NoError(t, runtime.sealActivatedBundle(context.Background(), 42, newHash[:]))
+	assert.Equal(t, BootStateSyncSealed, runtime.Phase())
+}
+
+func TestBootStateSyncRuntimeFailsClosedOnReplacementMismatch(t *testing.T) {
+	oldHash := sha256.Sum256([]byte("old"))
+	runtime := newBootRuntimeTestRuntime(t, &bootRuntimeTestApp{height: 40, appHash: oldHash[:]})
+	require.NoError(t, runtime.transitionBootStateSync(BootStateSyncDiscovering))
+	require.NoError(t, runtime.transitionBootStateSync(BootStateSyncAssembling))
+	require.NoError(t, runtime.transitionBootStateSync(BootStateSyncPrepared))
+
+	trustedHash := sha256.Sum256([]byte("trusted"))
+	wrongHash := sha256.Sum256([]byte("wrong"))
+	err := runtime.activatePreparedBundle(42, trustedHash[:], func(*ConsensusBundle) (*ConsensusBundle, error) {
+		return NewConsensusBundle(context.Background(), &bootRuntimeTestApp{height: 42, appHash: wrongHash[:]})
+	})
+	assert.ErrorContains(t, err, "does not match")
+	assert.Equal(t, BootStateSyncFailed, runtime.Phase())
+	assert.Error(t, runtime.transitionBootStateSync(BootStateSyncDiscovering), "failed runtime must not retry in-process")
+}
+
+func TestConsensusBundleRejectsInvalidInfo(t *testing.T) {
+	_, err := NewConsensusBundle(context.Background(), &bootRuntimeTestApp{height: 1, appHash: []byte("short")})
+	assert.ErrorContains(t, err, "SHA-256")
+	_, err = NewConsensusBundle(context.Background(), &bootRuntimeTestApp{infoErr: errors.New("Info unavailable")})
+	assert.ErrorContains(t, err, "Info unavailable")
+
+	hash := sha256.Sum256([]byte("copy"))
+	bundle := newBootRuntimeTestBundle(t, &bootRuntimeTestApp{height: 1, appHash: hash[:]})
+	input := append([]byte(nil), hash[:]...)
+	assert.True(t, bytes.Equal(input, bundle.expectedHash))
+}

--- a/internal/abci/boot_state_sync_runtime_test.go
+++ b/internal/abci/boot_state_sync_runtime_test.go
@@ -5,23 +5,29 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/store"
 )
 
 type bootRuntimeTestApp struct {
 	abcitypes.BaseApplication
 	height         int64
 	appHash        []byte
+	appVersion     uint64
 	queryValue     []byte
 	queryEntered   chan struct{}
 	queryRelease   chan struct{}
 	stateSyncCalls atomic.Int32
+	closeCalls     atomic.Int32
 	infoErr        error
 }
 
@@ -29,7 +35,16 @@ func (a *bootRuntimeTestApp) Info(context.Context, *abcitypes.RequestInfo) (*abc
 	if a.infoErr != nil {
 		return nil, a.infoErr
 	}
-	return &abcitypes.ResponseInfo{LastBlockHeight: a.height, LastBlockAppHash: append([]byte(nil), a.appHash...)}, nil
+	appVersion := a.appVersion
+	if appVersion == 0 {
+		appVersion = 1
+	}
+	return &abcitypes.ResponseInfo{LastBlockHeight: a.height, LastBlockAppHash: append([]byte(nil), a.appHash...), AppVersion: appVersion}, nil
+}
+
+func (a *bootRuntimeTestApp) Close() error {
+	a.closeCalls.Add(1)
+	return nil
 }
 
 func (a *bootRuntimeTestApp) Query(context.Context, *abcitypes.RequestQuery) (*abcitypes.ResponseQuery, error) {
@@ -62,7 +77,7 @@ func (a *bootRuntimeTestApp) ApplySnapshotChunk(context.Context, *abcitypes.Requ
 
 func newBootRuntimeTestBundle(t *testing.T, app *bootRuntimeTestApp) *ConsensusBundle {
 	t.Helper()
-	bundle, err := NewConsensusBundle(context.Background(), app)
+	bundle, err := NewConsensusBundleWithCleanup(context.Background(), app, app.Close)
 	require.NoError(t, err)
 	return bundle
 }
@@ -86,6 +101,7 @@ func TestBootStateSyncRuntimeDelegatesNormalABCI(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(7), info.LastBlockHeight)
 	assert.Equal(t, BootStateSyncDisabled, runtime.Phase())
+	assert.Equal(t, uint64(1), runtime.ExpectedAppVersion())
 	height, copiedHash := runtime.ExpectedState()
 	assert.Equal(t, int64(7), height)
 	assert.Equal(t, hash[:], copiedHash)
@@ -131,14 +147,14 @@ func TestBootStateSyncRuntimeReplacementWaitsForReaders(t *testing.T) {
 	<-oldApp.queryEntered
 
 	newHash := sha256.Sum256([]byte("new"))
-	newApp := &bootRuntimeTestApp{height: 42, appHash: newHash[:], queryValue: []byte("new bundle")}
+	newApp := &bootRuntimeTestApp{height: 42, appHash: newHash[:], appVersion: 20, queryValue: []byte("new bundle")}
 	activationStarted := make(chan struct{})
 	activationDone := make(chan error, 1)
 	go func() {
-		activationDone <- runtime.activatePreparedBundle(42, newHash[:], func(current *ConsensusBundle) (*ConsensusBundle, error) {
+		activationDone <- runtime.activatePreparedBundle(42, newHash[:], 20, func(current *ConsensusBundle) (*ConsensusBundle, error) {
 			close(activationStarted)
 			assert.Same(t, oldApp, current.application)
-			return NewConsensusBundle(context.Background(), newApp)
+			return NewConsensusBundleWithCleanup(context.Background(), newApp, newApp.Close)
 		})
 	}()
 
@@ -152,12 +168,34 @@ func TestBootStateSyncRuntimeReplacementWaitsForReaders(t *testing.T) {
 	assert.Equal(t, []byte("old bundle"), oldResponse.Value)
 	require.NoError(t, <-activationDone)
 	assert.Equal(t, BootStateSyncPendingComet, runtime.Phase())
+	assert.Equal(t, int32(1), oldApp.closeCalls.Load())
 
 	newResponse, err := runtime.Query(context.Background(), &abcitypes.RequestQuery{})
 	require.NoError(t, err)
 	assert.Equal(t, []byte("new bundle"), newResponse.Value)
-	require.NoError(t, runtime.sealActivatedBundle(context.Background(), 42, newHash[:]))
+	require.NoError(t, runtime.sealActivatedBundle(context.Background(), 42, newHash[:], 20))
 	assert.Equal(t, BootStateSyncSealed, runtime.Phase())
+	require.NoError(t, runtime.Close())
+	require.NoError(t, runtime.Close())
+	assert.Equal(t, int32(1), newApp.closeCalls.Load(), "active bundle closes exactly once")
+}
+
+func TestBootStateSyncRuntimeClosesCandidateReturnedWithError(t *testing.T) {
+	oldHash := sha256.Sum256([]byte("old"))
+	runtime := newBootRuntimeTestRuntime(t, &bootRuntimeTestApp{height: 40, appHash: oldHash[:], appVersion: 19})
+	require.NoError(t, runtime.transitionBootStateSync(BootStateSyncDiscovering))
+	require.NoError(t, runtime.transitionBootStateSync(BootStateSyncAssembling))
+	require.NoError(t, runtime.transitionBootStateSync(BootStateSyncPrepared))
+	newHash := sha256.Sum256([]byte("candidate"))
+	candidateApp := &bootRuntimeTestApp{height: 42, appHash: newHash[:], appVersion: 20}
+	err := runtime.activatePreparedBundle(42, newHash[:], 20, func(*ConsensusBundle) (*ConsensusBundle, error) {
+		candidate, bundleErr := NewConsensusBundleWithCleanup(context.Background(), candidateApp, candidateApp.Close)
+		require.NoError(t, bundleErr)
+		return candidate, errors.New("activation publication failed")
+	})
+	assert.ErrorContains(t, err, "publication failed")
+	assert.Equal(t, int32(1), candidateApp.closeCalls.Load())
+	assert.Equal(t, BootStateSyncFailed, runtime.Phase())
 }
 
 func TestBootStateSyncRuntimeFailsClosedOnReplacementMismatch(t *testing.T) {
@@ -169,22 +207,105 @@ func TestBootStateSyncRuntimeFailsClosedOnReplacementMismatch(t *testing.T) {
 
 	trustedHash := sha256.Sum256([]byte("trusted"))
 	wrongHash := sha256.Sum256([]byte("wrong"))
-	err := runtime.activatePreparedBundle(42, trustedHash[:], func(*ConsensusBundle) (*ConsensusBundle, error) {
-		return NewConsensusBundle(context.Background(), &bootRuntimeTestApp{height: 42, appHash: wrongHash[:]})
+	wrongApp := &bootRuntimeTestApp{height: 42, appHash: wrongHash[:], appVersion: 20}
+	err := runtime.activatePreparedBundle(42, trustedHash[:], 20, func(*ConsensusBundle) (*ConsensusBundle, error) {
+		return NewConsensusBundleWithCleanup(context.Background(), wrongApp, wrongApp.Close)
 	})
 	assert.ErrorContains(t, err, "does not match")
 	assert.Equal(t, BootStateSyncFailed, runtime.Phase())
+	assert.Equal(t, int32(1), wrongApp.closeCalls.Load(), "rejected candidate bundle must release its store graph")
 	assert.Error(t, runtime.transitionBootStateSync(BootStateSyncDiscovering), "failed runtime must not retry in-process")
 }
 
+func TestBootStateSyncRuntimeRejectsSnapshotRegressionOrSameHeightFork(t *testing.T) {
+	currentHash := sha256.Sum256([]byte("current"))
+	tests := []struct {
+		name   string
+		height int64
+		hash   []byte
+	}{
+		{name: "lower height", height: 39, hash: sha256.New().Sum(nil)},
+		{name: "same height different hash", height: 40, hash: bytes.Repeat([]byte{0xdd}, sha256.Size)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runtime := newBootRuntimeTestRuntime(t, &bootRuntimeTestApp{height: 40, appHash: currentHash[:], appVersion: 19})
+			require.NoError(t, runtime.transitionBootStateSync(BootStateSyncDiscovering))
+			require.NoError(t, runtime.transitionBootStateSync(BootStateSyncAssembling))
+			require.NoError(t, runtime.transitionBootStateSync(BootStateSyncPrepared))
+			called := false
+			err := runtime.activatePreparedBundle(tc.height, tc.hash, 20, func(*ConsensusBundle) (*ConsensusBundle, error) {
+				called = true
+				return nil, nil
+			})
+			assert.ErrorContains(t, err, "regress or fork")
+			assert.False(t, called)
+			assert.Equal(t, BootStateSyncFailed, runtime.Phase())
+		})
+	}
+}
+
+func TestBootStateSyncRuntimeSealAnchorsTrustedSnapshotAndVersion(t *testing.T) {
+	tests := []struct {
+		name         string
+		cometHeight  int64
+		cometHash    []byte
+		cometVersion uint64
+	}{
+		{name: "below snapshot", cometHeight: 41, cometHash: bytes.Repeat([]byte{0x41}, sha256.Size), cometVersion: 20},
+		{name: "equal wrong hash", cometHeight: 42, cometHash: bytes.Repeat([]byte{0x42}, sha256.Size), cometVersion: 20},
+		{name: "equal wrong version", cometHeight: 42, cometHash: nil, cometVersion: 19},
+	}
+	trustedHash := sha256.Sum256([]byte("trusted snapshot"))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.cometHash == nil {
+				tc.cometHash = trustedHash[:]
+			}
+			oldHash := sha256.Sum256([]byte("old"))
+			runtime := newBootRuntimeTestRuntime(t, &bootRuntimeTestApp{height: 40, appHash: oldHash[:], appVersion: 19})
+			require.NoError(t, runtime.transitionBootStateSync(BootStateSyncDiscovering))
+			require.NoError(t, runtime.transitionBootStateSync(BootStateSyncAssembling))
+			require.NoError(t, runtime.transitionBootStateSync(BootStateSyncPrepared))
+			newApp := &bootRuntimeTestApp{height: 42, appHash: trustedHash[:], appVersion: 20}
+			require.NoError(t, runtime.activatePreparedBundle(42, trustedHash[:], 20, func(*ConsensusBundle) (*ConsensusBundle, error) {
+				return NewConsensusBundleWithCleanup(context.Background(), newApp, newApp.Close)
+			}))
+			err := runtime.sealActivatedBundle(context.Background(), tc.cometHeight, tc.cometHash, tc.cometVersion)
+			assert.ErrorContains(t, err, "below or conflicts")
+			assert.Equal(t, BootStateSyncFailed, runtime.Phase())
+		})
+	}
+}
+
 func TestConsensusBundleRejectsInvalidInfo(t *testing.T) {
-	_, err := NewConsensusBundle(context.Background(), &bootRuntimeTestApp{height: 1, appHash: []byte("short")})
+	invalid := &bootRuntimeTestApp{height: 1, appHash: []byte("short")}
+	_, err := NewConsensusBundleWithCleanup(context.Background(), invalid, invalid.Close)
 	assert.ErrorContains(t, err, "SHA-256")
-	_, err = NewConsensusBundle(context.Background(), &bootRuntimeTestApp{infoErr: errors.New("Info unavailable")})
+	assert.Equal(t, int32(1), invalid.closeCalls.Load())
+	unavailable := &bootRuntimeTestApp{infoErr: errors.New("Info unavailable")}
+	_, err = NewConsensusBundleWithCleanup(context.Background(), unavailable, unavailable.Close)
 	assert.ErrorContains(t, err, "Info unavailable")
+	assert.Equal(t, int32(1), unavailable.closeCalls.Load())
 
 	hash := sha256.Sum256([]byte("copy"))
 	bundle := newBootRuntimeTestBundle(t, &bootRuntimeTestApp{height: 1, appHash: hash[:]})
 	input := append([]byte(nil), hash[:]...)
 	assert.True(t, bytes.Equal(input, bundle.expectedHash))
+}
+
+func TestConsensusBundleCleanupKeepsProcessProjectionOpen(t *testing.T) {
+	root := t.TempDir()
+	badgerStore, err := store.NewBadgerStore(filepath.Join(root, "badger"))
+	require.NoError(t, err)
+	projection, err := store.NewSQLiteStore(context.Background(), filepath.Join(root, "projection.db"))
+	require.NoError(t, err)
+	app, err := NewSageAppWithStores(badgerStore, projection, zerolog.Nop())
+	require.NoError(t, err)
+	bundle, err := NewConsensusBundleWithCleanup(context.Background(), app, app.CloseConsensusState)
+	require.NoError(t, err)
+	require.NoError(t, bundle.Close())
+	require.NoError(t, bundle.Close())
+	require.NoError(t, projection.Ping(context.Background()), "bundle replacement must not close the process-owned projection")
+	require.NoError(t, projection.Close())
 }

--- a/internal/abci/scoped_state_sync.go
+++ b/internal/abci/scoped_state_sync.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -46,6 +47,153 @@ func PrepareAppV20StateSyncBackup(ctx context.Context, backupPath, targetDir str
 	if !bytes.Equal(computed, expectedAppHash) {
 		_ = os.RemoveAll(targetDir)
 		return errors.New("prepared state sync AppHash does not match trusted AppHash")
+	}
+	return nil
+}
+
+// InspectAppV20StateSyncDirectory opens an existing closed Badger directory
+// read-only and returns its verified persisted height and narrow AppHash. Boot
+// recovery uses this before any live store is opened or ABCI handshake begins.
+func InspectAppV20StateSyncDirectory(ctx context.Context, path string) (uint64, []byte, error) {
+	if path == "" {
+		return 0, nil, errors.New("state sync directory path is required")
+	}
+	if contextErr := ctx.Err(); contextErr != nil {
+		return 0, nil, contextErr
+	}
+	readOnly, err := store.OpenBadgerStoreReadOnly(path)
+	if err != nil {
+		return 0, nil, err
+	}
+	height, appHash, inspectErr := inspectAppV20StateSyncStore(ctx, readOnly, "state sync")
+	closeErr := readOnly.CloseBadger()
+	if inspectErr != nil {
+		return 0, nil, inspectErr
+	}
+	if closeErr != nil {
+		return 0, nil, closeErr
+	}
+	return height, appHash, nil
+}
+
+// InspectStateSyncRecoveryDirectory accepts either a canonical fresh pre-chain
+// store (height 0, empty AppHash) or a fully verified positive-height app-v20
+// store. Fresh joining nodes have no trusted application hash yet, but their
+// quarantined pre-activation directory must still be recoverable after a crash.
+func InspectStateSyncRecoveryDirectory(ctx context.Context, path string) (uint64, []byte, error) {
+	if path == "" {
+		return 0, nil, errors.New("state sync recovery directory path is required")
+	}
+	if contextErr := ctx.Err(); contextErr != nil {
+		return 0, nil, contextErr
+	}
+	readOnly, err := store.OpenBadgerStoreReadOnly(path)
+	if err != nil {
+		return 0, nil, err
+	}
+	state, stateErr := LoadState(readOnly)
+	if stateErr != nil {
+		_ = readOnly.CloseBadger()
+		return 0, nil, fmt.Errorf("load state sync recovery app state: %w", stateErr)
+	}
+	if state.Height == 0 {
+		heightBytes, heightErr := readOnly.GetState(stateHeightKey)
+		if heightErr != nil || (heightBytes != nil && (len(heightBytes) != 8 || binary.BigEndian.Uint64(heightBytes) != 0)) {
+			_ = readOnly.CloseBadger()
+			return 0, nil, errors.New("fresh state sync recovery directory has invalid height bookkeeping")
+		}
+		storedAppHash, appHashErr := readOnly.GetState(stateAppHashKey)
+		if appHashErr != nil || len(storedAppHash) != 0 {
+			_ = readOnly.CloseBadger()
+			return 0, nil, errors.New("fresh state sync recovery directory has a non-empty AppHash")
+		}
+		epochBytes, epochErr := readOnly.GetState(stateEpochKey)
+		if epochErr != nil || (epochBytes != nil && (len(epochBytes) != 8 || binary.BigEndian.Uint64(epochBytes) != 0)) {
+			_ = readOnly.CloseBadger()
+			return 0, nil, errors.New("fresh state sync recovery directory has invalid epoch bookkeeping")
+		}
+		if len(state.AppHash) != 0 {
+			_ = readOnly.CloseBadger()
+			return 0, nil, errors.New("fresh state sync recovery directory has a non-empty AppHash")
+		}
+		computed, computeErr := readOnly.ComputeAppHashExcludingBookkeeping()
+		if computeErr != nil {
+			_ = readOnly.CloseBadger()
+			return 0, nil, computeErr
+		}
+		emptyHash := sha256.Sum256(nil)
+		if !bytes.Equal(computed, emptyHash[:]) {
+			_ = readOnly.CloseBadger()
+			return 0, nil, errors.New("fresh state sync recovery directory contains consensus state")
+		}
+		closeErr := readOnly.CloseBadger()
+		if closeErr != nil {
+			return 0, nil, closeErr
+		}
+		return 0, nil, nil
+	}
+	if state.Height < 0 {
+		_ = readOnly.CloseBadger()
+		return 0, nil, errors.New("state sync recovery directory has a negative height")
+	}
+	if len(state.AppHash) != sha256.Size {
+		_ = readOnly.CloseBadger()
+		return 0, nil, errors.New("positive-height state sync recovery directory has an invalid AppHash")
+	}
+	appV20, upgradeErr := readOnly.GetAppliedUpgrade(appV20UpgradeName)
+	if upgradeErr != nil {
+		_ = readOnly.CloseBadger()
+		return 0, nil, upgradeErr
+	}
+	// A quarantine may legitimately be from any older supported app version.
+	// Pre-app-v12 AppHashes include bookkeeping that SaveState changes after
+	// FinalizeBlock, so they cannot be recomputed from the closed post-Commit DB.
+	// The persisted height/AppHash are still compared exactly with Comet by the
+	// recovery executor. Once app-v20 is active, apply its stronger narrow-hash
+	// and scoped-state checks as well.
+	if appV20 == nil || appV20.TargetAppVersion != 20 || appV20.AppliedHeight <= 0 || state.Height <= appV20.AppliedHeight {
+		closeErr := readOnly.CloseBadger()
+		if closeErr != nil {
+			return 0, nil, closeErr
+		}
+		return uint64(state.Height), append([]byte(nil), state.AppHash...), nil // #nosec G115 -- positive int64 checked above
+	}
+	height, appHash, inspectErr := inspectAppV20StateSyncStore(ctx, readOnly, "state sync recovery")
+	closeErr := readOnly.CloseBadger()
+	if inspectErr != nil {
+		return 0, nil, inspectErr
+	}
+	if closeErr != nil {
+		return 0, nil, closeErr
+	}
+	return height, appHash, nil
+}
+
+// VerifyActivatedAppV20StateSyncDirectory reopens the promoted directory with
+// the writable no-migration constructor, re-verifies its exact trusted state,
+// and closes it. The runtime constructs the replacement SageApp only after this
+// succeeds.
+func VerifyActivatedAppV20StateSyncDirectory(ctx context.Context, path string, expectedHeight uint64, expectedAppHash []byte) error {
+	if path == "" || expectedHeight == 0 || expectedHeight > math.MaxInt64 || len(expectedAppHash) != sha256.Size {
+		return errors.New("activated state sync path, positive int64 height, and SHA-256 AppHash are required")
+	}
+	if contextErr := ctx.Err(); contextErr != nil {
+		return contextErr
+	}
+	writable, err := store.OpenBadgerStoreWithoutMigrations(path)
+	if err != nil {
+		return err
+	}
+	height, appHash, inspectErr := inspectAppV20StateSyncStore(ctx, writable, "activated")
+	closeErr := writable.CloseBadger()
+	if inspectErr != nil {
+		return inspectErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if height != expectedHeight || !bytes.Equal(appHash, expectedAppHash) {
+		return errors.New("activated state sync directory does not match trusted state")
 	}
 	return nil
 }
@@ -108,32 +256,49 @@ func inspectAppV20StateSyncBackup(ctx context.Context, backupPath, targetDir str
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = readOnly.CloseBadger() }()
-	state, err := LoadState(readOnly)
-	if err != nil {
-		return nil, fmt.Errorf("load staged app state: %w", err)
+	actualHeight, computed, inspectErr := inspectAppV20StateSyncStore(ctx, readOnly, "staged")
+	closeReadOnlyErr := readOnly.CloseBadger()
+	if inspectErr != nil {
+		return nil, inspectErr
 	}
-	if state.Height != int64(height) { // #nosec G115 -- bounded above by MaxInt64
-		return nil, fmt.Errorf("staged app height %d does not match snapshot height %d", state.Height, height)
+	if closeReadOnlyErr != nil {
+		return nil, closeReadOnlyErr
 	}
-	applied, err := readOnly.GetAppliedUpgrade(appV20UpgradeName)
-	if err != nil {
-		return nil, err
-	}
-	if applied == nil || applied.TargetAppVersion != 20 || applied.AppliedHeight <= 0 || int64(height) <= applied.AppliedHeight { // #nosec G115 -- bounded above by MaxInt64
-		return nil, errors.New("state sync backup is not from an active post-app-v20 height")
-	}
-	computed, err := readOnly.ComputeAppHashExcludingBookkeeping()
-	if err != nil {
-		return nil, err
-	}
-	if len(state.AppHash) != sha256.Size || !bytes.Equal(state.AppHash, computed) {
-		return nil, errors.New("staged persisted AppHash does not match staged Badger state")
-	}
-	probe := &SageApp{badgerStore: readOnly}
-	if _, err := probe.VerifyScopedCanonicalState(); err != nil {
-		return nil, fmt.Errorf("verify staged scoped state: %w", err)
+	if actualHeight != height {
+		return nil, fmt.Errorf("staged app height %d does not match snapshot height %d", actualHeight, height)
 	}
 	keep = true
 	return computed, nil
+}
+
+func inspectAppV20StateSyncStore(ctx context.Context, badgerStore *store.BadgerStore, label string) (uint64, []byte, error) {
+	if contextErr := ctx.Err(); contextErr != nil {
+		return 0, nil, contextErr
+	}
+	state, err := LoadState(badgerStore)
+	if err != nil {
+		return 0, nil, fmt.Errorf("load %s app state: %w", label, err)
+	}
+	if state.Height <= 0 {
+		return 0, nil, fmt.Errorf("%s app height must be positive", label)
+	}
+	applied, err := badgerStore.GetAppliedUpgrade(appV20UpgradeName)
+	if err != nil {
+		return 0, nil, err
+	}
+	if applied == nil || applied.TargetAppVersion != 20 || applied.AppliedHeight <= 0 || state.Height <= applied.AppliedHeight {
+		return 0, nil, errors.New("state sync state is not from an active post-app-v20 height")
+	}
+	computed, err := badgerStore.ComputeAppHashExcludingBookkeeping()
+	if err != nil {
+		return 0, nil, err
+	}
+	if len(state.AppHash) != sha256.Size || !bytes.Equal(state.AppHash, computed) {
+		return 0, nil, fmt.Errorf("%s persisted AppHash does not match Badger state", label)
+	}
+	probe := &SageApp{badgerStore: badgerStore}
+	if _, err := probe.VerifyScopedCanonicalState(); err != nil {
+		return 0, nil, fmt.Errorf("verify %s scoped state: %w", label, err)
+	}
+	return uint64(state.Height), computed, nil // #nosec G115 -- positive int64 checked above
 }

--- a/internal/abci/scoped_state_sync_test.go
+++ b/internal/abci/scoped_state_sync_test.go
@@ -3,6 +3,7 @@ package abci
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"os"
 	"path/filepath"
 	"sort"
@@ -84,6 +85,13 @@ func TestPrepareAppV20StateSyncBackupValidatesWithoutActivating(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, appHash, preparedHash)
 	require.NoError(t, prepared.CloseBadger())
+	inspectedHeight, inspectedHash, err := InspectAppV20StateSyncDirectory(context.Background(), target)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), inspectedHeight)
+	assert.Equal(t, appHash, inspectedHash)
+	require.NoError(t, VerifyActivatedAppV20StateSyncDirectory(context.Background(), target, 5, appHash))
+	wrongActivatedHash := bytes.Repeat([]byte{0xee}, len(appHash))
+	require.ErrorContains(t, VerifyActivatedAppV20StateSyncDirectory(context.Background(), target, 5, wrongActivatedHash), "trusted state")
 
 	verifierHash, err := AppV20StateSyncBackupVerifier(5)(context.Background(), backupPath)
 	require.NoError(t, err)
@@ -125,4 +133,54 @@ func TestPrepareAppV20StateSyncBackupRejectsMalformedCanonicalScope(t *testing.T
 
 	err = PrepareAppV20StateSyncBackup(context.Background(), backupPath, filepath.Join(root, "prepared"), 2, hash)
 	require.ErrorContains(t, err, "verify staged scoped state")
+}
+
+func TestInspectStateSyncRecoveryDirectoryAcceptsCanonicalFreshStore(t *testing.T) {
+	root := t.TempDir()
+	freshPath := filepath.Join(root, "fresh")
+	fresh, err := store.NewBadgerStore(freshPath)
+	require.NoError(t, err)
+	require.NoError(t, fresh.CloseBadger())
+	height, appHash, err := InspectStateSyncRecoveryDirectory(context.Background(), freshPath)
+	require.NoError(t, err)
+	assert.Zero(t, height)
+	assert.Empty(t, appHash)
+
+	tamperedPath := filepath.Join(root, "tampered")
+	tampered, err := store.NewBadgerStore(tamperedPath)
+	require.NoError(t, err)
+	tamperedHash := bytes.Repeat([]byte{0xaa}, sha256.Size)
+	require.NoError(t, SaveState(tampered, &AppState{Height: 0, AppHash: tamperedHash}))
+	require.NoError(t, tampered.CloseBadger())
+	_, _, err = InspectStateSyncRecoveryDirectory(context.Background(), tamperedPath)
+	require.ErrorContains(t, err, "non-empty AppHash")
+
+	hiddenPath := filepath.Join(root, "hidden-fresh-state")
+	hidden, err := store.NewBadgerStore(hiddenPath)
+	require.NoError(t, err)
+	require.NoError(t, hidden.DB().Update(func(txn *badger.Txn) error {
+		return txn.Set([]byte("memory:hidden"), []byte("unexpected consensus bytes"))
+	}))
+	require.NoError(t, hidden.CloseBadger())
+	_, _, err = InspectStateSyncRecoveryDirectory(context.Background(), hiddenPath)
+	require.ErrorContains(t, err, "contains consensus state")
+
+	corruptHeightPath := filepath.Join(root, "corrupt-fresh-height")
+	corruptHeight, err := store.NewBadgerStore(corruptHeightPath)
+	require.NoError(t, err)
+	require.NoError(t, corruptHeight.SetState(stateHeightKey, []byte{1}))
+	require.NoError(t, corruptHeight.CloseBadger())
+	_, _, err = InspectStateSyncRecoveryDirectory(context.Background(), corruptHeightPath)
+	require.ErrorContains(t, err, "invalid height bookkeeping")
+
+	legacyPath := filepath.Join(root, "pre-app-v20")
+	legacy, err := store.NewBadgerStore(legacyPath)
+	require.NoError(t, err)
+	legacyHash := bytes.Repeat([]byte{0xbb}, sha256.Size)
+	require.NoError(t, SaveState(legacy, &AppState{Height: 9, AppHash: legacyHash}))
+	require.NoError(t, legacy.CloseBadger())
+	height, appHash, err = InspectStateSyncRecoveryDirectory(context.Background(), legacyPath)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(9), height)
+	assert.Equal(t, legacyHash, appHash, "pre-app-v20 quarantine is anchored by exact persisted Comet state")
 }

--- a/internal/statesync/activation_directories.go
+++ b/internal/statesync/activation_directories.go
@@ -1,0 +1,494 @@
+package statesync
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ActivationDirectoryVerifier opens the newly named live database, verifies
+// its exact consensus height and AppHash, and closes it before returning. The
+// executor never publishes a database handle or starts ordinary services.
+type ActivationDirectoryVerifier func(path string, height uint64, appHash []byte) error
+
+// ActivationDirectoryInspector returns the consensus height and AppHash held
+// by one closed, real directory. Recovery verifies this result against the
+// already persisted CometBFT state before it renames or removes anything.
+type ActivationDirectoryInspector func(path string) (height uint64, appHash []byte, err error)
+
+type activationDirectoryPaths struct {
+	root       string
+	journal    string
+	prepared   string
+	quarantine string
+	live       string
+}
+
+type activationDirectoryLayout struct {
+	prepared   bool
+	quarantine bool
+	live       bool
+}
+
+type activationDirectoryStep string
+
+const (
+	activationStepJournalPrepared activationDirectoryStep = "journal_prepared"
+	activationStepLiveQuarantined activationDirectoryStep = "live_quarantined"
+	activationStepPreparedLive    activationDirectoryStep = "prepared_live"
+	activationStepVerified        activationDirectoryStep = "verified"
+	activationStepPendingComet    activationDirectoryStep = "pending_comet"
+)
+
+type activationDirectoryHook func(activationDirectoryStep) error
+
+// ActivatePreparedDirectory performs the durable, boot-only directory portion
+// of state-sync activation. journal must be in ActivationPrepared, the journal
+// file must not already exist, and all three directory names must be direct
+// children of root. The returned live directory is not safe to serve until
+// CometBFT persists the synchronized state and recovery seals the journal.
+func ActivatePreparedDirectory(root, journalPath string, journal ActivationJournal, verify ActivationDirectoryVerifier) error {
+	return activatePreparedDirectory(root, journalPath, journal, verify, nil)
+}
+
+func activatePreparedDirectory(root, journalPath string, journal ActivationJournal, verify ActivationDirectoryVerifier, hook activationDirectoryHook) error {
+	if verify == nil {
+		return errors.New("activation directory verifier is required")
+	}
+	if journal.Phase != ActivationPrepared {
+		return errors.New("activation directory transaction requires prepared phase")
+	}
+	paths, resolveErr := resolveActivationDirectoryPaths(root, journalPath, journal)
+	if resolveErr != nil {
+		return resolveErr
+	}
+	if err := requireMissingPath(paths.journal, "activation journal"); err != nil {
+		return err
+	}
+	layout, err := inspectActivationDirectoryLayout(paths)
+	if err != nil {
+		return err
+	}
+	if !layout.live || !layout.prepared || layout.quarantine {
+		return errors.New("activation requires live and prepared directories with no quarantine")
+	}
+
+	if err := WriteActivationJournal(paths.journal, journal); err != nil {
+		return fmt.Errorf("write prepared activation journal: %w", err)
+	}
+	if err := runActivationDirectoryHook(hook, activationStepJournalPrepared); err != nil {
+		return err
+	}
+	if err := os.Rename(paths.live, paths.quarantine); err != nil {
+		return fmt.Errorf("quarantine live activation directory: %w", err)
+	}
+	if err := syncDir(paths.root); err != nil {
+		return fmt.Errorf("sync quarantined activation directory: %w", err)
+	}
+	if err := runActivationDirectoryHook(hook, activationStepLiveQuarantined); err != nil {
+		return err
+	}
+	if err := os.Rename(paths.prepared, paths.live); err != nil {
+		return fmt.Errorf("promote prepared activation directory: %w", err)
+	}
+	if err := syncDir(paths.root); err != nil {
+		return fmt.Errorf("sync promoted activation directory: %w", err)
+	}
+	if err := runActivationDirectoryHook(hook, activationStepPreparedLive); err != nil {
+		return err
+	}
+
+	if err := verify(paths.live, journal.Height, append([]byte(nil), journal.AppHash...)); err != nil {
+		verifyErr := fmt.Errorf("verify promoted activation directory: %w", err)
+		if rollbackErr := rollbackActivatedDirectory(paths); rollbackErr != nil {
+			return errors.Join(verifyErr, fmt.Errorf("rollback promoted activation directory: %w", rollbackErr))
+		}
+		if cleanupErr := removeActivationJournal(paths.journal); cleanupErr != nil {
+			return errors.Join(verifyErr, fmt.Errorf("remove rolled-back activation journal: %w", cleanupErr))
+		}
+		return verifyErr
+	}
+	if err := runActivationDirectoryHook(hook, activationStepVerified); err != nil {
+		return err
+	}
+
+	journal.Phase = ActivationPendingComet
+	if err := WriteActivationJournal(paths.journal, journal); err != nil {
+		return fmt.Errorf("write pending-Comet activation journal: %w", err)
+	}
+	if err := runActivationDirectoryHook(hook, activationStepPendingComet); err != nil {
+		return err
+	}
+	return nil
+}
+
+// RecoverActivationDirectories resolves a durable activation journal before
+// the ABCI handshake. It either restores the store matching persisted CometBFT
+// state or seals the activated store; ambiguous layouts are left untouched.
+func RecoverActivationDirectories(root, journalPath string, cometHeight uint64, cometAppHash []byte, inspect ActivationDirectoryInspector) (RecoveryAction, error) {
+	if inspect == nil {
+		return 0, errors.New("activation directory inspector is required")
+	}
+	if !validPersistedState(cometHeight, cometAppHash) {
+		return 0, errors.New("persisted CometBFT state hash is invalid")
+	}
+	journal, err := LoadActivationJournal(journalPath)
+	if err != nil {
+		return 0, fmt.Errorf("load activation journal: %w", err)
+	}
+	paths, err := resolveActivationDirectoryPaths(root, journalPath, journal)
+	if err != nil {
+		return 0, err
+	}
+	layout, err := inspectActivationDirectoryLayout(paths)
+	if err != nil {
+		return 0, err
+	}
+
+	switch journal.Phase {
+	case ActivationPrepared:
+		return recoverPreparedActivation(paths, layout, cometHeight, cometAppHash, inspect)
+	case ActivationPendingComet:
+		return recoverPendingActivation(paths, layout, journal, cometHeight, cometAppHash, inspect)
+	case ActivationSealed:
+		return recoverSealedActivation(paths, layout, journal, cometHeight, cometAppHash, inspect)
+	default:
+		return 0, errors.New("activation journal phase is invalid")
+	}
+}
+
+func recoverPreparedActivation(paths activationDirectoryPaths, layout activationDirectoryLayout, cometHeight uint64, cometAppHash []byte, inspect ActivationDirectoryInspector) (RecoveryAction, error) {
+	switch {
+	case layout.live && layout.prepared && !layout.quarantine:
+		if err := inspectActivationState(inspect, paths.live, cometHeight, cometAppHash); err != nil {
+			return 0, err
+		}
+		if err := removeActivationDirectory(paths.root, paths.prepared); err != nil {
+			return 0, err
+		}
+		if err := removeActivationJournal(paths.journal); err != nil {
+			return 0, err
+		}
+		return RecoveryDiscardPrepared, nil
+
+	case layout.live && !layout.prepared && !layout.quarantine:
+		// Recovery itself may have restored live and removed prepared before
+		// crashing prior to journal removal.
+		if err := inspectActivationState(inspect, paths.live, cometHeight, cometAppHash); err != nil {
+			return 0, err
+		}
+		if err := removeActivationJournal(paths.journal); err != nil {
+			return 0, err
+		}
+		return RecoveryDiscardPrepared, nil
+
+	case !layout.live && layout.prepared && layout.quarantine:
+		if err := inspectActivationState(inspect, paths.quarantine, cometHeight, cometAppHash); err != nil {
+			return 0, err
+		}
+		if err := restoreQuarantineAndDiscardPrepared(paths, false); err != nil {
+			return 0, err
+		}
+		return RecoveryRestoreQuarantine, nil
+
+	case layout.live && !layout.prepared && layout.quarantine:
+		if err := inspectActivationState(inspect, paths.quarantine, cometHeight, cometAppHash); err != nil {
+			return 0, err
+		}
+		if err := restoreQuarantineAndDiscardPrepared(paths, true); err != nil {
+			return 0, err
+		}
+		return RecoveryRestoreQuarantine, nil
+
+	default:
+		return 0, errors.New("prepared activation directory layout is ambiguous")
+	}
+}
+
+func recoverPendingActivation(paths activationDirectoryPaths, layout activationDirectoryLayout, journal ActivationJournal, cometHeight uint64, cometAppHash []byte, inspect ActivationDirectoryInspector) (RecoveryAction, error) {
+	if cometHeight < journal.Height {
+		switch {
+		case layout.live && !layout.prepared && layout.quarantine:
+			if err := inspectActivationState(inspect, paths.quarantine, cometHeight, cometAppHash); err != nil {
+				return 0, err
+			}
+			if err := restoreQuarantineAndDiscardPrepared(paths, true); err != nil {
+				return 0, err
+			}
+			return RecoveryRestoreQuarantine, nil
+
+		case !layout.live && layout.prepared && layout.quarantine:
+			if err := inspectActivationState(inspect, paths.quarantine, cometHeight, cometAppHash); err != nil {
+				return 0, err
+			}
+			if err := restoreQuarantineAndDiscardPrepared(paths, false); err != nil {
+				return 0, err
+			}
+			return RecoveryRestoreQuarantine, nil
+
+		case layout.live && layout.prepared && !layout.quarantine:
+			if err := inspectActivationState(inspect, paths.live, cometHeight, cometAppHash); err != nil {
+				return 0, err
+			}
+			if err := removeActivationDirectory(paths.root, paths.prepared); err != nil {
+				return 0, err
+			}
+			if err := removeActivationJournal(paths.journal); err != nil {
+				return 0, err
+			}
+			return RecoveryRestoreQuarantine, nil
+
+		case layout.live && !layout.prepared && !layout.quarantine:
+			if err := inspectActivationState(inspect, paths.live, cometHeight, cometAppHash); err != nil {
+				return 0, err
+			}
+			if err := removeActivationJournal(paths.journal); err != nil {
+				return 0, err
+			}
+			return RecoveryRestoreQuarantine, nil
+
+		default:
+			return 0, errors.New("pending activation rollback layout is ambiguous")
+		}
+	}
+
+	if !layout.live || layout.prepared || !layout.quarantine {
+		return 0, errors.New("pending activation seal layout is ambiguous")
+	}
+	liveHeight, liveHash, err := inspectActivationDirectory(inspect, paths.live)
+	if err != nil {
+		return 0, err
+	}
+	action, err := DecideActivationRecovery(journal, cometHeight, cometAppHash, liveHeight, liveHash)
+	if err != nil {
+		return 0, err
+	}
+	if action != RecoveryKeepActivated {
+		return 0, errors.New("pending activation cannot be sealed")
+	}
+	if err := sealActivationDirectory(paths, journal, true); err != nil {
+		return 0, err
+	}
+	return RecoveryKeepActivated, nil
+}
+
+func recoverSealedActivation(paths activationDirectoryPaths, layout activationDirectoryLayout, journal ActivationJournal, cometHeight uint64, cometAppHash []byte, inspect ActivationDirectoryInspector) (RecoveryAction, error) {
+	if !layout.live || layout.prepared {
+		return 0, errors.New("sealed activation directory layout is ambiguous")
+	}
+	liveHeight, liveHash, err := inspectActivationDirectory(inspect, paths.live)
+	if err != nil {
+		return 0, err
+	}
+	action, err := DecideActivationRecovery(journal, cometHeight, cometAppHash, liveHeight, liveHash)
+	if err != nil {
+		return 0, err
+	}
+	if action != RecoveryKeepActivated {
+		return 0, errors.New("sealed activation cannot be kept")
+	}
+	if err := sealActivationDirectory(paths, journal, layout.quarantine); err != nil {
+		return 0, err
+	}
+	return RecoveryKeepActivated, nil
+}
+
+func sealActivationDirectory(paths activationDirectoryPaths, journal ActivationJournal, removeQuarantine bool) error {
+	if journal.Phase != ActivationSealed {
+		journal.Phase = ActivationSealed
+		if err := WriteActivationJournal(paths.journal, journal); err != nil {
+			return fmt.Errorf("write sealed activation journal: %w", err)
+		}
+	}
+	if removeQuarantine {
+		if err := removeActivationDirectory(paths.root, paths.quarantine); err != nil {
+			return err
+		}
+	}
+	if err := removeActivationJournal(paths.journal); err != nil {
+		return err
+	}
+	return nil
+}
+
+func rollbackActivatedDirectory(paths activationDirectoryPaths) error {
+	layout, err := inspectActivationDirectoryLayout(paths)
+	if err != nil {
+		return err
+	}
+	if !layout.live || layout.prepared || !layout.quarantine {
+		return errors.New("activated directory rollback layout is ambiguous")
+	}
+	return restoreQuarantineAndDiscardPrepared(paths, true)
+}
+
+func restoreQuarantineAndDiscardPrepared(paths activationDirectoryPaths, moveLiveAside bool) error {
+	if moveLiveAside {
+		if err := os.Rename(paths.live, paths.prepared); err != nil {
+			return fmt.Errorf("move activated live directory aside: %w", err)
+		}
+		if err := syncDir(paths.root); err != nil {
+			return fmt.Errorf("sync moved-aside activation directory: %w", err)
+		}
+	}
+	if err := os.Rename(paths.quarantine, paths.live); err != nil {
+		return fmt.Errorf("restore quarantined activation directory: %w", err)
+	}
+	if err := syncDir(paths.root); err != nil {
+		return fmt.Errorf("sync restored activation directory: %w", err)
+	}
+	if err := removeActivationDirectory(paths.root, paths.prepared); err != nil {
+		return err
+	}
+	if err := removeActivationJournal(paths.journal); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resolveActivationDirectoryPaths(root, journalPath string, journal ActivationJournal) (activationDirectoryPaths, error) {
+	if err := validateActivationJournal(journal); err != nil {
+		return activationDirectoryPaths{}, err
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return activationDirectoryPaths{}, err
+	}
+	rootInfo, err := os.Lstat(rootAbs)
+	if err != nil || !rootInfo.IsDir() || rootInfo.Mode()&os.ModeSymlink != 0 {
+		return activationDirectoryPaths{}, errors.New("activation root must be an existing real directory")
+	}
+	journalAbs, err := filepath.Abs(journalPath)
+	if err != nil {
+		return activationDirectoryPaths{}, err
+	}
+	if filepath.Dir(journalAbs) != rootAbs {
+		return activationDirectoryPaths{}, errors.New("activation journal must be a direct child of activation root")
+	}
+	journalName := filepath.Base(journalAbs)
+	if journalName == journal.PreparedName || journalName == journal.QuarantineName || journalName == journal.LiveName {
+		return activationDirectoryPaths{}, errors.New("activation journal conflicts with a state directory")
+	}
+	return activationDirectoryPaths{
+		root:       rootAbs,
+		journal:    journalAbs,
+		prepared:   filepath.Join(rootAbs, journal.PreparedName),
+		quarantine: filepath.Join(rootAbs, journal.QuarantineName),
+		live:       filepath.Join(rootAbs, journal.LiveName),
+	}, nil
+}
+
+func inspectActivationDirectoryLayout(paths activationDirectoryPaths) (activationDirectoryLayout, error) {
+	prepared, err := realDirectoryExists(paths.prepared)
+	if err != nil {
+		return activationDirectoryLayout{}, fmt.Errorf("inspect prepared activation directory: %w", err)
+	}
+	quarantine, err := realDirectoryExists(paths.quarantine)
+	if err != nil {
+		return activationDirectoryLayout{}, fmt.Errorf("inspect quarantined activation directory: %w", err)
+	}
+	live, err := realDirectoryExists(paths.live)
+	if err != nil {
+		return activationDirectoryLayout{}, fmt.Errorf("inspect live activation directory: %w", err)
+	}
+	return activationDirectoryLayout{prepared: prepared, quarantine: quarantine, live: live}, nil
+}
+
+func realDirectoryExists(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return false, errors.New("path must be a real directory or absent")
+	}
+	return true, nil
+}
+
+func requireMissingPath(path, label string) error {
+	_, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("%s already exists", label)
+}
+
+func inspectActivationState(inspect ActivationDirectoryInspector, path string, height uint64, appHash []byte) error {
+	actualHeight, actualHash, err := inspectActivationDirectory(inspect, path)
+	if err != nil {
+		return err
+	}
+	if actualHeight != height || !bytes.Equal(actualHash, appHash) {
+		return errors.New("activation directory state does not match persisted CometBFT state")
+	}
+	return nil
+}
+
+func inspectActivationDirectory(inspect ActivationDirectoryInspector, path string) (uint64, []byte, error) {
+	height, appHash, err := inspect(path)
+	if err != nil {
+		return 0, nil, fmt.Errorf("inspect activation directory %q: %w", filepath.Base(path), err)
+	}
+	if !validPersistedState(height, appHash) {
+		return 0, nil, fmt.Errorf("activation directory %q returned an invalid state hash", filepath.Base(path))
+	}
+	return height, append([]byte(nil), appHash...), nil
+}
+
+func removeActivationDirectory(root, path string) error {
+	exists, err := realDirectoryExists(path)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	if filepath.Dir(path) != root {
+		return errors.New("activation cleanup directory escapes root")
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return err
+	}
+	if err := syncDir(root); err != nil {
+		return fmt.Errorf("sync activation directory cleanup: %w", err)
+	}
+	return nil
+}
+
+func removeActivationJournal(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("activation journal cleanup requires a regular file")
+	}
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	if err := syncDir(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("sync activation journal cleanup: %w", err)
+	}
+	return nil
+}
+
+func runActivationDirectoryHook(hook activationDirectoryHook, step activationDirectoryStep) error {
+	if hook == nil {
+		return nil
+	}
+	if err := hook(step); err != nil {
+		return fmt.Errorf("activation interrupted after %s: %w", step, err)
+	}
+	return nil
+}

--- a/internal/statesync/activation_directories_test.go
+++ b/internal/statesync/activation_directories_test.go
@@ -1,0 +1,209 @@
+package statesync
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errSimulatedActivationCrash = errors.New("simulated process crash")
+
+func writeActivationTestState(t *testing.T, path string, height uint64, appHash []byte) {
+	t.Helper()
+	require.NoError(t, os.Mkdir(path, 0o700))
+	encoded := make([]byte, 8+len(appHash))
+	binary.BigEndian.PutUint64(encoded, height)
+	copy(encoded[8:], appHash)
+	require.NoError(t, os.WriteFile(filepath.Join(path, "state"), encoded, 0o600))
+}
+
+func inspectActivationTestState(path string) (uint64, []byte, error) {
+	encoded, err := os.ReadFile(filepath.Join(path, "state")) //nolint:gosec // test-owned path
+	if err != nil {
+		return 0, nil, err
+	}
+	if len(encoded) < 8 {
+		return 0, nil, errors.New("test state is truncated")
+	}
+	return binary.BigEndian.Uint64(encoded), append([]byte(nil), encoded[8:]...), nil
+}
+
+func setupActivationDirectories(t *testing.T) (string, string, ActivationJournal, []byte, []byte) {
+	t.Helper()
+	root := t.TempDir()
+	journal := activationTestJournal()
+	journal.Phase = ActivationPrepared
+	oldHash := sha256.Sum256([]byte("old-live"))
+	writeActivationTestState(t, filepath.Join(root, journal.LiveName), 40, oldHash[:])
+	writeActivationTestState(t, filepath.Join(root, journal.PreparedName), journal.Height, journal.AppHash)
+	return root, filepath.Join(root, "activation.journal"), journal, oldHash[:], append([]byte(nil), journal.AppHash...)
+}
+
+func verifyActivationTestState(path string, height uint64, appHash []byte) error {
+	actualHeight, actualHash, err := inspectActivationTestState(path)
+	if err != nil {
+		return err
+	}
+	if actualHeight != height || !bytes.Equal(actualHash, appHash) {
+		return errors.New("unexpected activated state")
+	}
+	return nil
+}
+
+func TestActivatePreparedDirectoryWritesPendingJournal(t *testing.T) {
+	root, journalPath, journal, _, newHash := setupActivationDirectories(t)
+	require.NoError(t, ActivatePreparedDirectory(root, journalPath, journal, verifyActivationTestState))
+
+	height, appHash, err := inspectActivationTestState(filepath.Join(root, journal.LiveName))
+	require.NoError(t, err)
+	assert.Equal(t, journal.Height, height)
+	assert.Equal(t, newHash, appHash)
+	assert.NoDirExists(t, filepath.Join(root, journal.PreparedName))
+	assert.DirExists(t, filepath.Join(root, journal.QuarantineName))
+	loaded, err := LoadActivationJournal(journalPath)
+	require.NoError(t, err)
+	assert.Equal(t, ActivationPendingComet, loaded.Phase)
+}
+
+func TestActivationDirectoryCrashRecoveryRestoresPersistedCometState(t *testing.T) {
+	steps := []activationDirectoryStep{
+		activationStepJournalPrepared,
+		activationStepLiveQuarantined,
+		activationStepPreparedLive,
+		activationStepVerified,
+		activationStepPendingComet,
+	}
+	for _, step := range steps {
+		t.Run(string(step), func(t *testing.T) {
+			root, journalPath, journal, oldHash, _ := setupActivationDirectories(t)
+			err := activatePreparedDirectory(root, journalPath, journal, verifyActivationTestState, func(current activationDirectoryStep) error {
+				if current == step {
+					return errSimulatedActivationCrash
+				}
+				return nil
+			})
+			require.ErrorIs(t, err, errSimulatedActivationCrash)
+
+			action, err := RecoverActivationDirectories(root, journalPath, 40, oldHash, inspectActivationTestState)
+			require.NoError(t, err)
+			if step == activationStepJournalPrepared {
+				assert.Equal(t, RecoveryDiscardPrepared, action)
+			} else {
+				assert.Equal(t, RecoveryRestoreQuarantine, action)
+			}
+			height, appHash, err := inspectActivationTestState(filepath.Join(root, journal.LiveName))
+			require.NoError(t, err)
+			assert.Equal(t, uint64(40), height)
+			assert.Equal(t, oldHash, appHash)
+			assert.NoDirExists(t, filepath.Join(root, journal.PreparedName))
+			assert.NoDirExists(t, filepath.Join(root, journal.QuarantineName))
+			assert.NoFileExists(t, journalPath)
+		})
+	}
+}
+
+func TestRecoverActivationDirectoriesSealsCommittedState(t *testing.T) {
+	root, journalPath, journal, _, newHash := setupActivationDirectories(t)
+	require.NoError(t, ActivatePreparedDirectory(root, journalPath, journal, verifyActivationTestState))
+
+	action, err := RecoverActivationDirectories(root, journalPath, journal.Height, newHash, inspectActivationTestState)
+	require.NoError(t, err)
+	assert.Equal(t, RecoveryKeepActivated, action)
+	height, appHash, err := inspectActivationTestState(filepath.Join(root, journal.LiveName))
+	require.NoError(t, err)
+	assert.Equal(t, journal.Height, height)
+	assert.Equal(t, newHash, appHash)
+	assert.NoDirExists(t, filepath.Join(root, journal.QuarantineName))
+	assert.NoFileExists(t, journalPath)
+}
+
+func TestRecoverActivationDirectoriesFinishesInterruptedRecovery(t *testing.T) {
+	t.Run("quarantine restored before prepared cleanup", func(t *testing.T) {
+		root, journalPath, journal, oldHash, _ := setupActivationDirectories(t)
+		require.NoError(t, WriteActivationJournal(journalPath, journal))
+		require.NoError(t, os.Rename(filepath.Join(root, journal.LiveName), filepath.Join(root, journal.QuarantineName)))
+		require.NoError(t, os.Rename(filepath.Join(root, journal.QuarantineName), filepath.Join(root, journal.LiveName)))
+
+		action, err := RecoverActivationDirectories(root, journalPath, 40, oldHash, inspectActivationTestState)
+		require.NoError(t, err)
+		assert.Equal(t, RecoveryDiscardPrepared, action)
+		assert.NoDirExists(t, filepath.Join(root, journal.PreparedName))
+		assert.NoFileExists(t, journalPath)
+	})
+
+	t.Run("sealed journal after quarantine cleanup", func(t *testing.T) {
+		root, journalPath, journal, _, newHash := setupActivationDirectories(t)
+		require.NoError(t, ActivatePreparedDirectory(root, journalPath, journal, verifyActivationTestState))
+		journal.Phase = ActivationSealed
+		require.NoError(t, WriteActivationJournal(journalPath, journal))
+		require.NoError(t, os.RemoveAll(filepath.Join(root, journal.QuarantineName)))
+
+		action, err := RecoverActivationDirectories(root, journalPath, journal.Height, newHash, inspectActivationTestState)
+		require.NoError(t, err)
+		assert.Equal(t, RecoveryKeepActivated, action)
+		assert.NoFileExists(t, journalPath)
+	})
+}
+
+func TestActivatePreparedDirectoryVerificationFailureRollsBack(t *testing.T) {
+	root, journalPath, journal, oldHash, _ := setupActivationDirectories(t)
+	err := ActivatePreparedDirectory(root, journalPath, journal, func(string, uint64, []byte) error {
+		return errors.New("writable verification failed")
+	})
+	require.ErrorContains(t, err, "writable verification failed")
+	height, appHash, inspectErr := inspectActivationTestState(filepath.Join(root, journal.LiveName))
+	require.NoError(t, inspectErr)
+	assert.Equal(t, uint64(40), height)
+	assert.Equal(t, oldHash, appHash)
+	assert.NoDirExists(t, filepath.Join(root, journal.PreparedName))
+	assert.NoDirExists(t, filepath.Join(root, journal.QuarantineName))
+	assert.NoFileExists(t, journalPath)
+}
+
+func TestActivationDirectoriesRejectUnsafeOrAmbiguousLayouts(t *testing.T) {
+	t.Run("symlink prepared", func(t *testing.T) {
+		root, journalPath, journal, _, _ := setupActivationDirectories(t)
+		require.NoError(t, os.RemoveAll(filepath.Join(root, journal.PreparedName)))
+		target := filepath.Join(root, "target")
+		writeActivationTestState(t, target, journal.Height, journal.AppHash)
+		require.NoError(t, os.Symlink(target, filepath.Join(root, journal.PreparedName)))
+
+		err := ActivatePreparedDirectory(root, journalPath, journal, verifyActivationTestState)
+		assert.ErrorContains(t, err, "real directory")
+		assert.NoFileExists(t, journalPath)
+		assert.DirExists(t, filepath.Join(root, journal.LiveName))
+	})
+
+	t.Run("all three directories", func(t *testing.T) {
+		root, journalPath, journal, oldHash, _ := setupActivationDirectories(t)
+		require.NoError(t, WriteActivationJournal(journalPath, journal))
+		writeActivationTestState(t, filepath.Join(root, journal.QuarantineName), 40, oldHash)
+
+		_, err := RecoverActivationDirectories(root, journalPath, 40, oldHash, inspectActivationTestState)
+		assert.ErrorContains(t, err, "ambiguous")
+		assert.DirExists(t, filepath.Join(root, journal.LiveName))
+		assert.DirExists(t, filepath.Join(root, journal.PreparedName))
+		assert.DirExists(t, filepath.Join(root, journal.QuarantineName))
+		assert.FileExists(t, journalPath)
+	})
+
+	t.Run("quarantine does not match Comet", func(t *testing.T) {
+		root, journalPath, journal, oldHash, _ := setupActivationDirectories(t)
+		require.NoError(t, ActivatePreparedDirectory(root, journalPath, journal, verifyActivationTestState))
+		wrongHash := sha256.Sum256([]byte("wrong persisted state"))
+
+		_, err := RecoverActivationDirectories(root, journalPath, 40, wrongHash[:], inspectActivationTestState)
+		assert.ErrorContains(t, err, "does not match")
+		assert.DirExists(t, filepath.Join(root, journal.LiveName))
+		assert.DirExists(t, filepath.Join(root, journal.QuarantineName))
+		assert.FileExists(t, journalPath)
+		assert.NotEqual(t, oldHash, wrongHash[:])
+	})
+}

--- a/internal/statesync/activation_directories_test.go
+++ b/internal/statesync/activation_directories_test.go
@@ -109,6 +109,48 @@ func TestActivationDirectoryCrashRecoveryRestoresPersistedCometState(t *testing.
 	}
 }
 
+func TestActivationDirectoryCrashRecoveryRestoresFreshCometState(t *testing.T) {
+	steps := []activationDirectoryStep{
+		activationStepJournalPrepared,
+		activationStepLiveQuarantined,
+		activationStepPreparedLive,
+		activationStepVerified,
+		activationStepPendingComet,
+	}
+	for _, step := range steps {
+		t.Run(string(step), func(t *testing.T) {
+			root := t.TempDir()
+			journal := activationTestJournal()
+			journal.Phase = ActivationPrepared
+			journalPath := filepath.Join(root, "activation.journal")
+			writeActivationTestState(t, filepath.Join(root, journal.LiveName), 0, nil)
+			writeActivationTestState(t, filepath.Join(root, journal.PreparedName), journal.Height, journal.AppHash)
+
+			err := activatePreparedDirectory(root, journalPath, journal, verifyActivationTestState, func(current activationDirectoryStep) error {
+				if current == step {
+					return errSimulatedActivationCrash
+				}
+				return nil
+			})
+			require.ErrorIs(t, err, errSimulatedActivationCrash)
+			action, err := RecoverActivationDirectories(root, journalPath, 0, nil, inspectActivationTestState)
+			require.NoError(t, err)
+			if step == activationStepJournalPrepared {
+				assert.Equal(t, RecoveryDiscardPrepared, action)
+			} else {
+				assert.Equal(t, RecoveryRestoreQuarantine, action)
+			}
+			height, appHash, err := inspectActivationTestState(filepath.Join(root, journal.LiveName))
+			require.NoError(t, err)
+			assert.Zero(t, height)
+			assert.Empty(t, appHash)
+			assert.NoDirExists(t, filepath.Join(root, journal.PreparedName))
+			assert.NoDirExists(t, filepath.Join(root, journal.QuarantineName))
+			assert.NoFileExists(t, journalPath)
+		})
+	}
+}
+
 func TestRecoverActivationDirectoriesSealsCommittedState(t *testing.T) {
 	root, journalPath, journal, _, newHash := setupActivationDirectories(t)
 	require.NoError(t, ActivatePreparedDirectory(root, journalPath, journal, verifyActivationTestState))


### PR DESCRIPTION
## Summary

- add a canonical fsynced activation journal and guarded prepared/live/quarantine directory transaction
- recover interrupted activation against persisted CometBFT height and AppHash before creating or opening the live Badger directory
- add a dormant BootStateSyncRuntime with full-duration ABCI read leases and exclusive complete-bundle replacement
- pin trusted height, AppHash, and app version 20 across activation and sealing
- keep shared SQLite projections process-owned while the runtime owns the active consensus Badger bundle
- document same-chain internet validator scope and the raw Comet TCP reachability requirement

## Safety properties

- crash recovery handles fresh, pre-app-v20, and post-app-v20 quarantine state
- lower-height and same-height conflicting replacement is rejected
- ambiguous paths, symlinks, malformed journals, corrupt fresh stores, and Comet state inconsistencies fail closed
- state-sync endpoints remain empty / reject / no chunk / abort

## Validation

- go test ./... -count=1
- full golangci-lint run ./...
- focused state-sync/runtime race loops
- three independent read-only audits, followed by fix-and-re-review loops; activation and runtime slices green

## Deliberately not release-enabling

This is a v11.9 foundation PR, not the v11.9.0 release. Snapshot endpoint sessions, validator-only reciprocal P2P authorization and join tickets, delayed serving-stack construction, and real multi-process kill/partition/reconfiguration acceptance gates remain open.