### PR TITLE
chore(release): prepare v11.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,20 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
-## What's New in v11.9.0
+## What's New in v11.9.1
+
+**Task creation now applies the `[TASK]` marker exactly once.** MCP `sage_task` and CEREBRUM's task-creation path preserve content that is already marked instead of storing `[TASK] [TASK] ...`; unmarked content still receives the canonical prefix. Direct regression tests cover both entry points and both marked/unmarked inputs.
+
+- **Safer release recovery.** A failed publication can be resumed only from the current protected `main` workflow and always checks out the exact immutable tag. The staged Python wheel smoke test installs declared runtime dependencies before importing the SDK, catching packaging metadata failures before any public channel is touched.
+- **Stronger real-network evidence.** The four-validator partition proof accepts observed reject activity on either symmetric firewall endpoint while still verifying the exact peer topology on every node before, during, and after healing. This removes a timing-sensitive false failure without weakening the partition assertion.
+- **Maintained build and storage stack.** The Go database, compression, TOML, and SQLite dependencies are refreshed through the full race and fault matrix. GitHub's Go, Node, and CodeQL actions are updated and remain pinned to immutable commits.
+
+This patch changes no SAGE consensus rule, AppHash input, transaction type, key encoding, fork target, or application version. App-v20 and the v11.9 rollout boundary are unchanged; existing chains upgrade in place. SDK 11.9.1.
+
+## Older releases
+
+<details>
+<summary>v11.9.0 - scoped consensus and colleague-style federation</summary>
 
 > **Release evidence:** the exact-source `make v119-state-sync` cold run passed on source identity `7080580b15e7e5158a04e8b294ab772e51f294633be2737f904276afec4c3458`. The branch and tag workflows independently rerun the complete race, lint, SDK/frontend, security, fault, packaging, and publication gates before exposing release artifacts.
 
@@ -71,7 +84,7 @@ This is same-chain validator replication, not a relabeling of v11.8 synchronizat
 
 App-v20 remains dormant until the governed upgrade activates it, preserving byte-identical pre-activation replay. A rolling binary install is safe only while the tagged target-20 ceremony has not been submitted. SDK 11.9.0.
 
-## Older releases
+</details>
 
 <details>
 <summary>v11.8.5 - anatomical MRI boundary</summary>
@@ -502,7 +515,7 @@ docker pull ghcr.io/l33tdawg/sage:latest
 docker run -p 8080:8080 -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.9.0`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.9.1`.
 
 ### Upgrading from an older version?
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-07):** **v11.9.0 is the current release.** The exact-source cold state-sync proof passed on the release source, and the complete CI/security/fault matrix remains a mandatory publication invariant. This document keeps v11.8's deferred federated inbox distinct from delivered synchronization groups and looks forward to the v11.10–v11.13 productization bridge and v12. Nothing after v11.9 is promised or dated.
+**Status (2026-07):** **v11.9.1 is the current release.** The exact-source cold state-sync proof passed on the v11.9 release source, and the complete CI/security/fault matrix remains a mandatory publication invariant. This document keeps v11.8's deferred federated inbox distinct from delivered synchronization groups and looks forward to the v11.10–v11.13 productization bridge and v12. Nothing after v11.9 is promised or dated.
 
 **Hard constraint driving the whole plan:** no chain reset, no operator-typed commands. Existing chains must upgrade in place across all future releases.
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.9.0. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.9.1. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -96,7 +96,7 @@ CometBFT without treating the consensus RPC as proof of application storage.
 
 ---
 
-## Related docs (reconciled through v11.9.0)
+## Related docs (reconciled through v11.9.1)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,4 +1,4 @@
-<!-- Core document reconciled through SAGE v11.9.0, including directional cross-chain peer RBAC and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.9.1, including directional cross-chain peer RBAC and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.9.0. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.9.1. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.9.0 code (2026-07-16). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.9.1 code (2026-07-17). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.9.0.
+Reconciled against internal/mcp for SAGE v11.9.1.
 
 # SAGE MCP Tools Reference
 
@@ -450,7 +450,7 @@ verifying memories were committed after storing.
 
 | Name        | Type     | Required | Description |
 |-------------|----------|----------|-------------|
-| `content`   | string   | no*      | Task description. Required when creating. Stored prefixed as `[TASK] <content>`. |
+| `content`   | string   | no*      | Task description. Required when creating. Stored with exactly one `[TASK] ` prefix, including when the input is already marked. |
 | `domain`    | string   | no       | Domain tag. Default: `general`. |
 | `memory_id` | string   | no*      | Existing task memory ID. Required when updating. |
 | `status`    | string   | no       | `planned`, `in_progress`, `done`, `dropped`. Default: `planned`. |

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -444,7 +444,7 @@ verifying memories were committed after storing.
 **Purpose:** Create or update a task in the persistent backlog. Tasks use
 `memory_type: task` and do not decay while open.
 
-**Source:** `tools.go:148-166` (definition), `tools.go:1201-1287` (handler)
+**Source:** `tools.go:161-178` (definition), `tools.go:1475-1589` (prefix helper and handler)
 
 **Parameters:**
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.9.0. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.9.1. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.9.0
+**Package:** `sage-agent-sdk` **Version:** 11.9.1
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.9.0. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.9.1. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "check:js": "node scripts/check-static-js.mjs",
-    "test": "npm run check:js && node --test scripts/cerebrum-shell.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/update-banner.test.mjs"
+    "test": "npm run check:js && node --test scripts/cerebrum-shell.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const root = new URL('../', import.meta.url);
+const read = (path) => readFileSync(new URL(path, root), 'utf8');
+const server = JSON.parse(read('server.json'));
+const version = server.version;
+
+test('release-facing version metadata stays aligned', () => {
+  assert.match(version, /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
+  assert.deepEqual(
+    server.packages.filter(({ registryType }) => registryType === 'oci'),
+    [{
+      registryType: 'oci',
+      identifier: `ghcr.io/l33tdawg/sage:${version}`,
+      transport: { type: 'stdio' },
+    }],
+  );
+
+  const exact = [
+    ['sdk/python/pyproject.toml', `version = "${version}"`],
+    ['sdk/python/src/sage_sdk/__init__.py', `__version__ = "${version}"`],
+    ['web/static/js/app.js', `const SAGE_VERSION = 'v${version}';`],
+    ['README.md', `## What's New in v${version}`],
+    ['README.md', `SDK ${version}.`],
+    ['README.md', `ghcr.io/l33tdawg/sage:${version}`],
+    ['sdk/python/README.md', `SAGE v${version} SDK`],
+    ['docs/reference/INDEX.md', `reconciled for SAGE v${version}`],
+    ['docs/reference/INDEX.md', `reconciled through v${version}`],
+    ['docs/reference/environment-variables.md', `Reconciled through SAGE v${version}`],
+    ['docs/reference/federation-and-brain-api.md', `Verified against SAGE v${version} code`],
+    ['docs/reference/mcp-tools.md', `internal/mcp for SAGE v${version}`],
+    ['docs/reference/python-sdk.md', `Version:** ${version}`],
+    ['docs/reference/rest-api.md', `Reconciled through SAGE v${version}`],
+    ['docs/reference/concepts/rbac-orgs-federation.md', `reconciled through SAGE v${version}`],
+    ['docs/ROADMAP.md', `v${version} is the current release`],
+  ];
+  for (const [path, marker] of exact) {
+    assert.ok(read(path).includes(marker), `${path} is missing current version marker: ${marker}`);
+  }
+});

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.9.0 SDK** | **TLS, RBAC, federation, domain recovery, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.9.1 SDK** | **TLS, RBAC, federation, domain recovery, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.9.0"
+version = "11.9.1"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.9.0"
+__version__ = "11.9.1"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.9.0",
+  "version": "11.9.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.9.0",
+      "identifier": "ghcr.io/l33tdawg/sage:11.9.1",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -23,7 +23,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.9.0';
+const SAGE_VERSION = 'v11.9.1';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
## Summary

- release the idempotent task-marker fix from #86
- include dependency and pinned-action refreshes from #82 and #83
- document the safer release recovery and real-network proof improvements already landed
- align all release-facing metadata at 11.9.1 and add an automated drift test
- refresh the authoritative sage_task source references

## Compatibility

No consensus, AppHash, transaction, key, fork, or application-version change. Existing v11.9.x chains upgrade in place and remain on app-v20.

## Verification

- full Go repository suite with race detector
- JavaScript/static: 88/88
- Python SDK: 120/120
- workflow YAML parse and git diff checks
- wheel/sdist build plus clean wheel import smoke test