### PR TITLE
test: stabilize symmetric firewall proof

### DIFF
--- a/deploy/scripts/run-v11.9-chaos.sh
+++ b/deploy/scripts/run-v11.9-chaos.sh
@@ -1014,20 +1014,30 @@ partition_firewall_packets() {
     awk '$3 == "REJECT" { packets += $1 } END { print packets + 0 }'
 }
 
-wait_partition_firewall_exercised() {
-  local service=$1
-  local timeout=${2:-30}
+wait_partition_firewalls_exercised() {
+  local timeout=${1:-30}
+  shift
+  [ "$#" -gt 0 ] || { echo "ERROR: no partition firewall services supplied" >&2; return 1; }
   local deadline=$((SECONDS + timeout))
-  local packets=0
+  local service packets total snapshot
   while [ "${SECONDS}" -lt "${deadline}" ]; do
-    packets=$(partition_firewall_packets "${service}" 2>/dev/null || echo 0)
-    if [ "${packets}" -gt 0 ]; then
-      echo "${service}: ${FIREWALL_CHAIN} rejected ${packets} P2P packets"
+    total=0
+    snapshot=""
+    for service in "$@"; do
+      packets=$(partition_firewall_packets "${service}" 2>/dev/null || echo 0)
+      total=$((total + packets))
+      snapshot="${snapshot} ${service}=${packets}"
+    done
+    # The rules are symmetric: when one endpoint rejects a packet, its peer
+    # cannot count that same packet. Exact peer-set assertions below prove the
+    # partition on every node; this counter gate proves the rules saw traffic.
+    if [ "${total}" -gt 0 ]; then
+      echo "${FIREWALL_CHAIN} rejected ${total} P2P packets across partition (${snapshot# })"
       return 0
     fi
     sleep 1
   done
-  echo "ERROR: ${service} P2P firewall did not reject any packets within ${timeout}s" >&2
+  echo "ERROR: partition firewalls did not reject any P2P packets within ${timeout}s (${snapshot# })" >&2
   return 1
 }
 
@@ -1520,9 +1530,7 @@ install_partition_firewall cometbft0 "${COMET_IPS[1]}"
 install_partition_firewall cometbft1 "${COMET_IPS[0]}" "${COMET_IPS[2]}" "${COMET_IPS[3]}"
 install_partition_firewall cometbft2 "${COMET_IPS[1]}"
 install_partition_firewall cometbft3 "${COMET_IPS[1]}"
-for service in cometbft0 cometbft1 cometbft2 cometbft3; do
-  wait_partition_firewall_exercised "${service}" 30
-done
+wait_partition_firewalls_exercised 30 cometbft0 cometbft1 cometbft2 cometbft3
 wait_exact_peer_set "${RPC_PORTS[0]}" "$(expected_peer_ids "${NODE_IDS[2]}" "${NODE_IDS[3]}")" 90
 wait_exact_peer_set "${RPC_PORTS[1]}" "$(expected_peer_ids)" 90
 wait_exact_peer_set "${RPC_PORTS[2]}" "$(expected_peer_ids "${NODE_IDS[0]}" "${NODE_IDS[3]}")" 90
@@ -1552,9 +1560,7 @@ install_partition_firewall cometbft0 "${COMET_IPS[2]}" "${COMET_IPS[3]}"
 install_partition_firewall cometbft1 "${COMET_IPS[2]}" "${COMET_IPS[3]}"
 install_partition_firewall cometbft2 "${COMET_IPS[0]}" "${COMET_IPS[1]}"
 install_partition_firewall cometbft3 "${COMET_IPS[0]}" "${COMET_IPS[1]}"
-for service in cometbft0 cometbft1 cometbft2 cometbft3; do
-  wait_partition_firewall_exercised "${service}" 30
-done
+wait_partition_firewalls_exercised 30 cometbft0 cometbft1 cometbft2 cometbft3
 wait_exact_peer_set "${RPC_PORTS[0]}" "$(expected_peer_ids "${NODE_IDS[1]}")" 90
 wait_exact_peer_set "${RPC_PORTS[1]}" "$(expected_peer_ids "${NODE_IDS[0]}")" 90
 wait_exact_peer_set "${RPC_PORTS[2]}" "$(expected_peer_ids "${NODE_IDS[3]}")" 90

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -208,6 +208,33 @@ test('the real-Comet fixture proves governance-domain binding before the long fo
   assert.ok(bindingGate >= 0 && bindingGate < forkLadder);
 });
 
+test('the real-Comet firewall proof allows one symmetric endpoint to count the rejection', () => {
+  assert.match(
+    v119Chaos,
+    /wait_partition_firewalls_exercised\(\)[\s\S]*?for service in "\$@"; do[\s\S]*?total=\$\(\(total \+ packets\)\)[\s\S]*?if \[ "\$\{total\}" -gt 0 \]/,
+  );
+  assert.doesNotMatch(v119Chaos, /wait_partition_firewall_exercised\(\)/);
+  assert.equal(
+    (v119Chaos.match(/wait_partition_firewalls_exercised 30 cometbft0 cometbft1 cometbft2 cometbft3/g) || []).length,
+    2,
+  );
+
+  for (const marker of [
+    '--- fault 1: isolate lower-power validator1',
+    '--- fault 2: post-removal stable-IP 2+2 split',
+  ]) {
+    const start = v119Chaos.indexOf(marker);
+    const counterGate = v119Chaos.indexOf('wait_partition_firewalls_exercised 30', start);
+    const heal = v119Chaos.indexOf('remove_partition_firewall', counterGate);
+    assert.ok(start >= 0 && counterGate > start && heal > counterGate);
+    assert.equal(
+      (v119Chaos.slice(counterGate, heal).match(/wait_exact_peer_set/g) || []).length,
+      4,
+      `${marker} must still prove the exact peer set on every node`,
+    );
+  }
+});
+
 test('all private artifacts converge at one publication gate', () => {
   assert.match(job('goreleaser-prepare'), /release --clean --skip=publish/);
   assert.doesNotMatch(job('docker-image'), /push:\s+true/);


### PR DESCRIPTION
## Summary
- treat iptables reject counters as an aggregate partition-activity proof
- retain per-container firewall rule validation and exact peer-set assertions on all four nodes
- add regression coverage for both fault topologies

## Why
Symmetric endpoint rules mean the endpoint that rejects a packet prevents its peer from counting that same packet. Requiring a nonzero counter on every container was therefore flaky even when the exact peer topology and Comet timeout logs proved the partition.

## Verification
- `bash -n deploy/scripts/run-v11.9-chaos.sh`
- `npm test` (87/87)
- `make v119-chaos` full four-node real Comet/ABCI gate passed
- `git diff --check`

This does not alter or move the immutable `v11.9.0` tag.