### PR TITLE
Release v11.9.2: colleague-style federation management

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,28 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
-## What's New in v11.9.1
+## What's New in v11.9.2
 
-**Task creation now applies the `[TASK]` marker exactly once.** MCP `sage_task` and CEREBRUM's task-creation path preserve content that is already marked instead of storing `[TASK] [TASK] ...`; unmarked content still receives the canonical prefix. Direct regression tests cover both entry points and both marked/unmarked inputs.
+**Federation now behaves like colleague sharing in CEREBRUM.** JOIN establishes exact node/operator trust but shares zero domains by default. Each SAGE independently chooses and changes existing domains for live **Read** or optional **Copy** after pairing; remote **Write** remains explicitly unavailable until a future connection-bound consensus authorization exists.
 
-- **Safer release recovery.** A failed publication can be resumed only from the current protected `main` workflow and always checks out the exact immutable tag. The staged Python wheel smoke test installs declared runtime dependencies before importing the SDK, catching packaging metadata failures before any public channel is touched.
-- **Stronger real-network evidence.** The four-validator partition proof accepts observed reject activity on either symmetric firewall endpoint while still verifying the exact peer topology on every node before, during, and after healing. This removes a timing-sensitive false failure without weakening the partition assertion.
-- **Maintained build and storage stack.** The Go database, compression, TOML, and SQLite dependencies are refreshed through the full race and fault matrix. GitHub's Go, Node, and CodeQL actions are updated and remain pinned to immutable commits.
+- **Connections that stay manageable.** Every active row opens into clear local-versus-remote permissions, current Read/Copy state, and domain selection. Pause temporarily disconnects a colleague without losing the pairing or saved choices; Resume reconnects immediately. Permanent revoke remains available in details, not as everyday clutter, and the peer receives a durable explanation instead of a mysterious failure. Revoked history is collapsed out of the main list.
+- **A shorter, clearer trust ceremony.** The common path is two reciprocal QR scans followed by one six-digit anti-swap fingerprint check per person. The host's redundant pre-confirmation screen is gone; peer identity and the “trust only—no domains shared” boundary now live on the single real confirmation screen. Wide layouts keep both scan cards side by side, while narrow and short screens scroll cleanly around the camera preview.
+- **Fail-closed under races and retries.** JOIN activation, permission replacement, Pause/Resume, revocation, peer notification, stale reconciliation, and policy-label delivery are linearized against the exact CA/operator/epoch agreement generation. An old generation cannot disclose a newly built domain list, overwrite a fresh pairing, resurrect retired access, or clear a concurrent operator Pause.
 
-This patch changes no SAGE consensus rule, AppHash input, transaction type, key encoding, fork target, or application version. App-v20 and the v11.9 rollout boundary are unchanged; existing chains upgrade in place. SDK 11.9.1.
+This patch changes no SAGE consensus rule, AppHash input, transaction type, key encoding, fork target, or application version. App-v20 and the v11.9 rollout boundary are unchanged; existing chains upgrade in place. SDK 11.9.2.
 
 ## Older releases
+
+<details>
+<summary>v11.9.1 - task-marker correctness and release hardening</summary>
+
+**Task creation applies the `[TASK]` marker exactly once.** MCP `sage_task` and CEREBRUM's task-creation path preserve content that is already marked instead of storing `[TASK] [TASK] ...`; unmarked content still receives the canonical prefix. Direct regression tests cover both entry points and both marked/unmarked inputs.
+
+- A failed publication can be resumed only from the current protected `main` workflow and always checks out the exact immutable tag. The staged Python wheel smoke test installs declared runtime dependencies before importing the SDK.
+- The four-validator partition proof accepts observed reject activity on either symmetric firewall endpoint while still verifying the exact peer topology on every node before, during, and after healing.
+- The Go database, compression, TOML, and SQLite dependencies were refreshed through the full race and fault matrix. GitHub's Go, Node, and CodeQL actions remain pinned to immutable commits.
+
+</details>
 
 <details>
 <summary>v11.9.0 - scoped consensus and colleague-style federation</summary>
@@ -515,7 +526,7 @@ docker pull ghcr.io/l33tdawg/sage:latest
 docker run -p 8080:8080 -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.9.1`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.9.2`.
 
 ### Upgrading from an older version?
 

--- a/api/rest/federated_recall_test.go
+++ b/api/rest/federated_recall_test.go
@@ -60,7 +60,7 @@ func (f *fakeFederation) HostSessionStatus(string) (*federation.HostSessionView,
 func (f *fakeFederation) HostApprove(string, string, federation.ScopeWire) error {
 	return errors.New("na")
 }
-func (f *fakeFederation) HostAbort(string) {}
+func (f *fakeFederation) HostAbort(string) error { return nil }
 func (f *fakeFederation) GuestScan(context.Context, string, string) (*federation.GuestScanResult, error) {
 	return nil, errors.New("na")
 }

--- a/api/rest/federation_handler.go
+++ b/api/rest/federation_handler.go
@@ -74,7 +74,12 @@ type federationAgreementMutationLeaser interface {
 	LockAgreementMutation() func()
 }
 
+type federationSyncPolicyGenerationLeaser interface {
+	BeginSyncPolicyGenerationMutation(remoteChainID string) *federation.SyncPolicyGenerationMutation
+}
+
 var _ federationAgreementMutationLeaser = (*federation.Manager)(nil)
+var _ federationSyncPolicyGenerationLeaser = (*federation.Manager)(nil)
 
 func (s *Server) lockFederationAgreementMutation(w http.ResponseWriter) (func(), bool) {
 	leaser, ok := s.federation.(federationAgreementMutationLeaser)
@@ -161,6 +166,13 @@ func (s *Server) handleCrossFedSet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer agreementUnlock()
+	// A raw legacy tx-33 can still replace an agreement used by a pending sync
+	// policy delivery. Quiesce that exact peer while the CA/terms generation is
+	// staged and committed; small handler fakes have no delivery engine.
+	if leaser, hasDelivery := s.federation.(federationSyncPolicyGenerationLeaser); hasDelivery {
+		generation := leaser.BeginSyncPolicyGenerationMutation(req.RemoteChainID)
+		defer generation.Restore()
+	}
 
 	// STAGE the remote CA to a pending sidecar and derive the pin, but do NOT
 	// commit it to the live path until the terms tx is authorized on-chain.
@@ -248,6 +260,37 @@ func (s *Server) handleCrossFedRevoke(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = decodeJSON(r, &req) // reason is optional; an empty body is fine
 
+	// A live Manager owns the complete permanent-disconnect workflow: notify
+	// the exact authenticated peer, revalidate the ceremony generation, commit
+	// tx-34, purge capabilities, and retain a human-readable local event. Keep
+	// the legacy REST transaction path below for deliberately transport-less
+	// deployments and small handler fakes.
+	if notifier, ok := s.federation.(interface {
+		RevokeAgreementNotifying(string) (*federation.RevokeAgreementResult, error)
+	}); ok {
+		result, err := notifier.RevokeAgreementNotifying(remoteChainID)
+		if err != nil {
+			s.logger.Error().Err(err).Str("remote", remoteChainID).Msg("cross_fed notifying revoke rejected")
+			writeProblem(w, http.StatusBadGateway, "Revoke rejected", err.Error())
+			return
+		}
+		if result == nil {
+			writeProblem(w, http.StatusBadGateway, "Revoke rejected", "Federation revoke returned no result.")
+			return
+		}
+		out := map[string]any{
+			"remote_chain_id": remoteChainID,
+			"tx_hash":         result.TxHash,
+			"status":          "revoked",
+			"peer_notified":   result.PeerNotified,
+		}
+		if result.NoticeError != "" {
+			out["notification_warning"] = result.NoticeError
+		}
+		writeJSON(w, http.StatusOK, out)
+		return
+	}
+
 	// Hold the same generation lease as tx-33/JOIN from before tx-34 through
 	// the complete local capability purge. A completed revoke therefore cannot
 	// later delete artifacts belonging to a newer agreement generation.
@@ -291,6 +334,15 @@ func (s *Server) handleCrossFedRevoke(w http.ResponseWriter, r *http.Request) {
 	} else if ss := s.syncStore(); ss != nil {
 		if purgeErr := ss.PurgeSyncPeerState(r.Context(), remoteChainID); purgeErr != nil {
 			s.logger.Warn().Err(purgeErr).Str("remote", remoteChainID).Msg("revoke: sync state purge failed")
+		}
+	}
+	if ss := s.syncStore(); ss != nil {
+		if eventErr := ss.SetFederationConnectionEvent(r.Context(), store.FederationConnectionEvent{
+			RemoteChainID: remoteChainID,
+			Event:         store.FederationConnectionRevokedLocally,
+			Message:       "This operator permanently revoked trust.",
+		}); eventErr != nil {
+			s.logger.Warn().Err(eventErr).Str("remote", remoteChainID).Msg("revoke: connection event write failed")
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]string{

--- a/api/rest/federation_join_handler.go
+++ b/api/rest/federation_join_handler.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -127,7 +128,14 @@ func (s *Server) handleJoinHostAbort(w http.ResponseWriter, r *http.Request) {
 	if !s.federationJoinReady(w, r) {
 		return
 	}
-	s.federation.HostAbort(chi.URLParam(r, "session_id"))
+	if err := s.federation.HostAbort(chi.URLParam(r, "session_id")); err != nil {
+		if errors.Is(err, federation.ErrJoinSessionNotFound) {
+			writeProblem(w, http.StatusNotFound, "Not found", "This connection setup no longer exists.")
+		} else {
+			writeProblem(w, http.StatusConflict, "Confirmation in progress", "This connection is already being confirmed. Check Federation before revoking it.")
+		}
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"session_id": chi.URLParam(r, "session_id"), "status": "aborted"})
 }
 

--- a/api/rest/federation_operator_auth_test.go
+++ b/api/rest/federation_operator_auth_test.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"crypto/ed25519"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,7 +11,19 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/l33tdawg/sage/api/rest/middleware"
+	"github.com/l33tdawg/sage/internal/federation"
 )
+
+type notifyingRevokeFederation struct {
+	*fakeFederation
+	called string
+	result *federation.RevokeAgreementResult
+}
+
+func (f *notifyingRevokeFederation) RevokeAgreementNotifying(chain string) (*federation.RevokeAgreementResult, error) {
+	f.called = chain
+	return f.result, nil
+}
 
 func legacyFederationControlRouter(s *Server, callerID string) http.Handler {
 	r := chi.NewRouter()
@@ -59,5 +72,36 @@ func TestLegacyFederationControlRequiresExactNodeOperator(t *testing.T) {
 		if rr.Code == http.StatusForbidden {
 			t.Fatalf("operator did not cross federation-control gate for %s %s", route.method, route.path)
 		}
+	}
+}
+
+func TestRESTFederationRevokeUsesPeerNotificationWorkflowWhenAvailable(t *testing.T) {
+	driver := &notifyingRevokeFederation{
+		fakeFederation: &fakeFederation{},
+		result: &federation.RevokeAgreementResult{
+			TxHash: "tx-notify", PeerNotified: false, NoticeError: "peer was offline",
+		},
+	}
+	s := &Server{logger: zerolog.Nop(), nodeOperatorID: "node-operator", federation: driver}
+	req := httptest.NewRequest(http.MethodPost, "/v1/federation/cross/chain-peer/revoke", nil)
+	rr := httptest.NewRecorder()
+	legacyFederationControlRouter(s, "node-operator").ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if driver.called != "chain-peer" {
+		t.Fatalf("notifier called with %q", driver.called)
+	}
+	var body struct {
+		Status              string `json:"status"`
+		TxHash              string `json:"tx_hash"`
+		PeerNotified        bool   `json:"peer_notified"`
+		NotificationWarning string `json:"notification_warning"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Status != "revoked" || body.TxHash != "tx-notify" || body.PeerNotified || body.NotificationWarning != "peer was offline" {
+		t.Fatalf("unexpected response: %+v", body)
 	}
 }

--- a/api/rest/server.go
+++ b/api/rest/server.go
@@ -121,7 +121,7 @@ type FederationService interface {
 	HostScanReturn(sessionID, returnURI string) error
 	HostSessionStatus(sessionID string) (*federation.HostSessionView, error)
 	HostApprove(sessionID, typedCode string, grant federation.ScopeWire) error
-	HostAbort(sessionID string)
+	HostAbort(sessionID string) error
 	// Guest side:
 	GuestScan(ctx context.Context, uri, guestEndpoint string) (*federation.GuestScanResult, error)
 	GuestRequest(ctx context.Context, sessionID, guestEndpoint string, scope federation.ScopeWire) (*federation.GuestRequestResult, error)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-07):** **v11.9.1 is the current release.** The exact-source cold state-sync proof passed on the v11.9 release source, and the complete CI/security/fault matrix remains a mandatory publication invariant. This document keeps v11.8's deferred federated inbox distinct from delivered synchronization groups and looks forward to the v11.10–v11.13 productization bridge and v12. Nothing after v11.9 is promised or dated.
+**Status (2026-07):** **v11.9.2 is the current release.** The exact-source cold state-sync proof passed on the v11.9 release source, and the complete CI/security/fault matrix remains a mandatory publication invariant. This document keeps v11.8's deferred federated inbox distinct from delivered synchronization groups and looks forward to the v11.10–v11.13 productization bridge and v12. Nothing after v11.9 is promised or dated.
 
 **Hard constraint driving the whole plan:** no chain reset, no operator-typed commands. Existing chains must upgrade in place across all future releases.
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.9.1. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.9.2. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -96,7 +96,7 @@ CometBFT without treating the consensus RPC as proof of application storage.
 
 ---
 
-## Related docs (reconciled through v11.9.1)
+## Related docs (reconciled through v11.9.2)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,4 +1,4 @@
-<!-- Core document reconciled through SAGE v11.9.1, including directional cross-chain peer RBAC and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.9.2, including directional cross-chain peer RBAC and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.9.1. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.9.2. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.9.1 code (2026-07-17). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.9.2 code (2026-07-17). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 
@@ -11,7 +11,7 @@ v11 adds two independent HTTP surfaces. v11.6 can carry the same mTLS HTTP proto
 
 Federation transport, routing, policy, and foreign recall results are **OFF-consensus**. Borrowed query results are merged into REST responses only and never persisted. Treaty lifecycle reaches chain state through the two operators' own `TxTypeCrossFedSet` (tx-33) and `TxTypeCrossFedRevoke` (tx-34) broadcasts. A peer receipt (Mode-2) reaches chain state as signed bytes inside `TxTypeCoCommitAttest`. Domain-sync copies enter independently as ordinary locally signed `TxTypeMemorySubmit` (tx-1) transactions and pass the receiver's consensus/RBAC gates. Remote Write does **not** enter this path in v11.9: the reserved route returns an authenticated `501` and never dispatches a body to `/v1/memory/submit` (`internal/federation/remote_write.go:41-52`). Trust and authorization checks fail **closed** on an unreachable peer, revoked/expired/unknown agreement, missing remote CA, SPKI pin mismatch, peer-operator mismatch, or absent domain permission; Write remains unavailable regardless of credentials.
 
-**The JOIN ceremony's peer-auth anchor is HUMAN** - an in-person / on-camera QR scan (or a spoken-code fallback). The TOTP factor proves co-possession of a shared seed and 2-of-2 consent; it does **not** prove the secret reached the right peer. Do not read the ceremony as machine-authenticated key exchange.
+**The JOIN ceremony's peer-auth anchor is HUMAN** - an in-person / on-camera QR scan (or a spoken-code fallback). The TOTP factor proves co-possession of a shared seed and bilateral consent; it does **not** prove the secret reached the right peer. Do not read the ceremony as machine-authenticated key exchange. CEREBRUM opens the common guest path directly on the reciprocal scan and progressively discloses remote/address fallbacks. It presents the remaining six-digit value as one short fingerprint check against a swapped or relayed QR, not as another login factor or protocol counter (`web/static/js/app.js`, `GuestJoinWizard`, `FedCodeCompare`).
 
 ### Trust and directional peer RBAC
 
@@ -49,6 +49,17 @@ domain, remove one, or change Read/Copy while the trusted connection stays
 active. A request containing `write:true` is rejected; it is not silently
 converted into an ordinary grant (`web/federation_permissions.go:223-258`).
 
+**Pause sharing** is a local, reversible kill switch for that complete
+directional snapshot. It immediately makes this node's Read and every Copy lane
+(direct, group-native, and relayed) evaluate as deny-all while preserving the
+JOIN trust, group membership, and saved domain choices. The operator may edit
+the dormant choices while paused; Resume activates the latest saved snapshot
+without another ceremony (`internal/store/peer_rbac_policy.go:425-463`;
+`internal/federation/peer_rbac.go:239-255`, `293-320`;
+`internal/federation/sync_outbox.go:318-364`). Pause is intentionally different
+from permanent revocation, which destroys the agreement generation and requires
+a fresh JOIN to reconnect.
+
 An existing v11.8-era trusted connection can migrate without pairing again
 when its original ceremony evidence still identifies the peer unambiguously.
 Legacy guest rows already name the remote host operator. A legacy host row is
@@ -77,8 +88,8 @@ A **separate port and router** from the local API. Started from `cmd/sage-gui/no
 
 | Group | Routes | Middleware | Why |
 |---|---|---|---|
-| Established peers | `status`, `query`, reserved `write`, `receipt`, `p2p/routes`, `sync/*` | `peerAuth` (`internal/federation/server.go:74-220`) | Requires an ACTIVE cross_fed agreement; v11.9 Write then returns `501` |
-| Pre-agreement JOIN | `join/ca`, `join/request`, `join/status`, `join/confirm` | `joinAuth` (`internal/federation/join_routes.go:192-226`) | No agreement exists yet during a join |
+| Established peers | `status`, `query`, reserved `write`, `receipt`, `connection/revoke-notice`, `p2p/routes`, `sync/*` | `peerAuth` (`internal/federation/server.go:74-220`) | Requires an ACTIVE cross_fed agreement; v11.9 Write then returns `501` |
+| Pre-agreement JOIN | `join/ca`, `join/request`, `join/status`, `join/confirm`, `join/abort` | `joinAuth` (`internal/federation/join_routes.go`) | No agreement exists yet during a join |
 
 ### `peerAuth` - the established-peer authenticator (`internal/federation/server.go:74-220`)
 
@@ -115,7 +126,7 @@ Authenticated reachability / identity and permission preflight (`handleStatus`,
 | `chain_id` | string | the serving node's own chain id |
 | `time` | int64 | serving node's unix time |
 | `capabilities` | []string | optional features. v11.9 may advertise `sync`; it never advertises reserved `write-v1` (`internal/federation/server.go:291-315`). |
-| `peer_rbac_grant` | object, optional | the serving node's current `{policy_version, domains:[{domain,read,write,copy}]}` snapshot, disclosed only to the exact bound peer; present with zero rows means deny-all. The versioned `write` member is always false in v11.9 (`internal/federation/peer_rbac.go:270-285`). |
+| `peer_rbac_grant` | object, optional | the serving node's current `{policy_version, paused, domains:[{domain,read,write,copy}]}` snapshot, disclosed only to the exact bound peer; present with zero rows means deny-all. While paused, current peers see `paused:true` and an empty domain list; the empty list also keeps older peers fail-closed. The versioned `write` member is always false in v11.9 (`internal/federation/peer_rbac.go:313-330`). |
 | `sharing_grant` | object, optional | legacy compatibility envelope (`allowed_domains`, `max_clearance`) |
 
 ### `POST /fed/v1/query`
@@ -225,6 +236,7 @@ the consensus path.
 | `GET /fed/v1/join/ca?session_id=…` | `handleJoinCA` (`join_routes.go:237-252`) | Serves the host's own CA PEM to a scanning guest (guest authenticates it by the scanned pin, not the transport). Returns `{chain_id, ca_pem}` (`JoinCAResp`). `404` if no live session. |
 | `POST /fed/v1/join/request` | `handleJoinRequest` (`join_routes.go:254-370`) | Guest -> host. Rejects non-trust-only scope, binds the guest to the session, asserts the presented guest CA SPKI equals the scanned anchor pin, verifies the TLS client cert chains to that CA, and stages (does not commit) the guest CA. |
 | `GET /fed/v1/join/status?session_id=…` | `handleJoinStatus` (`join_routes.go:370-406`) | Guest polls state flags; once the host approves, also returns the fixed compatibility scope. Only the bound client cert may read. |
+| `POST /fed/v1/join/abort` | `handleJoinAbort` (`join_routes.go`) | A bound guest propagates Stop to the host. The exact bound client-cert SPKI is required; active connections must use permanent revoke instead. |
 | `POST /fed/v1/join/confirm` | `handleJoinConfirm` (`join_routes.go:406-440`) | Guest -> host approval #2. Verifies the guest's signatures over the frozen attestation E, then the host broadcasts its tx-33, commits the staged CA + seed, marks ACTIVE. |
 
 Internet enrollment adds `x_sage_transport=p2p`, protocol, peer ID, and up to four complete peer multiaddrs to the otherwise compatible TOTP URI. Parsing is all-or-nothing: the peer ID must match every terminal `/p2p/<id>`, at least one route must contain `/p2p-circuit`, and malformed or partial P2P metadata is rejected. P2P route and peer identity digests are included in the frozen attestation E, so route substitution makes the signed confirmation fail. The spoken codes separately bind the seed, CA pins, session nonces, and step. Temporary pre-agreement stream admission is bounded by session and peer and becomes a durable allowlist entry only after the agreement commits.
@@ -232,6 +244,29 @@ Internet enrollment adds `x_sage_transport=p2p`, protocol, peer ID, and up to fo
 ### `POST /fed/v1/p2p/routes` (established peers)
 
 Authenticated v11.6 peers use this endpoint after a LAN ceremony to exchange `JoinP2PBundle{peer_id, protocol, addrs}`. Both bundles receive the same strict validation as Internet enrollment and are persisted atomically with the runtime allowlist. Older peers return 404 and remain LAN-only; the agreement itself stays valid. Revocation removes the stored route and inbound admission.
+
+### `POST /fed/v1/connection/revoke-notice` (established peers)
+
+Permanent revoke first commits the initiating operator's local tx-34. Only
+after that succeeds does it make one best-effort authenticated call to the
+exact peer, retaining the old CA/seed just long enough to sign that notice and
+purging them on return. This ordering prevents a failed local consensus write
+from revoking only the remote side. The notice carries the current ceremony
+`policy_epoch`; `peerAuth` captures the exact chain/operator/CA/epoch/binding
+generation, and the receiver revalidates that snapshot under the
+agreement-mutation lease before signing its own tx-34. Identical consensus
+terms after a fresh JOIN therefore cannot make an in-flight old request valid
+again. The receiver does not echo a notice, so bilateral and simultaneous
+revokes cannot loop (`internal/federation/revoke_notice.go`;
+`internal/federation/server.go`, `currentRequestAgreementBound`).
+
+Notification failure never rolls back or blocks the initiating operator's
+already-committed local revoke. A startup/tick reconciliation also purges any
+definitively revoked local sync binding left by a process crash between tx-34
+and cleanup; transient authoritative-store read failures leave credentials
+intact and retry rather than being mistaken for revocation. CEREBRUM reports
+whether the live peer was notified and retains a local `revoked_locally` /
+`revoked_by_peer` explanation for the collapsed past-connections audit row.
 
 **`JoinRequestWire`** (guest -> host, `internal/federation/join_routes.go:105-119`):
 `session_id`, `guest_chain`, `guest_agent_id` (hex ed25519), `guest_nonce`
@@ -264,7 +299,7 @@ The node operator's control surface. These routes sit inside the standard `/v1/`
 |---|---|---|---|
 | `POST /v1/federation/cross` | `handleCrossFedSet` (`federation_handler.go:69-193`) | Exact node operator + on-chain authz | Stage remote CA, derive SPKI pin, broadcast tx-33 CrossFedSet with that pin as `PeerPubKey`. |
 | `GET /v1/federation/cross` | `handleCrossFedList` (`federation_handler.go:266-297`) | Exact node operator | List on-chain agreements (reads chain state directly; works without the transport wired). |
-| `POST /v1/federation/cross/{chain_id}/revoke` | `handleCrossFedRevoke` (`federation_handler.go:195-251`) | Exact node operator + on-chain authz | Broadcast tx-34 CrossFedRevoke. |
+| `POST /v1/federation/cross/{chain_id}/revoke` | `handleCrossFedRevoke` (`federation_handler.go:229-318`) | Exact node operator + on-chain authz | Best-effort notify the exact active peer, then broadcast local tx-34 and purge the connection generation. |
 | `GET /v1/federation/cross/{chain_id}/status` | `handleCrossFedPeerStatus` (`federation_handler.go:299-333`) | Exact node operator | Live reachability preflight against the peer's `/fed/v1/status`. |
 | `POST /v1/federation/cross/{chain_id}/write` | `handleCrossFedWrite` (`api/rest/federation_write_handler.go:11-25`) | Ed25519 + exact node operator | Reserved compatibility surface. After operator and chain-id validation it returns `501` before parsing an inner credential or dialing a peer. |
 | `GET/PUT /v1/federation/cross/{chain_id}/sync` | `handleSyncDomainsGet/Set` (`api/rest/federation_handler.go:342-576`, `656-746`) | Ed25519 + exact node operator | Read or replace local v3 Publish/Subscribe lanes; true legacy links retain their `domains` contract. |
@@ -273,10 +308,12 @@ The node operator's control surface. These routes sit inside the standard `/v1/`
 
 Agreement generation changes are process-wide serialized across Manager and
 REST control surfaces. The lease covers tx-33 through its matching CA/JOIN
-activation and tx-34 through local purge; tx-33 also takes the sync-policy
-write side while it replaces the effective generation. The fixed lock order is
-agreement mutation, then sync policy. This prevents set/revoke interleavings
-from deleting or resurrecting the wrong local generation and prevents a
+activation and tx-34 through local purge. It also cancels and joins that exact
+peer's outbound policy-delivery lane; tx-33 then takes the sync-policy write
+side while it replaces the effective generation. The fixed lock order is
+agreement mutation, per-peer policy delivery, then sync policy. This prevents
+set/revoke interleavings from deleting or resurrecting the wrong local
+generation, prevents an E1 policy payload from using fresh E2 credentials, and prevents a
 completed narrowing from leaving an old broad response in flight
 (`internal/federation/manager.go`; `internal/federation/join_routes.go`;
 `api/rest/federation_handler.go`).
@@ -286,6 +323,12 @@ completed narrowing from leaving an old broad response in flight
 `GET /v1/federation/cross` returns `{agreements: []CrossFedListEntry, total}` where each entry (`federation_handler.go:253-264`) carries `remote_chain_id`, `endpoint`, `spki_pin`, `max_clearance`, `allowed_domains`, `allowed_depts`, `expires_at`, `status`, `expired`.
 
 `GET …/status` returns `{remote_chain_id, reachable, peer_time}` on success or `{remote_chain_id, reachable:false, error}` with `502` when unreachable - `reachable` stays a bool across both branches by design.
+
+The notifying revoke response adds `peer_notified` and, when the live notice
+failed, `notification_warning`; local revocation still succeeds. A peer that
+accepts the notice signs and commits its own tx-34 rather than trusting the
+remote node to mutate its chain (`api/rest/federation_handler.go:252-279`;
+`internal/federation/revoke_notice.go:113-150`).
 
 `POST …/write` reserves the path and `RemoteWriteRequest` wire type for
 compatibility and requires the exact configured node operator. In v11.9 the
@@ -337,11 +380,12 @@ Every route 501s when the transport is not wired (`fedReady`,
 | Method + path | Handler | Purpose |
 |---|---|---|
 | `GET /v1/dashboard/federation/shareable-domains` | `handleFedShareableDomains` (`web/federation_permissions.go:30-111`) | List existing registered/observed local domains and whether this operator may share them; never creates a domain. |
-| `GET /v1/dashboard/federation/connections` | `handleFedConnections` (`web/federation_join.go:718`) | List cross_fed agreements from chain state |
-| `GET /v1/dashboard/federation/connections/{chain_id}/permissions` | `handleFedPermissionsGet` (`web/federation_permissions.go:161-220`) | Return editable `local_permissions` and the authenticated peer's read-only `remote_permissions`. |
+| `GET /v1/dashboard/federation/connections` | `handleFedConnections` (`web/federation_join.go:748-800`) | List agreements with `sharing_paused` and durable end-event context for past rows. |
+| `GET /v1/dashboard/federation/connections/{chain_id}/permissions` | `handleFedPermissionsGet` (`web/federation_permissions.go:161-227`) | Return editable `local_permissions`, `local_paused`, and the authenticated peer's read-only permissions/pause state. |
 | `PUT /v1/dashboard/federation/connections/{chain_id}/permissions` | `handleFedPermissionsPut` (`web/federation_permissions.go:254-402`) | Replace this node's complete existing-domain Read/Copy snapshot for the frozen peer. A true `write` field is rejected. |
+| `PUT /v1/dashboard/federation/connections/{chain_id}/pause` | `handleFedPause` (`web/federation_permissions.go:230-270`) | Set `{"paused":true|false}` for this node's directional grant without deleting trust or saved domains. |
 | `GET/PUT /v1/dashboard/federation/connections/{chain_id}/sync` | `handleFedSyncGet/Set` (`web/federation_join.go:344-579`) | Read or change directional copy lanes; current UI changes only the receiver's `subscribe_domains` choice. |
-| `POST /v1/dashboard/federation/connections/{chain_id}/revoke` | `handleFedRevoke` (`web/federation_join.go:757`) | Revoke (drives `RevokeAgreement` -> tx-34 + local seed/CA purge) |
+| `POST /v1/dashboard/federation/connections/{chain_id}/revoke` | `handleFedRevoke` (`web/federation_join.go`) | Commit local tx-34, best-effort notify the peer with the retained exact old credentials, purge locally, and return notification status. |
 | `GET /v1/dashboard/federation/connections/{chain_id}/status` | `handleFedPeerStatus` (`web/federation_join.go:778`) | Peer reachability preflight |
 | `POST /v1/dashboard/federation/join/host/create` | `handleFedHostCreate` (`web/federation_join.go:795`) | Host H1; body includes `transport` (`lan` or `internet`) |
 | `POST /v1/dashboard/federation/join/host/scan-return` | `handleFedHostScanReturn` (`web/federation_join.go:827`) | Host scans guest return QR |
@@ -351,11 +395,26 @@ Every route 501s when the transport is not wired (`fedReady`,
 | `POST /v1/dashboard/federation/join/guest/scan` | `handleFedGuestScan` (`web/federation_join.go:896`) | Guest scan host QR |
 | `POST /v1/dashboard/federation/join/guest/request` | `handleFedGuestRequest` (`web/federation_join.go:918`) | Guest request |
 | `GET /v1/dashboard/federation/join/guest/{session_id}/status` | `handleFedGuestStatus` (`web/federation_join.go:949`) | Guest poll host approval |
+| `POST /v1/dashboard/federation/join/guest/{session_id}/abort` | `handleFedGuestAbort` (`web/federation_join.go`) | Propagate a guest-side Stop and zeroize the local draft |
 | `POST /v1/dashboard/federation/join/guest/confirm` | `handleFedGuestConfirm` (`web/federation_join.go:963`) | Guest approval #2 |
 
 (JOIN handlers live in `web/federation_join.go`.) Except for the dashboard-only
 host `transport` choice and its fixed trust-only compatibility scope, the join
 request/response bodies mirror the operator REST bodies of §2.
+
+CEREBRUM treats this as an admin-management surface: active connection rows
+open their Read/Copy details and expose the everyday Pause/Resume action;
+permanent Revoke lives inside the expanded danger section. Revoked/expired rows
+are retained for accountability but collapsed under `Past connections` by
+default, avoiding dead-row clutter. A peer-originated revoke also produces an
+immediate toast plus a persistent dismissible explanation above the collapsed
+history, and a failed poll retains the last good rows and any unsaved permission
+draft instead of rendering a false empty state (`web/static/js/app.js`,
+`FederationPage`). On a wide viewport the initial host exchange shows “they scan
+this SAGE” and “scan their SAGE back” side by side; it stacks into the page's
+real vertical scroll container on narrow/short viewports and bounds the camera
+preview so it cannot be cut off (`web/static/js/app.js:11928-11950`;
+`web/static/css/sage.css:4597-4604`, `4726-4753`, `4870-4892`).
 
 The permissions `PUT` body is
 `{"permissions":[{"domain":"tii.work","read":true,"write":false,"copy":true}]}`.
@@ -425,7 +484,7 @@ and publishes that domain. The receiver independently decides whether to retain
 it in local `subscribe_domains`. Effective source egress is:
 
 ```
-source PeerRBAC Copy ∩ source Publish ∩ receiver Subscribe
+connection not paused ∩ source PeerRBAC Copy ∩ source Publish ∩ receiver Subscribe
 ```
 
 Receiver admission independently rechecks `remote Publish ∩ local Subscribe`.
@@ -446,6 +505,18 @@ peer-RBAC `Copy` rows while preserving the receiver's separate Subscribe lane
 (`web/federation_permissions.go:600-615`). `SetDirectionalSyncPolicy` also
 rejects any v3 Publish domain that lacks the source's current `Copy` grant, so a
 caller cannot bypass the permissions UI (`internal/federation/sync_policy.go:252-306`).
+
+The permission and lane snapshots can still be edited while paused; those are
+local configuration changes, while effective network authorization stays
+deny-all until Resume. Pending directional policy—including its domain
+labels—is withheld from the peer while paused, and Resume nudges delivery of
+only the latest saved revision. Policy delivery is bounded, uses the exact
+agreement snapshot that produced its payload, and is canceled/joined by Pause,
+revoke, or re-pair before their generation change completes. Claimed Copy work
+remains retryable rather than being terminally rejected if Pause races a drain.
+The same per-edge pause gate runs before group-owner and relay routing, so group
+membership cannot bypass an operator's temporary stop
+(`internal/federation/sync_outbox.go`; `internal/federation/sync_policy.go`).
 
 ### `PUT /fed/v1/sync/policy` (peer-facing, behind `peerAuth`)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.9.1.
+Reconciled against internal/mcp for SAGE v11.9.2.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.9.1. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.9.2. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.9.1
+**Package:** `sage-agent-sdk` **Version:** 11.9.2
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.9.1. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.9.2. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/internal/federation/agreement_sharing.go
+++ b/internal/federation/agreement_sharing.go
@@ -59,6 +59,8 @@ func (m *Manager) UpdateAgreementSharing(remoteChainID string, domains []string)
 
 	m.agreementMutationMu.Lock()
 	defer m.agreementMutationMu.Unlock()
+	generation := m.BeginSyncPolicyGenerationMutation(remoteChainID)
+	defer generation.Restore()
 	// Legacy tx-33 terms are still the effective read policy until a peer is
 	// upgraded to directional RBAC. Take the same write side used by peer
 	// handlers before resolving the current terms and retain it through the

--- a/internal/federation/join_agreement_mutation_test.go
+++ b/internal/federation/join_agreement_mutation_test.go
@@ -27,8 +27,8 @@ func TestJoinStopCannotOverwriteConfirming(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CheckConfirm: %v", err)
 	}
-	if err := node.mgr.HostAbort(sessionID); !errors.Is(err, ErrJoinAbortConflict) {
-		t.Fatalf("HostAbort after confirm = %v, want conflict", err)
+	if abortErr := node.mgr.HostAbort(sessionID); !errors.Is(abortErr, ErrJoinAbortConflict) {
+		t.Fatalf("HostAbort after confirm = %v, want conflict", abortErr)
 	}
 	body, marshalErr := json.Marshal(JoinAbortWire{SessionID: sessionID})
 	if marshalErr != nil {
@@ -45,8 +45,8 @@ func TestJoinStopCannotOverwriteConfirming(t *testing.T) {
 	if err != nil || view.State != JoinConfirming {
 		t.Fatalf("state after rejected Stops = %q err=%v, want %s", view.State, err, JoinConfirming)
 	}
-	if err := joins.MarkActive(sessionID); err != nil {
-		t.Fatalf("MarkActive: %v", err)
+	if activeErr := joins.MarkActive(sessionID); activeErr != nil {
+		t.Fatalf("MarkActive: %v", activeErr)
 	}
 	view, err = node.mgr.HostSessionStatus(sessionID)
 	if err != nil || !view.Active || view.State != JoinActive {

--- a/internal/federation/join_agreement_mutation_test.go
+++ b/internal/federation/join_agreement_mutation_test.go
@@ -1,13 +1,113 @@
 package federation
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/l33tdawg/sage/internal/tx"
 )
+
+// TestJoinStopCannotOverwriteConfirming pins the operator-facing race: once a
+// verified confirm atomically owns the session, neither local nor peer Stop may
+// return success and overwrite it with ABORTED while activation continues.
+func TestJoinStopCannotOverwriteConfirming(t *testing.T) {
+	node := newCeremonyNode(t, "host-stop")
+	joins, sessionID, certSPKI, attestation, guestKey, _ := approvedSession(t)
+	node.mgr.joins = joins
+	_, err := joins.CheckConfirm(sessionID, certSPKI,
+		SignEnroll(guestKey, attestation, false),
+		SignEnroll(guestKey, attestation, true), time.Now())
+	if err != nil {
+		t.Fatalf("CheckConfirm: %v", err)
+	}
+	if err := node.mgr.HostAbort(sessionID); !errors.Is(err, ErrJoinAbortConflict) {
+		t.Fatalf("HostAbort after confirm = %v, want conflict", err)
+	}
+	body, marshalErr := json.Marshal(JoinAbortWire{SessionID: sessionID})
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/fed/v1/join/abort", bytes.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), joinCertSPKIKey{}, certSPKI))
+	rr := httptest.NewRecorder()
+	node.mgr.handleJoinAbort(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("bound guest Abort HTTP status=%d body=%s, want 409", rr.Code, rr.Body.String())
+	}
+	view, err := node.mgr.HostSessionStatus(sessionID)
+	if err != nil || view.State != JoinConfirming {
+		t.Fatalf("state after rejected Stops = %q err=%v, want %s", view.State, err, JoinConfirming)
+	}
+	if err := joins.MarkActive(sessionID); err != nil {
+		t.Fatalf("MarkActive: %v", err)
+	}
+	view, err = node.mgr.HostSessionStatus(sessionID)
+	if err != nil || !view.Active || view.State != JoinActive {
+		t.Fatalf("final state = %+v err=%v", view, err)
+	}
+}
+
+func TestHostConfirmPreActivationFailuresLeaveRestartableTerminalSession(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, node *ceremonyNode, joins *JoinStore, sessionID string)
+	}{
+		{
+			name: "prepare sync control",
+			setup: func(t *testing.T, node *ceremonyNode, _ *JoinStore, _ string) {
+				t.Helper()
+				if err := node.mgr.syncStore().Close(); err != nil {
+					t.Fatalf("close SQLite failure seam: %v", err)
+				}
+			},
+		},
+		{
+			name: "missing P2P persistence",
+			setup: func(t *testing.T, _ *ceremonyNode, joins *JoinStore, sessionID string) {
+				t.Helper()
+				joins.mu.Lock()
+				joins.sessions[sessionID].ExpectedGuestP2P = []string{"/ip4/203.0.113.10/tcp/4001"}
+				joins.mu.Unlock()
+			},
+		},
+		{
+			name: "tx33 broadcast",
+			setup: func(_ *testing.T, node *ceremonyNode, _ *JoinStore, _ string) {
+				node.mgr.broadcastFn = func([]byte) (string, int64, error) {
+					return "", 0, errors.New("forced tx33 failure")
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node := newCeremonyNode(t, "host-xxxxx")
+			joins, sessionID, certSPKI, attestation, guestKey, _ := approvedSession(t)
+			node.mgr.joins = joins
+			tc.setup(t, node, joins, sessionID)
+			_, _, err := node.mgr.hostConfirm(sessionID, certSPKI,
+				SignEnroll(guestKey, attestation, false),
+				SignEnroll(guestKey, attestation, true), "")
+			if err == nil {
+				t.Fatal("hostConfirm unexpectedly succeeded")
+			}
+			view, statusErr := node.mgr.HostSessionStatus(sessionID)
+			if statusErr != nil || view.State != JoinAborted || view.Active {
+				t.Fatalf("failed confirm state=%+v err=%v, want ABORTED", view, statusErr)
+			}
+			if stopErr := node.mgr.HostAbort(sessionID); stopErr != nil {
+				t.Fatalf("Stop after failed confirm must be honest and idempotent: %v", stopErr)
+			}
+		})
+	}
+}
 
 // TestHostConfirmAgreementLeaseSpansLocalActivation pins the gap that used to
 // exist after JOIN's tx-33 commit: revocation must not commit and purge while

--- a/internal/federation/join_ceremony_test.go
+++ b/internal/federation/join_ceremony_test.go
@@ -88,6 +88,11 @@ func newCeremonyNode(t *testing.T, chainID string) *ceremonyNode {
 				return "", 0, setErr
 			}
 		}
+		if parsed.Type == tx.TxTypeCrossFedRevoke && parsed.CrossFedRevoke != nil {
+			if revokeErr := badger.UpdateCrossFedStatus(parsed.CrossFedRevoke.RemoteChainID, "revoked"); revokeErr != nil {
+				return "", 0, revokeErr
+			}
+		}
 		node.mu.Lock()
 		node.broadcasts++
 		node.mu.Unlock()

--- a/internal/federation/join_routes.go
+++ b/internal/federation/join_routes.go
@@ -150,6 +150,13 @@ type JoinConfirmWire struct {
 	GroupInviteProof string `json:"group_invite_proof"` // invitee signature over exact group identity + signed scope
 }
 
+// JoinAbortWire lets the already-bound guest end the host's copy of an
+// unfinished ceremony. It carries no secret; joinAuth plus the exact bound
+// client-certificate SPKI is the authorization.
+type JoinAbortWire struct {
+	SessionID string `json:"session_id"`
+}
+
 // JoinConfirmResp reports the host's activation.
 type JoinConfirmResp struct {
 	Status        string                    `json:"status"`
@@ -180,6 +187,7 @@ func (m *Manager) mountJoinRoutes(r chi.Router) {
 		r.Use(m.joinAuth(false))
 		r.Post("/fed/v1/join/request", m.handleJoinRequest)
 		r.Post("/fed/v1/join/confirm", m.handleJoinConfirm)
+		r.Post("/fed/v1/join/abort", m.handleJoinAbort)
 	})
 	// Read-only routes: generous rate limit so a bound guest's ~2s status poll
 	// over a multi-minute ceremony is never throttled (the stuck-guest bug).
@@ -403,6 +411,34 @@ func (m *Manager) handleJoinStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// handleJoinAbort propagates a guest-side Stop decision so the host does not
+// sit on an unexplained waiting screen. Only the certificate pinned by the
+// bound request may burn that session; unknown and pre-bind sessions are not
+// remotely abortable.
+func (m *Manager) handleJoinAbort(w http.ResponseWriter, r *http.Request) {
+	var req JoinAbortWire
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || strings.TrimSpace(req.SessionID) == "" {
+		httpError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	err := m.joins.AbortBound(req.SessionID, joinCertSPKI(r.Context()))
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrJoinSessionNotFound):
+			httpError(w, http.StatusNotFound, "no such join session")
+		case errors.Is(err, ErrJoinAbortUnbound):
+			httpError(w, http.StatusForbidden, "abort from an unbound client certificate")
+		default:
+			httpError(w, http.StatusConflict, "connection confirmation is already in progress; check Federation before revoking")
+		}
+		return
+	}
+	if end := m.joinP2PHooks().End; end != nil {
+		end(req.SessionID)
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "aborted"})
+}
+
 // handleJoinConfirm verifies the guest's approval-#2 signatures over the FROZEN
 // E, then broadcasts the host's tx-33, commits the staged guest CA + seed, and
 // marks the session ACTIVE. This is the host's half of the 2-of-2 gate.
@@ -455,6 +491,13 @@ func (m *Manager) hostConfirm(sessionID string, certSPKI, guestSig, guestAckSig 
 	// the nested gate explicitly around the consensus generation change.
 	agreementUnlock := m.LockAgreementMutation()
 	defer agreementUnlock()
+	generation := m.BeginSyncPolicyGenerationMutation(ctx.GuestChain)
+	defer generation.Restore()
+	// Every return before MarkActive must terminate CONFIRMING. FailConfirm is
+	// state-conditional, so it becomes a no-op after successful activation and
+	// safely covers preparation, route persistence, and tx-33 failures without
+	// duplicating a fragile rollback call at every branch.
+	defer m.joins.FailConfirm(sessionID)
 	epoch := syncPolicyEpoch(ctx.ApprovedE)
 	if ss := m.syncStore(); ss != nil {
 		if prepareErr := ss.PrepareSyncControl(context.Background(), store.SyncControl{
@@ -532,7 +575,10 @@ func (m *Manager) hostConfirm(sessionID string, certSPKI, guestSig, guestAckSig 
 	if err := m.initializePeerRBACPolicy(context.Background(), ctx.GuestChain); err != nil {
 		return m.undoPartialHostConfirmLocked(sessionID, ctx, "peer RBAC initialization failed", err)
 	}
-	m.joins.MarkActive(sessionID)
+	if activeErr := m.joins.MarkActive(sessionID); activeErr != nil {
+		return m.undoPartialHostConfirmLocked(sessionID, ctx, "join session activation failed", activeErr)
+	}
+	generation.Activate()
 	if hooks.End != nil {
 		hooks.End(sessionID)
 	}
@@ -582,7 +628,7 @@ func (m *Manager) undoPartialHostConfirmLocked(sessionID string, ctx *ConfirmCon
 		m.logger.Error().Err(rErr).Str("guest", ctx.GuestChain).Msg("revoke after partial host confirm failed - manual cleanup may be needed")
 	}
 	ctx.RollbackGuestCA()
-	m.joins.Abort(sessionID)
+	m.joins.FailConfirm(sessionID)
 	return "", "", fmt.Errorf("%s after broadcast; agreement revoked: %w", what, cause)
 }
 
@@ -643,7 +689,7 @@ func (m *Manager) HostCreateMode(hostEndpoint string, requireP2P bool) (*HostCre
 		}
 	}
 	if requireP2P && transport != "p2p" {
-		m.joins.Abort(js.ID)
+		_ = m.joins.Abort(js.ID)
 		return nil, fmt.Errorf("internet connection is not ready: enable P2P and wait for a relay reservation")
 	}
 	return &HostCreateResult{
@@ -764,12 +810,17 @@ func (m *Manager) HostApprove(sessionID, typedCode string, grant ScopeWire) erro
 	return err
 }
 
-// HostAbort burns a session (H4 "No" / operator ignore).
-func (m *Manager) HostAbort(sessionID string) {
-	m.joins.Abort(sessionID)
+// HostAbort burns a pre-confirm session (H4 "No" / operator ignore). Once a
+// verified confirm owns the session, callers receive a conflict instead of a
+// misleading successful Stop while activation continues.
+func (m *Manager) HostAbort(sessionID string) error {
+	if err := m.joins.Abort(sessionID); err != nil {
+		return err
+	}
 	if end := m.joinP2PHooks().End; end != nil {
 		end(sessionID)
 	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1149,6 +1200,34 @@ func (m *Manager) GuestPollStatus(ctx context.Context, sessionID string) (*JoinS
 	return &resp, nil
 }
 
+// GuestAbort tells the host why this side stopped, then zeroizes the local
+// draft regardless of transport success. It is intentionally limited to the
+// requested state: once activation starts, GuestConfirm owns recovery and a
+// normal connection must use the explicit revoke path.
+func (m *Manager) GuestAbort(ctx context.Context, sessionID string) error {
+	m.guestConfirmMu.Lock()
+	defer m.guestConfirmMu.Unlock()
+	d, ok := m.getGuestDraft(sessionID)
+	if !ok {
+		return fmt.Errorf("no scanned connection for this session (re-scan)")
+	}
+	if d.state != guestDraftScanned && d.state != guestDraftRequested {
+		return fmt.Errorf("connection ceremony cannot be stopped in state %s", d.state)
+	}
+	defer m.dropGuestDraft(sessionID, d.generation)
+	if d.state == guestDraftScanned {
+		// The host has not bound this guest certificate yet, so there is no
+		// authenticated remote session we are allowed to abort. Local zeroization
+		// is the complete cancellation at this stage.
+		return nil
+	}
+	var resp map[string]string
+	if err := m.guestCall(ctx, d, http.MethodPost, "/fed/v1/join/abort", &JoinAbortWire{SessionID: sessionID}, &resp); err != nil {
+		return fmt.Errorf("tell peer the connection was stopped: %w", err)
+	}
+	return nil
+}
+
 // GuestConfirm is approval #2: it computes E, broadcasts the guest's OWN tx-33
 // first (guest-first activation, RT-7), then POSTs /fed/v1/join/confirm so the
 // host activates its side. hostScope is what the guest polled from /join/status.
@@ -1231,6 +1310,8 @@ func (m *Manager) GuestConfirm(ctx context.Context, sessionID, guestEndpoint str
 		txHash, err = func() (string, error) {
 			agreementUnlock := m.LockAgreementMutation()
 			defer agreementUnlock()
+			generation := m.BeginSyncPolicyGenerationMutation(d.hostChain)
+			defer generation.Restore()
 
 			if ss := m.syncStore(); ss != nil {
 				if prepareErr := ss.PrepareSyncControl(context.Background(), store.SyncControl{
@@ -1303,6 +1384,7 @@ func (m *Manager) GuestConfirm(ctx context.Context, sessionID, guestEndpoint str
 				_, _ = m.revokeAgreementLocked(d.hostChain)
 				return "", fmt.Errorf("peer RBAC initialization failed; agreement rolled back: %w", initErr)
 			}
+			generation.Activate()
 			return activatedHash, nil
 		}()
 		if err != nil {
@@ -1447,15 +1529,36 @@ func (m *Manager) broadcastCrossFedSetLocked(terms *tx.CrossFedTerms) (string, e
 // nothing on disk (consensus cannot touch node-local files); the purge is the
 // off-consensus half.
 func (m *Manager) RevokeAgreement(remoteChainID string) (string, error) {
-	agreementUnlock := m.LockAgreementMutation()
-	defer agreementUnlock()
-	return m.revokeAgreementLocked(remoteChainID)
+	result, err := m.RevokeAgreementNotifying(remoteChainID)
+	if result == nil {
+		return "", err
+	}
+	return result.TxHash, err
 }
 
 // revokeAgreementLocked commits tx-34 and purges all matching node-local
 // capabilities while the caller owns agreementMutationMu. JOIN rollback uses
 // this form to avoid recursively acquiring the non-reentrant agreement lease.
 func (m *Manager) revokeAgreementLocked(remoteChainID string) (string, error) {
+	return m.revokeAgreementLockedReason(remoteChainID, "operator disconnect")
+}
+
+func (m *Manager) revokeAgreementLockedReason(remoteChainID, reason string) (string, error) {
+	hash, err := m.broadcastRevokeAgreementLockedReason(remoteChainID, reason)
+	if err != nil {
+		return "", err
+	}
+	// Caller holds the matching SyncPolicyGenerationMutation through this purge.
+	m.purgeLocalFederationStateQuiesced(remoteChainID)
+	return hash, nil
+}
+
+// broadcastRevokeAgreementLockedReason commits tx-34 but deliberately leaves
+// the old node-local authentication material intact. The notifying revoke path
+// uses that short fail-closed window to tell the peer only after local consensus
+// has succeeded, then purges in a defer. ActiveAgreement already denies the
+// revoked edge during the window, so retained files cannot authorize requests.
+func (m *Manager) broadcastRevokeAgreementLockedReason(remoteChainID, reason string) (string, error) {
 	if err := ValidateChainID(remoteChainID); err != nil {
 		return "", err
 	}
@@ -1472,7 +1575,7 @@ func (m *Manager) revokeAgreementLocked(remoteChainID string) (string, error) {
 		Timestamp: time.Unix(ts, 0),
 		CrossFedRevoke: &tx.CrossFedRevoke{
 			RemoteChainID: remoteChainID,
-			Reason:        "operator disconnect",
+			Reason:        reason,
 		},
 		AgentPubKey:    m.agentPub,
 		AgentSig:       agentSig,
@@ -1490,7 +1593,6 @@ func (m *Manager) revokeAgreementLocked(remoteChainID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	m.PurgeLocalFederationState(remoteChainID)
 	return hash, nil
 }
 
@@ -1498,6 +1600,14 @@ func (m *Manager) revokeAgreementLocked(remoteChainID string) (string, error) {
 // with a revoked agreement. REST's independently-broadcast revoke calls this
 // same helper so no control surface leaves routes or sync authority behind.
 func (m *Manager) PurgeLocalFederationState(remoteChainID string) {
+	generation := m.BeginSyncPolicyGenerationMutation(remoteChainID)
+	defer generation.Retire()
+	m.purgeLocalFederationStateQuiesced(remoteChainID)
+}
+
+// purgeLocalFederationStateQuiesced is the destructive half used by callers
+// that already own the per-peer generation-delivery lease across tx-34.
+func (m *Manager) purgeLocalFederationStateQuiesced(remoteChainID string) {
 	// Off-consensus purge (zeroize seed cache + delete seed files + drop cached CA).
 	m.purgeSeed(remoteChainID)
 	m.invalidateCACache(remoteChainID)

--- a/internal/federation/joinsession.go
+++ b/internal/federation/joinsession.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base32"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -108,6 +109,19 @@ const (
 )
 
 var joinB32 = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+var (
+	// ErrJoinSessionNotFound distinguishes an already-reaped/unknown ceremony
+	// from a valid session whose state no longer permits a Stop decision.
+	ErrJoinSessionNotFound = errors.New("join session not found")
+	// ErrJoinAbortConflict means confirmation has already crossed the atomic
+	// commit boundary (CONFIRMING or ACTIVE), so reporting a successful Stop
+	// would be false and could surprise the operator with an active pairing.
+	ErrJoinAbortConflict = errors.New("join session can no longer be stopped")
+	// ErrJoinAbortUnbound prevents one guest certificate from burning another
+	// guest's ceremony.
+	ErrJoinAbortUnbound = errors.New("join abort certificate is not bound to this session")
+)
 
 // JoinStore is the host-side session registry: TTL'd, single-ceremony, with a
 // per-session fail cap and a TLS-connection rate limiter (never XFF, RT-3).
@@ -571,31 +585,83 @@ func (js *JoinSession) scrubSeed() {
 	}
 }
 
-// MarkActive transitions to ACTIVE after the host broadcasts its tx-33 (the
-// staged guest CA is committed by the driver first).
-func (s *JoinStore) MarkActive(id string) {
+// MarkActive transitions CONFIRMING to ACTIVE after the host broadcasts its
+// tx-33 (the staged guest CA is committed by the driver first). The state
+// condition is deliberately checked under the same lock as Abort: neither a
+// late Stop nor an unrelated terminal transition may be overwritten.
+func (s *JoinStore) MarkActive(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if js, ok := s.sessions[id]; ok {
-		js.State = JoinActive
-		js.rollbackGuestCA = nil // committed; do not roll back on later cleanup
-		js.commitGuestCA = nil
-		js.scrubSeed() // persistent seed is committed; drop the ceremony copy now
+	js, ok := s.sessions[id]
+	if !ok {
+		return ErrJoinSessionNotFound
 	}
+	if js.State != JoinConfirming {
+		return fmt.Errorf("activate join from %s: %w", js.State, ErrJoinAbortConflict)
+	}
+	js.State = JoinActive
+	js.rollbackGuestCA = nil // committed; do not roll back on later cleanup
+	js.commitGuestCA = nil
+	js.scrubSeed() // persistent seed is committed; drop the ceremony copy now
+	return nil
 }
 
-// Abort marks a session aborted (burned on a human "No" or an error) and rolls
-// back any staged-but-uncommitted guest CA sidecar.
-func (s *JoinStore) Abort(id string) {
+// abortLocked performs the human Stop transition. CONFIRMING is already owned
+// by the confirm driver and ACTIVE must use permanent revocation, so both are
+// conflicts rather than false-success ABORTED responses.
+func (s *JoinStore) abortLocked(js *JoinSession) error {
+	switch js.State {
+	case JoinAborted:
+		return nil // idempotent Stop
+	case JoinConfirming, JoinActive:
+		return fmt.Errorf("join session is %s: %w", js.State, ErrJoinAbortConflict)
+	case JoinExpired:
+		return fmt.Errorf("join session is expired: %w", ErrJoinAbortConflict)
+	}
+	if js.rollbackGuestCA != nil {
+		js.rollbackGuestCA()
+		js.rollbackGuestCA = nil
+		js.commitGuestCA = nil
+	}
+	js.scrubSeed()
+	js.State = JoinAborted
+	return nil
+}
+
+// Abort atomically burns a locally controlled, pre-confirm session.
+func (s *JoinStore) Abort(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if js, ok := s.sessions[id]; ok {
-		if js.State != JoinActive && js.rollbackGuestCA != nil {
-			js.rollbackGuestCA()
-			js.rollbackGuestCA = nil
-			js.commitGuestCA = nil
-		}
-		js.scrubSeed() // burned session: don't leave the seed lingering until reap
+	js, ok := s.sessions[id]
+	if !ok {
+		return ErrJoinSessionNotFound
+	}
+	return s.abortLocked(js)
+}
+
+// AbortBound combines guest-certificate authorization and the Stop transition
+// in one critical section, closing the Get -> check -> Abort race with confirm.
+func (s *JoinStore) AbortBound(id string, certSPKI []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	js, ok := s.sessions[id]
+	if !ok {
+		return ErrJoinSessionNotFound
+	}
+	if len(js.BoundCertSPKI) == 0 || subtle.ConstantTimeCompare(js.BoundCertSPKI, certSPKI) != 1 {
+		return ErrJoinAbortUnbound
+	}
+	return s.abortLocked(js)
+}
+
+// FailConfirm is the driver's internal rollback path after CheckConfirm has
+// transferred ownership of the staged artifacts. It is intentionally not used
+// by operator-facing Stop routes.
+func (s *JoinStore) FailConfirm(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if js, ok := s.sessions[id]; ok && js.State == JoinConfirming {
+		js.scrubSeed()
 		js.State = JoinAborted
 	}
 }

--- a/internal/federation/manager.go
+++ b/internal/federation/manager.go
@@ -22,6 +22,132 @@ import (
 // commit timeout).
 const maxConcurrentReceiptBroadcasts = 4
 
+// syncPolicyDeliveryLease is per peer: one unreachable colleague must never
+// delay the admin from pausing another. Pause intent is published before the
+// lease is acquired so it can cancel an in-flight same-peer PUT immediately.
+type syncPolicyDeliveryLease struct {
+	mu               sync.Mutex
+	stateMu          sync.Mutex
+	pauseRequested   bool
+	pauseRevision    uint64
+	pauseMutations   int
+	pendingPauses    int
+	generationBlocks int
+	cancel           context.CancelFunc
+}
+
+// SyncPolicyGenerationMutation blocks and cancels outbound policy-label
+// delivery for one peer while an agreement generation is replaced or retired.
+// Call exactly one terminal method. Methods are idempotent so deferred Restore
+// can safely guard early returns before Activate/Retire succeeds.
+type SyncPolicyGenerationMutation struct {
+	lease         *syncPolicyDeliveryLease
+	pauseRevision uint64
+	once          sync.Once
+}
+
+func (g *SyncPolicyGenerationMutation) finish(resetOperatorPause bool) {
+	if g == nil || g.lease == nil {
+		return
+	}
+	g.once.Do(func() {
+		g.lease.stateMu.Lock()
+		if resetOperatorPause && g.lease.pauseRevision == g.pauseRevision && g.lease.pauseMutations == 0 {
+			// A fresh JOIN starts with an empty, unpaused deny-all policy. Never
+			// inherit the retired connection's steady in-memory Pause intent, but
+			// never erase a Pause/Resume that began while this generation held
+			// the delivery lease.
+			if g.lease.pauseRequested {
+				g.lease.pauseRequested = false
+				g.lease.pauseRevision++
+			}
+		}
+		if g.lease.generationBlocks > 0 {
+			g.lease.generationBlocks--
+		}
+		g.lease.stateMu.Unlock()
+		g.lease.mu.Unlock()
+	})
+}
+
+// Restore releases a failed generation mutation without touching the
+// operator's independent Pause/Resume intent.
+func (g *SyncPolicyGenerationMutation) Restore() { g.finish(false) }
+
+// Activate releases a completely installed active generation for delivery.
+func (g *SyncPolicyGenerationMutation) Activate() { g.finish(true) }
+
+// Retire releases a purged/revoked generation while keeping delivery blocked.
+func (g *SyncPolicyGenerationMutation) Retire() { g.finish(false) }
+
+// beginPauseMutation publishes one operator mutation before waiting on the
+// delivery lease. Pause is fail-closed immediately so it can cancel an active
+// PUT; Resume keeps the old latch until its durable policy update succeeds.
+func (l *syncPolicyDeliveryLease) beginPauseMutation(paused bool) {
+	l.stateMu.Lock()
+	l.pauseRevision++
+	l.pauseMutations++
+	if paused {
+		l.pendingPauses++
+		l.pauseRequested = true
+	}
+	cancel := l.cancel
+	l.stateMu.Unlock()
+	if paused && cancel != nil {
+		cancel()
+	}
+}
+
+// completePauseMutation commits the ordered durable state when it is known.
+// A later Pause publishes before it can acquire the lease, so an earlier
+// Resume must never clear the latch while any Pause is still pending. A nil
+// durable state means the ordered read itself failed; retain the fail-closed
+// in-memory state. Advancing the revision again prevents a generation token
+// captured mid-mutation from treating it as an inherited Pause.
+func (l *syncPolicyDeliveryLease) completePauseMutation(requestedPause bool, durablePause *bool) {
+	l.stateMu.Lock()
+	if requestedPause && l.pendingPauses > 0 {
+		l.pendingPauses--
+	}
+	if durablePause != nil {
+		l.pauseRequested = *durablePause
+	}
+	if l.pendingPauses > 0 {
+		l.pauseRequested = true
+	}
+	l.pauseRevision++
+	if l.pauseMutations > 0 {
+		l.pauseMutations--
+	}
+	l.stateMu.Unlock()
+}
+
+func (l *syncPolicyDeliveryLease) deliveryBlocked() (paused bool, generation bool) {
+	l.stateMu.Lock()
+	defer l.stateMu.Unlock()
+	return l.pauseRequested, l.generationBlocks > 0
+}
+
+func (l *syncPolicyDeliveryLease) registerCancel(cancel context.CancelFunc) bool {
+	l.stateMu.Lock()
+	l.cancel = cancel
+	blocked := l.pauseRequested || l.generationBlocks > 0
+	l.stateMu.Unlock()
+	if blocked {
+		cancel()
+	}
+	return blocked
+}
+
+func (l *syncPolicyDeliveryLease) clearCancel(cancel context.CancelFunc) {
+	l.stateMu.Lock()
+	// A delivery owns l.mu, so no second delivery can replace this callback.
+	// Clear unconditionally; the parameter documents which lifecycle ended.
+	_ = cancel
+	l.cancel = nil
+	l.stateMu.Unlock()
+}
+
 // Config wires a Manager into the node.
 type Config struct {
 	// LocalChainID is this network's globally-unique chain id (v11 Phase 0),
@@ -104,6 +230,22 @@ type Manager struct {
 	// tests so drain logic is testable without a TLS peer.
 	syncPushFn       func(ctx context.Context, remoteChainID string, req *SyncPushRequest) (*SyncPushResponse, error)
 	syncPolicyPushFn func(ctx context.Context, remoteChainID string, req *SyncPolicyRequest) (*SyncPolicyResponse, error)
+	// syncPolicyDeliveryLeases linearize outbound policy-label disclosure with
+	// Pause per remote chain. The map mutex is held only for lookup/creation;
+	// each per-peer lease may span a bounded network request without blocking an
+	// unrelated peer or either node's inbound SQLite policy writer.
+	syncPolicyDeliveryLeasesMu sync.Mutex
+	syncPolicyDeliveryLeases   map[string]*syncPolicyDeliveryLease
+	// syncPolicyFinalGateHook is a deterministic test barrier immediately before
+	// the delivery-vs-pause lease. It is nil in production.
+	syncPolicyFinalGateHook func(remoteChainID string)
+	// syncPolicyBeforePushHook is a deterministic test barrier after the exact
+	// agreement/control payload is built but before any network call.
+	syncPolicyBeforePushHook func(remoteChainID string)
+	// syncPolicyPauseLeaseHook is a deterministic test barrier after Pause or
+	// Resume owns the per-peer delivery lease but before it reads the bound
+	// policy snapshot. It is nil in production.
+	syncPolicyPauseLeaseHook func(remoteChainID string)
 
 	// syncNudge wakes the outbox drainer ahead of its ticker when the commit
 	// watcher enqueues new work. Buffered-1 (a pending nudge covers all
@@ -234,6 +376,44 @@ type Manager struct {
 func (m *Manager) LockAgreementMutation() func() {
 	m.agreementMutationMu.Lock()
 	return m.agreementMutationMu.Unlock
+}
+
+func (m *Manager) syncPolicyDeliveryLease(remoteChainID string) *syncPolicyDeliveryLease {
+	m.syncPolicyDeliveryLeasesMu.Lock()
+	defer m.syncPolicyDeliveryLeasesMu.Unlock()
+	if m.syncPolicyDeliveryLeases == nil {
+		m.syncPolicyDeliveryLeases = make(map[string]*syncPolicyDeliveryLease)
+	}
+	lease := m.syncPolicyDeliveryLeases[remoteChainID]
+	if lease == nil {
+		lease = &syncPolicyDeliveryLease{}
+		m.syncPolicyDeliveryLeases[remoteChainID] = lease
+	}
+	return lease
+}
+
+// BeginSyncPolicyGenerationMutation joins the canonical agreement -> per-peer
+// delivery -> SQLite policy lock order. It publishes the block before waiting,
+// cancels an in-flight policy PUT, and prevents an E1 payload from being sent
+// after E2 or a completed revoke becomes authoritative.
+func (m *Manager) BeginSyncPolicyGenerationMutation(remoteChainID string) *SyncPolicyGenerationMutation {
+	lease := m.syncPolicyDeliveryLease(remoteChainID)
+	lease.stateMu.Lock()
+	lease.generationBlocks++
+	cancel := lease.cancel
+	lease.stateMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	lease.mu.Lock()
+	// Capture only after this generation owns the delivery lease. Operator
+	// mutations that completed while Begin waited belong to the retiring
+	// generation and may be reset by Activate; mutations that start after this
+	// point advance the revision and must survive into the fresh generation.
+	lease.stateMu.Lock()
+	pauseRevision := lease.pauseRevision
+	lease.stateMu.Unlock()
+	return &SyncPolicyGenerationMutation{lease: lease, pauseRevision: pauseRevision}
 }
 
 // PeerDialFunc returns a stream-backed connection for remoteChainID. handled

--- a/internal/federation/p2p_routes.go
+++ b/internal/federation/p2p_routes.go
@@ -120,9 +120,10 @@ func (m *Manager) handleP2PRoutes(w http.ResponseWriter, r *http.Request) {
 	// Snapshot the ceremony generation that authenticated this request. This
 	// short lease does not cover body parsing or local route discovery.
 	unlock := ss.LockSyncPolicyRead()
+	_, requestErr := m.currentRequestAgreementBound(r.Context(), identity)
 	_, expectedBinding, err := m.currentP2PRouteBinding(r.Context(), identity.ChainID)
 	unlock()
-	if err != nil || identity.Agreement.RemoteChainID != identity.ChainID ||
+	if requestErr != nil || err != nil || identity.Agreement.RemoteChainID != identity.ChainID ||
 		expectedBinding.peerAgentID == "" || identity.AgentID != expectedBinding.peerAgentID ||
 		expectedBinding.agreementCAPin != hex.EncodeToString(identity.Agreement.PeerPubKey) {
 		httpError(w, http.StatusForbidden, "p2p route exchange requires the frozen peer operator")
@@ -145,8 +146,9 @@ func (m *Manager) handleP2PRoutes(w http.ResponseWriter, r *http.Request) {
 	// and finally Remove runs after this write; a completed purge makes this
 	// recheck fail before any route can be re-added.
 	unlock = ss.LockSyncPolicyRead()
+	_, requestErr = m.currentRequestAgreementBound(r.Context(), identity)
 	_, currentBinding, err := m.currentP2PRouteBinding(r.Context(), identity.ChainID)
-	if err != nil || currentBinding != expectedBinding {
+	if requestErr != nil || err != nil || currentBinding != expectedBinding {
 		unlock()
 		httpError(w, http.StatusForbidden, "p2p route binding changed before persistence")
 		return

--- a/internal/federation/p2p_routes_test.go
+++ b/internal/federation/p2p_routes_test.go
@@ -109,6 +109,42 @@ func TestRouteExchangeRejectsAuthenticatedChainWithWrongOperator(t *testing.T) {
 	assert.False(t, called)
 }
 
+func TestStaleAuthenticatedRouteRequestCannotPersistIntoFreshCeremonyEpoch(t *testing.T) {
+	m, ss, bs := newDrainTestManager(t)
+	seedDrainAgreement(t, bs, "remote-chain", 4)
+	peerPub, _, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	peerAgentID := hex.EncodeToString(peerPub)
+	agreement := bindP2PRouteControl(t, m, "remote-chain", peerAgentID, "epoch-routes-e1")
+	e1, err := ss.GetSyncControl(context.Background(), "remote-chain")
+	require.NoError(t, err)
+	require.NotNil(t, e1)
+	stalePeer := &peerIdentity{
+		ChainID: "remote-chain", AgentID: peerAgentID, Agreement: agreement, CeremonyCaptured: true,
+		Ceremony: &peerCeremonyBinding{PeerAgentID: e1.PeerAgentID, PolicyEpoch: e1.PolicyEpoch,
+			RemoteCAPin: e1.RemoteCAPin, State: e1.BindingState},
+	}
+	e2 := *e1
+	e2.PolicyEpoch = "epoch-routes-e2"
+	require.NoError(t, ss.PurgeSyncPeerState(context.Background(), e1.RemoteChainID))
+	require.NoError(t, ss.PrepareSyncControl(context.Background(), e2))
+	require.NoError(t, ss.ActivateSyncControl(context.Background(), e2.RemoteChainID, e2.PolicyEpoch))
+
+	persisted := false
+	m.SetJoinP2PHooks(JoinP2PHooks{
+		LocalBundle: func() (JoinP2PBundle, error) { return testRouteBundle(t, "203.0.113.20"), nil },
+		Persist:     func(string, []string) error { persisted = true; return nil },
+	})
+	body, err := json.Marshal(testRouteBundle(t, "203.0.113.10"))
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/fed/v1/p2p/routes", bytes.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), peerCtxKey{}, stalePeer))
+	rr := httptest.NewRecorder()
+	m.handleP2PRoutes(rr, req)
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.False(t, persisted, "E1-authenticated route bundle must not persist into E2")
+}
+
 func TestRouteExchangeRejectsNonActiveOrCorruptFrozenBinding(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/federation/peer_generation_test.go
+++ b/internal/federation/peer_generation_test.go
@@ -1,0 +1,60 @@
+package federation
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+// Consensus terms and the CA/operator can be byte-identical after a fresh
+// reciprocal JOIN. The off-consensus policy epoch is therefore part of every
+// authenticated request generation: work captured under E1 must not authorize
+// a query, group mutation, or revoke after E2 becomes active.
+func TestCapturedRequestGenerationRejectsIdenticalTermsFreshPolicyEpoch(t *testing.T) {
+	ctx := context.Background()
+	m, ss, bs := newDrainTestManager(t)
+	seedDrainAgreement(t, bs, "chain-peer", 4)
+	agreement, err := m.ActiveAgreement("chain-peer")
+	require.NoError(t, err)
+	peerPub, _, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	peerID := hex.EncodeToString(peerPub)
+	pin := hex.EncodeToString(agreement.PeerPubKey)
+	activate := func(epoch string) {
+		require.NoError(t, ss.PrepareSyncControl(ctx, store.SyncControl{
+			RemoteChainID: "chain-peer", Role: "guest", ControllerChainID: "chain-peer",
+			ControllerAgentID: peerID, PeerAgentID: peerID, PolicyEpoch: epoch,
+			RemoteCAPin: pin, PolicyVersion: SyncPolicyVersionPeerRBAC,
+		}))
+		require.NoError(t, ss.ActivateSyncControl(ctx, "chain-peer", epoch))
+	}
+	activate("epoch-e1")
+	stale := &peerIdentity{
+		ChainID: "chain-peer", AgentID: peerID, Agreement: agreement,
+		CeremonyCaptured: true,
+		Ceremony: &peerCeremonyBinding{
+			PeerAgentID: peerID, PolicyEpoch: "epoch-e1", RemoteCAPin: pin, State: "active",
+		},
+	}
+
+	require.NoError(t, ss.PurgeSyncPeerState(ctx, "chain-peer"))
+	activate("epoch-e2")
+	_, err = m.currentRequestAgreementBound(ctx, stale)
+	require.ErrorContains(t, err, "ceremony generation changed")
+	bound, bindErr := m.currentInboundGroupPeerBound(ctx, ss, stale)
+	require.NoError(t, bindErr)
+	assert.False(t, bound, "stale E1 group work became valid under identical E2 terms")
+
+	// Use E2 in the body to prove the denial comes from the captured request
+	// generation, not merely from comparing notice.PolicyEpoch to live control.
+	m.broadcastFn = func([]byte) (string, int64, error) { return "must-not-broadcast", 1, nil }
+	_, err = m.acceptPeerRevokeNotice(ctx, stale, RevokeNotice{PolicyEpoch: "epoch-e2"})
+	require.Error(t, err)
+	assert.Equal(t, "active", m.crossFedStatus("chain-peer"))
+}

--- a/internal/federation/peer_rbac.go
+++ b/internal/federation/peer_rbac.go
@@ -236,6 +236,58 @@ func (m *Manager) ReplacePeerRBACPolicy(ctx context.Context, remoteChainID strin
 	})
 }
 
+// SetPeerRBACPaused temporarily turns this node's complete directional grant
+// into deny-all without discarding the saved domain snapshot or the JOIN trust
+// binding. Resume is the inverse one-bit update; neither operation broadcasts a
+// consensus transaction or requires a new ceremony.
+func (m *Manager) SetPeerRBACPaused(ctx context.Context, remoteChainID string, paused bool) (*store.PeerRBACPolicy, error) {
+	ss := m.syncStore()
+	if ss == nil {
+		return nil, fmt.Errorf("peer RBAC requires the SQLite store backend")
+	}
+	// A completed Pause must be a hard disclosure boundary. Publish the operator
+	// mutation first (and Pause itself fail-closed) so an in-flight same-peer PUT
+	// is canceled, then take only this peer's delivery lease through the local
+	// bit update. Other peers stay independent.
+	lease := m.syncPolicyDeliveryLease(remoteChainID)
+	lease.beginPauseMutation(paused)
+	var durablePause *bool
+	lease.mu.Lock()
+	defer lease.mu.Unlock()
+	defer func() { lease.completePauseMutation(paused, durablePause) }()
+	if hook := m.syncPolicyPauseLeaseHook; hook != nil {
+		hook(remoteChainID)
+	}
+	// A queued HTTP request may be canceled before it owns the delivery lease.
+	// Read the ordered durable state without that cancellation so rollback never
+	// restores a stale latch captured before an earlier mutation committed. The
+	// requested write below still uses the caller's context and remains canceled.
+	policy, err := m.GetPeerRBACPolicy(context.WithoutCancel(ctx), remoteChainID)
+	if err != nil {
+		return nil, err
+	}
+	if policy == nil {
+		return nil, fmt.Errorf("connection has no exact peer RBAC snapshot; configure its domain permissions before pausing")
+	}
+	// The durable snapshot is authoritative if the in-memory latch was rebuilt
+	// after process start or another completed mutation preceded this one.
+	persistedPause := policy.Paused
+	durablePause = &persistedPause
+	updated, err := ss.SetBoundPeerRBACPaused(ctx, *policy, paused)
+	if err != nil {
+		return nil, err
+	}
+	committedPause := paused
+	durablePause = &committedPause
+	if !paused {
+		// A paused connection may have a newer local Copy/subscription snapshot
+		// that was deliberately withheld (including its domain labels). Deliver
+		// that latest revision as soon as sharing resumes.
+		m.nudgeSync()
+	}
+	return updated, nil
+}
+
 // initializePeerRBACPolicy is part of fresh JOIN activation, not a mutable
 // permission update. It deliberately discards any retired snapshot left behind
 // as a managed-grant cleanup identity, then binds a present, empty deny-all
@@ -271,7 +323,7 @@ func (m *Manager) initializePeerRBACPolicy(ctx context.Context, remoteChainID st
 	return nil
 }
 
-func peerRBACAllows(policy *store.PeerRBACPolicy, domain string, permission func(store.PeerRBACDomainPermission) bool) bool {
+func peerRBACConfiguredAllows(policy *store.PeerRBACPolicy, domain string, permission func(store.PeerRBACDomainPermission) bool) bool {
 	if policy == nil || domain == "" {
 		return false
 	}
@@ -283,6 +335,10 @@ func peerRBACAllows(policy *store.PeerRBACPolicy, domain string, permission func
 	return false
 }
 
+func peerRBACAllows(policy *store.PeerRBACPolicy, domain string, permission func(store.PeerRBACDomainPermission) bool) bool {
+	return policy != nil && !policy.Paused && peerRBACConfiguredAllows(policy, domain, permission)
+}
+
 func peerRBACAllowsRead(policy *store.PeerRBACPolicy, domain string) bool {
 	return peerRBACAllows(policy, domain, func(grant store.PeerRBACDomainPermission) bool { return grant.Read })
 }
@@ -290,6 +346,11 @@ func peerRBACAllowsRead(policy *store.PeerRBACPolicy, domain string) bool {
 func peerRBACGrantFromPolicy(policy *store.PeerRBACPolicy) *PeerRBACGrant {
 	if policy == nil {
 		return nil
+	}
+	if policy.Paused {
+		// Empty domains keeps older peers fail-closed; the additive Paused field
+		// lets current CEREBRUM builds explain why the saved grants disappeared.
+		return &PeerRBACGrant{PolicyVersion: policy.PolicyVersion, Paused: true, Domains: []PeerRBACDomainGrant{}}
 	}
 	domains := make([]PeerRBACDomainGrant, 0, len(policy.Domains))
 	for _, permission := range policy.Domains {
@@ -302,5 +363,5 @@ func peerRBACGrantFromPolicy(policy *store.PeerRBACPolicy) *PeerRBACGrant {
 			Copy:  permission.Copy,
 		})
 	}
-	return &PeerRBACGrant{PolicyVersion: policy.PolicyVersion, Domains: domains}
+	return &PeerRBACGrant{PolicyVersion: policy.PolicyVersion, Paused: false, Domains: domains}
 }

--- a/internal/federation/peer_rbac_test.go
+++ b/internal/federation/peer_rbac_test.go
@@ -257,6 +257,26 @@ func TestPeerRBACQueryAuthoritativeDynamicReadAndWrongAgent(t *testing.T) {
 	if err := json.NewDecoder(allowed.Body).Decode(&response); err != nil || len(response.Results) != 1 || response.Results[0].MemoryID != "rbac-memory" {
 		t.Fatalf("RBAC response = %+v err=%v", response, err)
 	}
+	paused, err := m.SetPeerRBACPaused(context.Background(), "chain-peer", true)
+	if err != nil || paused == nil || !paused.Paused || len(paused.Domains) != 1 {
+		t.Fatalf("pause result=%+v err=%v", paused, err)
+	}
+	deniedWhilePaused := peerRBACQuery(t, m, agreement, "chain-peer", peerID, "rbac.shared", "directional")
+	if deniedWhilePaused.Code != http.StatusForbidden {
+		t.Fatalf("paused read status=%d, want 403", deniedWhilePaused.Code)
+	}
+	advertised := peerRBACGrantFromPolicy(paused)
+	if advertised == nil || !advertised.Paused || advertised.Domains == nil || len(advertised.Domains) != 0 {
+		t.Fatalf("paused grant did not advertise fail-closed state: %#v", advertised)
+	}
+	resumed, err := m.SetPeerRBACPaused(context.Background(), "chain-peer", false)
+	if err != nil || resumed == nil || resumed.Paused || len(resumed.Domains) != 1 {
+		t.Fatalf("resume result=%+v err=%v", resumed, err)
+	}
+	allowedAgain := peerRBACQuery(t, m, agreement, "chain-peer", peerID, "rbac.shared", "directional")
+	if allowedAgain.Code != http.StatusOK {
+		t.Fatalf("resumed read status=%d body=%s", allowedAgain.Code, allowedAgain.Body.String())
+	}
 
 	wrongAgent := peerRBACQuery(t, m, agreement, "chain-peer", newPeerOperatorID(t), "rbac.shared", "directional")
 	if wrongAgent.Code != http.StatusForbidden {
@@ -360,6 +380,61 @@ func TestPeerRBACReadRevokeWaitsForInFlightResponse(t *testing.T) {
 	denied := peerRBACQuery(t, m, agreement, "chain-peer", peerID, "rbac.shared", "leased")
 	if denied.Code != http.StatusForbidden {
 		t.Fatalf("post-revoke query status=%d want 403", denied.Code)
+	}
+}
+
+func TestPeerRBACPauseWaitsForInFlightReadAndDeniesNextRequest(t *testing.T) {
+	m, ss, bs := newDrainTestManager(t)
+	peerID := newPeerOperatorID(t)
+	agreement := configurePeerRBACConnection(t, m, ss, bs, "chain-pause", peerID, "host", nil, 4)
+	seedCommitted(t, ss, "pause-memory", "rbac.shared", "leased pause response")
+	if err := bs.SetMemoryClassification("pause-memory", 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.ReplacePeerRBACPolicy(context.Background(), "chain-pause", []store.PeerRBACDomainPermission{{Domain: "rbac", Read: true}}); err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(QueryRequest{Mode: ModeText, Query: "leased", DomainTag: "rbac.shared", TopK: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/fed/v1/query", bytes.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), peerCtxKey{}, &peerIdentity{
+		ChainID: "chain-pause", AgentID: peerID, Agreement: agreement,
+	}))
+	bw := newBlockingResponseWriter()
+	served := make(chan struct{})
+	go func() {
+		m.handleQuery(bw, req)
+		close(served)
+	}()
+	select {
+	case <-bw.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("query did not reach response write")
+	}
+
+	pauseDone := make(chan error, 1)
+	go func() {
+		_, pauseErr := m.SetPeerRBACPaused(context.Background(), "chain-pause", true)
+		pauseDone <- pauseErr
+	}()
+	select {
+	case err := <-pauseDone:
+		t.Fatalf("pause returned while old-policy response was in flight: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(bw.release)
+	<-served
+	if err := <-pauseDone; err != nil {
+		t.Fatal(err)
+	}
+	if bw.status != http.StatusOK {
+		t.Fatalf("authorized in-flight response status=%d", bw.status)
+	}
+	denied := peerRBACQuery(t, m, agreement, "chain-pause", peerID, "rbac.shared", "leased")
+	if denied.Code != http.StatusForbidden {
+		t.Fatalf("post-pause query status=%d want 403", denied.Code)
 	}
 }
 

--- a/internal/federation/revoke_notice.go
+++ b/internal/federation/revoke_notice.go
@@ -1,0 +1,181 @@
+package federation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+const revokeNoticeTimeout = 5 * time.Second
+
+// RevokeAgreementNotifying permanently revokes a connection while making a
+// best-effort authenticated notification to the exact peer first. Notification
+// failure never weakens or blocks the local operator's right to revoke.
+func (m *Manager) RevokeAgreementNotifying(remoteChainID string) (*RevokeAgreementResult, error) {
+	result := &RevokeAgreementResult{}
+	unlock := m.LockAgreementMutation()
+	defer unlock()
+	agreement, err := m.ActiveAgreement(remoteChainID)
+	if err != nil {
+		if m.crossFedStatus(remoteChainID) == "revoked" {
+			// Idempotent concurrent peer/local revoke: the desired terminal state
+			// already committed while this caller waited for the generation lease.
+			return result, nil
+		}
+		return nil, err
+	}
+	ss := m.syncStore()
+	var control *store.SyncControl
+	if ss != nil {
+		control, err = ss.GetSyncControl(context.Background(), remoteChainID)
+	}
+	peerBound := false
+	if err == nil && control != nil && control.BindingState == "active" && control.PolicyEpoch != "" {
+		peerBound = m.syncControlPeerBound(control, &peerIdentity{
+			ChainID: remoteChainID, AgentID: control.PeerAgentID, Agreement: agreement,
+		})
+	}
+	if !peerBound {
+		result.NoticeError = "peer notification unavailable: connection has no exact active ceremony generation"
+	}
+	generation := m.BeginSyncPolicyGenerationMutation(remoteChainID)
+	defer generation.Restore()
+
+	// Commit our irreversible tx-34 first. The peer is never asked to revoke if
+	// local consensus rejects. Keep the exact old CA/seed only long enough to
+	// sign the best-effort notice; ActiveAgreement already denies this edge.
+	hash, err := m.broadcastRevokeAgreementLockedReason(remoteChainID, "operator disconnect")
+	if err != nil {
+		return nil, err
+	}
+	result.TxHash = hash
+	if peerBound {
+		noticeCtx, cancel := context.WithTimeout(context.Background(), revokeNoticeTimeout)
+		noticeErr := m.sendRevokeNotice(noticeCtx, agreement, control.PolicyEpoch)
+		cancel()
+		if noticeErr != nil {
+			result.NoticeError = noticeErr.Error()
+		} else {
+			result.PeerNotified = true
+		}
+	}
+	m.recordConnectionEvent(remoteChainID, store.FederationConnectionRevokedLocally,
+		"This operator permanently revoked trust.")
+	m.purgeLocalFederationStateQuiesced(remoteChainID)
+	generation.Retire()
+	return result, nil
+}
+
+func (m *Manager) sendRevokeNotice(ctx context.Context, agreement *store.CrossFedRecord, policyEpoch string) error {
+	body, status, err := m.doPeerRequest(ctx, agreement, http.MethodPost, "/fed/v1/connection/revoke-notice", &RevokeNotice{
+		PolicyEpoch: policyEpoch,
+		Reason:      "The peer operator permanently revoked this connection.",
+	})
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("peer returned %d: %s", status, truncate(body, 200))
+	}
+	var response RevokeNoticeResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return fmt.Errorf("decode revoke notice response: %w", err)
+	}
+	if response.Status != "revoked" && response.Status != "already_revoked" {
+		return fmt.Errorf("peer returned unexpected revoke notice status %q", response.Status)
+	}
+	return nil
+}
+
+func (m *Manager) handleRevokeNotice(w http.ResponseWriter, r *http.Request) {
+	peer := peerFromCtx(r.Context())
+	if peer == nil || peer.Agreement == nil {
+		httpError(w, http.StatusForbidden, "unauthenticated")
+		return
+	}
+	var notice RevokeNotice
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&notice); err != nil {
+		httpError(w, http.StatusBadRequest, "invalid revoke notice")
+		return
+	}
+	notice.PolicyEpoch = strings.TrimSpace(notice.PolicyEpoch)
+	if notice.PolicyEpoch == "" || len(notice.PolicyEpoch) > 256 || len(notice.Reason) > 512 {
+		httpError(w, http.StatusBadRequest, "invalid revoke notice binding")
+		return
+	}
+	response, err := m.acceptPeerRevokeNotice(r.Context(), peer, notice)
+	if err != nil {
+		m.logger.Warn().Err(err).Str("peer", peer.ChainID).Msg("authenticated peer revoke notice rejected")
+		httpError(w, http.StatusConflict, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// acceptPeerRevokeNotice lets either exact peer end a bilateral trust link. It
+// never sends another notice, avoiding revoke loops. The peer identity, current
+// agreement generation, operator key and ceremony epoch are all revalidated
+// beneath the agreement mutation lease before our own tx-34 is signed.
+func (m *Manager) acceptPeerRevokeNotice(ctx context.Context, peer *peerIdentity, notice RevokeNotice) (*RevokeNoticeResponse, error) {
+	unlock := m.LockAgreementMutation()
+	defer unlock()
+	current, err := m.currentRequestAgreementBound(ctx, peer)
+	if err != nil {
+		if m.crossFedStatus(peer.ChainID) == "revoked" {
+			return &RevokeNoticeResponse{Status: "already_revoked"}, nil
+		}
+		return nil, err
+	}
+	ss := m.syncStore()
+	if ss == nil {
+		return nil, fmt.Errorf("peer revoke requires the SQLite store backend")
+	}
+	control, err := ss.GetSyncControl(ctx, peer.ChainID)
+	if err != nil || control == nil || control.BindingState != "active" ||
+		control.PolicyEpoch != notice.PolicyEpoch {
+		return nil, fmt.Errorf("revoke notice does not match the active ceremony epoch")
+	}
+	peerOperator, err := m.resolvePeerOperatorAgentID(ctx, current)
+	if err != nil || peerOperator != peer.AgentID {
+		return nil, fmt.Errorf("revoke notice operator does not match the frozen peer")
+	}
+	generation := m.BeginSyncPolicyGenerationMutation(peer.ChainID)
+	defer generation.Restore()
+
+	hash, err := m.revokeAgreementLockedReason(peer.ChainID, "peer disconnect")
+	if err != nil {
+		return nil, err
+	}
+	generation.Retire()
+	m.recordConnectionEvent(peer.ChainID, store.FederationConnectionRevokedByPeer,
+		"The peer operator permanently revoked trust.")
+	return &RevokeNoticeResponse{Status: "revoked", TxHash: hash}, nil
+}
+
+func (m *Manager) crossFedStatus(remoteChainID string) string {
+	if m.badger == nil {
+		return ""
+	}
+	_, _, _, _, _, _, status, err := m.badger.GetCrossFed(remoteChainID)
+	if err != nil {
+		return ""
+	}
+	return status
+}
+
+func (m *Manager) recordConnectionEvent(remoteChainID, event, message string) {
+	if ss := m.syncStore(); ss != nil {
+		if err := ss.SetFederationConnectionEvent(context.Background(), store.FederationConnectionEvent{
+			RemoteChainID: remoteChainID,
+			Event:         event,
+			Message:       message,
+		}); err != nil {
+			m.logger.Warn().Err(err).Str("remote", remoteChainID).Msg("record federation connection event")
+		}
+	}
+}

--- a/internal/federation/revoke_notice_test.go
+++ b/internal/federation/revoke_notice_test.go
@@ -1,0 +1,158 @@
+package federation
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+func startCeremonyTLSServer(t *testing.T, node *ceremonyNode) *httptest.Server {
+	t.Helper()
+	tlsConfig, err := node.mgr.ServerTLSConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewUnstartedServer(node.mgr.Router())
+	server.TLS = tlsConfig
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestNotifyingRevokeDoesNotTouchPeerWhenLocalConsensusRejects(t *testing.T) {
+	host := newCeremonyNode(t, "host-revoke3")
+	guest := newCeremonyNode(t, "guest-revok4")
+	hostServer := startCeremonyTLSServer(t, host)
+	guestServer := startCeremonyTLSServer(t, guest)
+	completeTwoServerCeremony(t, host, guest, hostServer.URL, guestServer.URL)
+
+	host.mgr.broadcastFn = func([]byte) (string, int64, error) {
+		return "", 0, errors.New("local consensus unavailable")
+	}
+	result, err := host.mgr.RevokeAgreementNotifying("guest-revok4")
+	if err == nil || result != nil {
+		t.Fatalf("revoke result=%+v err=%v, want local commit failure", result, err)
+	}
+	if host.mgr.crossFedStatus("guest-revok4") != "active" || guest.mgr.crossFedStatus("host-revoke3") != "active" {
+		t.Fatalf("failed local revoke split the peers: host=%q guest=%q",
+			host.mgr.crossFedStatus("guest-revok4"), guest.mgr.crossFedStatus("host-revoke3"))
+	}
+	if event, eventErr := host.mgr.syncStore().GetFederationConnectionEvent(context.Background(), "guest-revok4"); eventErr != nil || event != nil {
+		t.Fatalf("failed revoke wrote presentation event=%+v err=%v", event, eventErr)
+	}
+}
+
+func TestGuestAbortPropagatesAndZeroizesBothCeremonySides(t *testing.T) {
+	host := newCeremonyNode(t, "host-abort01")
+	guest := newCeremonyNode(t, "guest-abort2")
+	hostServer := startCeremonyTLSServer(t, host)
+	guestServer := startCeremonyTLSServer(t, guest)
+	ctx := context.Background()
+	created, err := host.mgr.HostCreate(hostServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanned, err := guest.mgr.GuestScan(ctx, created.OTPAuthURI, guestServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := host.mgr.HostScanReturn(created.SessionID, scanned.ReturnURI); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := guest.mgr.GuestRequest(ctx, created.SessionID, guestServer.URL, trustOnlyJoinScope); err != nil {
+		t.Fatal(err)
+	}
+	if err := guest.mgr.GuestAbort(ctx, created.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	view, err := host.mgr.HostSessionStatus(created.SessionID)
+	if err != nil || view.State != JoinAborted {
+		t.Fatalf("host did not learn guest stopped: view=%+v err=%v", view, err)
+	}
+	if _, ok := guest.mgr.getGuestDraft(created.SessionID); ok {
+		t.Fatal("guest abort left the seed-bearing draft in memory")
+	}
+}
+
+func completeTwoServerCeremony(t *testing.T, host, guest *ceremonyNode, hostEndpoint, guestEndpoint string) {
+	t.Helper()
+	ctx := context.Background()
+	created, err := host.mgr.HostCreate(hostEndpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanned, err := guest.mgr.GuestScan(ctx, created.OTPAuthURI, guestEndpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := host.mgr.HostScanReturn(created.SessionID, scanned.ReturnURI); err != nil {
+		t.Fatal(err)
+	}
+	request, err := guest.mgr.GuestRequest(ctx, created.SessionID, guestEndpoint, trustOnlyJoinScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := host.mgr.HostApprove(created.SessionID, request.CodeG, trustOnlyJoinScope); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := guest.mgr.GuestConfirm(ctx, created.SessionID, guestEndpoint, trustOnlyJoinScope); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPermanentRevokeNotifiesExactPeerAndExplainsBothPastRows(t *testing.T) {
+	host := newCeremonyNode(t, "host-revoke1")
+	guest := newCeremonyNode(t, "guest-revok2")
+	hostServer := startCeremonyTLSServer(t, host)
+	guestServer := startCeremonyTLSServer(t, guest)
+	completeTwoServerCeremony(t, host, guest, hostServer.URL, guestServer.URL)
+
+	// A delayed or forged notice from another ceremony generation is rejected
+	// before either chain state or presentation metadata changes.
+	guestAgreement, err := guest.mgr.ActiveAgreement("host-revoke1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongEpochPeer := &peerIdentity{
+		ChainID: "host-revoke1", AgentID: hex.EncodeToString(host.mgr.agentPub), Agreement: guestAgreement,
+	}
+	if _, err := guest.mgr.acceptPeerRevokeNotice(context.Background(), wrongEpochPeer, RevokeNotice{PolicyEpoch: "retired-epoch"}); err == nil {
+		t.Fatal("retired ceremony epoch terminated the active connection")
+	}
+	if guest.mgr.crossFedStatus("host-revoke1") != "active" {
+		t.Fatal("rejected notice changed the active agreement")
+	}
+	if event, err := guest.mgr.syncStore().GetFederationConnectionEvent(context.Background(), "host-revoke1"); err != nil || event != nil {
+		t.Fatalf("rejected notice wrote event=%+v err=%v", event, err)
+	}
+
+	result, err := host.mgr.RevokeAgreementNotifying("guest-revok2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil || !result.PeerNotified || result.NoticeError != "" || result.TxHash == "" {
+		t.Fatalf("notifying revoke result=%+v", result)
+	}
+	if host.mgr.crossFedStatus("guest-revok2") != "revoked" || guest.mgr.crossFedStatus("host-revoke1") != "revoked" {
+		t.Fatalf("bilateral revoke did not converge: host=%q guest=%q",
+			host.mgr.crossFedStatus("guest-revok2"), guest.mgr.crossFedStatus("host-revoke1"))
+	}
+
+	assertEvent := func(node *ceremonyNode, chain, want string) {
+		t.Helper()
+		event, err := node.mgr.syncStore().GetFederationConnectionEvent(context.Background(), chain)
+		if err != nil || event == nil || event.Event != want || event.Message == "" || event.CreatedAt == "" {
+			t.Fatalf("connection event chain=%s got=%+v err=%v want=%s", chain, event, err, want)
+		}
+		policy, err := node.mgr.syncStore().GetPeerRBACPolicy(context.Background(), chain)
+		if err != nil || policy != nil {
+			t.Fatalf("revoked peer policy survived chain=%s policy=%+v err=%v", chain, policy, err)
+		}
+	}
+	assertEvent(host, "guest-revok2", store.FederationConnectionRevokedLocally)
+	assertEvent(guest, "host-revoke1", store.FederationConnectionRevokedByPeer)
+}

--- a/internal/federation/revoke_notice_test.go
+++ b/internal/federation/revoke_notice_test.go
@@ -60,14 +60,14 @@ func TestGuestAbortPropagatesAndZeroizesBothCeremonySides(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := host.mgr.HostScanReturn(created.SessionID, scanned.ReturnURI); err != nil {
-		t.Fatal(err)
+	if scanErr := host.mgr.HostScanReturn(created.SessionID, scanned.ReturnURI); scanErr != nil {
+		t.Fatal(scanErr)
 	}
-	if _, err := guest.mgr.GuestRequest(ctx, created.SessionID, guestServer.URL, trustOnlyJoinScope); err != nil {
-		t.Fatal(err)
+	if _, requestErr := guest.mgr.GuestRequest(ctx, created.SessionID, guestServer.URL, trustOnlyJoinScope); requestErr != nil {
+		t.Fatal(requestErr)
 	}
-	if err := guest.mgr.GuestAbort(ctx, created.SessionID); err != nil {
-		t.Fatal(err)
+	if abortErr := guest.mgr.GuestAbort(ctx, created.SessionID); abortErr != nil {
+		t.Fatal(abortErr)
 	}
 	view, err := host.mgr.HostSessionStatus(created.SessionID)
 	if err != nil || view.State != JoinAborted {
@@ -89,8 +89,8 @@ func completeTwoServerCeremony(t *testing.T, host, guest *ceremonyNode, hostEndp
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := host.mgr.HostScanReturn(created.SessionID, scanned.ReturnURI); err != nil {
-		t.Fatal(err)
+	if scanErr := host.mgr.HostScanReturn(created.SessionID, scanned.ReturnURI); scanErr != nil {
+		t.Fatal(scanErr)
 	}
 	request, err := guest.mgr.GuestRequest(ctx, created.SessionID, guestEndpoint, trustOnlyJoinScope)
 	if err != nil {
@@ -120,14 +120,14 @@ func TestPermanentRevokeNotifiesExactPeerAndExplainsBothPastRows(t *testing.T) {
 	wrongEpochPeer := &peerIdentity{
 		ChainID: "host-revoke1", AgentID: hex.EncodeToString(host.mgr.agentPub), Agreement: guestAgreement,
 	}
-	if _, err := guest.mgr.acceptPeerRevokeNotice(context.Background(), wrongEpochPeer, RevokeNotice{PolicyEpoch: "retired-epoch"}); err == nil {
+	if _, noticeErr := guest.mgr.acceptPeerRevokeNotice(context.Background(), wrongEpochPeer, RevokeNotice{PolicyEpoch: "retired-epoch"}); noticeErr == nil {
 		t.Fatal("retired ceremony epoch terminated the active connection")
 	}
 	if guest.mgr.crossFedStatus("host-revoke1") != "active" {
 		t.Fatal("rejected notice changed the active agreement")
 	}
-	if event, err := guest.mgr.syncStore().GetFederationConnectionEvent(context.Background(), "host-revoke1"); err != nil || event != nil {
-		t.Fatalf("rejected notice wrote event=%+v err=%v", event, err)
+	if event, eventErr := guest.mgr.syncStore().GetFederationConnectionEvent(context.Background(), "host-revoke1"); eventErr != nil || event != nil {
+		t.Fatalf("rejected notice wrote event=%+v err=%v", event, eventErr)
 	}
 
 	result, err := host.mgr.RevokeAgreementNotifying("guest-revok2")

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -37,11 +37,20 @@ const (
 
 type peerCtxKey struct{}
 
+type peerCeremonyBinding struct {
+	PeerAgentID string
+	PolicyEpoch string
+	RemoteCAPin string
+	State       string
+}
+
 // peerIdentity is what peerAuth binds for downstream handlers.
 type peerIdentity struct {
-	ChainID   string
-	AgentID   string
-	Agreement *store.CrossFedRecord
+	ChainID          string
+	AgentID          string
+	Agreement        *store.CrossFedRecord
+	Ceremony         *peerCeremonyBinding
+	CeremonyCaptured bool
 }
 
 // Router returns the federation listener's HTTP handler. EVERY route sits
@@ -54,6 +63,7 @@ func (m *Manager) Router() http.Handler {
 		r.Post("/fed/v1/query", m.handleQuery)
 		r.Post("/fed/v1/write", m.handleRemoteWrite)
 		r.Post("/fed/v1/receipt", m.handleReceipt)
+		r.Post("/fed/v1/connection/revoke-notice", m.handleRevokeNotice)
 		r.Post("/fed/v1/sync/push", m.handleSyncPush)       // v11.5 domain sync
 		r.Post("/fed/v1/sync/digest", m.handleSyncDigest)   // v11.5 anti-entropy
 		r.Post("/fed/v1/sync/journal", m.handleSyncJournal) // v11.8 group journal exchange
@@ -101,7 +111,11 @@ func (m *Manager) peerAuth(next http.Handler) http.Handler {
 			return
 		}
 
-		agreement, err := m.ActiveAgreement(peerChain)
+		// Snapshot consensus terms and the off-consensus JOIN epoch beneath the
+		// same mutation lease used by tx-33/tx-34 activation. Reading the epoch
+		// only after signature verification would let an E1 request be mislabeled
+		// E2 if an otherwise-identical re-pair completed during authentication.
+		agreement, ceremony, err := m.snapshotPeerAuthGeneration(r.Context(), peerChain)
 		if err != nil {
 			m.logger.Warn().Err(err).Str("peer", peerChain).Msg("federation request denied: no active agreement")
 			httpError(w, http.StatusForbidden, "no active agreement")
@@ -211,13 +225,45 @@ func (m *Manager) peerAuth(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx := context.WithValue(r.Context(), peerCtxKey{}, &peerIdentity{
-			ChainID:   peerChain,
-			AgentID:   agentID,
-			Agreement: agreement,
-		})
+		identity := &peerIdentity{
+			ChainID:          peerChain,
+			AgentID:          agentID,
+			Agreement:        agreement,
+			Ceremony:         ceremony,
+			CeremonyCaptured: true,
+		}
+		if _, err := m.currentRequestAgreementBound(r.Context(), identity); err != nil {
+			httpError(w, http.StatusForbidden, "federation agreement generation changed during authentication")
+			return
+		}
+		ctx := context.WithValue(r.Context(), peerCtxKey{}, identity)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func (m *Manager) snapshotPeerAuthGeneration(ctx context.Context, peerChain string) (*store.CrossFedRecord, *peerCeremonyBinding, error) {
+	unlock := m.LockAgreementMutation()
+	defer unlock()
+	agreement, err := m.ActiveAgreement(peerChain)
+	if err != nil {
+		return nil, nil, err
+	}
+	var ceremony *peerCeremonyBinding
+	if ss := m.syncStore(); ss != nil {
+		control, controlErr := ss.GetSyncControl(ctx, peerChain)
+		if controlErr != nil {
+			return nil, nil, fmt.Errorf("read federation ceremony binding: %w", controlErr)
+		}
+		if control != nil {
+			ceremony = &peerCeremonyBinding{
+				PeerAgentID: control.PeerAgentID,
+				PolicyEpoch: control.PolicyEpoch,
+				RemoteCAPin: control.RemoteCAPin,
+				State:       control.BindingState,
+			}
+		}
+	}
+	return agreement, ceremony, nil
 }
 
 // verifyV3AnyEpoch tries the v3 signature against each candidate seed (current
@@ -324,7 +370,17 @@ func (m *Manager) currentRequestAgreementBound(ctx context.Context, peer *peerId
 		return nil, fmt.Errorf("read peer operator binding: %w", err)
 	}
 	if control == nil {
+		if peer.CeremonyCaptured && peer.Ceremony != nil {
+			return nil, fmt.Errorf("authenticated federation ceremony generation changed")
+		}
 		return current, nil
+	}
+	if peer.CeremonyCaptured {
+		if peer.Ceremony == nil || peer.Ceremony.PeerAgentID != control.PeerAgentID ||
+			peer.Ceremony.PolicyEpoch != control.PolicyEpoch || peer.Ceremony.RemoteCAPin != control.RemoteCAPin ||
+			peer.Ceremony.State != control.BindingState || control.BindingState != "active" {
+			return nil, fmt.Errorf("authenticated federation ceremony generation changed")
+		}
 	}
 	peerOperator, err := m.resolvePeerOperatorAgentID(ctx, current)
 	if err != nil {

--- a/internal/federation/sync_client.go
+++ b/internal/federation/sync_client.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/l33tdawg/sage/internal/store"
 )
 
 // ErrSyncUnsupported reports that the peer does not expose /fed/v1/sync/*:
@@ -93,6 +95,17 @@ func (m *Manager) SyncPolicyPush(ctx context.Context, remoteChainID string, req 
 	if err != nil {
 		return nil, err
 	}
+	return m.syncPolicyPushAgreement(ctx, agreement, req)
+}
+
+// syncPolicyPushAgreement sends with the exact agreement snapshot captured at
+// delivery linearization. It must never re-resolve remoteChainID to a newer E2
+// after the caller built an E1 policy payload.
+func (m *Manager) syncPolicyPushAgreement(ctx context.Context, agreement *store.CrossFedRecord, req *SyncPolicyRequest) (*SyncPolicyResponse, error) {
+	if agreement == nil {
+		return nil, fmt.Errorf("sync policy agreement is unavailable")
+	}
+	remoteChainID := agreement.RemoteChainID
 	body, status, err := m.doPeerRequest(ctx, agreement, http.MethodPut, "/fed/v1/sync/policy", req)
 	if err != nil {
 		return nil, err

--- a/internal/federation/sync_digest_test.go
+++ b/internal/federation/sync_digest_test.go
@@ -137,6 +137,41 @@ func TestGroupDigestServeLeaseLinearizesMemberRemoval(t *testing.T) {
 	assert.Nil(t, resp, "no post-removal group digest may be served")
 }
 
+func TestPausedConnectionReturnsGenericGroupDigestDenial(t *testing.T) {
+	ctx := context.Background()
+	m, ms := newSyncTestManager(t, &scriptedComet{responses: []string{cometOK}})
+	seedGroup(t, ms, "g-paused", "chain-ctl")
+	peerPub, _, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	peer := &peerIdentity{ChainID: "chain-peer", AgentID: hex.EncodeToString(peerPub), Agreement: &store.CrossFedRecord{
+		RemoteChainID: "chain-peer", AllowedDomains: []string{"hr"}, Status: "active",
+	}}
+	bindInboundGroupPeer(t, m, ms, peer, "guest")
+	for _, member := range []store.SyncGroupMember{
+		{GroupID: "g-paused", MemberChainID: m.localChainID, Role: store.GroupRoleFullSync, MemberState: store.GroupMemberActive, MemberAgentPubkey: hex.EncodeToString(m.agentPub)},
+		{GroupID: "g-paused", MemberChainID: peer.ChainID, Role: store.GroupRoleFullSync, MemberState: store.GroupMemberActive, MemberAgentPubkey: peer.AgentID},
+	} {
+		require.NoError(t, ms.UpsertSyncGroupMember(ctx, member))
+	}
+	require.NoError(t, ms.UpsertSyncGroupDomain(ctx, store.SyncGroupDomain{
+		GroupID: "g-paused", DomainTag: "hr", OwnerChainID: m.localChainID, AddedRevision: 1,
+	}))
+	require.NoError(t, ms.RecordSyncOrigin(ctx, store.SyncOrigin{
+		OriginChainID: peer.ChainID, OriginMemoryID: "must-stay-hidden", DomainTag: "hr",
+		Outcome: store.SyncOutcomeAdmitted, LocalMemoryID: "local-hidden",
+	}))
+	_, err = m.ReplacePeerRBACPolicy(ctx, peer.ChainID, nil)
+	require.NoError(t, err)
+	_, err = m.SetPeerRBACPaused(ctx, peer.ChainID, true)
+	require.NoError(t, err)
+
+	rr, resp := digestAs(t, m, peer, SyncDigestRequest{GroupID: "g-paused", Domain: "hr"})
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Nil(t, resp)
+	assert.JSONEq(t, `{"error":"not_admitted"}`, rr.Body.String())
+	assert.NotContains(t, rr.Body.String(), "must-stay-hidden")
+}
+
 func TestPairwiseDigestServeLeaseLinearizesConsentRemoval(t *testing.T) {
 	ctx := context.Background()
 	m, ms := newSyncTestManager(t, &scriptedComet{responses: []string{cometOK}})

--- a/internal/federation/sync_emit.go
+++ b/internal/federation/sync_emit.go
@@ -375,7 +375,7 @@ func (m *Manager) admitOwnerDomainAdd(ctx context.Context, groupID string, e sto
 		if requiredPeer.ChainID != e.AuthorChainID || requiredPeer.AgentID != e.AuthorAgentPubkey {
 			return store.SyncGroupLogEntry{}, fmt.Errorf("domain admission peer does not match the signed owner")
 		}
-		bound, bindErr := m.currentInboundGroupPeerBound(ctx, ss, requiredPeer.ChainID, requiredPeer.AgentID)
+		bound, bindErr := m.currentInboundGroupPeerBound(ctx, ss, requiredPeer)
 		if bindErr != nil {
 			return store.SyncGroupLogEntry{}, fmt.Errorf("revalidate domain admission peer: %w", bindErr)
 		}

--- a/internal/federation/sync_group_ceremony.go
+++ b/internal/federation/sync_group_ceremony.go
@@ -603,7 +603,7 @@ func (m *Manager) admitMemberBootstrap(ctx context.Context, ss *store.SQLiteStor
 	err := func() error {
 		defer m.journalMu.Unlock()
 		defer policyWriteUnlock()
-		bound, bindErr := m.currentInboundGroupPeerBound(ctx, ss, peer.ChainID, peer.AgentID)
+		bound, bindErr := m.currentInboundGroupPeerBound(ctx, ss, peer)
 		if bindErr != nil {
 			return fmt.Errorf("revalidate bootstrap peer: %w", bindErr)
 		}

--- a/internal/federation/sync_group_ceremony_v3_test.go
+++ b/internal/federation/sync_group_ceremony_v3_test.go
@@ -33,10 +33,8 @@ func TestTrustOnlyV3MemberInviteIsIndependentFromDirectCopy(t *testing.T) {
 		"chain-r", "https://controller.invalid:8444", controllerPin, 4, 0,
 		nil, nil, "active",
 	))
-	agreement := &store.CrossFedRecord{
-		RemoteChainID: "chain-r", PeerPubKey: controllerPin, MaxClearance: 4,
-		AllowedDomains: nil, Status: "active",
-	}
+	agreement, err := invitee.mgr.ActiveAgreement("chain-r")
+	require.NoError(t, err)
 	require.NoError(t, ss.PrepareSyncControl(ctx, store.SyncControl{
 		RemoteChainID: "chain-r", Role: "guest", ControllerChainID: "chain-r",
 		ControllerAgentID: controllerID, PeerAgentID: controllerID,

--- a/internal/federation/sync_group_trust_v3_test.go
+++ b/internal/federation/sync_group_trust_v3_test.go
@@ -104,6 +104,34 @@ func TestFreshTrustOnlyV3GroupOwnerFanoutIgnoresEmptyDirectLane(t *testing.T) {
 	require.Len(t, pushed, 1)
 	assert.Equal(t, "m-group", pushed[0].OriginMemoryID)
 
+	// A connection Pause is stronger than direct pairwise policy: it must also
+	// close group-native fanout to this exact peer without deleting the roster.
+	_, err = m.ReplacePeerRBACPolicy(ctx, "chain-b", nil)
+	require.NoError(t, err)
+	_, err = m.SetPeerRBACPaused(ctx, "chain-b", true)
+	require.NoError(t, err)
+	pausedConsent, err := m.effectiveConsent(ctx, ms, "chain-b")
+	require.NoError(t, err)
+	assert.Empty(t, pausedConsent)
+	seedCommitted(t, ms, "m-paused-group", "studio", "must not cross a paused edge")
+	m.onCommitted([]string{"m-paused-group"})
+	counts, err = ms.CountSyncOutboxByState(ctx, "chain-b")
+	require.NoError(t, err)
+	assert.Zero(t, counts[store.SyncStatePending], "paused group edge must not enqueue new work")
+	_, err = ms.EnqueueSyncOutbox(ctx, "chain-b", "m-paused-group")
+	require.NoError(t, err)
+	m.syncDrain(ctx, ms, agreement, []string{"studio"}) // deliberately stale caller snapshot
+	assert.Len(t, pushed, 1, "paused group edge must fail closed again at drain")
+	counts, err = ms.CountSyncOutboxByState(ctx, "chain-b")
+	require.NoError(t, err)
+	assert.Equal(t, 1, counts[store.SyncStatePending], "pause must return a claimed row to retryable pending")
+	assert.Zero(t, counts[store.SyncStateRejected], "temporary pause must never terminally reject queued Copy work")
+	_, err = m.SetPeerRBACPaused(ctx, "chain-b", false)
+	require.NoError(t, err)
+	resumedConsent, err := m.effectiveConsent(ctx, ms, "chain-b")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"studio"}, resumedConsent, "resume restores the unchanged group roster")
+
 	// Removal closes the journal capability without touching/re-pairing the trust
 	// edge. Even a stale/manual outbox row cannot cross the send-time group gate.
 	require.NoError(t, ms.SetSyncGroupMemberState(ctx, "g1", "chain-b", store.GroupMemberRemoved, 1))
@@ -229,6 +257,21 @@ func TestFreshTrustOnlyV3GroupRelayWorksWithoutDirectCopy(t *testing.T) {
 	r.syncDrain(ctx, msR, agreement, consented)
 	require.Len(t, pushed, 1)
 	assert.Equal(t, "chain-x", pushed[0].OriginChainID)
+	relayGroup, relayAllowed, err := r.resolveGroupRelayForAgreement(ctx, msR, agreement,
+		"chain-x", hex.EncodeToString(xPub), "studio")
+	require.NoError(t, err)
+	require.True(t, relayAllowed)
+	require.Equal(t, "g1", relayGroup)
+	_, err = r.ReplacePeerRBACPolicy(ctx, "chain-m", nil)
+	require.NoError(t, err)
+	_, err = r.SetPeerRBACPaused(ctx, "chain-m", true)
+	require.NoError(t, err)
+	_, relayAllowed, err = r.resolveGroupRelayForAgreement(ctx, msR, agreement,
+		"chain-x", hex.EncodeToString(xPub), "studio")
+	require.NoError(t, err)
+	require.False(t, relayAllowed, "pause must close a relayed Copy lane to the exact peer")
+	_, err = r.SetPeerRBACPaused(ctx, "chain-m", false)
+	require.NoError(t, err)
 
 	// Removal invalidates the exact three-member relay even though the transport
 	// trust edge remains active and the caller deliberately supplies stale consent.

--- a/internal/federation/sync_outbox.go
+++ b/internal/federation/sync_outbox.go
@@ -95,6 +95,11 @@ func (m *Manager) startSyncDrainer(parent context.Context) {
 	m.syncNudge = make(chan struct{}, 1)
 	nudge := m.syncNudge
 
+	// A process can die after tx-34 commits but before node-local CA/seed/sync
+	// cleanup. Reconcile before workers start, then retry on every normal tick so
+	// a transient SQLite or route-store failure cannot permanently block re-pair.
+	m.reconcileRetiredFederationState(context.Background(), ss)
+
 	// Crash recovery: any row left 'delivering' by a previous process death
 	// (or a shutdown that cancelled the outcome write) is returned to
 	// 'pending' before the first scan, so it can be re-claimed.
@@ -159,10 +164,18 @@ func (m *Manager) StopSyncDrainer() {
 
 // syncTick runs one scan+drain pass over every peer with sync consent.
 func (m *Manager) syncTick(ctx context.Context, ss *store.SQLiteStore) {
+	m.reconcileRetiredFederationState(ctx, ss)
 	if pending, err := ss.ListPendingSyncControls(ctx); err == nil {
 		for _, control := range pending {
 			if ctx.Err() != nil {
 				return
+			}
+			agreement, activeErr := m.ActiveAgreement(control.RemoteChainID)
+			if activeErr != nil {
+				continue
+			}
+			if paused, pauseErr := m.connectionSharingPaused(ctx, agreement); pauseErr != nil || paused {
+				continue
 			}
 			pctx, cancel := context.WithTimeout(ctx, syncPushTimeout)
 			if deliveryErr := m.deliverSyncPolicy(pctx, ss, control.RemoteChainID); deliveryErr != nil {
@@ -208,6 +221,70 @@ func (m *Manager) syncTick(ctx context.Context, ss *store.SQLiteStore) {
 			m.syncScan(ctx, ss, agreement, senderScope)
 		}
 		m.syncDrain(ctx, ss, agreement, consented)
+	}
+}
+
+func (m *Manager) reconcileRetiredFederationState(ctx context.Context, ss *store.SQLiteStore) {
+	m.reconcileRetiredFederationStateAfterList(ctx, ss, nil)
+}
+
+func sameSyncControlGeneration(a, b store.SyncControl) bool {
+	return a.RemoteChainID == b.RemoteChainID && a.Role == b.Role &&
+		a.ControllerChainID == b.ControllerChainID && a.ControllerAgentID == b.ControllerAgentID &&
+		a.PeerAgentID == b.PeerAgentID && a.PolicyEpoch == b.PolicyEpoch &&
+		a.RemoteCAPin == b.RemoteCAPin && a.BindingState == b.BindingState
+}
+
+// reconcileRetiredFederationStateAfterList repairs the tx-34 -> local-purge
+// crash window. beforeLease is a deterministic test barrier after the stale
+// list snapshot; production passes nil.
+func (m *Manager) reconcileRetiredFederationStateAfterList(ctx context.Context, ss *store.SQLiteStore, beforeLease func(store.SyncControl)) {
+	controls, err := ss.ListSyncControls(ctx)
+	if err != nil {
+		m.logger.Warn().Err(err).Msg("federation: list local bindings for revoke reconciliation")
+		return
+	}
+	for _, control := range controls {
+		if ctx.Err() != nil {
+			return
+		}
+		if beforeLease != nil {
+			beforeLease(control)
+		}
+		// JOIN/re-pair and revoke both use agreement -> policy ordering. Join that
+		// generation lease before re-reading the listed control and authoritative
+		// record, then retain it through destructive cleanup so a stale E1 pass
+		// can never purge a freshly activated or pending E2.
+		agreementUnlock := m.LockAgreementMutation()
+		currentControl, controlErr := ss.GetSyncControl(ctx, control.RemoteChainID)
+		if controlErr != nil || currentControl == nil || !sameSyncControlGeneration(control, *currentControl) {
+			agreementUnlock()
+			if controlErr != nil {
+				m.logger.Warn().Err(controlErr).Str("remote", control.RemoteChainID).Msg("federation: local binding changed during revoke reconciliation")
+			}
+			continue
+		}
+		// Reconciliation is destructive to node-local credentials, so act only on
+		// an authoritative record we could read successfully. A transient Badger
+		// failure must never be interpreted as a revoked peer. The tx-34 crash
+		// window we are repairing is explicit status=revoked; expiry is equally
+		// definitive because ActiveAgreement would already deny the edge.
+		_, _, _, expiresAt, _, _, status, getErr := m.badger.GetCrossFed(control.RemoteChainID)
+		if getErr != nil {
+			agreementUnlock()
+			m.logger.Warn().Err(getErr).Str("remote", control.RemoteChainID).Msg("federation: authoritative revoke state unavailable; leaving local binding intact")
+			continue
+		}
+		retired := status == "revoked" || (status == "active" && expiresAt > 0 && time.Now().Unix() >= expiresAt)
+		if !retired {
+			agreementUnlock()
+			continue
+		}
+		m.PurgeLocalFederationState(control.RemoteChainID)
+		if remaining, readErr := ss.GetSyncControl(ctx, control.RemoteChainID); readErr != nil || remaining != nil {
+			m.logger.Warn().Err(readErr).Str("remote", control.RemoteChainID).Msg("federation: retired local binding cleanup will retry")
+		}
+		agreementUnlock()
 	}
 }
 
@@ -315,7 +392,22 @@ func (m *Manager) exactGroupPeerAgentID(ctx context.Context, ss *store.SQLiteSto
 	return control.PeerAgentID, true, nil
 }
 
+// connectionSharingPaused is the per-edge kill switch for every outbound
+// Read/Copy capability, including group-native and relayed Copy lanes. Group
+// membership and saved policies remain intact; returning an empty scope makes
+// Resume lossless without allowing a group to bypass the operator's pause.
+func (m *Manager) connectionSharingPaused(ctx context.Context, agreement *store.CrossFedRecord) (bool, error) {
+	policy, err := m.getPeerRBACPolicyForAgreement(ctx, agreement)
+	if err != nil {
+		return false, err
+	}
+	return policy != nil && policy.Paused, nil
+}
+
 func (m *Manager) groupSharedDomainsForAgreement(ctx context.Context, ss *store.SQLiteStore, agreement *store.CrossFedRecord) ([]string, error) {
+	if paused, err := m.connectionSharingPaused(ctx, agreement); err != nil || paused {
+		return nil, err
+	}
 	peerAgentID, ok, err := m.exactGroupPeerAgentID(ctx, ss, agreement)
 	if err != nil || !ok {
 		return nil, err
@@ -325,6 +417,9 @@ func (m *Manager) groupSharedDomainsForAgreement(ctx context.Context, ss *store.
 }
 
 func (m *Manager) groupSharedDomainsWithGroupForAgreement(ctx context.Context, ss *store.SQLiteStore, agreement *store.CrossFedRecord) ([]store.GroupDomainRef, error) {
+	if paused, err := m.connectionSharingPaused(ctx, agreement); err != nil || paused {
+		return nil, err
+	}
 	peerAgentID, ok, err := m.exactGroupPeerAgentID(ctx, ss, agreement)
 	if err != nil || !ok {
 		return nil, err
@@ -340,6 +435,9 @@ func sharedGroupOwnedDomainsForAgents(ctx context.Context, ss *store.SQLiteStore
 }
 
 func (m *Manager) sharedGroupOwnedDomainsForAgreement(ctx context.Context, ss *store.SQLiteStore, agreement *store.CrossFedRecord) ([]string, error) {
+	if paused, err := m.connectionSharingPaused(ctx, agreement); err != nil || paused {
+		return nil, err
+	}
 	peerAgentID, ok, err := m.exactGroupPeerAgentID(ctx, ss, agreement)
 	if err != nil || !ok {
 		return nil, err
@@ -349,6 +447,9 @@ func (m *Manager) sharedGroupOwnedDomainsForAgreement(ctx context.Context, ss *s
 }
 
 func (m *Manager) resolveGroupRelayForAgreement(ctx context.Context, ss *store.SQLiteStore, agreement *store.CrossFedRecord, originChainID, originAgentID, domain string) (string, bool, error) {
+	if paused, err := m.connectionSharingPaused(ctx, agreement); err != nil || paused {
+		return "", false, err
+	}
 	peerAgentID, ok, err := m.exactGroupPeerAgentID(ctx, ss, agreement)
 	if err != nil || !ok {
 		return "", false, err
@@ -495,6 +596,9 @@ func (m *Manager) pairwiseEgressPolicy(ctx context.Context, ss *store.SQLiteStor
 	if policy == nil {
 		return []string{}, true, nil
 	}
+	if policy.Paused {
+		return []string{}, true, nil
+	}
 	copyGrants := make([]string, 0, len(policy.Domains))
 	for _, grant := range policy.Domains {
 		if grant.Copy {
@@ -615,16 +719,33 @@ func (m *Manager) syncScan(ctx context.Context, ss *store.SQLiteStore, agreement
 // syncDrain claims one batch and delivers it.
 func (m *Manager) syncDrain(ctx context.Context, ss *store.SQLiteStore, agreement *store.CrossFedRecord, consented []string) {
 	chain := agreement.RemoteChainID
+	// Capture the configured egress lanes and Pause bit under one policy lease.
+	// Without this small snapshot boundary, Pause could make one lane read empty
+	// between calls and a quick Resume could then make the final bit read false,
+	// incorrectly turning queued work into a terminal scope rejection. A pause
+	// after this snapshot is caught by the second leased check before transport.
+	initialPolicyUnlock := ss.LockSyncPolicyRead()
+	paused, pauseErr := m.connectionSharingPaused(ctx, agreement)
+	if pauseErr != nil || paused {
+		initialPolicyUnlock()
+		if pauseErr != nil {
+			m.logger.Warn().Err(pauseErr).Str("peer", chain).Msg("sync: pause state lookup failed")
+		}
+		return
+	}
 	directV3, v3, directErr := m.pairwiseEgressPolicy(ctx, ss, agreement)
 	if directErr != nil {
+		initialPolicyUnlock()
 		m.logger.Warn().Err(directErr).Str("peer", chain).Msg("sync: direct copy policy lookup failed")
 		return
 	}
 	groupOwned, groupErr := m.sharedGroupOwnedDomainsForAgreement(ctx, ss, agreement)
 	if groupErr != nil {
+		initialPolicyUnlock()
 		m.logger.Warn().Err(groupErr).Str("peer", chain).Msg("sync: group owner policy lookup failed")
 		return
 	}
+	initialPolicyUnlock()
 	claimed, claimErr := ss.ClaimDueSyncOutbox(ctx, chain, SyncPushMaxItems)
 	if claimErr != nil {
 		m.logger.Warn().Err(claimErr).Str("peer", chain).Msg("sync: claim failed")
@@ -810,13 +931,24 @@ func (m *Manager) syncDrain(ctx context.Context, ss *store.SQLiteStore, agreemen
 	control, controlErr := ss.GetSyncControl(ctx, chain)
 	currentDirectV3, currentV3, directPolicyErr := m.pairwiseEgressPolicy(ctx, ss, currentAgreement)
 	currentGroupOwned, currentGroupErr := m.sharedGroupOwnedDomainsForAgreement(ctx, ss, currentAgreement)
+	currentPaused, pauseErr := m.connectionSharingPaused(ctx, currentAgreement)
 	policyPending := control != nil && control.Revision > control.DeliveredRevision &&
 		(control.Role == "host" || control.PolicyVersion >= SyncPolicyVersionPeerRBAC)
-	if gateErr != nil || consentErr != nil || controlErr != nil || directPolicyErr != nil || currentGroupErr != nil {
+	if gateErr != nil || consentErr != nil || controlErr != nil || directPolicyErr != nil || currentGroupErr != nil || pauseErr != nil {
 		policyUnlock()
 		policyLocked = false
 		for _, row := range itemRows {
 			retry(row, false, false, syncBackoffBase, "sync policy changed before delivery")
+		}
+		return
+	}
+	if currentPaused {
+		policyUnlock()
+		policyLocked = false
+		for _, row := range itemRows {
+			// Pause is reversible configuration, not a terminal scope removal.
+			// Return claimed rows to pending unchanged so Resume can deliver them.
+			retry(row, false, false, syncBackoffBase, "connection sharing is paused")
 		}
 		return
 	}

--- a/internal/federation/sync_outbox_test.go
+++ b/internal/federation/sync_outbox_test.go
@@ -117,6 +117,72 @@ func TestSyncDrainEndToEnd(t *testing.T) {
 	assert.Empty(t, pushed)
 }
 
+func TestReconcileRetiredFederationStatePurgesOnlyDefinitiveRetirement(t *testing.T) {
+	ctx := context.Background()
+	m, ms, bs := newDrainTestManager(t)
+	seedControl := func(chain, epoch string) {
+		seedDrainAgreement(t, bs, chain, 2)
+		agreement := mustDrainAgreement(t, m, chain)
+		require.NoError(t, ms.PrepareSyncControl(ctx, store.SyncControl{
+			RemoteChainID: chain, Role: "host", ControllerChainID: m.localChainID,
+			ControllerAgentID: hex.EncodeToString(m.agentPub), PeerAgentID: hex.EncodeToString(m.agentPub),
+			PolicyEpoch: epoch, RemoteCAPin: hex.EncodeToString(agreement.PeerPubKey),
+		}))
+		require.NoError(t, ms.ActivateSyncControl(ctx, chain, epoch))
+	}
+	seedControl("chain-retired", "epoch-retired")
+	seedControl("chain-active", "epoch-active")
+	require.NoError(t, bs.UpdateCrossFedStatus("chain-retired", "revoked"))
+
+	m.reconcileRetiredFederationState(ctx, ms)
+	retired, err := ms.GetSyncControl(ctx, "chain-retired")
+	require.NoError(t, err)
+	assert.Nil(t, retired, "tx-34 crash residue must be purged on reconciliation")
+	active, err := ms.GetSyncControl(ctx, "chain-active")
+	require.NoError(t, err)
+	assert.NotNil(t, active, "an authoritative active agreement must never be treated as cleanup residue")
+}
+
+func TestRetiredReconcilerCannotPurgeFreshRepairGeneration(t *testing.T) {
+	ctx := context.Background()
+	m, ms, bs := newDrainTestManager(t)
+	seedDrainAgreement(t, bs, "chain-repair", 2)
+	agreement := mustDrainAgreement(t, m, "chain-repair")
+	base := store.SyncControl{
+		RemoteChainID: "chain-repair", Role: "host", ControllerChainID: m.localChainID,
+		ControllerAgentID: hex.EncodeToString(m.agentPub), PeerAgentID: hex.EncodeToString(m.agentPub),
+		RemoteCAPin: hex.EncodeToString(agreement.PeerPubKey),
+	}
+	e1 := base
+	e1.PolicyEpoch = "epoch-retired-e1"
+	require.NoError(t, ms.PrepareSyncControl(ctx, e1))
+	require.NoError(t, ms.ActivateSyncControl(ctx, e1.RemoteChainID, e1.PolicyEpoch))
+	require.NoError(t, bs.UpdateCrossFedStatus(e1.RemoteChainID, "revoked"))
+
+	barrierCalls := 0
+	m.reconcileRetiredFederationStateAfterList(ctx, ms, func(listed store.SyncControl) {
+		barrierCalls++
+		require.Equal(t, e1.PolicyEpoch, listed.PolicyEpoch, "reconciler must hold the stale E1 list snapshot")
+		// Model a complete fresh JOIN generation landing after ListSyncControls
+		// but before this stale reconciler obtains agreementMutationMu and re-reads:
+		// a competing old-generation cleanup completes, then JOIN installs E2.
+		m.PurgeLocalFederationState(e1.RemoteChainID)
+		seedDrainAgreement(t, bs, e1.RemoteChainID, 2)
+		e2 := base
+		e2.PolicyEpoch = "epoch-fresh-e2"
+		require.NoError(t, ms.PrepareSyncControl(ctx, e2))
+		require.NoError(t, ms.ActivateSyncControl(ctx, e2.RemoteChainID, e2.PolicyEpoch))
+	})
+	require.Equal(t, 1, barrierCalls)
+	remaining, err := ms.GetSyncControl(ctx, e1.RemoteChainID)
+	require.NoError(t, err)
+	require.NotNil(t, remaining)
+	assert.Equal(t, "epoch-fresh-e2", remaining.PolicyEpoch,
+		"a stale retired-generation cleanup must not delete a fresh re-pair")
+	_, err = m.ActiveAgreement(e1.RemoteChainID)
+	require.NoError(t, err, "fresh authoritative E2 agreement must remain active")
+}
+
 func TestSyncDrainV3RequiresCopyGrantAndRecipientSubscription(t *testing.T) {
 	ctx := context.Background()
 	m, ms, bs := newDrainTestManager(t)
@@ -148,6 +214,19 @@ func TestSyncDrainV3RequiresCopyGrantAndRecipientSubscription(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, v3)
 	assert.Equal(t, []string{"tii.project"}, effective, "subtree intersection must narrow to the recipient subscription")
+	paused, err := m.SetPeerRBACPaused(ctx, "chain-b", true)
+	require.NoError(t, err)
+	assert.True(t, paused.Paused)
+	effective, v3, err = m.pairwiseEgressPolicy(ctx, ms, agreement)
+	require.NoError(t, err)
+	assert.True(t, v3)
+	assert.Empty(t, effective, "pause must stop an already-configured Copy lane without deleting it")
+	resumed, err := m.SetPeerRBACPaused(ctx, "chain-b", false)
+	require.NoError(t, err)
+	assert.False(t, resumed.Paused)
+	effective, _, err = m.pairwiseEgressPolicy(ctx, ms, agreement)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tii.project"}, effective, "resume must restore the saved Copy lane without re-pairing")
 	require.NoError(t, ms.DeletePeerRBACPolicy(ctx, "chain-b"))
 	effective, v3, err = m.pairwiseEgressPolicy(ctx, ms, agreement)
 	require.NoError(t, err)

--- a/internal/federation/sync_policy.go
+++ b/internal/federation/sync_policy.go
@@ -160,12 +160,41 @@ func (m *Manager) handleSyncPolicy(w http.ResponseWriter, r *http.Request) {
 		httpError(w, http.StatusBadRequest, "invalid sync policy")
 		return
 	}
+
+	// Parse and canonicalize the untrusted body before taking the final write
+	// lease. The exact authenticated agreement + ceremony generation is then
+	// revalidated under that lease and kept stable through the SQLite commit.
+	var publish, subscribe, formattedDomains []string
+	var err error
+	if req.Version == SyncPolicyVersionPeerRBAC {
+		var pErr, sErr error
+		publish, pErr = canonicalSyncDomainsFormat(req.PublishDomains)
+		subscribe, sErr = canonicalSyncDomainsFormat(req.SubscribeDomains)
+		if pErr != nil || sErr != nil {
+			httpError(w, http.StatusBadRequest, "invalid directional sync policy")
+			return
+		}
+	} else {
+		formattedDomains, err = canonicalSyncDomainsFormat(req.Domains)
+		if err != nil {
+			httpError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
+	policyUnlock := ss.LockSyncPolicyWrite()
+	defer policyUnlock()
+	currentAgreement, err := m.currentRequestAgreementBound(r.Context(), peer)
+	if err != nil {
+		httpError(w, http.StatusForbidden, "federation agreement generation changed before policy update")
+		return
+	}
 	control, err := ss.GetSyncControl(r.Context(), peer.ChainID)
 	if err != nil || control == nil || control.BindingState != "active" {
 		httpError(w, http.StatusForbidden, "peer is not this node's sync controller")
 		return
 	}
-	if control.PolicyEpoch != req.Epoch || control.RemoteCAPin != hex.EncodeToString(peer.Agreement.PeerPubKey) {
+	if control.PolicyEpoch != req.Epoch || control.RemoteCAPin != hex.EncodeToString(currentAgreement.PeerPubKey) {
 		httpError(w, http.StatusForbidden, "sync controller binding mismatch")
 		return
 	}
@@ -179,14 +208,8 @@ func (m *Manager) handleSyncPolicy(w http.ResponseWriter, r *http.Request) {
 			httpError(w, http.StatusForbidden, "sync peer binding mismatch")
 			return
 		}
-		publish, pErr := canonicalSyncDomainsFormat(req.PublishDomains)
-		subscribe, sErr := canonicalSyncDomainsFormat(req.SubscribeDomains)
-		if pErr != nil || sErr != nil {
-			httpError(w, http.StatusBadRequest, "invalid directional sync policy")
-			return
-		}
 		hash := directionalSyncPolicyHash(req.Epoch, peer.ChainID, req.Revision, publish, subscribe)
-		status, applyErr := ss.ApplyRemoteDirectionalSyncPolicy(r.Context(), peer.ChainID, req.Epoch,
+		status, applyErr := ss.ApplyRemoteDirectionalSyncPolicyLocked(r.Context(), peer.ChainID, req.Epoch,
 			req.Version, req.Revision, hash, publish, subscribe)
 		if applyErr != nil {
 			httpError(w, http.StatusConflict, applyErr.Error())
@@ -200,18 +223,17 @@ func (m *Manager) handleSyncPolicy(w http.ResponseWriter, r *http.Request) {
 		httpError(w, http.StatusForbidden, "peer is not this node's sync controller")
 		return
 	}
-	var domains []string
-	if req.Version == SyncPolicyVersionDirectional {
-		domains, err = canonicalSyncDomainsFormat(req.Domains)
-	} else {
-		domains, err = canonicalSyncDomains(req.Domains, peer.Agreement)
-	}
-	if err != nil {
-		httpError(w, http.StatusBadRequest, err.Error())
-		return
+	domains := formattedDomains
+	if req.Version == SyncPolicyVersionLegacy {
+		for _, domain := range domains {
+			if !DomainAllowed(currentAgreement.AllowedDomains, domain) {
+				httpError(w, http.StatusBadRequest, fmt.Sprintf("domain %q is outside the federation treaty", domain))
+				return
+			}
+		}
 	}
 	hash := syncPolicyHashVersion(req.Version, req.Epoch, peer.ChainID, req.Revision, domains)
-	status, err := ss.ApplySyncPolicyVersion(r.Context(), peer.ChainID, req.Epoch, req.Version, req.Revision, hash, domains)
+	status, err := ss.ApplySyncPolicyVersionLocked(r.Context(), peer.ChainID, req.Epoch, req.Version, req.Revision, hash, domains)
 	if err != nil {
 		httpError(w, http.StatusConflict, err.Error())
 		return
@@ -241,6 +263,10 @@ func (m *Manager) inboundGroupPeerBound(ctx context.Context, ss *store.SQLiteSto
 	if ss == nil || peer == nil || peer.Agreement == nil {
 		return false, nil
 	}
+	current, err := m.currentRequestAgreementBound(ctx, peer)
+	if err != nil {
+		return false, nil
+	}
 	control, err := ss.GetSyncControl(ctx, peer.ChainID)
 	if err != nil {
 		return false, err
@@ -248,7 +274,9 @@ func (m *Manager) inboundGroupPeerBound(ctx context.Context, ss *store.SQLiteSto
 	if control == nil {
 		return false, nil
 	}
-	return m.syncControlPeerBound(control, peer), nil
+	currentPeer := *peer
+	currentPeer.Agreement = current
+	return m.syncControlPeerBound(control, &currentPeer), nil
 }
 
 // currentInboundGroupPeerBound re-resolves the consensus agreement before
@@ -256,16 +284,8 @@ func (m *Manager) inboundGroupPeerBound(ctx context.Context, ss *store.SQLiteSto
 // sync-policy write lease immediately before a group mutation: a request may
 // have authenticated under an agreement that was revoked while it waited for
 // the journal/write lock, and that stale request must not commit afterward.
-func (m *Manager) currentInboundGroupPeerBound(ctx context.Context, ss *store.SQLiteStore, chainID, agentID string) (bool, error) {
-	agreement, err := m.ActiveAgreement(chainID)
-	if err != nil {
-		return false, nil
-	}
-	return m.inboundGroupPeerBound(ctx, ss, &peerIdentity{
-		ChainID:   chainID,
-		AgentID:   agentID,
-		Agreement: agreement,
-	})
+func (m *Manager) currentInboundGroupPeerBound(ctx context.Context, ss *store.SQLiteStore, peer *peerIdentity) (bool, error) {
+	return m.inboundGroupPeerBound(ctx, ss, peer)
 }
 
 // peerRBACSyncBinding is the exact direct-pair identity binding. Callers select
@@ -321,7 +341,10 @@ func (m *Manager) SetDirectionalSyncPolicy(ctx context.Context, remoteChainID st
 		return nil, fmt.Errorf("read peer copy permission: %w", err)
 	}
 	for _, domain := range publish {
-		if peerPolicy == nil || !peerRBACAllows(peerPolicy, domain, func(grant store.PeerRBACDomainPermission) bool { return grant.Copy }) {
+		// Pause controls effective egress, not configuration. Let the operator
+		// edit the dormant Copy snapshot while paused so Resume activates exactly
+		// the latest saved choices; pairwiseEgressPolicy still returns deny-all.
+		if peerPolicy == nil || !peerRBACConfiguredAllows(peerPolicy, domain, func(grant store.PeerRBACDomainPermission) bool { return grant.Copy }) {
 			return nil, fmt.Errorf("copy permission for %q is not granted to this peer", domain)
 		}
 	}
@@ -335,10 +358,16 @@ func (m *Manager) SetDirectionalSyncPolicy(ctx context.Context, remoteChainID st
 		return nil, err
 	}
 	state := "pending"
-	if err := m.deliverSyncPolicy(ctx, ss, remoteChainID); err == nil {
-		state = "delivered"
+	// While paused, keep the latest directional snapshot entirely local. Even
+	// domain labels are authorization metadata; sending them to the peer would
+	// make a supposedly disconnected edge observable. Resume nudges the drainer,
+	// which sends only the latest saved revision.
+	if peerPolicy == nil || !peerPolicy.Paused {
+		if err := m.deliverSyncPolicy(ctx, ss, remoteChainID); err == nil {
+			state = "delivered"
+		}
+		m.nudgeSync()
 	}
-	m.nudgeSync()
 	return &DirectionalSyncPolicyResult{Version: SyncPolicyVersionPeerRBAC, Revision: revision,
 		PublishDomains: publish, SubscribeDomains: subscribe, State: state}, nil
 }
@@ -435,10 +464,40 @@ func (m *Manager) authorizeOwnerUnilateralDomain(tag string, requireStoredOwner 
 }
 
 func (m *Manager) deliverSyncPolicy(ctx context.Context, ss *store.SQLiteStore, remoteChainID string) error {
+	if hook := m.syncPolicyFinalGateHook; hook != nil {
+		hook(remoteChainID)
+	}
+	lease := m.syncPolicyDeliveryLease(remoteChainID)
+	lease.mu.Lock()
+	defer lease.mu.Unlock()
+	paused, generationBlocked := lease.deliveryBlocked()
+	if paused {
+		return fmt.Errorf("sharing pause requested; policy labels withheld")
+	}
+	if generationBlocked {
+		return fmt.Errorf("agreement generation is changing; policy labels withheld")
+	}
 	control, err := ss.GetSyncControl(ctx, remoteChainID)
 	if err != nil || control == nil || control.Revision <= control.DeliveredRevision ||
 		(control.Role != "host" && control.PolicyVersion < SyncPolicyVersionPeerRBAC) {
 		return err
+	}
+	agreement, err := m.ActiveAgreement(remoteChainID)
+	if err != nil {
+		return err
+	}
+	if control.BindingState != "active" || control.PolicyEpoch == "" ||
+		control.RemoteCAPin != hex.EncodeToString(agreement.PeerPubKey) {
+		return fmt.Errorf("sync policy generation does not match the active agreement")
+	}
+	if control.PolicyVersion >= SyncPolicyVersionPeerRBAC {
+		policy, policyErr := m.GetPeerRBACPolicy(ctx, remoteChainID)
+		if policyErr != nil {
+			return fmt.Errorf("recheck paused sharing before policy delivery: %w", policyErr)
+		}
+		if policy == nil || policy.Paused {
+			return fmt.Errorf("sharing is paused; policy labels withheld")
+		}
 	}
 	var req *SyncPolicyRequest
 	if control.PolicyVersion >= SyncPolicyVersionPeerRBAC {
@@ -459,12 +518,40 @@ func (m *Manager) deliverSyncPolicy(ctx context.Context, ss *store.SQLiteStore, 
 		}
 		req = &SyncPolicyRequest{Version: SyncPolicyVersionDirectional, Epoch: control.PolicyEpoch, Revision: control.Revision, Domains: domains}
 	}
-	push := m.syncPolicyPushFn
-	if push == nil {
-		push = m.SyncPolicyPush
+	if hook := m.syncPolicyBeforePushHook; hook != nil {
+		hook(remoteChainID)
 	}
-	if _, err := push(ctx, remoteChainID, req); err != nil {
+	// Every caller, including a dashboard request with no explicit deadline, is
+	// bounded. Pause can additionally cancel this exact peer request through the
+	// lease without waiting for the timeout.
+	deliveryCtx, cancel := context.WithTimeout(ctx, syncPushTimeout)
+	if lease.registerCancel(cancel) {
+		lease.clearCancel(cancel)
+		cancel()
+		paused, _ := lease.deliveryBlocked()
+		if paused {
+			return fmt.Errorf("sharing pause requested; policy labels withheld")
+		}
+		return fmt.Errorf("agreement generation is changing; policy labels withheld")
+	}
+	defer func() {
+		lease.clearCancel(cancel)
+		cancel()
+	}()
+	if push := m.syncPolicyPushFn; push != nil {
+		if _, err := push(deliveryCtx, remoteChainID, req); err != nil {
+			return err
+		}
+	} else if _, err := m.syncPolicyPushAgreement(deliveryCtx, agreement, req); err != nil {
 		return err
+	}
+	currentAgreement, err := m.ActiveAgreement(remoteChainID)
+	if err != nil || !sameAgreementGeneration(agreement, currentAgreement) {
+		return fmt.Errorf("sync policy agreement generation changed before acknowledgement")
+	}
+	currentControl, err := ss.GetSyncControl(ctx, remoteChainID)
+	if err != nil || currentControl == nil || !sameSyncControlGeneration(*control, *currentControl) {
+		return fmt.Errorf("sync policy ceremony generation changed before acknowledgement")
 	}
 	return ss.MarkSyncPolicyDelivered(context.Background(), remoteChainID, control.PolicyEpoch, control.Revision)
 }

--- a/internal/federation/sync_policy.go
+++ b/internal/federation/sync_policy.go
@@ -76,21 +76,6 @@ func canonicalSyncDomainsFormat(raw []string) ([]string, error) {
 	return out, nil
 }
 
-// canonicalSyncDomains preserves the v1 bilateral treaty check for legacy
-// links. New host-managed links use canonicalSyncDomainsFormat instead.
-func canonicalSyncDomains(raw []string, agreement *store.CrossFedRecord) ([]string, error) {
-	out, err := canonicalSyncDomainsFormat(raw)
-	if err != nil {
-		return nil, err
-	}
-	for _, domain := range out {
-		if agreement == nil || !DomainAllowed(agreement.AllowedDomains, domain) {
-			return nil, fmt.Errorf("domain %q is outside the federation treaty", domain)
-		}
-	}
-	return out, nil
-}
-
 func syncPolicyHashVersion(version int, epoch, controller string, revision int64, domains []string) string {
 	h := sha256.New()
 	if version == SyncPolicyVersionDirectional {
@@ -512,9 +497,9 @@ func (m *Manager) deliverSyncPolicy(ctx context.Context, ss *store.SQLiteStore, 
 		req = &SyncPolicyRequest{Version: SyncPolicyVersionPeerRBAC, Epoch: control.PolicyEpoch,
 			Revision: control.Revision, PublishDomains: publish, SubscribeDomains: subscribe}
 	} else {
-		domains, err := ss.GetSyncDomains(ctx, remoteChainID)
-		if err != nil {
-			return err
+		domains, domainsErr := ss.GetSyncDomains(ctx, remoteChainID)
+		if domainsErr != nil {
+			return domainsErr
 		}
 		req = &SyncPolicyRequest{Version: SyncPolicyVersionDirectional, Epoch: control.PolicyEpoch, Revision: control.Revision, Domains: domains}
 	}
@@ -539,11 +524,11 @@ func (m *Manager) deliverSyncPolicy(ctx context.Context, ss *store.SQLiteStore, 
 		cancel()
 	}()
 	if push := m.syncPolicyPushFn; push != nil {
-		if _, err := push(deliveryCtx, remoteChainID, req); err != nil {
-			return err
+		if _, pushErr := push(deliveryCtx, remoteChainID, req); pushErr != nil {
+			return pushErr
 		}
-	} else if _, err := m.syncPolicyPushAgreement(deliveryCtx, agreement, req); err != nil {
-		return err
+	} else if _, pushErr := m.syncPolicyPushAgreement(deliveryCtx, agreement, req); pushErr != nil {
+		return pushErr
 	}
 	currentAgreement, err := m.ActiveAgreement(remoteChainID)
 	if err != nil || !sameAgreementGeneration(agreement, currentAgreement) {

--- a/internal/federation/sync_policy_test.go
+++ b/internal/federation/sync_policy_test.go
@@ -9,7 +9,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,33 +20,42 @@ import (
 )
 
 func TestSyncPolicyHandlerRequiresFrozenHostAndAppliesSnapshot(t *testing.T) {
-	m, ss, _ := newDrainTestManager(t)
-	agreement := &store.CrossFedRecord{RemoteChainID: "chain-host", PeerPubKey: []byte("pin-bytes-32-aaaaaaaaaaaaaaaaaaaa"),
-		AllowedDomains: []string{"shared"}, Status: "active"}
-	require.NoError(t, ss.PrepareSyncControl(context.Background(), store.SyncControl{
+	m, ss, bs := newDrainTestManager(t)
+	pin := []byte("pin-bytes-32-aaaaaaaaaaaaaaaaaaaa")
+	hostAgentID := newPeerOperatorID(t)
+	otherAgentID := newPeerOperatorID(t)
+	require.NoError(t, bs.SetCrossFed("chain-host", "https://peer:8444", pin, 4, 0, []string{"shared"}, nil, "active"))
+	agreement, err := m.ActiveAgreement("chain-host")
+	require.NoError(t, err)
+	control := store.SyncControl{
 		RemoteChainID: "chain-host", Role: "guest", ControllerChainID: "chain-host",
-		ControllerAgentID: "host-agent", PolicyEpoch: "epoch", RemoteCAPin: hex.EncodeToString(agreement.PeerPubKey),
+		ControllerAgentID: hostAgentID, PeerAgentID: hostAgentID, PolicyEpoch: "epoch", RemoteCAPin: hex.EncodeToString(agreement.PeerPubKey),
 		PolicyVersion: SyncPolicyVersionLegacy,
-	}))
+	}
+	require.NoError(t, ss.PrepareSyncControl(context.Background(), control))
 	require.NoError(t, ss.ActivateSyncControl(context.Background(), "chain-host", "epoch"))
 
 	call := func(agent string, revision int64, domains []string) *httptest.ResponseRecorder {
 		body, _ := json.Marshal(SyncPolicyRequest{Version: 1, Epoch: "epoch", Revision: revision, Domains: domains})
 		req := httptest.NewRequest(http.MethodPut, "/fed/v1/sync/policy", bytes.NewReader(body))
-		ctx := context.WithValue(req.Context(), peerCtxKey{}, &peerIdentity{ChainID: "chain-host", AgentID: agent, Agreement: agreement})
+		ctx := context.WithValue(req.Context(), peerCtxKey{}, &peerIdentity{
+			ChainID: "chain-host", AgentID: agent, Agreement: agreement, CeremonyCaptured: true,
+			Ceremony: &peerCeremonyBinding{PeerAgentID: control.PeerAgentID, PolicyEpoch: control.PolicyEpoch,
+				RemoteCAPin: control.RemoteCAPin, State: "active"},
+		})
 		rr := httptest.NewRecorder()
 		m.handleSyncPolicy(rr, req.WithContext(ctx))
 		return rr
 	}
 
-	assert.Equal(t, http.StatusForbidden, call("other-agent", 1, []string{"shared"}).Code)
-	assert.Equal(t, http.StatusBadRequest, call("host-agent", 1, []string{"private"}).Code)
-	assert.Equal(t, http.StatusOK, call("host-agent", 1, []string{"shared.alpha"}).Code)
+	assert.Equal(t, http.StatusForbidden, call(otherAgentID, 1, []string{"shared"}).Code)
+	assert.Equal(t, http.StatusBadRequest, call(hostAgentID, 1, []string{"private"}).Code)
+	assert.Equal(t, http.StatusOK, call(hostAgentID, 1, []string{"shared.alpha"}).Code)
 	domains, err := ss.GetSyncDomains(context.Background(), "chain-host")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"shared.alpha"}, domains)
-	assert.Equal(t, http.StatusOK, call("host-agent", 1, []string{"shared.alpha"}).Code, "same revision+hash is idempotent")
-	assert.Equal(t, http.StatusConflict, call("host-agent", 1, []string{"shared.beta"}).Code, "equal revision equivocation is refused")
+	assert.Equal(t, http.StatusOK, call(hostAgentID, 1, []string{"shared.alpha"}).Code, "same revision+hash is idempotent")
+	assert.Equal(t, http.StatusConflict, call(hostAgentID, 1, []string{"shared.beta"}).Code, "equal revision equivocation is refused")
 }
 
 func TestHostSyncPolicyPersistsAndDeliversLatestSnapshot(t *testing.T) {
@@ -78,14 +89,19 @@ func TestHostSyncPolicyPersistsAndDeliversLatestSnapshot(t *testing.T) {
 }
 
 func TestPeerRBACPolicyPinsGuestOperatorOnHostSide(t *testing.T) {
-	m, ss, _ := newDrainTestManager(t)
-	agreement := &store.CrossFedRecord{RemoteChainID: "chain-guest",
-		PeerPubKey: []byte("pin-bytes-32-aaaaaaaaaaaaaaaaaaaa"), Status: "active"}
-	require.NoError(t, ss.PrepareSyncControl(context.Background(), store.SyncControl{
+	m, ss, bs := newDrainTestManager(t)
+	pin := []byte("pin-bytes-32-aaaaaaaaaaaaaaaaaaaa")
+	guestAgentID := newPeerOperatorID(t)
+	otherAgentID := newPeerOperatorID(t)
+	require.NoError(t, bs.SetCrossFed("chain-guest", "https://peer:8444", pin, 4, 0, nil, nil, "active"))
+	agreement, err := m.ActiveAgreement("chain-guest")
+	require.NoError(t, err)
+	control := store.SyncControl{
 		RemoteChainID: "chain-guest", Role: "host", ControllerChainID: m.localChainID,
-		ControllerAgentID: hex.EncodeToString(m.agentPub), PeerAgentID: "guest-agent",
+		ControllerAgentID: hex.EncodeToString(m.agentPub), PeerAgentID: guestAgentID,
 		PolicyEpoch: "epoch-v3", RemoteCAPin: hex.EncodeToString(agreement.PeerPubKey),
-	}))
+	}
+	require.NoError(t, ss.PrepareSyncControl(context.Background(), control))
 	require.NoError(t, ss.ActivateSyncControl(context.Background(), "chain-guest", "epoch-v3"))
 
 	call := func(agent string, version int, revision int64) *httptest.ResponseRecorder {
@@ -93,17 +109,55 @@ func TestPeerRBACPolicyPinsGuestOperatorOnHostSide(t *testing.T) {
 			Epoch: "epoch-v3", Revision: revision})
 		req := httptest.NewRequest(http.MethodPut, "/fed/v1/sync/policy", bytes.NewReader(body))
 		ctx := context.WithValue(req.Context(), peerCtxKey{}, &peerIdentity{
-			ChainID: "chain-guest", AgentID: agent, Agreement: agreement,
+			ChainID: "chain-guest", AgentID: agent, Agreement: agreement, CeremonyCaptured: true,
+			Ceremony: &peerCeremonyBinding{PeerAgentID: control.PeerAgentID, PolicyEpoch: control.PolicyEpoch,
+				RemoteCAPin: control.RemoteCAPin, State: "active"},
 		})
 		rr := httptest.NewRecorder()
 		m.handleSyncPolicy(rr, req.WithContext(ctx))
 		return rr
 	}
 
-	assert.Equal(t, http.StatusForbidden, call("other-agent", SyncPolicyVersionPeerRBAC, 1).Code)
-	assert.Equal(t, http.StatusConflict, call("guest-agent", SyncPolicyVersionLegacy, 1).Code)
-	assert.Equal(t, http.StatusConflict, call("guest-agent", SyncPolicyVersionDirectional, 1).Code)
-	assert.Equal(t, http.StatusOK, call("guest-agent", SyncPolicyVersionPeerRBAC, 1).Code)
+	assert.Equal(t, http.StatusForbidden, call(otherAgentID, SyncPolicyVersionPeerRBAC, 1).Code)
+	assert.Equal(t, http.StatusConflict, call(guestAgentID, SyncPolicyVersionLegacy, 1).Code)
+	assert.Equal(t, http.StatusConflict, call(guestAgentID, SyncPolicyVersionDirectional, 1).Code)
+	assert.Equal(t, http.StatusOK, call(guestAgentID, SyncPolicyVersionPeerRBAC, 1).Code)
+}
+
+func TestStaleAuthenticatedPolicyRequestCannotMutateFreshCeremonyEpoch(t *testing.T) {
+	m, ss, bs := newDrainTestManager(t)
+	peerID := newPeerOperatorID(t)
+	agreement := configurePeerRBACConnection(t, m, ss, bs, "chain-peer", peerID, "host", nil, 4)
+	e1, err := ss.GetSyncControl(context.Background(), "chain-peer")
+	require.NoError(t, err)
+	require.NotNil(t, e1)
+	stalePeer := &peerIdentity{
+		ChainID: "chain-peer", AgentID: peerID, Agreement: agreement, CeremonyCaptured: true,
+		Ceremony: &peerCeremonyBinding{PeerAgentID: e1.PeerAgentID, PolicyEpoch: e1.PolicyEpoch,
+			RemoteCAPin: e1.RemoteCAPin, State: e1.BindingState},
+	}
+
+	e2 := *e1
+	e2.PolicyEpoch = "epoch-chain-peer-e2"
+	require.NoError(t, ss.PurgeSyncPeerState(context.Background(), e1.RemoteChainID))
+	require.NoError(t, ss.PrepareSyncControl(context.Background(), e2))
+	require.NoError(t, ss.ActivateSyncControl(context.Background(), e2.RemoteChainID, e2.PolicyEpoch))
+	body, err := json.Marshal(SyncPolicyRequest{Version: SyncPolicyVersionPeerRBAC,
+		Epoch: e2.PolicyEpoch, Revision: 1, PublishDomains: []string{"fresh.secret"}})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPut, "/fed/v1/sync/policy", bytes.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), peerCtxKey{}, stalePeer))
+	rr := httptest.NewRecorder()
+	m.handleSyncPolicy(rr, req)
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	current, err := ss.GetSyncControl(context.Background(), "chain-peer")
+	require.NoError(t, err)
+	require.NotNil(t, current)
+	assert.Equal(t, e2.PolicyEpoch, current.PolicyEpoch)
+	assert.Zero(t, current.RemoteRevision, "E1-authenticated body must not advance E2's revision lane")
+	domains, err := ss.GetDirectionalSyncDomains(context.Background(), "chain-peer", store.SyncDirectionRemotePublish)
+	require.NoError(t, err)
+	assert.Empty(t, domains)
 }
 
 func TestHostSyncPolicyCannotReplacePeerRBACPolicy(t *testing.T) {
@@ -154,7 +208,9 @@ func TestDirectionalPublishRequiresPeerRBACCopy(t *testing.T) {
 		PolicyEpoch: "epoch-rbac", RemoteCAPin: hex.EncodeToString(agreement.PeerPubKey),
 	}))
 	require.NoError(t, ss.ActivateSyncControl(ctx, "chain-peer", "epoch-rbac"))
+	var pushedPolicies [][]string
 	m.syncPolicyPushFn = func(_ context.Context, _ string, req *SyncPolicyRequest) (*SyncPolicyResponse, error) {
+		pushedPolicies = append(pushedPolicies, append([]string(nil), req.PublishDomains...))
 		return &SyncPolicyResponse{Status: "applied", Revision: req.Revision}, nil
 	}
 
@@ -165,6 +221,38 @@ func TestDirectionalPublishRequiresPeerRBACCopy(t *testing.T) {
 	result, err := m.SetDirectionalSyncPolicy(ctx, "chain-peer", []string{"tii.project"}, []string{"peer.notes"})
 	require.NoError(t, err, "configured PeerRBAC Copy must replace legacy tx-33 scope")
 	assert.Equal(t, []string{"tii.project"}, result.PublishDomains)
+	require.Equal(t, [][]string{{"tii.project"}}, pushedPolicies)
+
+	_, err = m.SetPeerRBACPaused(ctx, "chain-peer", true)
+	require.NoError(t, err)
+	_, err = m.ReplacePeerRBACPolicy(ctx, "chain-peer", []store.PeerRBACDomainPermission{
+		{Domain: "tii.next", Read: true, Copy: true},
+	})
+	require.NoError(t, err)
+	result, err = m.SetDirectionalSyncPolicy(ctx, "chain-peer", []string{"tii.next"}, []string{"peer.notes"})
+	require.NoError(t, err, "the latest dormant Copy configuration must remain editable while paused")
+	assert.Equal(t, []string{"tii.next"}, result.PublishDomains)
+	assert.Equal(t, "pending", result.State)
+	assert.Equal(t, [][]string{{"tii.project"}}, pushedPolicies,
+		"paused edits must not disclose even the new domain labels")
+	control, err := ss.GetSyncControl(ctx, "chain-peer")
+	require.NoError(t, err)
+	require.NotNil(t, control)
+	assert.Greater(t, control.Revision, control.DeliveredRevision)
+	_, err = ss.ApplyRemoteDirectionalSyncPolicy(ctx, "chain-peer", "epoch-rbac",
+		SyncPolicyVersionPeerRBAC, 1, "remote-paused", nil, []string{"tii.next"})
+	require.NoError(t, err)
+	effective, _, err := m.pairwiseEgressPolicy(ctx, ss, agreement)
+	require.NoError(t, err)
+	assert.Empty(t, effective, "editing while paused must not send data")
+	_, err = m.SetPeerRBACPaused(ctx, "chain-peer", false)
+	require.NoError(t, err)
+	m.syncTick(ctx, ss)
+	assert.Equal(t, [][]string{{"tii.project"}, {"tii.next"}}, pushedPolicies,
+		"resume must deliver only the latest withheld snapshot")
+	effective, _, err = m.pairwiseEgressPolicy(ctx, ss, agreement)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tii.next"}, effective, "resume must activate the latest saved Copy choice")
 
 	_, err = m.SetDirectionalSyncPolicy(ctx, "chain-peer", []string{"legacy"}, []string{"peer.notes"})
 	require.ErrorContains(t, err, "not granted", "present PeerRBAC policy must not fall back to legacy scope")
@@ -174,4 +262,452 @@ func TestDirectionalPublishRequiresPeerRBACCopy(t *testing.T) {
 	require.ErrorContains(t, err, "not granted", "v3 must never promote legacy tx-33 scope into Copy")
 	_, err = m.SetDirectionalSyncPolicy(ctx, "chain-peer", nil, []string{"legacy"})
 	require.NoError(t, err, "a recipient may subscribe without granting the peer Copy in the other direction")
+}
+
+func preparePendingPeerRBACPolicy(t *testing.T, m *Manager, ss *store.SQLiteStore, bs *store.BadgerStore, chainID string) {
+	t.Helper()
+	peerID := newPeerOperatorID(t)
+	configurePeerRBACConnection(t, m, ss, bs, chainID, peerID, "host", nil, 4)
+	_, err := m.ReplacePeerRBACPolicy(context.Background(), chainID, []store.PeerRBACDomainPermission{
+		{Domain: "shared", Read: true, Copy: true},
+	})
+	require.NoError(t, err)
+	control, err := ss.GetSyncControl(context.Background(), chainID)
+	require.NoError(t, err)
+	require.NotNil(t, control)
+	revision := control.Revision + 1
+	publish := []string{"shared.docs"}
+	hash := directionalSyncPolicyHash(control.PolicyEpoch, m.localChainID, revision, publish, nil)
+	_, err = ss.ApplyLocalDirectionalSyncPolicy(context.Background(), chainID, control.PolicyEpoch,
+		SyncPolicyVersionPeerRBAC, revision, hash, publish, nil)
+	require.NoError(t, err)
+}
+
+func TestPauseBeforeFinalPolicyDeliveryGateWithholdsDomainLabels(t *testing.T) {
+	m, ss, bs := newDrainTestManager(t)
+	preparePendingPeerRBACPolicy(t, m, ss, bs, "chain-peer")
+
+	gateEntered := make(chan struct{})
+	releaseGate := make(chan struct{})
+	m.syncPolicyFinalGateHook = func(chainID string) {
+		if chainID == "chain-peer" {
+			close(gateEntered)
+			<-releaseGate
+		}
+	}
+	pushCalled := false
+	m.syncPolicyPushFn = func(context.Context, string, *SyncPolicyRequest) (*SyncPolicyResponse, error) {
+		pushCalled = true
+		return &SyncPolicyResponse{Status: "applied"}, nil
+	}
+
+	deliveryDone := make(chan error, 1)
+	go func() { deliveryDone <- m.deliverSyncPolicy(context.Background(), ss, "chain-peer") }()
+	select {
+	case <-gateEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("policy delivery did not reach its final pause gate")
+	}
+	paused, err := m.SetPeerRBACPaused(context.Background(), "chain-peer", true)
+	require.NoError(t, err)
+	require.True(t, paused.Paused)
+	close(releaseGate)
+	select {
+	case err := <-deliveryDone:
+		require.ErrorContains(t, err, "pause")
+	case <-time.After(2 * time.Second):
+		t.Fatal("withheld delivery did not return")
+	}
+	assert.False(t, pushCalled, "a Pause committed before the final gate must withhold all domain labels")
+}
+
+func TestBlockedPolicyDeliveryDoesNotBlockPausingAnotherPeer(t *testing.T) {
+	m, ss, bs := newDrainTestManager(t)
+	preparePendingPeerRBACPolicy(t, m, ss, bs, "chain-a")
+	preparePendingPeerRBACPolicy(t, m, ss, bs, "chain-b")
+
+	pushEntered := make(chan struct{})
+	m.syncPolicyPushFn = func(ctx context.Context, chainID string, _ *SyncPolicyRequest) (*SyncPolicyResponse, error) {
+		if chainID == "chain-a" {
+			close(pushEntered)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return &SyncPolicyResponse{Status: "applied"}, nil
+	}
+	deliveryCtx, cancelDelivery := context.WithCancel(context.Background())
+	deliveryDone := make(chan error, 1)
+	go func() { deliveryDone <- m.deliverSyncPolicy(deliveryCtx, ss, "chain-a") }()
+	select {
+	case <-pushEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("chain-a delivery did not start")
+	}
+
+	pauseDone := make(chan error, 1)
+	go func() {
+		_, err := m.SetPeerRBACPaused(context.Background(), "chain-b", true)
+		pauseDone <- err
+	}()
+	select {
+	case err := <-pauseDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("offline chain-a blocked the independent chain-b Pause control")
+	}
+	cancelDelivery()
+	select {
+	case <-deliveryDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled chain-a delivery did not return")
+	}
+}
+
+func TestPauseCancelsInFlightSamePeerPolicyDelivery(t *testing.T) {
+	m, ss, bs := newDrainTestManager(t)
+	preparePendingPeerRBACPolicy(t, m, ss, bs, "chain-peer")
+
+	pushEntered := make(chan struct{})
+	m.syncPolicyPushFn = func(ctx context.Context, _ string, _ *SyncPolicyRequest) (*SyncPolicyResponse, error) {
+		close(pushEntered)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	deliveryDone := make(chan error, 1)
+	go func() { deliveryDone <- m.deliverSyncPolicy(context.Background(), ss, "chain-peer") }()
+	select {
+	case <-pushEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("same-peer policy delivery did not start")
+	}
+
+	pauseDone := make(chan error, 1)
+	go func() {
+		_, err := m.SetPeerRBACPaused(context.Background(), "chain-peer", true)
+		pauseDone <- err
+	}()
+	select {
+	case err := <-pauseDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pause did not cancel and linearize behind the in-flight same-peer delivery")
+	}
+	select {
+	case err := <-deliveryDone:
+		require.Error(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled same-peer delivery did not return")
+	}
+	policy, err := m.GetPeerRBACPolicy(context.Background(), "chain-peer")
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	assert.True(t, policy.Paused)
+}
+
+func TestResumeAndFailedGenerationMutationCannotLeaveStalePauseLatch(t *testing.T) {
+	m, ss, bs := newDrainTestManager(t)
+	preparePendingPeerRBACPolicy(t, m, ss, bs, "chain-peer")
+	_, err := m.SetPeerRBACPaused(context.Background(), "chain-peer", true)
+	require.NoError(t, err)
+
+	resumeOwnsDelivery := make(chan struct{})
+	releaseResume := make(chan struct{})
+	m.syncPolicyPauseLeaseHook = func(chainID string) {
+		if chainID != "chain-peer" {
+			return
+		}
+		close(resumeOwnsDelivery)
+		<-releaseResume
+	}
+	resumeDone := make(chan error, 1)
+	go func() {
+		_, resumeErr := m.SetPeerRBACPaused(context.Background(), "chain-peer", false)
+		resumeDone <- resumeErr
+	}()
+	select {
+	case <-resumeOwnsDelivery:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Resume did not acquire the per-peer delivery lease")
+	}
+
+	generationReady := make(chan *SyncPolicyGenerationMutation, 1)
+	go func() {
+		generationReady <- m.BeginSyncPolicyGenerationMutation("chain-peer")
+	}()
+	lease := m.syncPolicyDeliveryLease("chain-peer")
+	require.Eventually(t, func() bool {
+		lease.stateMu.Lock()
+		defer lease.stateMu.Unlock()
+		return lease.generationBlocks == 1
+	}, 2*time.Second, time.Millisecond, "generation block was not published before waiting on Resume")
+
+	close(releaseResume)
+	select {
+	case resumeErr := <-resumeDone:
+		require.NoError(t, resumeErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Resume did not finish after its test barrier was released")
+	}
+	var generation *SyncPolicyGenerationMutation
+	select {
+	case generation = <-generationReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("generation mutation did not acquire after Resume released the delivery lease")
+	}
+	generation.Restore()
+
+	policy, err := m.GetPeerRBACPolicy(context.Background(), "chain-peer")
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	assert.False(t, policy.Paused, "Resume must remain the persisted operator intent")
+	operatorPaused, generationBlocked := lease.deliveryBlocked()
+	assert.False(t, operatorPaused, "a failed generation mutation must not restore a stale Pause latch")
+	assert.False(t, generationBlocked, "Restore must release its independent generation block")
+}
+
+func TestFreshGenerationActivateCannotEraseConcurrentPauseIntent(t *testing.T) {
+	m, ss, bs := newDrainTestManager(t)
+	preparePendingPeerRBACPolicy(t, m, ss, bs, "chain-peer")
+	lease := m.syncPolicyDeliveryLease("chain-peer")
+	generation := m.BeginSyncPolicyGenerationMutation("chain-peer")
+
+	pauseDone := make(chan error, 1)
+	go func() {
+		_, pauseErr := m.SetPeerRBACPaused(context.Background(), "chain-peer", true)
+		pauseDone <- pauseErr
+	}()
+	require.Eventually(t, func() bool {
+		lease.stateMu.Lock()
+		defer lease.stateMu.Unlock()
+		return lease.pauseRequested && lease.pauseMutations == 1 && lease.pauseRevision > generation.pauseRevision
+	}, 2*time.Second, time.Millisecond, "Pause intent was not published while the fresh generation held delivery")
+
+	generation.Activate()
+	operatorPaused, generationBlocked := lease.deliveryBlocked()
+	assert.True(t, operatorPaused, "fresh-generation activation must preserve a concurrent operator Pause")
+	assert.False(t, generationBlocked, "Activate must release only the generation block")
+
+	select {
+	case pauseErr := <-pauseDone:
+		require.NoError(t, pauseErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pause did not finish after generation activation released the delivery lease")
+	}
+	policy, err := m.GetPeerRBACPolicy(context.Background(), "chain-peer")
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	assert.True(t, policy.Paused)
+	operatorPaused, generationBlocked = lease.deliveryBlocked()
+	assert.True(t, operatorPaused)
+	assert.False(t, generationBlocked)
+}
+
+func TestFreshGenerationClearsPauseThatLinearizedBeforeItAcquiredDelivery(t *testing.T) {
+	m, ss, bs := newDrainTestManager(t)
+	preparePendingPeerRBACPolicy(t, m, ss, bs, "chain-peer")
+	lease := m.syncPolicyDeliveryLease("chain-peer")
+
+	pauseOwnsDelivery := make(chan struct{})
+	releasePause := make(chan struct{})
+	m.syncPolicyPauseLeaseHook = func(chainID string) {
+		if chainID == "chain-peer" {
+			close(pauseOwnsDelivery)
+			<-releasePause
+		}
+	}
+	pauseDone := make(chan error, 1)
+	go func() {
+		_, pauseErr := m.SetPeerRBACPaused(context.Background(), "chain-peer", true)
+		pauseDone <- pauseErr
+	}()
+	select {
+	case <-pauseOwnsDelivery:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pause did not acquire the retiring generation's delivery lease")
+	}
+
+	generationReady := make(chan *SyncPolicyGenerationMutation, 1)
+	go func() { generationReady <- m.BeginSyncPolicyGenerationMutation("chain-peer") }()
+	require.Eventually(t, func() bool {
+		lease.stateMu.Lock()
+		defer lease.stateMu.Unlock()
+		return lease.generationBlocks == 1
+	}, 2*time.Second, time.Millisecond, "generation did not publish its block while waiting for Pause")
+	select {
+	case generation := <-generationReady:
+		generation.Restore()
+		t.Fatal("generation acquired delivery before the older Pause completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releasePause)
+	select {
+	case pauseErr := <-pauseDone:
+		require.NoError(t, pauseErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pause did not finish")
+	}
+	var generation *SyncPolicyGenerationMutation
+	select {
+	case generation = <-generationReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("generation did not acquire after Pause released delivery")
+	}
+	generation.Activate()
+
+	operatorPaused, generationBlocked := lease.deliveryBlocked()
+	assert.False(t, operatorPaused, "fresh generation must not inherit Pause committed on the retiring generation")
+	assert.False(t, generationBlocked)
+}
+
+func TestEarlierResumeCannotEraseLaterQueuedPauseIntent(t *testing.T) {
+	m, _, bs := newDrainTestManager(t)
+	ss := m.syncStore()
+	require.NotNil(t, ss)
+	preparePendingPeerRBACPolicy(t, m, ss, bs, "chain-peer")
+	_, err := m.SetPeerRBACPaused(context.Background(), "chain-peer", true)
+	require.NoError(t, err)
+	lease := m.syncPolicyDeliveryLease("chain-peer")
+
+	resumeOwnsDelivery := make(chan struct{})
+	releaseResume := make(chan struct{})
+	pauseOwnsDelivery := make(chan struct{})
+	releasePause := make(chan struct{})
+	var hookCalls atomic.Int32
+	m.syncPolicyPauseLeaseHook = func(chainID string) {
+		if chainID != "chain-peer" {
+			return
+		}
+		switch hookCalls.Add(1) {
+		case 1:
+			close(resumeOwnsDelivery)
+			<-releaseResume
+		case 2:
+			close(pauseOwnsDelivery)
+			<-releasePause
+		}
+	}
+	resumeDone := make(chan error, 1)
+	go func() {
+		_, resumeErr := m.SetPeerRBACPaused(context.Background(), "chain-peer", false)
+		resumeDone <- resumeErr
+	}()
+	select {
+	case <-resumeOwnsDelivery:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Resume did not acquire the delivery lease")
+	}
+
+	pauseDone := make(chan error, 1)
+	go func() {
+		_, pauseErr := m.SetPeerRBACPaused(context.Background(), "chain-peer", true)
+		pauseDone <- pauseErr
+	}()
+	require.Eventually(t, func() bool {
+		lease.stateMu.Lock()
+		defer lease.stateMu.Unlock()
+		return lease.pauseRequested && lease.pendingPauses == 1 && lease.pauseMutations == 2
+	}, 2*time.Second, time.Millisecond, "the later Pause did not publish while Resume owned delivery")
+
+	close(releaseResume)
+	select {
+	case resumeErr := <-resumeDone:
+		require.NoError(t, resumeErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Resume did not finish")
+	}
+	select {
+	case <-pauseOwnsDelivery:
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued Pause did not acquire after Resume")
+	}
+	operatorPaused, generationBlocked := lease.deliveryBlocked()
+	assert.True(t, operatorPaused, "Resume completion must not clear a later published Pause intent")
+	assert.False(t, generationBlocked)
+
+	close(releasePause)
+	select {
+	case pauseErr := <-pauseDone:
+		require.NoError(t, pauseErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued Pause did not finish")
+	}
+	policy, err := m.GetPeerRBACPolicy(context.Background(), "chain-peer")
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	assert.True(t, policy.Paused)
+}
+
+func TestFreshGenerationCannotInheritBuiltStalePolicyPayload(t *testing.T) {
+	m, ss, bs := newDrainTestManager(t)
+	preparePendingPeerRBACPolicy(t, m, ss, bs, "chain-peer")
+	e1, err := ss.GetSyncControl(context.Background(), "chain-peer")
+	require.NoError(t, err)
+	require.NotNil(t, e1)
+
+	built := make(chan struct{})
+	releaseBuilt := make(chan struct{})
+	m.syncPolicyBeforePushHook = func(chainID string) {
+		if chainID == "chain-peer" {
+			close(built)
+			<-releaseBuilt
+		}
+	}
+	pushCalled := false
+	m.syncPolicyPushFn = func(context.Context, string, *SyncPolicyRequest) (*SyncPolicyResponse, error) {
+		pushCalled = true
+		return &SyncPolicyResponse{Status: "applied"}, nil
+	}
+	deliveryDone := make(chan error, 1)
+	go func() { deliveryDone <- m.deliverSyncPolicy(context.Background(), ss, "chain-peer") }()
+	select {
+	case <-built:
+	case <-time.After(2 * time.Second):
+		t.Fatal("E1 policy payload was not built")
+	}
+
+	type mutationLease struct {
+		generation *SyncPolicyGenerationMutation
+		unlock     func()
+	}
+	mutationReady := make(chan mutationLease, 1)
+	go func() {
+		unlock := m.LockAgreementMutation()
+		generation := m.BeginSyncPolicyGenerationMutation("chain-peer")
+		mutationReady <- mutationLease{generation: generation, unlock: unlock}
+	}()
+	select {
+	case lease := <-mutationReady:
+		lease.generation.Restore()
+		lease.unlock()
+		t.Fatal("generation mutation bypassed the in-flight E1 delivery lease")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseBuilt)
+	var mutation mutationLease
+	select {
+	case mutation = <-mutationReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("generation mutation did not acquire after E1 delivery was canceled")
+	}
+	defer mutation.unlock()
+	defer mutation.generation.Restore()
+	select {
+	case err := <-deliveryDone:
+		require.ErrorContains(t, err, "generation")
+	case <-time.After(2 * time.Second):
+		t.Fatal("stale E1 delivery did not terminate")
+	}
+	assert.False(t, pushCalled, "a payload built under E1 must not be sent after E2 mutation begins")
+
+	require.NoError(t, ss.PurgeSyncPeerState(context.Background(), "chain-peer"))
+	e2 := *e1
+	e2.PolicyEpoch = "epoch-chain-peer-e2"
+	require.NoError(t, ss.PrepareSyncControl(context.Background(), e2))
+	require.NoError(t, ss.ActivateSyncControl(context.Background(), e2.RemoteChainID, e2.PolicyEpoch))
+	mutation.generation.Activate()
+	current, err := ss.GetSyncControl(context.Background(), "chain-peer")
+	require.NoError(t, err)
+	require.NotNil(t, current)
+	assert.Equal(t, e2.PolicyEpoch, current.PolicyEpoch)
 }

--- a/internal/federation/sync_policy_test.go
+++ b/internal/federation/sync_policy_test.go
@@ -693,8 +693,8 @@ func TestFreshGenerationCannotInheritBuiltStalePolicyPayload(t *testing.T) {
 	defer mutation.unlock()
 	defer mutation.generation.Restore()
 	select {
-	case err := <-deliveryDone:
-		require.ErrorContains(t, err, "generation")
+	case deliveryErr := <-deliveryDone:
+		require.ErrorContains(t, deliveryErr, "generation")
 	case <-time.After(2 * time.Second):
 		t.Fatal("stale E1 delivery did not terminate")
 	}

--- a/internal/federation/sync_server.go
+++ b/internal/federation/sync_server.go
@@ -218,7 +218,12 @@ func (m *Manager) handleSyncPush(w http.ResponseWriter, r *http.Request) {
 			httpError(w, http.StatusInternalServerError, "peer RBAC visibility lookup failed")
 			return
 		}
-		if policy != nil {
+		if policy != nil && policy.Paused {
+			// Inbound Copy remains the receiver's independent choice, but Pause
+			// makes every local content-existence signal invisible to this peer.
+			// Otherwise guessed pushes could distinguish same/cross-domain matches.
+			peerVisibleDomains = []string{}
+		} else if policy != nil {
 			for _, grant := range policy.Domains {
 				if grant.Read {
 					peerVisibleDomains = append(peerVisibleDomains, grant.Domain)
@@ -376,6 +381,12 @@ func (m *Manager) handleSyncDigestGroup(w http.ResponseWriter, r *http.Request, 
 	// historical treaty gate in addition to group membership.
 	_, v3, edgeErr := m.pairwiseIngressPolicy(ctx, ss, peer.Agreement, peer.AgentID)
 	if edgeErr != nil || (!v3 && !DomainAllowed(peer.Agreement.AllowedDomains, req.Domain)) {
+		httpError(w, http.StatusForbidden, "not_admitted")
+		return
+	}
+	if paused, pauseErr := m.connectionSharingPaused(ctx, peer.Agreement); pauseErr != nil || paused {
+		// Group digests enumerate receiver-side admission metadata for origins
+		// beyond the requester. A locally paused edge exposes none of it.
 		httpError(w, http.StatusForbidden, "not_admitted")
 		return
 	}

--- a/internal/federation/sync_server_test.go
+++ b/internal/federation/sync_server_test.go
@@ -286,6 +286,60 @@ func TestSyncPushV3RequiresRemoteCopyAndLocalSubscription(t *testing.T) {
 	assert.Equal(t, int32(1), comet.calls.Load(), "denied v3 items must never reach consensus")
 }
 
+func TestPausedV3PushDoesNotRevealSavedReadDomainDuplicates(t *testing.T) {
+	ctx := context.Background()
+	comet := &scriptedComet{responses: []string{cometOK}}
+	m, ms := newSyncTestManager(t, comet)
+	peerPub, _, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	peer := testPeer(2)
+	peer.AgentID = hex.EncodeToString(peerPub)
+	peer.Agreement.PeerPubKey = []byte("pin-bytes-32-aaaaaaaaaaaaaaaaaaaa")
+	bindTestPeerAgreement(t, m, peer)
+	require.NoError(t, ms.PrepareSyncControl(ctx, store.SyncControl{
+		RemoteChainID: peer.ChainID, Role: "guest", ControllerChainID: peer.ChainID,
+		ControllerAgentID: peer.AgentID, PeerAgentID: peer.AgentID,
+		PolicyEpoch: "epoch-paused-oracle", RemoteCAPin: hex.EncodeToString(peer.Agreement.PeerPubKey),
+	}))
+	require.NoError(t, ms.ActivateSyncControl(ctx, peer.ChainID, "epoch-paused-oracle"))
+	_, err = ms.ApplyLocalDirectionalSyncPolicy(ctx, peer.ChainID, "epoch-paused-oracle",
+		SyncPolicyVersionPeerRBAC, 1, "local", nil, []string{"shared"})
+	require.NoError(t, err)
+	_, err = ms.ApplyRemoteDirectionalSyncPolicy(ctx, peer.ChainID, "epoch-paused-oracle",
+		SyncPolicyVersionPeerRBAC, 1, "remote", []string{"shared"}, nil)
+	require.NoError(t, err)
+	_, err = m.ReplacePeerRBACPolicy(ctx, peer.ChainID, []store.PeerRBACDomainPermission{
+		{Domain: "shared", Read: true}, {Domain: "private", Read: true},
+	})
+	require.NoError(t, err)
+	_, err = m.SetPeerRBACPaused(ctx, peer.ChainID, true)
+	require.NoError(t, err)
+
+	sameDomain := syncItem("paused-same", "shared", "known same-domain bytes")
+	seedCommitted(t, ms, "native-same", "shared", sameDomain.Content)
+	comet.after = func() {
+		_ = seedCommittedMemory(ctx, ms, syncMemoryID(peer.ChainID, sameDomain.OriginMemoryID),
+			sameDomain.Domain, sameDomain.Content, mustDecodeHex(t, sameDomain.ContentHash))
+	}
+	_, sameResp := pushAs(t, m, peer, SyncPushRequest{Items: []SyncItem{sameDomain}})
+	require.NotNil(t, sameResp)
+	require.Len(t, sameResp.Results, 1)
+	assert.Equal(t, SyncOutcomeAccepted, sameResp.Results[0].Outcome)
+
+	crossDomain := syncItem("paused-cross", "shared", "known cross-domain bytes")
+	seedCommitted(t, ms, "native-private", "private", crossDomain.Content)
+	comet.after = func() {
+		_ = seedCommittedMemory(ctx, ms, syncMemoryID(peer.ChainID, crossDomain.OriginMemoryID),
+			crossDomain.Domain, crossDomain.Content, mustDecodeHex(t, crossDomain.ContentHash))
+	}
+	_, crossResp := pushAs(t, m, peer, SyncPushRequest{Items: []SyncItem{crossDomain}})
+	require.NotNil(t, crossResp)
+	require.Len(t, crossResp.Results, 1)
+	assert.Equal(t, SyncOutcomeAccepted, crossResp.Results[0].Outcome)
+	assert.NotEqual(t, SyncOutcomeDuplicate, crossResp.Results[0].Outcome)
+	assert.NotEqual(t, SyncOutcomeRejectedXDomainDup, crossResp.Results[0].Outcome)
+}
+
 // TestSyncPushOriginSig exercises Gate 5.5: an origin-signed item is admitted;
 // a forged (corrupted-sig) or mis-attributed (sig over different content) item
 // is rejected terminally; and a pre-v11.8 item with no sig still admits.

--- a/internal/federation/sync_watcher.go
+++ b/internal/federation/sync_watcher.go
@@ -111,6 +111,9 @@ func (m *Manager) onCommitted(ids []string) {
 				if aErr != nil {
 					continue // no active trust edge to this member: fail closed
 				}
+				if paused, pauseErr := m.connectionSharingPaused(ctx, ag); pauseErr != nil || paused {
+					continue
+				}
 				peerAgentID, bound, bindErr := m.exactGroupPeerAgentID(ctx, ss, ag)
 				if bindErr != nil || !bound {
 					continue

--- a/internal/federation/types.go
+++ b/internal/federation/types.go
@@ -155,7 +155,27 @@ type SharingUpdateResult struct {
 // rows is explicit deny-all.
 type PeerRBACGrant struct {
 	PolicyVersion int                   `json:"policy_version"`
+	Paused        bool                  `json:"paused,omitempty"`
 	Domains       []PeerRBACDomainGrant `json:"domains"`
+}
+
+// RevokeNotice is sent best-effort to the exact authenticated peer before a
+// permanent local tx-34 revoke. PolicyEpoch prevents a delayed notice from a
+// retired JOIN generation terminating a newly paired connection.
+type RevokeNotice struct {
+	PolicyEpoch string `json:"policy_epoch"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+type RevokeNoticeResponse struct {
+	Status string `json:"status"`
+	TxHash string `json:"tx_hash,omitempty"`
+}
+
+type RevokeAgreementResult struct {
+	TxHash       string `json:"tx_hash"`
+	PeerNotified bool   `json:"peer_notified"`
+	NoticeError  string `json:"notice_error,omitempty"`
 }
 
 type PeerRBACDomainGrant struct {

--- a/internal/store/peer_rbac_policy.go
+++ b/internal/store/peer_rbac_policy.go
@@ -49,12 +49,17 @@ type PeerRBACDomainPermission struct {
 // operator. Domains is always non-nil for a configured policy, including an
 // explicit deny-all snapshot.
 type PeerRBACPolicy struct {
-	RemoteChainID string                     `json:"remote_chain_id"`
-	PeerAgentID   string                     `json:"peer_agent_id"`
-	PolicyEpoch   string                     `json:"policy_epoch"`
-	RemoteCAPin   string                     `json:"remote_ca_pin"`
-	PolicyVersion int                        `json:"policy_version"`
-	Domains       []PeerRBACDomainPermission `json:"domains"`
+	RemoteChainID string `json:"remote_chain_id"`
+	PeerAgentID   string `json:"peer_agent_id"`
+	PolicyEpoch   string `json:"policy_epoch"`
+	RemoteCAPin   string `json:"remote_ca_pin"`
+	PolicyVersion int    `json:"policy_version"`
+	// Paused is a local operator kill-switch for this directional grant. The
+	// domain snapshot remains intact so sharing can resume without repeating
+	// JOIN, but every Read/Copy authorization path treats a paused policy as
+	// deny-all. It is bound to the same frozen peer/epoch/CA header as Domains.
+	Paused  bool                       `json:"paused"`
+	Domains []PeerRBACDomainPermission `json:"domains"`
 }
 
 func (s *SQLiteStore) migratePeerRBACPolicies(ctx context.Context) {
@@ -65,6 +70,7 @@ func (s *SQLiteStore) migratePeerRBACPolicies(ctx context.Context) {
 		policy_epoch    TEXT NOT NULL DEFAULT '',
 		remote_ca_pin   TEXT NOT NULL DEFAULT '',
 		policy_version  INTEGER NOT NULL,
+		paused          INTEGER NOT NULL DEFAULT 0 CHECK (paused IN (0,1)),
 		updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 	)`)
 	_, _ = s.writeExecContext(ctx, `
@@ -98,6 +104,11 @@ func (s *SQLiteStore) migratePeerRBACPolicies(ctx context.Context) {
 			`SELECT COUNT(*) FROM pragma_table_info('peer_rbac_policy') WHERE name=?`, column).Scan(&present); err == nil && present == 0 {
 			_, _ = s.writeExecContext(ctx, `ALTER TABLE peer_rbac_policy ADD COLUMN `+column+` TEXT NOT NULL DEFAULT ''`)
 		}
+	}
+	var hasPaused int
+	if err := s.conn.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pragma_table_info('peer_rbac_policy') WHERE name='paused'`).Scan(&hasPaused); err == nil && hasPaused == 0 {
+		_, _ = s.writeExecContext(ctx, `ALTER TABLE peer_rbac_policy ADD COLUMN paused INTEGER NOT NULL DEFAULT 0 CHECK (paused IN (0,1))`)
 	}
 	// Development builds briefly wrote headers without ceremony-generation
 	// fields. Backfill only from the same chain's frozen sync_control row; if no
@@ -246,16 +257,21 @@ func validatePeerRBACPolicyHeader(policy PeerRBACPolicy) error {
 // deny-all snapshot and must never be collapsed into the legacy case.
 func (s *SQLiteStore) GetPeerRBACPolicy(ctx context.Context, remoteChainID string) (*PeerRBACPolicy, error) {
 	policy := &PeerRBACPolicy{Domains: make([]PeerRBACDomainPermission, 0)}
+	var paused int
 	err := s.conn.QueryRowContext(ctx, `
-		SELECT remote_chain_id, peer_agent_id, policy_epoch, remote_ca_pin, policy_version
+		SELECT remote_chain_id, peer_agent_id, policy_epoch, remote_ca_pin, policy_version, paused
 		FROM peer_rbac_policy WHERE remote_chain_id=?`, remoteChainID).
-		Scan(&policy.RemoteChainID, &policy.PeerAgentID, &policy.PolicyEpoch, &policy.RemoteCAPin, &policy.PolicyVersion)
+		Scan(&policy.RemoteChainID, &policy.PeerAgentID, &policy.PolicyEpoch, &policy.RemoteCAPin, &policy.PolicyVersion, &paused)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get peer RBAC policy header: %w", err)
 	}
+	if paused != 0 && paused != 1 {
+		return nil, fmt.Errorf("stored peer RBAC pause state is invalid")
+	}
+	policy.Paused = paused == 1
 	if validationErr := validatePeerRBACPolicyHeader(*policy); validationErr != nil {
 		return nil, fmt.Errorf("stored peer RBAC policy header is invalid: %w", validationErr)
 	}
@@ -404,6 +420,47 @@ func (s *SQLiteStore) replacePeerRBACPolicy(ctx context.Context, policy PeerRBAC
 		return nil, err
 	}
 	return s.GetPeerRBACPolicy(ctx, policy.RemoteChainID)
+}
+
+// SetBoundPeerRBACPaused flips the local directional kill-switch without
+// modifying its saved domain snapshot. The update is accepted only while the
+// exact JOIN-frozen peer, epoch and CA binding remains active. Holding the
+// sync-policy write lease makes a completed pause linearize after every
+// response that was already authorized under the old state.
+func (s *SQLiteStore) SetBoundPeerRBACPaused(ctx context.Context, binding PeerRBACPolicy, paused bool) (*PeerRBACPolicy, error) {
+	if err := validatePeerRBACPolicyHeader(binding); err != nil {
+		return nil, err
+	}
+	unlock := s.LockSyncPolicyWrite()
+	defer unlock()
+	err := s.RunInTx(ctx, func(txStore OffchainStore) error {
+		tx := txStore.(*SQLiteStore)
+		result, execErr := tx.writeExecContext(ctx, `UPDATE peer_rbac_policy SET
+			paused=?, updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now')
+			WHERE remote_chain_id=? AND peer_agent_id=? AND policy_epoch=? AND remote_ca_pin=? AND policy_version=?
+			AND EXISTS (SELECT 1 FROM sync_control c WHERE c.remote_chain_id=peer_rbac_policy.remote_chain_id
+				AND c.peer_agent_id=peer_rbac_policy.peer_agent_id
+				AND c.policy_epoch=peer_rbac_policy.policy_epoch
+				AND c.remote_ca_pin=peer_rbac_policy.remote_ca_pin
+				AND c.binding_state='active')`,
+			paused, binding.RemoteChainID, binding.PeerAgentID, binding.PolicyEpoch,
+			binding.RemoteCAPin, binding.PolicyVersion)
+		if execErr != nil {
+			return fmt.Errorf("set peer RBAC pause state: %w", execErr)
+		}
+		rows, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return fmt.Errorf("inspect peer RBAC pause update: %w", rowsErr)
+		}
+		if rows != 1 {
+			return fmt.Errorf("%w: active peer RBAC binding changed during pause update", ErrPeerRBACBindingMismatch)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return s.GetPeerRBACPolicy(ctx, binding.RemoteChainID)
 }
 
 // DeletePeerRBACPolicy removes both the explicit header and its rows. It is a

--- a/internal/store/peer_rbac_policy_test.go
+++ b/internal/store/peer_rbac_policy_test.go
@@ -247,6 +247,60 @@ func TestPeerRBACPolicyAtomicDynamicReplaceAndCanonicalPermissions(t *testing.T)
 	}
 }
 
+func TestBoundPeerRBACPausePreservesSnapshotAndRequiresExactActiveBinding(t *testing.T) {
+	ctx := context.Background()
+	s := newSyncTestStore(t)
+	epoch, caPin := testPeerRBACBinding()
+	policy := PeerRBACPolicy{
+		RemoteChainID: "chain-pause", PeerAgentID: testPeerAgentID(t),
+		PolicyEpoch: epoch, RemoteCAPin: caPin, PolicyVersion: CurrentPeerRBACPolicyVersion,
+		Domains: []PeerRBACDomainPermission{{Domain: "tii", Read: true, Copy: true}},
+	}
+	if err := s.PrepareSyncControl(ctx, testLegacyPeerRBACControl(policy)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ActivateSyncControl(ctx, policy.RemoteChainID, policy.PolicyEpoch); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := s.ReplaceBoundPeerRBACPolicy(ctx, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paused, err := s.SetBoundPeerRBACPaused(ctx, *stored, true)
+	if err != nil || paused == nil || !paused.Paused || len(paused.Domains) != 1 || !paused.Domains[0].Copy {
+		t.Fatalf("paused policy=%+v err=%v", paused, err)
+	}
+
+	// Editing the complete permission snapshot while paused must not silently
+	// reconnect the peer. Resume is the only operation that clears the bit.
+	replacement := *paused
+	replacement.Domains = []PeerRBACDomainPermission{{Domain: "replacement", Read: true}}
+	replaced, err := s.ReplaceBoundPeerRBACPolicy(ctx, replacement)
+	if err != nil || replaced == nil || !replaced.Paused || len(replaced.Domains) != 1 || replaced.Domains[0].Domain != "replacement" {
+		t.Fatalf("paused replacement=%+v err=%v", replaced, err)
+	}
+	resumed, err := s.SetBoundPeerRBACPaused(ctx, *replaced, false)
+	if err != nil || resumed == nil || resumed.Paused || len(resumed.Domains) != 1 {
+		t.Fatalf("resumed policy=%+v err=%v", resumed, err)
+	}
+
+	// A stale UI request cannot change a retired generation after revocation.
+	paused, err = s.SetBoundPeerRBACPaused(ctx, *resumed, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DeleteSyncControl(ctx, policy.RemoteChainID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SetBoundPeerRBACPaused(ctx, *paused, false); !errors.Is(err, ErrPeerRBACBindingMismatch) {
+		t.Fatalf("retired generation pause error=%v, want ErrPeerRBACBindingMismatch", err)
+	}
+	stillPaused, err := s.GetPeerRBACPolicy(ctx, policy.RemoteChainID)
+	if err != nil || stillPaused == nil || !stillPaused.Paused {
+		t.Fatalf("failed stale resume changed policy=%+v err=%v", stillPaused, err)
+	}
+}
+
 func TestPeerRBACPolicyValidationAndFrozenBinding(t *testing.T) {
 	ctx := context.Background()
 	s := newSyncTestStore(t)

--- a/internal/store/peer_rbac_policy_test.go
+++ b/internal/store/peer_rbac_policy_test.go
@@ -289,11 +289,11 @@ func TestBoundPeerRBACPausePreservesSnapshotAndRequiresExactActiveBinding(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.DeleteSyncControl(ctx, policy.RemoteChainID); err != nil {
-		t.Fatal(err)
+	if deleteErr := s.DeleteSyncControl(ctx, policy.RemoteChainID); deleteErr != nil {
+		t.Fatal(deleteErr)
 	}
-	if _, err := s.SetBoundPeerRBACPaused(ctx, *paused, false); !errors.Is(err, ErrPeerRBACBindingMismatch) {
-		t.Fatalf("retired generation pause error=%v, want ErrPeerRBACBindingMismatch", err)
+	if _, resumeErr := s.SetBoundPeerRBACPaused(ctx, *paused, false); !errors.Is(resumeErr, ErrPeerRBACBindingMismatch) {
+		t.Fatalf("retired generation pause error=%v, want ErrPeerRBACBindingMismatch", resumeErr)
 	}
 	stillPaused, err := s.GetPeerRBACPolicy(ctx, policy.RemoteChainID)
 	if err != nil || stillPaused == nil || !stillPaused.Paused {

--- a/internal/store/sync_tables.go
+++ b/internal/store/sync_tables.go
@@ -144,6 +144,21 @@ type SyncControl struct {
 }
 
 const (
+	FederationConnectionRevokedLocally = "revoked_locally"
+	FederationConnectionRevokedByPeer  = "revoked_by_peer"
+)
+
+// FederationConnectionEvent is node-local presentation metadata for an
+// immutable cross_fed audit row. It never grants authority; it only lets
+// CEREBRUM explain why a past connection ended.
+type FederationConnectionEvent struct {
+	RemoteChainID string `json:"remote_chain_id"`
+	Event         string `json:"event"`
+	Message       string `json:"message,omitempty"`
+	CreatedAt     string `json:"created_at"`
+}
+
+const (
 	SyncDirectionLocalPublish    = "local_publish"
 	SyncDirectionLocalSubscribe  = "local_subscribe"
 	SyncDirectionRemotePublish   = "remote_publish"
@@ -260,6 +275,16 @@ func (s *SQLiteStore) migrateSyncTables(ctx context.Context) {
 		name            TEXT NOT NULL,
 		updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 	)`)
+	// fed_connection_events explains immutable revoked rows in CEREBRUM. It is
+	// deliberately separate from sync_control because revocation purges that
+	// live capability binding. A fresh enrollment clears the old event.
+	_, _ = s.writeExecContext(ctx, `
+	CREATE TABLE IF NOT EXISTS fed_connection_events (
+		remote_chain_id TEXT PRIMARY KEY,
+		event           TEXT NOT NULL CHECK (event IN ('revoked_locally','revoked_by_peer')),
+		message         TEXT NOT NULL DEFAULT '',
+		created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+	)`)
 	// v11.8 mesh pull-relay (docs §9.2 must-fix #1). Both additive + idempotent,
 	// pragma-guarded (the migrateTaskPickup / sync_control.group_id idiom):
 	//   - sync_origin.origin_sig: the ORIGIN agent's ed25519 signature over the
@@ -356,6 +381,39 @@ func (s *SQLiteStore) PrepareSyncControl(ctx context.Context, c SyncControl) err
 	return nil
 }
 
+// SetFederationConnectionEvent records why a past agreement row is no longer
+// live. It is presentation-only and cannot influence any authorization path.
+func (s *SQLiteStore) SetFederationConnectionEvent(ctx context.Context, event FederationConnectionEvent) error {
+	if strings.TrimSpace(event.RemoteChainID) == "" || strings.TrimSpace(event.RemoteChainID) != event.RemoteChainID {
+		return fmt.Errorf("remote chain id is required")
+	}
+	if event.Event != FederationConnectionRevokedLocally && event.Event != FederationConnectionRevokedByPeer {
+		return fmt.Errorf("unsupported federation connection event %q", event.Event)
+	}
+	if len(event.Message) > 512 {
+		return fmt.Errorf("federation connection event message is too long")
+	}
+	_, err := s.writeExecContext(ctx, `INSERT INTO fed_connection_events(remote_chain_id,event,message)
+		VALUES(?,?,?) ON CONFLICT(remote_chain_id) DO UPDATE SET event=excluded.event,
+		message=excluded.message, created_at=strftime('%Y-%m-%dT%H:%M:%fZ','now')`,
+		event.RemoteChainID, event.Event, event.Message)
+	return err
+}
+
+func (s *SQLiteStore) GetFederationConnectionEvent(ctx context.Context, remoteChainID string) (*FederationConnectionEvent, error) {
+	event := &FederationConnectionEvent{}
+	err := s.conn.QueryRowContext(ctx, `SELECT remote_chain_id,event,message,created_at
+		FROM fed_connection_events WHERE remote_chain_id=?`, remoteChainID).
+		Scan(&event.RemoteChainID, &event.Event, &event.Message, &event.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get federation connection event: %w", err)
+	}
+	return event, nil
+}
+
 func (s *SQLiteStore) ActivateSyncControl(ctx context.Context, remoteChainID, epoch string) error {
 	unlock := s.LockSyncPolicyWrite()
 	defer unlock()
@@ -378,11 +436,16 @@ func (s *SQLiteStore) ActivateSyncControl(ctx context.Context, remoteChainID, ep
 		if _, err := tx.writeExecContext(ctx, `DELETE FROM sync_directional_domains WHERE remote_chain_id=?`, remoteChainID); err != nil {
 			return err
 		}
-		_, err := tx.writeExecContext(ctx, `UPDATE sync_control SET binding_state='active', revision=0,
+		if _, err := tx.writeExecContext(ctx, `UPDATE sync_control SET binding_state='active', revision=0,
 			policy_hash='', delivered_revision=0, remote_policy_version=0, remote_revision=0,
 			remote_policy_hash='', updated_at=strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-			WHERE remote_chain_id=? AND policy_epoch=?`, remoteChainID, epoch)
-		return err
+			WHERE remote_chain_id=? AND policy_epoch=?`, remoteChainID, epoch); err != nil {
+			return err
+		}
+		if _, err := tx.writeExecContext(ctx, `DELETE FROM fed_connection_events WHERE remote_chain_id=?`, remoteChainID); err != nil {
+			return fmt.Errorf("clear retired federation connection event: %w", err)
+		}
+		return nil
 	})
 }
 
@@ -505,6 +568,31 @@ func (s *SQLiteStore) GetSyncControl(ctx context.Context, remoteChainID string) 
 	return c, err
 }
 
+// ListSyncControls enumerates every live or crash-stranded local federation
+// binding. Authorization never uses this list; the Manager uses it only to
+// reconcile node-local artifacts whose on-chain agreement is no longer active.
+func (s *SQLiteStore) ListSyncControls(ctx context.Context) ([]SyncControl, error) {
+	rows, err := s.conn.QueryContext(ctx, `SELECT remote_chain_id, role, controller_chain_id,
+		controller_agent_id, peer_agent_id, policy_epoch, remote_ca_pin, binding_state, policy_version, revision,
+		policy_hash, delivered_revision, remote_policy_version, remote_revision, remote_policy_hash
+		FROM sync_control ORDER BY remote_chain_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := make([]SyncControl, 0)
+	for rows.Next() {
+		var c SyncControl
+		if err := rows.Scan(&c.RemoteChainID, &c.Role, &c.ControllerChainID, &c.ControllerAgentID,
+			&c.PeerAgentID, &c.PolicyEpoch, &c.RemoteCAPin, &c.BindingState, &c.PolicyVersion, &c.Revision,
+			&c.PolicyHash, &c.DeliveredRevision, &c.RemotePolicyVersion, &c.RemoteRevision, &c.RemotePolicyHash); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
 func (s *SQLiteStore) ListPendingSyncControls(ctx context.Context) ([]SyncControl, error) {
 	rows, err := s.conn.QueryContext(ctx, `SELECT remote_chain_id, role, controller_chain_id,
 		controller_agent_id, peer_agent_id, policy_epoch, remote_ca_pin, binding_state, policy_version, revision,
@@ -552,6 +640,16 @@ func (s *SQLiteStore) ApplySyncPolicyVersion(ctx context.Context, remoteChainID,
 	}
 	unlock := s.LockSyncPolicyWrite()
 	defer unlock()
+	return s.ApplySyncPolicyVersionLocked(ctx, remoteChainID, epoch, policyVersion, revision, policyHash, domains)
+}
+
+// ApplySyncPolicyVersionLocked is the final-write variant for authenticated
+// handlers that must revalidate an exact peer generation while holding the
+// same sync-policy write lease. The caller MUST hold LockSyncPolicyWrite.
+func (s *SQLiteStore) ApplySyncPolicyVersionLocked(ctx context.Context, remoteChainID, epoch string, policyVersion int, revision int64, policyHash string, domains []string) (string, error) {
+	if policyVersion != 1 && policyVersion != 2 {
+		return "", fmt.Errorf("unsupported sync policy version %d", policyVersion)
+	}
 	result := "applied"
 	err := s.RunInTx(ctx, func(txStore OffchainStore) error {
 		tx := txStore.(*SQLiteStore)
@@ -692,6 +790,16 @@ func (s *SQLiteStore) ApplyRemoteDirectionalSyncPolicy(ctx context.Context, remo
 	}
 	unlock := s.LockSyncPolicyWrite()
 	defer unlock()
+	return s.ApplyRemoteDirectionalSyncPolicyLocked(ctx, remoteChainID, epoch, version, revision, policyHash, publish, subscribe)
+}
+
+// ApplyRemoteDirectionalSyncPolicyLocked mirrors
+// ApplySyncPolicyVersionLocked for the peer-authored v3 revision lane. The
+// caller MUST hold LockSyncPolicyWrite.
+func (s *SQLiteStore) ApplyRemoteDirectionalSyncPolicyLocked(ctx context.Context, remoteChainID, epoch string, version int, revision int64, policyHash string, publish, subscribe []string) (string, error) {
+	if version < 3 {
+		return "", fmt.Errorf("directional sync policy requires version 3 or newer")
+	}
 	result := "applied"
 	err := s.RunInTx(ctx, func(txStore OffchainStore) error {
 		tx := txStore.(*SQLiteStore)

--- a/internal/store/sync_tables_test.go
+++ b/internal/store/sync_tables_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -135,6 +136,54 @@ func TestSyncControlPolicyRevisionAndAtomicDomains(t *testing.T) {
 	domains, _ = s.GetSyncDomains(ctx, "chain-b")
 	if len(domains) != 0 {
 		t.Fatalf("disable left domains: %v", domains)
+	}
+}
+
+func TestFederationConnectionEventSurvivesPurgeAndClearsOnlyOnFreshActivation(t *testing.T) {
+	ctx := context.Background()
+	s := newSyncTestStore(t)
+	binding := SyncControl{
+		RemoteChainID: "chain-event", Role: "guest", ControllerChainID: "chain-event",
+		ControllerAgentID: testPeerAgentID(t), PeerAgentID: testPeerAgentID(t),
+		PolicyEpoch: "epoch-event", RemoteCAPin: strings.Repeat("ab", 32), PolicyVersion: 3,
+	}
+	if err := s.SetFederationConnectionEvent(ctx, FederationConnectionEvent{
+		RemoteChainID: binding.RemoteChainID,
+		Event:         FederationConnectionRevokedByPeer,
+		Message:       "The peer operator permanently revoked trust.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PrepareSyncControl(ctx, binding); err != nil {
+		t.Fatal(err)
+	}
+	// A pending/aborted ceremony must not erase the explanation attached to the
+	// immutable past row. Only a successfully activated replacement does.
+	event, err := s.GetFederationConnectionEvent(ctx, binding.RemoteChainID)
+	if err != nil || event == nil || event.Event != FederationConnectionRevokedByPeer {
+		t.Fatalf("pending enrollment cleared event=%+v err=%v", event, err)
+	}
+	if err := s.ActivateSyncControl(ctx, binding.RemoteChainID, binding.PolicyEpoch); err != nil {
+		t.Fatal(err)
+	}
+	event, err = s.GetFederationConnectionEvent(ctx, binding.RemoteChainID)
+	if err != nil || event != nil {
+		t.Fatalf("fresh active enrollment retained old event=%+v err=%v", event, err)
+	}
+
+	if err := s.SetFederationConnectionEvent(ctx, FederationConnectionEvent{
+		RemoteChainID: binding.RemoteChainID,
+		Event:         FederationConnectionRevokedLocally,
+		Message:       "This operator permanently revoked trust.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PurgeSyncPeerState(ctx, binding.RemoteChainID); err != nil {
+		t.Fatal(err)
+	}
+	event, err = s.GetFederationConnectionEvent(ctx, binding.RemoteChainID)
+	if err != nil || event == nil || event.Event != FederationConnectionRevokedLocally || event.CreatedAt == "" {
+		t.Fatalf("purge lost past-connection event=%+v err=%v", event, err)
 	}
 }
 

--- a/internal/store/sync_tables_test.go
+++ b/internal/store/sync_tables_test.go
@@ -163,23 +163,23 @@ func TestFederationConnectionEventSurvivesPurgeAndClearsOnlyOnFreshActivation(t 
 	if err != nil || event == nil || event.Event != FederationConnectionRevokedByPeer {
 		t.Fatalf("pending enrollment cleared event=%+v err=%v", event, err)
 	}
-	if err := s.ActivateSyncControl(ctx, binding.RemoteChainID, binding.PolicyEpoch); err != nil {
-		t.Fatal(err)
+	if activateErr := s.ActivateSyncControl(ctx, binding.RemoteChainID, binding.PolicyEpoch); activateErr != nil {
+		t.Fatal(activateErr)
 	}
 	event, err = s.GetFederationConnectionEvent(ctx, binding.RemoteChainID)
 	if err != nil || event != nil {
 		t.Fatalf("fresh active enrollment retained old event=%+v err=%v", event, err)
 	}
 
-	if err := s.SetFederationConnectionEvent(ctx, FederationConnectionEvent{
+	if setEventErr := s.SetFederationConnectionEvent(ctx, FederationConnectionEvent{
 		RemoteChainID: binding.RemoteChainID,
 		Event:         FederationConnectionRevokedLocally,
 		Message:       "This operator permanently revoked trust.",
-	}); err != nil {
-		t.Fatal(err)
+	}); setEventErr != nil {
+		t.Fatal(setEventErr)
 	}
-	if err := s.PurgeSyncPeerState(ctx, binding.RemoteChainID); err != nil {
-		t.Fatal(err)
+	if purgeErr := s.PurgeSyncPeerState(ctx, binding.RemoteChainID); purgeErr != nil {
+		t.Fatal(purgeErr)
 	}
 	event, err = s.GetFederationConnectionEvent(ctx, binding.RemoteChainID)
 	if err != nil || event == nil || event.Event != FederationConnectionRevokedLocally || event.CreatedAt == "" {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "check:js": "node scripts/check-static-js.mjs",
-    "test": "npm run check:js && node --test scripts/cerebrum-shell.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
+    "test": "npm run check:js && node --test scripts/cerebrum-shell.test.mjs scripts/federation-flow.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/cerebrum-shell.test.mjs
+++ b/scripts/cerebrum-shell.test.mjs
@@ -55,6 +55,48 @@ test('federation owns a viewport-bounded vertical scroll container', () => {
     assert.match(federationPage, /flex:\s*1/);
     assert.match(federationPage, /min-height:\s*0/);
     assert.match(federationPage, /overflow-y:\s*auto/);
+    const scanVideo = cssSource.match(/\.fed-scan-video\s*\{([^}]*)\}/)?.[1] || '';
+    assert.match(scanVideo, /max-height:\s*min\(46vh,\s*340px\)/,
+        'a live camera must remain bounded on short laptop viewports');
+    assert.match(cssSource, /@media \(max-width:\s*820px\)[\s\S]*\.fed-exchange\s*\{\s*grid-template-columns:\s*1fr/,
+        'the two-way scan cards must stack into the page scroll container on narrow screens');
+});
+
+test('federation ceremony presents one clear two-way scan flow without dropping the safety check', () => {
+    const hostWizard = appSource.slice(appSource.indexOf('function HostJoinWizard('), appSource.indexOf('function fedCatalogMap('));
+    assert.match(hostWizard, /fed-wizard-wide/);
+    assert.match(hostWizard, /class="fed-exchange"/);
+    assert.match(hostWizard, /They scan this SAGE/);
+    assert.match(hostWizard, /Scan their SAGE back/);
+    assert.ok(hostWizard.indexOf('They scan this SAGE') < hostWizard.indexOf('Scan their SAGE back'));
+    assert.match(appSource, /Scan each other[\s\S]*Confirm colleague[\s\S]*Connected/,
+        'operators should see three human stages rather than protocol internals');
+    assert.match(hostWizard, /expectedCode=\$\{view\.code_g\}/,
+        'the pin-bound anti-relay safety code remains deliberate and unskippable');
+    assert.match(appSource, /expectedCode=\$\{codes\.code_h\}/,
+        'both operators still independently confirm the connection');
+    const guestWizard = appSource.slice(appSource.indexOf('function GuestJoinWizard('), appSource.indexOf('// HostJoinWizard'));
+    assert.match(guestWizard, /useState\('scan'\)/,
+        'the normal guest flow must open directly on the camera scan');
+    assert.doesNotMatch(appSource, /function FedChannelGate/,
+        'remote/fallback help must be progressive disclosure, not a three-choice preflight');
+    assert.match(guestWizard, /Connecting remotely or need to change the network address\?/);
+    assert.match(appSource, /Why check a number after scanning\?/,
+        'the remaining anti-relay fingerprint must explain why it exists');
+    assert.match(guestWizard, /They confirm you[\s\S]*You confirm them/,
+        'the guest should see one mutual check with one responsibility per person');
+    assert.match(hostWizard, /You confirm them[\s\S]*They confirm you/,
+        'the host should see the same mutual check from the opposite perspective');
+    assert.match(hostWizard, /step === 'waiting' && v\.guest_chain\) setStep\('compare'\)/,
+        'the host should move directly from the reciprocal scan to the one real trust decision');
+    assert.doesNotMatch(hostWizard, /step === 'review'/,
+        'a redundant pre-confirmation screen must not make the host approve the same colleague twice');
+    assert.match(hostWizard, /trustOnly=\$\{true\}/);
+    assert.match(appSource, /This establishes trust only; no domains are shared yet/,
+        'the single host confirmation screen must preserve the trust-versus-permissions boundary');
+    assert.match(apiSource, /fedGuestAbort/);
+    assert.match(guestWizard, /await fedGuestAbort\(scan\.session_id\)/,
+        'a guest-side Stop must notify the waiting peer');
 });
 
 test('federation separates trust from directional per-domain RBAC', () => {
@@ -99,6 +141,42 @@ test('federation separates trust from directional per-domain RBAC', () => {
     assert.doesNotMatch(panel, /Add a topic|syncRole|Managed by the host|host-managed/);
     assert.match(appSource, /<\$\{FedPermissionsPanel\} conn=\$\{c\}/);
     assert.doesNotMatch(appSource, /FedSyncPanel/);
+});
+
+test('federation keeps temporary pause separate from permanent revocation and hides past clutter', () => {
+    const page = appSource.slice(appSource.indexOf('function FederationPage('), appSource.indexOf('// PAGE_LABELS'));
+    const panel = appSource.slice(appSource.indexOf('function FedPermissionsPanel('), appSource.indexOf('// FederationWarmup'));
+    assert.match(apiSource, /connections\/\$\{encodeURIComponent\(chainId\)\}\/pause/);
+    assert.match(page, /Resume sharing/);
+    assert.match(page, /pairing preserved/);
+    assert.match(panel, /Revoke trust permanently/);
+    assert.match(page, /Past connections \(\$\{pastConns\.length\}\)/);
+    assert.match(page, /showPast && html/,
+        'immutable past rows must remain collapsed until the operator asks for history');
+    assert.match(panel, /remotePaused/);
+    assert.match(panel, /paused sharing/);
+    assert.match(page, /lastGoodConns/);
+    assert.doesNotMatch(page, /setConns\(\[\]\)/,
+        'one failed poll must not unmount live rows and unsaved permission drafts');
+    assert.match(page, /ended this connection/);
+    assert.match(page, /sage-fed-revoke-dismissed/,
+        'peer revocation must have a persistent, dismissible explanation outside collapsed history');
+    assert.match(page, /ended_at/);
+});
+
+test('federation ceremony controls expose accessible dialog, focus, and table semantics', () => {
+    assert.match(appSource, /aria-label="Enlarge connection QR code"/);
+    assert.match(appSource, /role="dialog" aria-modal="true"/);
+    assert.match(appSource, /triggerRef\.current\.focus\(\)/);
+    assert.match(appSource, /for="fed-safety-code"/);
+    assert.match(appSource, /role="alert">That doesn't match/);
+    assert.match(appSource, /querySelector\('\.fed-step h2, \.fed-step h3, \.fed-compare h3'\)/);
+    assert.match(appSource, /role="table" aria-label=/);
+    assert.match(appSource, /class="fed-perm-cell" role="cell"/);
+    assert.match(appSource, /fed-qr-manual-code/,
+        'clipboard or QR failure must expose selectable plaintext instead of a dead-end instruction');
+    assert.match(appSource, /aria-controls=\$\{`fed-connection-/);
+    assert.match(cssSource, /@media \(max-width:\s*560px\)[\s\S]*\.fed-perm-grid-copy-choice/);
 });
 
 test('task cards expand fully and planned task edits preserve consensus history', () => {

--- a/scripts/federation-flow.test.mjs
+++ b/scripts/federation-flow.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { normalizeFederationJoinState } from '../web/static/js/federation-flow.js';
+
+test('join terminal states are handled independently of protocol casing', () => {
+    assert.equal(normalizeFederationJoinState('ABORTED'), 'aborted');
+    assert.equal(normalizeFederationJoinState('EXPIRED'), 'expired');
+    assert.equal(normalizeFederationJoinState(' active '), 'active');
+    assert.equal(normalizeFederationJoinState(null), '');
+});

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.9.1 SDK** | **TLS, RBAC, federation, domain recovery, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.9.2 SDK** | **TLS, RBAC, federation, domain recovery, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.9.1"
+version = "11.9.2"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.9.1"
+__version__ = "11.9.2"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.9.1",
+  "version": "11.9.2",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.9.1",
+      "identifier": "ghcr.io/l33tdawg/sage:11.9.2",
       "transport": {
         "type": "stdio"
       }

--- a/web/federation_join.go
+++ b/web/federation_join.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -32,7 +33,7 @@ type FederationJoinDriver interface {
 	HostScanReturn(sessionID, returnURI string) error
 	HostSessionStatus(sessionID string) (*federation.HostSessionView, error)
 	HostApprove(sessionID, typedCode string, grant federation.ScopeWire) error
-	HostAbort(sessionID string)
+	HostAbort(sessionID string) error
 	GuestScan(ctx context.Context, uri, guestEndpoint string) (*federation.GuestScanResult, error)
 	GuestRequest(ctx context.Context, sessionID, guestEndpoint string, scope federation.ScopeWire) (*federation.GuestRequestResult, error)
 	GuestPollStatus(ctx context.Context, sessionID string) (*federation.JoinStatusResp, error)
@@ -84,6 +85,7 @@ func (h *DashboardHandler) registerFederationRoutes(r chi.Router) {
 	fr.Get("/v1/dashboard/federation/connections", h.handleFedConnections)
 	fr.Get("/v1/dashboard/federation/connections/{chain_id}/permissions", h.handleFedPermissionsGet)
 	fr.Put("/v1/dashboard/federation/connections/{chain_id}/permissions", h.handleFedPermissionsPut)
+	fr.Put("/v1/dashboard/federation/connections/{chain_id}/pause", h.handleFedPause)
 	fr.Post("/v1/dashboard/federation/connections/{chain_id}/revoke", h.handleFedRevoke)
 	fr.Get("/v1/dashboard/federation/connections/{chain_id}/status", h.handleFedPeerStatus)
 
@@ -106,6 +108,7 @@ func (h *DashboardHandler) registerFederationRoutes(r chi.Router) {
 	fr.Post("/v1/dashboard/federation/join/guest/scan", h.handleFedGuestScan)
 	fr.Post("/v1/dashboard/federation/join/guest/request", h.handleFedGuestRequest)
 	fr.Get("/v1/dashboard/federation/join/guest/{session_id}/status", h.handleFedGuestStatus)
+	fr.Post("/v1/dashboard/federation/join/guest/{session_id}/abort", h.handleFedGuestAbort)
 	fr.Post("/v1/dashboard/federation/join/guest/confirm", h.handleFedGuestConfirm)
 
 	// v11.8 sync-group management (INT1): the local operator's authoring surface
@@ -696,6 +699,10 @@ type FedConnection struct {
 	AllowedDomains []string `json:"allowed_domains"`
 	Status         string   `json:"status"`
 	Expired        bool     `json:"expired"`
+	SharingPaused  bool     `json:"sharing_paused"`
+	EndedBy        string   `json:"ended_by,omitempty"`
+	EndedMessage   string   `json:"ended_message,omitempty"`
+	EndedAt        string   `json:"ended_at,omitempty"`
 }
 
 // handleGetNetworkName returns the local network's friendly label + the raw
@@ -764,7 +771,7 @@ func (h *DashboardHandler) handleFedConnections(w http.ResponseWriter, _ *http.R
 		now := time.Now().Unix()
 		conns := make([]FedConnection, 0, len(records))
 		for _, rec := range records {
-			conns = append(conns, FedConnection{
+			conn := FedConnection{
 				RemoteChainID:  rec.RemoteChainID,
 				PeerName:       peerNames[rec.RemoteChainID],
 				Endpoint:       rec.Endpoint,
@@ -772,7 +779,22 @@ func (h *DashboardHandler) handleFedConnections(w http.ResponseWriter, _ *http.R
 				AllowedDomains: rec.AllowedDomains,
 				Status:         rec.Status,
 				Expired:        rec.ExpiresAt != 0 && now >= rec.ExpiresAt,
-			})
+			}
+			if rec.Status == "active" && !conn.Expired {
+				if driver, ok := h.Federation.(peerRBACPolicyDriver); ok {
+					if policy, policyErr := driver.GetPeerRBACPolicy(context.Background(), rec.RemoteChainID); policyErr == nil && policy != nil {
+						conn.SharingPaused = policy.Paused
+					}
+				}
+			}
+			if ss := h.syncStore(); ss != nil {
+				if event, eventErr := ss.GetFederationConnectionEvent(context.Background(), rec.RemoteChainID); eventErr == nil && event != nil {
+					conn.EndedBy = event.Event
+					conn.EndedMessage = event.Message
+					conn.EndedAt = event.CreatedAt
+				}
+			}
+			conns = append(conns, conn)
 		}
 		out["connections"] = conns
 	}
@@ -784,12 +806,36 @@ func (h *DashboardHandler) handleFedRevoke(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	chain := chi.URLParam(r, "chain_id")
-	hash, err := h.Federation.RevokeAgreement(chain)
+	var hash string
+	var notifyResult *federation.RevokeAgreementResult
+	var err error
+	if driver, ok := h.Federation.(interface {
+		RevokeAgreementNotifying(string) (*federation.RevokeAgreementResult, error)
+	}); ok {
+		notifyResult, err = driver.RevokeAgreementNotifying(chain)
+		if notifyResult != nil {
+			hash = notifyResult.TxHash
+		}
+	} else {
+		hash, err = h.Federation.RevokeAgreement(chain)
+	}
 	if err != nil {
 		fedWriteErr(w, http.StatusBadGateway, err.Error())
 		return
 	}
+	if _, notifying := h.Federation.(interface {
+		RevokeAgreementNotifying(string) (*federation.RevokeAgreementResult, error)
+	}); notifying && notifyResult == nil {
+		fedWriteErr(w, http.StatusBadGateway, "Federation revoke returned no result.")
+		return
+	}
 	out := map[string]any{"remote_chain_id": chain, "status": "revoked", "tx_hash": hash}
+	if notifyResult != nil {
+		out["peer_notified"] = notifyResult.PeerNotified
+		if notifyResult.NoticeError != "" {
+			out["notification_warning"] = notifyResult.NoticeError
+		}
+	}
 	if cleanupErr := h.ReconcileFederationManagedGrants(r.Context()); cleanupErr != nil {
 		// Trust is already revoked and the peer-RBAC policy denies immediately.
 		// Keep the durable ledger for the background tx-7 retry and report that
@@ -912,7 +958,14 @@ func (h *DashboardHandler) handleFedHostAbort(w http.ResponseWriter, r *http.Req
 	if !h.fedReady(w) {
 		return
 	}
-	h.Federation.HostAbort(chi.URLParam(r, "session_id"))
+	if err := h.Federation.HostAbort(chi.URLParam(r, "session_id")); err != nil {
+		if errors.Is(err, federation.ErrJoinSessionNotFound) {
+			fedWriteErr(w, http.StatusNotFound, "This connection setup no longer exists.")
+		} else {
+			fedWriteErr(w, http.StatusConflict, "This connection is already being confirmed. Check its status in Federation before revoking it.")
+		}
+		return
+	}
 	fedWriteJSON(w, http.StatusOK, map[string]string{"status": "aborted"})
 }
 
@@ -983,6 +1036,26 @@ func (h *DashboardHandler) handleFedGuestStatus(w http.ResponseWriter, r *http.R
 		return
 	}
 	fedWriteJSON(w, http.StatusOK, resp)
+}
+
+func (h *DashboardHandler) handleFedGuestAbort(w http.ResponseWriter, r *http.Request) {
+	if !h.fedReady(w) {
+		return
+	}
+	driver, ok := h.Federation.(interface {
+		GuestAbort(context.Context, string) error
+	})
+	if !ok {
+		fedWriteErr(w, http.StatusNotImplemented, "Guest-side connection cancellation is unavailable.")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), fedCallTimeout)
+	defer cancel()
+	if err := driver.GuestAbort(ctx, chi.URLParam(r, "session_id")); err != nil {
+		fedWriteErr(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	fedWriteJSON(w, http.StatusOK, map[string]string{"status": "aborted"})
 }
 
 func (h *DashboardHandler) handleFedGuestConfirm(w http.ResponseWriter, r *http.Request) {

--- a/web/federation_permissions.go
+++ b/web/federation_permissions.go
@@ -116,6 +116,11 @@ type peerRBACPolicyDriver interface {
 	ReplacePeerRBACPolicy(context.Context, string, []store.PeerRBACDomainPermission) (*store.PeerRBACPolicy, error)
 }
 
+type peerRBACPauseDriver interface {
+	peerRBACPolicyDriver
+	SetPeerRBACPaused(context.Context, string, bool) (*store.PeerRBACPolicy, error)
+}
+
 type directionalSyncPolicyDriver interface {
 	SetDirectionalSyncPolicy(context.Context, string, []string, []string) (*federation.DirectionalSyncPolicyResult, error)
 }
@@ -214,9 +219,53 @@ func (h *DashboardHandler) handleFedPermissionsGet(w http.ResponseWriter, r *htt
 		"remote_chain_id":    chain,
 		"local_permissions":  local,
 		"local_legacy":       localLegacy,
+		"local_paused":       localPolicy != nil && localPolicy.Paused,
 		"remote_permissions": remote,
 		"remote_known":       remoteKnown,
 		"remote_legacy":      remoteLegacy,
+		"remote_paused":      statusErr == nil && status != nil && status.PeerRBACGrant != nil && status.PeerRBACGrant.Paused,
+	})
+}
+
+// handleFedPause is the everyday temporary disconnect control. It preserves
+// trust and the complete saved domain snapshot while all authorization paths
+// evaluate the local grant as deny-all. Revoke is intentionally separate.
+func (h *DashboardHandler) handleFedPause(w http.ResponseWriter, r *http.Request) {
+	if !h.isFederationMutationOperatorRequest(r) {
+		fedWriteErr(w, http.StatusForbidden, "Pausing federation sharing requires the local node operator.")
+		return
+	}
+	if !h.fedReady(w) {
+		return
+	}
+	h.federationPolicyMu.Lock()
+	defer h.federationPolicyMu.Unlock()
+	chain := chi.URLParam(r, "chain_id")
+	if h.findAgreement(chain) == nil {
+		fedWriteErr(w, http.StatusConflict, "No active agreement for this connection.")
+		return
+	}
+	driver, ok := h.Federation.(peerRBACPauseDriver)
+	if !ok {
+		fedWriteErr(w, http.StatusNotImplemented, "Peer RBAC pause is unavailable on this node.")
+		return
+	}
+	var body struct {
+		Paused *bool `json:"paused"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&body); err != nil || body.Paused == nil {
+		fedWriteErr(w, http.StatusBadRequest, "Expected {\"paused\": true|false}.")
+		return
+	}
+	policy, err := driver.SetPeerRBACPaused(r.Context(), chain, *body.Paused)
+	if err != nil {
+		fedWriteErr(w, http.StatusConflict, err.Error())
+		return
+	}
+	fedWriteJSON(w, http.StatusOK, map[string]any{
+		"remote_chain_id": chain,
+		"paused":          policy.Paused,
+		"permissions":     clonePeerPermissions(policy.Domains),
 	})
 }
 
@@ -397,6 +446,7 @@ func (h *DashboardHandler) handleFedPermissionsPut(w http.ResponseWriter, r *htt
 	fedWriteJSON(w, http.StatusOK, map[string]any{
 		"remote_chain_id":   chain,
 		"local_permissions": clonePeerPermissions(policy.Domains),
+		"local_paused":      policy.Paused,
 		"grant_results":     grantResults,
 		"warnings":          warnings,
 	})

--- a/web/federation_permissions_test.go
+++ b/web/federation_permissions_test.go
@@ -1,11 +1,48 @@
 package web
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
+	"github.com/l33tdawg/sage/internal/federation"
 	"github.com/l33tdawg/sage/internal/store"
 	"github.com/stretchr/testify/require"
 )
+
+type pauseContractDriver struct {
+	FederationJoinDriver
+	policy *store.PeerRBACPolicy
+	calls  []bool
+}
+
+func (d *pauseContractDriver) ResolvePeerOperatorAgentID(context.Context, string) (string, error) {
+	return d.policy.PeerAgentID, nil
+}
+func (d *pauseContractDriver) GetPeerRBACPolicy(context.Context, string) (*store.PeerRBACPolicy, error) {
+	clone := *d.policy
+	clone.Domains = append([]store.PeerRBACDomainPermission(nil), d.policy.Domains...)
+	return &clone, nil
+}
+func (d *pauseContractDriver) ReplacePeerRBACPolicy(_ context.Context, _ string, domains []store.PeerRBACDomainPermission) (*store.PeerRBACPolicy, error) {
+	d.policy.Domains = append([]store.PeerRBACDomainPermission(nil), domains...)
+	return d.GetPeerRBACPolicy(context.Background(), d.policy.RemoteChainID)
+}
+func (d *pauseContractDriver) SetPeerRBACPaused(_ context.Context, _ string, paused bool) (*store.PeerRBACPolicy, error) {
+	d.calls = append(d.calls, paused)
+	d.policy.Paused = paused
+	return d.GetPeerRBACPolicy(context.Background(), d.policy.RemoteChainID)
+}
+func (d *pauseContractDriver) PeerStatus(context.Context, string) (*federation.StatusResponse, error) {
+	return &federation.StatusResponse{PeerRBACGrant: &federation.PeerRBACGrant{
+		PolicyVersion: federation.SyncPolicyVersionPeerRBAC, Paused: true,
+		Domains: []federation.PeerRBACDomainGrant{},
+	}}, nil
+}
 
 func TestNormalizeRequestedPeerPermissionsEnforcesDependencies(t *testing.T) {
 	permissions, err := normalizeRequestedPeerPermissions([]store.PeerRBACDomainPermission{
@@ -36,4 +73,69 @@ func TestClonePeerPermissionsSanitizesStaleWriteAndCanonicalizesCopy(t *testing.
 	require.Equal(t, []store.PeerRBACDomainPermission{{
 		Domain: "tii", Read: true, Write: false, Copy: true,
 	}}, permissions)
+}
+
+func TestFederationPauseEndpointPreservesPolicyAndReportsBothDirections(t *testing.T) {
+	ctx := context.Background()
+	ss, err := store.NewSQLiteStore(ctx, filepath.Join(t.TempDir(), "pause.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ss.Close() })
+	bs, err := store.NewBadgerStore(filepath.Join(t.TempDir(), "badger"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bs.CloseBadger() })
+	peerPin := bytes.Repeat([]byte{0x55}, 32)
+	require.NoError(t, bs.SetCrossFed("chain-peer", "https://peer:8444", peerPin, 4, 0, nil, nil, "active"))
+	driver := &pauseContractDriver{policy: &store.PeerRBACPolicy{
+		RemoteChainID: "chain-peer", PeerAgentID: "peer-agent", PolicyEpoch: "epoch-pause",
+		RemoteCAPin: "pin", PolicyVersion: federation.SyncPolicyVersionPeerRBAC,
+		Domains: []store.PeerRBACDomainPermission{{Domain: "tii", Read: true, Copy: true}},
+	}}
+	h := NewDashboardHandler(ss, "test")
+	h.BadgerStore = bs
+	h.Federation = driver
+
+	pauseReq := withFederationChain(httptest.NewRequest(http.MethodPut,
+		"http://localhost/v1/dashboard/federation/connections/chain-peer/pause",
+		bytes.NewBufferString(`{"paused":true}`)), "chain-peer")
+	pauseReq.RemoteAddr = "127.0.0.1:4242"
+	pauseReq.Header.Set("Sec-Fetch-Site", "same-origin")
+	pauseRR := httptest.NewRecorder()
+	h.handleFedPause(pauseRR, pauseReq)
+	require.Equal(t, http.StatusOK, pauseRR.Code, pauseRR.Body.String())
+	require.Equal(t, []bool{true}, driver.calls)
+	require.True(t, driver.policy.Paused)
+	require.Equal(t, []store.PeerRBACDomainPermission{{Domain: "tii", Read: true, Copy: true}}, driver.policy.Domains)
+	var pauseBody struct {
+		Paused      bool                             `json:"paused"`
+		Permissions []store.PeerRBACDomainPermission `json:"permissions"`
+	}
+	require.NoError(t, json.NewDecoder(pauseRR.Body).Decode(&pauseBody))
+	require.True(t, pauseBody.Paused)
+	require.Len(t, pauseBody.Permissions, 1)
+
+	permissionsReq := withFederationChain(httptest.NewRequest(http.MethodGet,
+		"http://localhost/v1/dashboard/federation/connections/chain-peer/permissions", nil), "chain-peer")
+	permissionsReq.RemoteAddr = "127.0.0.1:4242"
+	permissionsReq.Header.Set("Sec-Fetch-Site", "same-origin")
+	permissionsRR := httptest.NewRecorder()
+	h.handleFedPermissionsGet(permissionsRR, permissionsReq)
+	require.Equal(t, http.StatusOK, permissionsRR.Code, permissionsRR.Body.String())
+	var permissionsBody struct {
+		LocalPaused  bool `json:"local_paused"`
+		RemotePaused bool `json:"remote_paused"`
+	}
+	require.NoError(t, json.NewDecoder(permissionsRR.Body).Decode(&permissionsBody))
+	require.True(t, permissionsBody.LocalPaused)
+	require.True(t, permissionsBody.RemotePaused)
+
+	resumeReq := withFederationChain(httptest.NewRequest(http.MethodPut,
+		"http://localhost/v1/dashboard/federation/connections/chain-peer/pause",
+		bytes.NewBufferString(`{"paused":false}`)), "chain-peer")
+	resumeReq.RemoteAddr = "127.0.0.1:4242"
+	resumeReq.Header.Set("Sec-Fetch-Site", "same-origin")
+	resumeRR := httptest.NewRecorder()
+	h.handleFedPause(resumeRR, resumeReq)
+	require.Equal(t, http.StatusOK, resumeRR.Code, resumeRR.Body.String())
+	require.Equal(t, []bool{true, false}, driver.calls)
+	require.False(t, driver.policy.Paused)
 }

--- a/web/static/css/sage.css
+++ b/web/static/css/sage.css
@@ -4598,7 +4598,9 @@ input[type="range"]::-moz-range-thumb {
     flex: 1;
     min-height: 0;
     overflow-y: auto;
-    padding: 24px 32px;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    padding: 24px 32px max(36px, env(safe-area-inset-bottom));
 }
 .fed-page .fed-landing { max-width: 1100px; margin: 0 auto; }
 .fed-landing h1 { margin: 0 0 16px; }
@@ -4651,10 +4653,31 @@ input[type="range"]::-moz-range-thumb {
 .fed-conn-main { display: flex; align-items: center; gap: 10px; min-width: 0; }
 .fed-conn-status { width: 9px; height: 9px; border-radius: 50%; background: var(--text-muted); flex: none; }
 .fed-conn-status.on { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.fed-conn-status.paused { background: var(--warning); box-shadow: 0 0 6px rgba(245, 158, 11, 0.55); }
 .fed-conn-status.off { background: var(--text-muted); }
 .fed-conn-name { font-weight: 600; }
 .fed-conn-meta { font-size: 12px; }
 .fed-conn-off { flex: none; }
+.fed-past { margin-top: 14px; }
+.fed-past-toggle {
+    display: inline-flex; align-items: center; gap: 7px; padding: 6px 0;
+    border: 0; background: none; color: var(--text-muted); cursor: pointer;
+    font: inherit; font-size: 12px; font-weight: 600;
+}
+.fed-past-toggle:hover { color: var(--text); }
+.fed-past-list { margin-top: 4px; opacity: 0.82; }
+.fed-conn-past { justify-content: flex-start; }
+.fed-conn-past .fed-conn-meta { margin-left: 2px; }
+.fed-past-reason { margin-left: auto; font-size: 11px; text-align: right; }
+.fed-past-time { flex: none; font-size: 10.5px; }
+.fed-peer-revoke-notice {
+    display: flex; align-items: center; justify-content: space-between; gap: 16px;
+    margin: 12px 0 18px; padding: 13px 15px; border-radius: var(--radius-lg);
+    border: 1px solid rgba(245, 158, 11, 0.38); background: var(--warning-tint);
+}
+.fed-peer-revoke-notice strong { color: var(--warning); font-size: 13.5px; }
+.fed-peer-revoke-notice p { margin: 3px 0 0; color: var(--text-muted); font-size: 12px; line-height: 1.45; }
+.fed-peer-revoke-notice .btn { flex: none; }
 
 /* Wizard shell */
 /* Network name (friendly rename) */
@@ -4668,9 +4691,35 @@ input[type="range"]::-moz-range-thumb {
 .fed-netname-row .fed-share-input { flex: 1; }
 
 .fed-wizard { max-width: 560px; margin: 0 auto; }
+.fed-wizard-wide { max-width: 980px; }
 .fed-wizard-head { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
 .fed-wizard-title { font-weight: 600; color: var(--text-dim); }
 .fed-back { padding: 5px 10px; font-size: 13px; }
+.fed-ceremony-progress {
+    display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0; margin: 0 0 14px; color: var(--text-muted); font-size: 11.5px;
+}
+.fed-ceremony-progress-item {
+    position: relative; display: flex; align-items: center; justify-content: center;
+    gap: 7px; min-width: 0; padding: 3px 8px; text-align: center;
+}
+.fed-ceremony-progress-item:not(:last-child)::after {
+    content: ''; position: absolute; left: calc(50% + 55px); right: calc(-50% + 55px);
+    top: 50%; height: 1px; background: var(--border-light);
+}
+.fed-ceremony-progress-dot {
+    display: inline-flex; align-items: center; justify-content: center; flex: none;
+    width: 21px; height: 21px; border: 1px solid var(--border-light);
+    border-radius: 50%; background: var(--bg-deep); font-size: 10px; font-weight: 700;
+}
+.fed-ceremony-progress-item.active { color: var(--text); font-weight: 600; }
+.fed-ceremony-progress-item.active .fed-ceremony-progress-dot {
+    color: var(--on-accent); border-color: var(--primary); background: var(--primary);
+}
+.fed-ceremony-progress-item.done { color: var(--accent); }
+.fed-ceremony-progress-item.done .fed-ceremony-progress-dot {
+    color: var(--accent); border-color: var(--accent); background: var(--accent-dim);
+}
 .fed-step { background: var(--bg-surface); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 22px; text-align: center; }
 .fed-step h2 { margin: 0 0 6px; }
 .fed-step h3 { margin: 14px 0 8px; }
@@ -4682,6 +4731,35 @@ input[type="range"]::-moz-range-thumb {
 .fed-err { background: var(--danger-tint); border: 1px solid var(--danger); color: var(--danger); border-radius: var(--radius); padding: 10px 14px; margin-bottom: 14px; font-size: 13px; }
 .fed-warn { background: var(--warn-tint, rgba(245,158,11,0.12)); border: 1px solid var(--warn, #f59e0b); color: var(--warn, #f59e0b); border-radius: var(--radius); padding: 8px 12px; margin-top: 8px; font-size: 12.5px; line-height: 1.45; text-align: center; }
 .fed-warn code { background: rgba(127,127,127,0.16); padding: 1px 5px; border-radius: 4px; }
+
+/* The first exchange is one action with two directions. Keep both cards in
+   view on a laptop; on narrow screens they stack inside the page's real scroll
+   container instead of clipping the camera below the fold. */
+.fed-exchange-step { padding: 20px; }
+.fed-exchange-step > .fed-green-rail { margin-top: 0; }
+.fed-exchange-lead { margin: 4px auto 16px; max-width: 620px; line-height: 1.45; }
+.fed-exchange {
+    display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px; align-items: stretch; text-align: left;
+}
+.fed-exchange-card {
+    min-width: 0; padding: 16px; border: 1px solid var(--border);
+    border-radius: var(--radius-lg); background: var(--bg-elevated);
+}
+.fed-exchange-card-active { border-color: rgba(56, 189, 248, 0.42); }
+.fed-exchange-card-head { display: flex; align-items: flex-start; gap: 10px; }
+.fed-exchange-card-head h3 { margin: 1px 0 3px; font-size: 14px; }
+.fed-exchange-card-head p { margin: 0; text-align: left; font-size: 11.5px; line-height: 1.4; }
+.fed-exchange-number {
+    display: inline-flex; align-items: center; justify-content: center; flex: none;
+    width: 24px; height: 24px; border-radius: 50%; background: var(--primary-dim);
+    border: 1px solid var(--primary); color: var(--primary); font-size: 11px; font-weight: 800;
+}
+.fed-exchange-card .fed-qr { margin: 12px 0 10px; }
+.fed-exchange-card .fed-scan-choose { min-height: 212px; align-content: center; align-items: center; }
+.fed-exchange-card .fed-scan { margin-top: 12px; }
+.fed-exchange-card > .fed-linkbtn { display: block; margin: 0 auto; font-size: 11.5px; }
+.fed-exchange-note { margin: 14px 0 0; font-size: 11.5px; }
 
 /* Federation warm-up (fork-ladder cold start) */
 .fed-warmup { text-align: center; max-width: 460px; margin: 28px auto; padding: 28px 24px; background: var(--surface-inset, rgba(127,127,127,0.05)); border: 1px solid var(--border); border-radius: 14px; }
@@ -4705,6 +4783,13 @@ input[type="range"]::-moz-range-thumb {
 .fed-permissions-panel { padding: 14px; background: var(--surface-inset, rgba(127,127,127,0.05)); border-radius: var(--radius); margin: 4px 0 14px; }
 .fed-permissions-intro { font-size: 12.5px; line-height: 1.55; padding: 10px 12px; margin-bottom: 12px; color: var(--text-muted); background: rgba(16,185,129,0.08); border: 1px solid rgba(16,185,129,0.28); border-radius: var(--radius); }
 .fed-permissions-intro strong { color: var(--text); }
+.fed-perm-pause-note {
+    margin: 0 0 12px; padding: 9px 11px; color: var(--text-dim); font-size: 12px;
+    line-height: 1.45; background: var(--warning-tint); border: 1px solid rgba(245, 158, 11, 0.32);
+    border-radius: var(--radius);
+}
+.fed-perm-pause-note strong { color: var(--warning); }
+.fed-perm-section .fed-perm-pause-note { margin-top: 12px; }
 .fed-perm-section { padding: 14px; background: var(--bg-surface); border: 1px solid var(--border); border-radius: var(--radius); }
 .fed-perm-section + .fed-perm-section { margin-top: 12px; }
 .fed-perm-section-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; }
@@ -4716,6 +4801,7 @@ input[type="range"]::-moz-range-thumb {
 .fed-perm-bulk { display: flex; flex-wrap: wrap; gap: 6px; }
 .fed-perm-bulk .btn { padding: 6px 9px; font-size: 11.5px; }
 .fed-perm-count { margin: 7px 0 8px; font-size: 11px; }
+.fed-perm-table { min-width: 0; }
 .fed-perm-grid { display: grid; grid-template-columns: minmax(0, 1fr) repeat(3, minmax(58px, 76px)); align-items: stretch; }
 .fed-perm-grid-copy-choice { grid-template-columns: minmax(0, 1fr) repeat(4, minmax(58px, 76px)); }
 .fed-perm-grid-head { color: var(--text-muted); border-bottom: 1px solid var(--border); font-size: 10.5px; font-weight: 700; letter-spacing: 0.03em; text-transform: uppercase; }
@@ -4739,6 +4825,14 @@ input[type="range"]::-moz-range-thumb {
 .fed-perm-state { display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; border-radius: 50%; font-size: 12px; font-weight: 800; }
 .fed-perm-state.on { color: #10b981; background: rgba(16,185,129,0.14); }
 .fed-perm-state.off { color: var(--text-muted); background: rgba(127,127,127,0.1); }
+.fed-perm-danger {
+    display: flex; align-items: center; justify-content: space-between; gap: 18px;
+    margin-top: 14px; padding: 12px 14px; border: 1px solid rgba(239, 68, 68, 0.35);
+    border-radius: var(--radius); background: var(--danger-tint, rgba(239,68,68,0.06));
+}
+.fed-perm-danger strong { display: block; font-size: 12.5px; color: var(--text); }
+.fed-perm-danger p { margin: 3px 0 0; max-width: 720px; color: var(--text-muted); font-size: 11.5px; line-height: 1.45; }
+.fed-perm-danger .btn { flex: none; }
 
 @media (max-width: 700px) {
     .fed-permissions-panel { padding: 8px; }
@@ -4749,6 +4843,15 @@ input[type="range"]::-moz-range-thumb {
     .fed-perm-grid-head { font-size: 9px; letter-spacing: 0; }
     .fed-perm-domain { font-size: 11.5px; }
     .fed-perm-bulk { width: 100%; }
+    .fed-perm-danger { align-items: flex-start; flex-direction: column; }
+    .fed-past-reason { display: none; }
+    .fed-conn-row { align-items: flex-start; flex-wrap: wrap; gap: 8px; }
+    .fed-conn-main { flex: 1 1 100%; width: 100%; }
+    .fed-conn-off { margin-left: 19px; }
+    .fed-conn-meta { line-height: 1.35; }
+    .fed-conn-past .fed-conn-meta { flex: 1; }
+    .fed-past-time { width: 100%; margin-left: 19px; }
+    .fed-peer-revoke-notice { align-items: flex-start; }
 }
 
 /* Channel gate */
@@ -4762,8 +4865,17 @@ input[type="range"]::-moz-range-thumb {
 .fed-qr-canvas { background: #fff; padding: 12px; border-radius: var(--radius); min-width: 60px; min-height: 60px; cursor: zoom-in; }
 .fed-qr-canvas img, .fed-qr-canvas canvas { display: block; }
 .fed-qr-caption { font-size: 12px; text-align: center; }
+.fed-qr-actions { flex-wrap: wrap; justify-content: center; }
 .fed-qr-enlarge { font-size: 12px; }
 .fed-copy-btn { font-size: 12px; }
+.fed-qr-manual { width: min(100%, 520px); }
+.fed-qr-copy-error { max-width: 360px; color: var(--danger); font-size: 12px; line-height: 1.4; }
+.fed-qr-manual-code {
+    width: 100%; min-height: 64px; resize: vertical; padding: 8px 10px;
+    color: var(--text); background: var(--bg-deep); border: 1px solid var(--border-light);
+    border-radius: var(--radius); font: 10px/1.35 ui-monospace, SFMono-Regular, Menlo, monospace;
+    overflow-wrap: anywhere;
+}
 .fed-linkbtn { background: none; border: none; color: var(--accent); cursor: pointer; padding: 0; font-size: inherit; text-decoration: underline; }
 
 /* QR lightbox — a big, high-contrast QR the other laptop's built-in camera can
@@ -4774,30 +4886,69 @@ input[type="range"]::-moz-range-thumb {
     gap: 20px; padding: 24px; cursor: zoom-out;
     background: rgba(6, 10, 18, 0.9); backdrop-filter: blur(3px);
 }
-.fed-qr-lightbox-canvas { background: #fff; padding: 24px; border-radius: 16px; box-shadow: 0 12px 48px rgba(0,0,0,0.5); }
-.fed-qr-lightbox-canvas img, .fed-qr-lightbox-canvas canvas { display: block; }
+.fed-qr-lightbox-canvas { max-width: calc(100vw - 48px); max-height: calc(100vh - 140px); background: #fff; padding: 24px; border-radius: 16px; box-shadow: 0 12px 48px rgba(0,0,0,0.5); }
+.fed-qr-lightbox-canvas img, .fed-qr-lightbox-canvas canvas {
+    display: block; max-width: calc(100vw - 96px); max-height: calc(100vh - 188px);
+    width: auto !important; height: auto !important;
+}
 .fed-qr-lightbox-hint { color: #fff; font-size: 14px; text-align: center; opacity: 0.85; }
 
 /* Scanner */
 .fed-scan { display: flex; flex-direction: column; gap: 12px; align-items: center; }
 .fed-scan-choose { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; margin-top: 8px; }
-.fed-scan-video { width: 100%; max-width: 340px; border-radius: var(--radius); background: #000; aspect-ratio: 1; object-fit: cover; }
+.fed-scan-video {
+    width: 100%; max-width: 340px; max-height: min(46vh, 340px);
+    border-radius: var(--radius); background: #000; aspect-ratio: 1; object-fit: cover;
+}
 .fed-scan-hint { font-size: 12px; }
 .fed-scan-actions { display: flex; justify-content: center; gap: 10px; flex-wrap: wrap; }
 .fed-paste { width: 100%; background: var(--bg-deep); border: 1px solid var(--border-light); border-radius: var(--radius); color: var(--text); padding: 10px; font-family: monospace; font-size: 12px; resize: vertical; }
 
+@media (max-width: 820px) {
+    .fed-page { padding-left: 18px; padding-right: 18px; }
+    .fed-exchange { grid-template-columns: 1fr; }
+    .fed-exchange-card .fed-scan-choose { min-height: 0; padding: 24px 0; }
+}
+
+@media (max-width: 560px) {
+    .fed-ceremony-progress-item { flex-direction: column; gap: 4px; padding: 2px 3px; font-size: 10px; }
+    .fed-ceremony-progress-item:not(:last-child)::after { left: calc(50% + 18px); right: calc(-50% + 18px); top: 11px; }
+    .fed-exchange-step, .fed-step { padding: 16px; }
+    .fed-master, .fed-netname-view, .fed-peer-revoke-notice { align-items: flex-start; flex-direction: column; }
+    .fed-roles { grid-template-columns: 1fr; }
+    .fed-perm-grid { grid-template-columns: minmax(86px, 1fr) repeat(3, 38px); }
+    .fed-perm-grid-copy-choice { grid-template-columns: minmax(66px, 1.4fr) repeat(4, minmax(0, 1fr)); }
+    .fed-perm-grid-head { font-size: 7.5px; }
+    .fed-perm-grid-head > span { padding: 7px 2px; overflow-wrap: anywhere; }
+    .fed-perm-cell { font-size: 10px; }
+    .fed-qr-lightbox { padding: 12px; }
+    .fed-qr-lightbox-canvas { max-width: calc(100vw - 24px); padding: 12px; }
+    .fed-qr-lightbox-canvas img, .fed-qr-lightbox-canvas canvas { max-width: calc(100vw - 48px); max-height: calc(100vh - 164px); }
+    .fed-compare { padding: 16px; }
+    .fed-compare-input { font-size: 23px; letter-spacing: 5px; padding: 10px 6px; }
+}
+
+@media (max-height: 760px) {
+    .fed-scan-video { max-height: 270px; max-width: 270px; }
+    .fed-exchange-card .fed-scan-choose { min-height: 180px; }
+}
+
 /* Big spoken code */
-.fed-bigcode { display: flex; gap: 10px; justify-content: center; margin: 20px 0; }
+.fed-bigcode { display: flex; gap: clamp(4px, 1.6vw, 10px); justify-content: center; margin: 20px 0; }
 .fed-bigcode-d {
-    font-size: 40px; font-weight: 700; font-variant-numeric: tabular-nums;
+    font-size: clamp(28px, 7vw, 40px); font-weight: 700; font-variant-numeric: tabular-nums;
     background: var(--bg-elevated); border: 1px solid var(--border-light);
-    border-radius: var(--radius); width: 52px; text-align: center; padding: 8px 0; color: var(--primary);
+    border-radius: var(--radius); width: clamp(34px, 9vw, 52px); text-align: center; padding: 8px 0; color: var(--primary);
 }
 .fed-read-instr { text-align: center; color: var(--text-dim); font-size: 14px; margin: 8px 0 14px; }
 
 /* Compare - the trust moment */
 .fed-compare { background: var(--bg-surface); border: 1px solid var(--border-light); border-radius: var(--radius-lg); padding: 24px; text-align: center; }
 .fed-compare h3 { margin: 0 0 8px; }
+.fed-compare-peer { display: flex; justify-content: center; align-items: baseline; gap: 8px; flex-wrap: wrap; margin: 4px 0 8px; }
+.fed-compare-peer .muted { font-size: 11px; }
+.fed-compare-peer code { font-size: 10px; }
+.fed-compare-trust { max-width: 470px; margin: 0 auto 12px; text-align: center; color: var(--text-dim); font-size: 13px; line-height: 1.45; }
 .fed-compare-instr { color: var(--text-dim); font-size: 14px; line-height: 1.5; }
 .fed-compare-label { display: block; font-size: 13px; color: var(--text-dim); margin: 16px 0 8px; }
 .fed-compare-input {
@@ -4807,6 +4958,10 @@ input[type="range"]::-moz-range-thumb {
 }
 .fed-compare-input:focus { border-color: var(--primary); outline: none; }
 .fed-compare-bad { color: var(--danger); font-size: 13px; margin-top: 10px; line-height: 1.4; }
+.fed-why-code, .fed-advanced { margin: 14px 0; text-align: left; color: var(--text-muted); font-size: 12px; }
+.fed-why-code summary, .fed-advanced summary { color: var(--accent); cursor: pointer; text-align: center; }
+.fed-why-code p { margin: 8px auto 0; max-width: 440px; line-height: 1.5; }
+.fed-advanced[open] { padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface-inset, rgba(127,127,127,0.04)); }
 .fed-compare-actions { display: flex; justify-content: center; gap: 40px; margin-top: 22px; }
 .fed-compare-actions .btn { flex: 1; padding: 14px; font-size: 15px; }
 .btn-confirm-live { background: var(--accent); border-color: var(--accent); color: var(--on-accent); font-weight: 600; }
@@ -4824,12 +4979,6 @@ input[type="range"]::-moz-range-thumb {
 .fed-share-clr { font-size: 13px; font-weight: 600; margin-top: 6px; color: var(--accent); }
 .fed-share-clr.warn { color: var(--warning); }
 .fed-share-clr.danger { color: var(--danger); }
-
-/* 2-of-2 meter */
-.fed-2of2 { display: flex; align-items: center; gap: 8px; justify-content: center; margin: 14px 0; }
-.fed-dot { width: 12px; height: 12px; border-radius: 50%; border: 2px solid var(--border-light); background: transparent; }
-.fed-dot.on { background: var(--accent); border-color: var(--accent); box-shadow: 0 0 6px var(--accent); }
-.fed-2of2-text { font-size: 12px; color: var(--text-muted); margin-left: 6px; }
 
 /* Waiting / done */
 .fed-waiting { display: flex; align-items: center; gap: 10px; justify-content: center; color: var(--text-dim); font-size: 14px; margin: 16px 0; }

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -855,6 +855,7 @@ export function fedSettingSet(enabled) { return fedPost('/v1/dashboard/settings/
 export function fedShareableDomains() { return fedFetch('/v1/dashboard/federation/shareable-domains'); }
 export function fedPermissionsGet(chainId) { return fedFetch(`/v1/dashboard/federation/connections/${encodeURIComponent(chainId)}/permissions`); }
 export function fedPermissionsSet(chainId, permissions) { return fedPut(`/v1/dashboard/federation/connections/${encodeURIComponent(chainId)}/permissions`, { permissions }); }
+export function fedPause(chainId, paused) { return fedPut(`/v1/dashboard/federation/connections/${encodeURIComponent(chainId)}/pause`, { paused }); }
 // Directional copy policy and status for one trusted connection.
 export function fedSyncGet(chainId) { return fedFetch(`/v1/dashboard/federation/connections/${encodeURIComponent(chainId)}/sync`); }
 // A source's Copy grant is permission; subscribe_domains is this receiver's
@@ -880,6 +881,7 @@ export function fedHostAbort(sessionId) { return fedPost(`/v1/dashboard/federati
 export function fedGuestScan(uri, endpoint) { return fedPost('/v1/dashboard/federation/join/guest/scan', { uri, endpoint }); }
 export function fedGuestRequest(body) { return fedPost('/v1/dashboard/federation/join/guest/request', body); }
 export function fedGuestStatus(sessionId) { return fedFetch(`/v1/dashboard/federation/join/guest/${encodeURIComponent(sessionId)}/status`); }
+export function fedGuestAbort(sessionId) { return fedPost(`/v1/dashboard/federation/join/guest/${encodeURIComponent(sessionId)}/abort`); }
 export function fedGuestConfirm(body) { return fedPost('/v1/dashboard/federation/join/guest/confirm', body); }
 
 // Managed reranker sidecar (guided setup: detect llama-server, download the

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -7,11 +7,12 @@ deprecateUnreadable, getRecoveryKey, recoverOrphansPreview, recoverOrphans,
 joinHostInterfaces, enableNetworkMode, joinHostStart, joinHostStatus, joinHostApprove, joinHostAbort,
 joinGuestStart, joinGuestStatus, joinGuestCancel, joinGuestRestart,
 chatGPTTunnelStatus, chatGPTTunnelSetup, chatGPTTunnelStop,
-fedConnections, fedRevoke, fedPeerStatus, fedGetNetworkName, fedSetNetworkName, fedLanEndpoint, fedReadiness, fedSettingGet, fedSettingSet, fedShareableDomains, fedPermissionsGet, fedPermissionsSet, fedSyncGet, fedSyncSet, fedHostCreate, fedHostScanReturn, fedHostStatus, fedHostApprove, fedHostAbort, fedGuestScan, fedGuestRequest, fedGuestStatus, fedGuestConfirm } from './api.js';
+fedConnections, fedPause, fedRevoke, fedPeerStatus, fedGetNetworkName, fedSetNetworkName, fedLanEndpoint, fedReadiness, fedSettingGet, fedSettingSet, fedShareableDomains, fedPermissionsGet, fedPermissionsSet, fedSyncGet, fedSyncSet, fedHostCreate, fedHostScanReturn, fedHostStatus, fedHostApprove, fedHostAbort, fedGuestScan, fedGuestRequest, fedGuestStatus, fedGuestAbort, fedGuestConfirm } from './api.js';
 
 import { mountMriBrain } from './mri-brain.js';
 import { restartBaselineBootID, requestedRestartIsReady } from './restart-proof.js';
 import { buildUpdateBanner } from './update-banner.js';
+import { normalizeFederationJoinState } from './federation-flow.js';
 
 const { h, render, createContext } = preact;
 const { useState, useEffect, useRef, useLayoutEffect, useCallback, useContext } = preactHooks;
@@ -23,7 +24,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.9.1';
+const SAGE_VERSION = 'v11.9.2';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace
@@ -11384,12 +11385,23 @@ function FedGreenRail() {
     </div>`;
 }
 
-// TwoOfTwoMeter - the ●○ / ●● 2-of-2 consent meter. n = 0..2.
-function TwoOfTwoMeter({ n, labelA = 'You', labelB = 'Them' }) {
-    return html`<div class="fed-2of2" role="status" aria-label=${`${n} of 2 confirmed`}>
-        <span class="fed-dot ${n >= 1 ? 'on' : ''}" title=${labelA}></span>
-        <span class="fed-dot ${n >= 2 ? 'on' : ''}" title=${labelB}></span>
-        <span class="fed-2of2-text">${n} of 2 confirmed</span>
+// FedCeremonyProgress keeps the security ceremony legible as three human
+// moments. The protocol still has two independent confirmations underneath,
+// but the operator should not have to think in implementation steps.
+function FedCeremonyProgress({ stage }) {
+    const stages = [
+        ['scan', 'Scan each other'],
+        ['check', 'Confirm colleague'],
+        ['done', 'Connected'],
+    ];
+    const active = Math.max(0, stages.findIndex(([id]) => id === stage));
+    return html`<div class="fed-ceremony-progress" aria-label="Connection progress">
+        ${stages.map(([id, label], index) => html`<div
+            class="fed-ceremony-progress-item ${index < active ? 'done' : ''} ${index === active ? 'active' : ''}"
+            aria-current=${index === active ? 'step' : null} key=${id}>
+            <span class="fed-ceremony-progress-dot">${index < active ? '✓' : index + 1}</span>
+            <span>${label}</span>
+        </div>`)}
     </div>`;
 }
 
@@ -11421,8 +11433,11 @@ function paintQr(el, text, size) {
 
 function FedQr({ text, size = 220, caption }) {
     const ref = useRef(null);
+    const triggerRef = useRef(null);
     const bigRef = useRef(null);
+    const dialogRef = useRef(null);
     const [copied, setCopied] = useState(false);
+    const [copyError, setCopyError] = useState(false);
     const [rendered, setRendered] = useState(false);
     const [big, setBig] = useState(false);
     useEffect(() => { setRendered(paintQr(ref.current, text, size)); }, [text, size]);
@@ -11431,26 +11446,48 @@ function FedQr({ text, size = 220, caption }) {
     // to the screen can lock on from across a desk.
     useEffect(() => {
         if (!big) return;
-        const px = Math.min(Math.round(Math.min(window.innerWidth, window.innerHeight) * 0.8), 640);
+        // Leave room for dialog padding, the white QR surround, hint text and
+        // gap. Sizing from the raw viewport at 80% clipped landscape laptops.
+        const px = Math.min(640,
+            Math.max(96, Math.floor(window.innerWidth - 96)),
+            Math.max(96, Math.floor(window.innerHeight - 180)));
         paintQr(bigRef.current, text, px);
-        const onKey = (e) => { if (e.key === 'Escape') setBig(false); };
+        if (dialogRef.current) dialogRef.current.focus();
+        const onKey = (e) => {
+            if (e.key === 'Escape') closeBig();
+            if (e.key === 'Tab') { e.preventDefault(); if (dialogRef.current) dialogRef.current.focus(); }
+        };
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);
     }, [big, text]);
 
+    const closeBig = () => {
+        setBig(false);
+        requestAnimationFrame(() => { if (triggerRef.current) triggerRef.current.focus(); });
+    };
     const copy = async () => {
-        try { await navigator.clipboard.writeText(text); setCopied(true); setTimeout(() => setCopied(false), 1500); } catch (e) {}
+        setCopyError(false);
+        try { await navigator.clipboard.writeText(text); setCopied(true); setTimeout(() => setCopied(false), 1500); }
+        catch (e) { setCopyError(true); }
     };
     return html`<div class="fed-qr">
-        <div class="fed-qr-canvas" ref=${ref} onClick=${() => rendered && setBig(true)}
-            role="button" title="Click to enlarge for scanning"></div>
+        <div class="fed-qr-canvas" ref=${el => { ref.current = el; triggerRef.current = el; }}
+            onClick=${() => rendered && setBig(true)}
+            onKeyDown=${e => { if (rendered && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); setBig(true); } }}
+            role="button" tabindex="0" aria-label="Enlarge connection QR code" title="Click to enlarge for scanning"></div>
         ${!rendered && html`<div class="fed-qr-fallback muted">QR unavailable - share the code below instead.</div>`}
         ${caption && html`<div class="fed-qr-caption muted">${caption}</div>`}
         <div class="fed-qr-actions" style="display:flex;gap:8px;">
             ${rendered && html`<button class="btn fed-qr-enlarge" onClick=${() => setBig(true)}>⤢ Make it bigger</button>`}
             <button class="btn fed-copy-btn" onClick=${copy}>${copied ? '✓ Copied' : 'Copy code instead'}</button>
         </div>
-        ${big && html`<div class="fed-qr-lightbox" onClick=${() => setBig(false)}>
+        ${(copyError || !rendered) && html`<div class="fed-qr-manual">
+            ${copyError && html`<div class="fed-qr-copy-error" role="alert">Couldn’t copy automatically. Select and copy the connection code below.</div>`}
+            <textarea class="fed-qr-manual-code" readonly aria-label="Connection code for manual copy"
+                value=${text} onFocus=${e => e.currentTarget.select()} onClick=${e => e.currentTarget.select()}></textarea>
+        </div>`}
+        ${big && html`<div class="fed-qr-lightbox" ref=${dialogRef} role="dialog" aria-modal="true"
+            aria-label="Enlarged connection QR code" tabindex="-1" onClick=${closeBig}>
             <div class="fed-qr-lightbox-canvas" ref=${bigRef} onClick=${e => e.stopPropagation()}></div>
             <div class="fed-qr-lightbox-hint">Point the other computer's camera at this. Click anywhere or press Esc to close.</div>
         </div>`}
@@ -11508,7 +11545,7 @@ function FedScanInput({ onValue, busy }) {
                         const r = window.jsQR(img.data, img.width, img.height);
                         if (r) value = r.data;
                     }
-                    if (value) { stop(); onValue(value); return; }
+                    if (value) { stop(); onValue(value, 'camera'); return; }
                 } catch (e) {}
                 rafRef.current = requestAnimationFrame(scanLoop);
             };
@@ -11537,13 +11574,13 @@ function FedScanInput({ onValue, busy }) {
                 value=${pasted} onInput=${e => setPasted(e.target.value)}></textarea>
             <div class="fed-scan-actions">
                 <button class="btn" onClick=${() => setMode('choose')}>Back</button>
-                <button class="btn btn-primary" disabled=${!v || busy} onClick=${() => onValue(v)}>Use this code</button>
+                <button class="btn btn-primary" disabled=${!v || busy} onClick=${() => onValue(v, 'paste')}>Use this code</button>
             </div>
         </div>`;
     }
     return html`<div class="fed-scan-choose">
         <button class="btn btn-primary" disabled=${busy} onClick=${startCamera}>📷 Scan with camera</button>
-        <button class="btn" disabled=${busy} onClick=${() => setMode('paste')}>Paste the code</button>
+        <button class="fed-linkbtn" disabled=${busy} onClick=${() => setMode('paste')}>Can’t scan? Paste a connection code</button>
     </div>`;
 }
 
@@ -11551,19 +11588,28 @@ function FedScanInput({ onValue, busy }) {
 // pre-highlighted "Yes", no auto-advance, no timeout-confirm. Decisive consent
 // requires TYPING the code you heard; the confirm button stays inert until the
 // typed value matches what this node computed. "No - stop" is first-class danger.
-function FedCodeCompare({ title, instruction, expectedCode, confirmLabel, onConfirm, onReject, busy, tier4 }) {
+function FedCodeCompare({ title, instruction, expectedCode, confirmLabel, onConfirm, onReject, busy, tier4, peerName, peerID, trustOnly }) {
     const [typed, setTyped] = useState('');
     const norm = typed.replace(/\D/g, '');
     const match = norm.length === 6 && expectedCode && norm === String(expectedCode);
     return html`<div class="fed-compare">
         <${FedGreenRail} />
         <h3>${title}</h3>
+        ${peerName && html`<div class="fed-compare-peer">
+            <strong>${peerName}</strong>
+            ${peerID && html`<span class="muted">Network id: <code>${peerID}</code></span>`}
+        </div>`}
+        ${trustOnly && html`<p class="fed-compare-trust">This establishes trust only; no domains are shared yet. You choose access after connecting.</p>`}
         <p class="fed-compare-instr">${instruction}</p>
         ${tier4 && html`<div class="fed-tier4-note">No camera or shared screen? This spoken-code compare is your ONLY safety check - say it out loud on a call you placed to someone you trust, and only continue if it matches exactly.</div>`}
-        <label class="fed-compare-label">Type the code they read you</label>
-        <input class="fed-compare-input" inputmode="numeric" autocomplete="off" maxlength="7"
+        <details class="fed-why-code">
+            <summary>Why check a number after scanning?</summary>
+            <p>The two scans exchange the computers’ keys. This short fingerprint catches a code that was swapped or relayed before you approve it. Each person checks it once; it is not another account or password.</p>
+        </details>
+        <label class="fed-compare-label" for="fed-safety-code">Type the number on their screen</label>
+        <input id="fed-safety-code" class="fed-compare-input" inputmode="numeric" autocomplete="off" maxlength="7"
             placeholder="• • • • • •" value=${typed} onInput=${e => setTyped(e.target.value)} />
-        ${norm.length === 6 && !match && html`<div class="fed-compare-bad">That doesn't match what's on your screen. Do NOT continue - hang up and call them back on a number you trust.</div>`}
+        ${norm.length === 6 && !match && html`<div class="fed-compare-bad" role="alert">That doesn't match what's on your screen. Do NOT continue - hang up and call them back on a number you trust.</div>`}
         <div class="fed-compare-actions">
             <button class="btn btn-danger" disabled=${busy} onClick=${onReject}>No - stop</button>
             <button class="btn ${match ? 'btn-confirm-live' : ''}" disabled=${!match || busy} onClick=${() => onConfirm(norm)}>
@@ -11592,6 +11638,7 @@ function isLoopbackEndpoint(ep) {
 function useLanEndpoint() {
     const [endpoint, setEndpoint] = useState(`https://${location.hostname}:8444`);
     const [candidates, setCandidates] = useState([]);
+    const [resolved, setResolved] = useState(false);
     const touched = useRef(false);
     const set = (v) => { touched.current = true; setEndpoint(v); };
     useEffect(() => {
@@ -11606,10 +11653,11 @@ function useLanEndpoint() {
                     setEndpoint(r.suggested_endpoint);
                 }
             })
-            .catch(() => {});
+            .catch(() => {})
+            .finally(() => { if (live) setResolved(true); });
         return () => { live = false; };
     }, []);
-    return [endpoint, set, candidates];
+    return [endpoint, set, candidates, resolved];
 }
 
 // FedEndpointPicker - a labeled address chooser for multi-homed machines (VPN +
@@ -11630,37 +11678,11 @@ function FedEndpointPicker({ candidates, endpoint, onPick }) {
     </div>`;
 }
 
-// FedChannelGate - the physical-object question (redteam #2). Distinguishes a
-// code held as a PHYSICAL object from a transmitted image. A shared screen /
-// forwarded image / pure phone call routes to the spoken-code (Tier-4) path,
-// never presented as equal to in-person. Also collects the guest's own reachable
-// address (where the host will connect back).
-function FedChannelGate({ endpoint, onEndpoint, candidates, onChoose }) {
-    return html`<div class="fed-step">
-        <h2>Connect to another network</h2>
-        <${FedGreenRail} />
-        <div class="fed-field">
-            <label>Your network address (how they'll reach you)</label>
-            <input class="fed-share-input" value=${endpoint} onInput=${e => onEndpoint(e.target.value)}
-                placeholder="https://192.168.1.20:8444" />
-            <div class="muted">Usually https://[your computer's address]:8444 on your network.</div>
-            ${isLoopbackEndpoint(endpoint) && html`<div class="fed-warn">⚠︎ This is a localhost address — the other computer can't reach it. Use this machine's network address (e.g. <code>https://192.168.1.20:8444</code>), not <code>localhost</code>.</div>`}
-        </div>
-        <${FedEndpointPicker} candidates=${candidates} endpoint=${endpoint} onPick=${onEndpoint} />
-        <div class="fed-gate-q">Are you looking at their code as a physical thing they're holding - in the same room, or held up to the camera on a call YOU placed to someone you trust?</div>
-        <div class="fed-gate-choices">
-            <button class="btn btn-primary" onClick=${() => onChoose(false)}>Yes - same room, or their phone on my camera</button>
-            <button class="btn" onClick=${() => onChoose(true)}>We're on a call, I'd see a shared screen or an image</button>
-            <button class="btn" onClick=${() => onChoose(true)}>We're just on the phone / no camera</button>
-        </div>
-        <div class="muted fed-gate-note">A shared screen or a forwarded image can be faked. For those we use the spoken-code method - it's built for calls.</div>
-    </div>`;
-}
-
 // GuestJoinWizard - "Join a network". Maps to guest STEP 1-4.
 function GuestJoinWizard({ onExit }) {
-    const [step, setStep] = useState('channel');
-    const [endpoint, setEndpoint, lanCandidates] = useLanEndpoint();
+    const wizardRef = useRef(null);
+    const [step, setStep] = useState('scan');
+    const [endpoint, setEndpoint, lanCandidates, endpointReady] = useLanEndpoint();
     const [tier4, setTier4] = useState(false);
     const [scan, setScan] = useState(null);       // {session_id, host_chain, host_endpoint, host_pin, return_uri}
     const [codes, setCodes] = useState(null);      // {code_g, code_h, confirm_step}
@@ -11668,12 +11690,23 @@ function GuestJoinWizard({ onExit }) {
     const [busy, setBusy] = useState(false);
     const [err, setErr] = useState('');
     const [pollNote, setPollNote] = useState('');
+    const [endedReason, setEndedReason] = useState('');
+
+    useEffect(() => {
+        requestAnimationFrame(() => {
+            const heading = wizardRef.current && wizardRef.current.querySelector('.fed-step h2, .fed-step h3, .fed-compare h3');
+            if (heading) { heading.setAttribute('tabindex', '-1'); heading.focus(); }
+        });
+    }, [step]);
 
     const fail = (e) => { setErr(String(e.message || e)); setBusy(false); };
 
-    const doScan = async (uri) => {
+    const doScan = async (uri, source = 'camera') => {
         setBusy(true); setErr('');
-        try { const r = await fedGuestScan(uri, endpoint); setScan(r); setStep('return'); }
+        try {
+            if (source !== 'camera') setTier4(true);
+            const r = await fedGuestScan(uri, endpoint); setScan(r); setStep('return');
+        }
         catch (e) { fail(e); }
         setBusy(false);
     };
@@ -11704,12 +11737,24 @@ function GuestJoinWizard({ onExit }) {
         } catch (e) { fail(e); }
         setBusy(false);
     };
+    const stopGuest = async (nextStep = 'aborted') => {
+        setBusy(true);
+        try { if (scan) await fedGuestAbort(scan.session_id); }
+        catch (e) { setErr(`Stopped locally, but we couldn't notify the other computer: ${String(e.message || e)}`); }
+        setBusy(false); setStep(nextStep);
+    };
+    const exitGuest = async () => {
+        if (scan && !['done', 'aborted', 'ended'].includes(step)) {
+            try { await fedGuestAbort(scan.session_id); } catch (e) {}
+        }
+        onExit();
+    };
 
     // Poll host status while showing our code (waiting for host approval #1).
     // After a run of failed checks we surface a soft "still trying" note so a
     // genuinely stalled connection shows a reason instead of an eternal spinner.
     useEffect(() => {
-        if (step !== 'yourcode' || !scan) return;
+        if (!['yourcode', 'theircode'].includes(step) || !scan) return;
         let live = true;
         let misses = 0;
         const tick = async () => {
@@ -11717,69 +11762,87 @@ function GuestJoinWizard({ onExit }) {
                 const s = await fedGuestStatus(scan.session_id);
                 if (!live) return;
                 misses = 0; setPollNote('');
-                if (s.aborted) { setErr('They stopped the connection.'); setStep('channel'); return; }
-                if (s.host_approved) { setHostScope(s.host_scope || {}); setStep('theircode'); }
+                if (s.aborted || s.state === 'aborted') { setEndedReason('They stopped the connection before it completed.'); setStep('ended'); return; }
+                if (s.expired || s.state === 'expired') { setEndedReason('The connection code expired before both computers finished.'); setStep('ended'); return; }
+                if (s.active) { setStep('done'); return; }
+                if (step === 'yourcode' && s.host_approved) { setHostScope(s.host_scope || {}); setStep('theircode'); }
             } catch (e) {
                 if (!live) return;
                 misses += 1;
                 if (misses >= 4) setPollNote(`Can't check their side (${e && e.message ? e.message : 'no response'}). Make sure the other computer is on and you're both on the same network.`);
+                if (misses >= 15) { setEndedReason('We could not reach the other computer for about 30 seconds. Your connection has not been approved; check the network and try again.'); setStep('interrupted'); }
             }
         };
         const id = setInterval(tick, 2000); tick();
         return () => { live = false; clearInterval(id); setPollNote(''); };
     }, [step, scan]);
 
-    return html`<div class="fed-wizard">
+    const progressStage = step === 'done' ? 'done'
+        : (['yourcode', 'theircode'].includes(step) ? 'check' : 'scan');
+
+    return html`<div class="fed-wizard" ref=${wizardRef}>
         <div class="fed-wizard-head">
-            <button class="btn fed-back" onClick=${onExit}>← Back</button>
+            <button class="btn fed-back" onClick=${exitGuest}>← Back</button>
             <span class="fed-wizard-title">Join someone’s network</span>
         </div>
-        ${err && html`<div class="fed-err">${err}</div>`}
-
-        ${step === 'channel' && html`<${FedChannelGate} endpoint=${endpoint} onEndpoint=${setEndpoint} candidates=${lanCandidates}
-            onChoose=${(t) => { setTier4(t); setStep('scan'); }} />`}
+        ${!['aborted', 'ended', 'interrupted'].includes(step) && html`<${FedCeremonyProgress} stage=${progressStage} />`}
+        ${err && html`<div class="fed-err" role="alert">${err}</div>`}
 
         ${step === 'scan' && html`<div class="fed-step">
             <${FedGreenRail} />
-            <h3>Point your camera at their code</h3>
-            ${tier4 && html`<div class="fed-tier4-note">No camera / shared screen: paste the code they send, then we'll double-check with a spoken code you compare out loud.</div>`}
-            <${FedScanInput} onValue=${doScan} busy=${busy} />
+            <h2>Scan their SAGE</h2>
+            <p class="muted">Point your camera at the connection code your colleague is showing you.</p>
+            ${tier4 && html`<div class="fed-tier4-note">Connecting remotely or using a pasted image? The short number check later protects against a code being swapped or relayed.</div>`}
+            ${!endpointReady && html`<div class="muted">Finding this computer’s network address…</div>`}
+            <${FedScanInput} onValue=${doScan} busy=${busy || !endpointReady} />
+            <details class="fed-advanced" open=${isLoopbackEndpoint(endpoint) || lanCandidates.length > 1}>
+                <summary onClick=${() => setTier4(true)}>Connecting remotely or need to change the network address?</summary>
+                <div class="fed-field">
+                    <label for="fed-guest-endpoint">This computer’s reachable address</label>
+                    <input id="fed-guest-endpoint" class="fed-share-input" value=${endpoint} onInput=${e => setEndpoint(e.target.value)}
+                        placeholder="https://192.168.1.20:8444" />
+                    ${isLoopbackEndpoint(endpoint) && html`<div class="fed-warn">This is a localhost address. Another computer needs this SAGE’s LAN or internet-reachable address.</div>`}
+                </div>
+                <${FedEndpointPicker} candidates=${lanCandidates} endpoint=${endpoint} onPick=${setEndpoint} />
+            </details>
         </div>`}
 
         ${step === 'return' && scan && html`<div class="fed-step">
             <${FedGreenRail} />
-            <h3>Now show them YOUR code</h3>
+            <h3>Now let them scan you</h3>
             <p class="muted">Connecting to <strong>${scan.host_name || scan.host_chain}</strong>${scan.host_name ? html` <span style="font-size:11px;">(id: <code>${scan.host_chain}</code>)</span>` : ''}. Hold this up to their camera, or send it for them to paste.</p>
             <${FedQr} text=${scan.return_uri} caption="Their SAGE scans this to check it's really you." />
             <div class="fed-step-actions">
-                <button class="btn btn-primary" disabled=${busy} onClick=${doRequest}>${busy ? 'Working…' : "They've got my code - verify trust"}</button>
+                <button class="btn btn-primary" disabled=${busy} onClick=${doRequest}>${busy ? 'Working…' : "They've scanned me — continue"}</button>
             </div>
         </div>`}
 
         ${step === 'yourcode' && codes && html`<div class="fed-step">
             <${FedGreenRail} />
-            <h3>Read this to them out loud</h3>
+            <h3>They confirm you</h3>
             <${BigCode} code=${codes.code_g} />
-            <p class="fed-read-instr">Call them and read this code. It proves you're really connected to each other - not someone in the middle.</p>
+            <p class="fed-read-instr">${tier4
+                ? 'Read this code to them out loud. It catches a connection code that was swapped or relayed.'
+                : 'Have them compare this with their screen, or read it aloud. It catches a swapped connection code.'}</p>
             <div class="fed-waiting"><span class="fed-spinner"></span> Waiting for them to check your code…</div>
             ${pollNote && html`<div class="fed-tier4-note" style="margin-top:10px;">${pollNote}</div>`}
-            <${TwoOfTwoMeter} n=${0} />
         </div>`}
 
         ${step === 'theircode' && codes && html`<${FedCodeCompare}
-            title="Check the code they read you"
-            instruction="They'll read you a code. Type exactly what you hear."
+            title="You confirm them"
+            instruction=${tier4
+                ? "They'll read you one final code. Type exactly what you hear."
+                : "Compare with their screen, or type exactly what they read aloud."}
             expectedCode=${codes.code_h}
             tier4=${tier4}
             confirmLabel="Yes - connect"
             busy=${busy}
             onConfirm=${doConfirm}
-            onReject=${() => setStep('aborted')} />`}
+            onReject=${() => stopGuest('aborted')} />`}
 
         ${step === 'done' && html`<div class="fed-step fed-done">
             <div class="fed-done-check">✓</div>
             <h2>You're connected to ${scan && scan.host_chain}</h2>
-            <${TwoOfTwoMeter} n=${2} />
             <p class="muted">Trust is established. Each computer now manages what it shares. Open this connection to choose existing domains for live Read or optional Copy; disconnecting always stops future access. Connection-bound Write is reserved but not active yet.</p>
             <button class="btn btn-primary" onClick=${onExit}>Done</button>
         </div>`}
@@ -11790,16 +11853,35 @@ function GuestJoinWizard({ onExit }) {
             <p class="fed-compare-bad">Nothing was shared and nothing was changed on your brain. Hang up and call them back on a number you trust, then start over.</p>
             <div class="fed-step-actions"><button class="btn btn-primary" onClick=${onExit}>Back to Federation</button></div>
         </div>`}
+        ${step === 'ended' && html`<div class="fed-step">
+            <${FedGreenRail} />
+            <h3>Connection stopped</h3>
+            <p class="muted">${endedReason}</p>
+            <div class="fed-step-actions"><button class="btn btn-primary" onClick=${onExit}>Back to Federation</button></div>
+        </div>`}
+        ${step === 'interrupted' && html`<div class="fed-step">
+            <${FedGreenRail} />
+            <h3>Couldn’t reach the other SAGE</h3>
+            <p class="muted">${endedReason}</p>
+            <div class="fed-step-actions">
+                <button class="btn" onClick=${exitGuest}>Cancel</button>
+                <button class="btn btn-primary" onClick=${() => { setPollNote(''); setEndedReason(''); setStep('yourcode'); }}>Try again</button>
+            </div>
+        </div>`}
     </div>`;
 }
 
 // HostJoinWizard - "Let someone join". Maps to host H1-H7.
 function HostJoinWizard({ onExit }) {
+    const wizardRef = useRef(null);
     const [step, setStep] = useState('route');
     const [routeMode, setRouteMode] = useState('');
     const [endpoint, setEndpoint, lanCandidates] = useLanEndpoint();
     const [session, setSession] = useState(null);   // {session_id, otpauth_uri, host_pin}
     const [view, setView] = useState(null);          // host status view
+    const [tier4, setTier4] = useState(false);
+    const [endedReason, setEndedReason] = useState('');
+    const interruptedFrom = useRef('waiting');
     // The ceremony establishes trust, not authorization. The empty legacy
     // scope keeps the existing consensus transaction compatible; operators
     // add directional domain permissions only after the peer is trusted.
@@ -11808,9 +11890,16 @@ function HostJoinWizard({ onExit }) {
     const [err, setErr] = useState('');
     const fail = (e) => { setErr(String(e.message || e)); setBusy(false); };
 
+    useEffect(() => {
+        requestAnimationFrame(() => {
+            const heading = wizardRef.current && wizardRef.current.querySelector('.fed-step h2, .fed-step h3, .fed-compare h3');
+            if (heading) { heading.setAttribute('tabindex', '-1'); heading.focus(); }
+        });
+    }, [step]);
+
     const doCreate = async (mode = routeMode || 'lan') => {
         setBusy(true); setErr('');
-        try { const r = await fedHostCreate(endpoint, mode); setSession(r); setRouteMode(mode); setStep('showqr'); }
+        try { const r = await fedHostCreate(endpoint, mode); setSession(r); setRouteMode(mode); setTier4(mode === 'internet'); setStep('showqr'); }
         catch (e) { fail(e); }
         setBusy(false);
     };
@@ -11834,9 +11923,9 @@ function HostJoinWizard({ onExit }) {
         autoTried.current = true; // don't immediately re-auto-create; let them edit
         setSession(null); setView(null); setStep('create');
     };
-    const doScanReturn = async (uri) => {
+    const doScanReturn = async (uri, source = 'camera') => {
         setBusy(true); setErr('');
-        try { await fedHostScanReturn(session.session_id, uri); setStep('waiting'); }
+        try { if (source !== 'camera') setTier4(true); await fedHostScanReturn(session.session_id, uri); setStep('waiting'); }
         catch (e) { fail(e); }
         setBusy(false);
     };
@@ -11848,8 +11937,13 @@ function HostJoinWizard({ onExit }) {
     };
     // Cancel from a non-decision screen: burn the session and leave.
     const abort = async () => {
-        try { if (session) await fedHostAbort(session.session_id); } catch (e) {}
-        onExit();
+        setErr('');
+        try {
+            if (session) await fedHostAbort(session.session_id);
+            onExit();
+        } catch (e) {
+            setErr(String(e.message || e));
+        }
     };
     // Reject at the trust moment: burn the session but STAY mounted so the
     // "Do NOT approve" safety message is actually seen.
@@ -11858,29 +11952,47 @@ function HostJoinWizard({ onExit }) {
         setStep('aborted');
     };
 
-    // Poll host session status during waiting / readback.
+    // Poll every in-flight host screen so a guest-side Stop, expiry, or network
+    // failure always becomes visible instead of leaving a dead spinner/card.
     useEffect(() => {
-        if (!session || (step !== 'waiting' && step !== 'readback')) return;
+        if (!session || !['waiting', 'compare', 'readback'].includes(step)) return;
         let live = true;
+        let misses = 0;
         const tick = async () => {
             try {
                 const v = await fedHostStatus(session.session_id);
                 if (!live) return;
+                misses = 0;
                 setView(v);
-                if (step === 'waiting' && v.guest_chain) setStep('review');
+                const state = normalizeFederationJoinState(v.state);
+                if (state === 'aborted') { setEndedReason('They stopped the connection before it completed.'); setStep('ended'); return; }
+                if (state === 'expired') { setEndedReason('The connection code expired before both computers finished.'); setStep('ended'); return; }
+                if (step === 'waiting' && v.guest_chain) setStep('compare');
                 if (step === 'readback' && v.active) setStep('done');
-            } catch (e) {}
+            } catch (e) {
+                if (!live) return;
+                misses += 1;
+                if (misses >= 15) {
+                    interruptedFrom.current = step;
+                    setEndedReason('We could not reach the local federation service for about 30 seconds. The connection has not silently advanced.');
+                    setStep('interrupted');
+                }
+            }
         };
         const id = setInterval(tick, 2000); tick();
         return () => { live = false; clearInterval(id); };
     }, [step, session]);
 
-    return html`<div class="fed-wizard">
+    const progressStage = step === 'done' ? 'done'
+        : (['compare', 'readback'].includes(step) ? 'check' : 'scan');
+
+    return html`<div class="fed-wizard ${step === 'showqr' ? 'fed-wizard-wide' : ''}" ref=${wizardRef}>
         <div class="fed-wizard-head">
             <button class="btn fed-back" onClick=${step === 'route' ? onExit : abort}>← ${step === 'route' ? 'Back' : 'Cancel'}</button>
             <span class="fed-wizard-title">Let someone join</span>
         </div>
-        ${err && html`<div class="fed-err">${err}</div>`}
+        ${!['aborted', 'ended', 'interrupted'].includes(step) && html`<${FedCeremonyProgress} stage=${progressStage} />`}
+        ${err && html`<div class="fed-err" role="alert">${err}</div>`}
 
         ${step === 'route' && html`<div class="fed-step">
             <h2>How are the two computers connected?</h2>
@@ -11896,22 +12008,36 @@ function HostJoinWizard({ onExit }) {
             <h2>Let someone join your network</h2>
             <${FedGreenRail} />
             <div class="fed-field">
-                <label>Your network address (how they'll reach you)</label>
-                <input class="fed-share-input" value=${endpoint} onInput=${e => setEndpoint(e.target.value)} placeholder="https://192.168.1.10:8444" />
+                <label for="fed-host-endpoint">Your network address (how they'll reach you)</label>
+                <input id="fed-host-endpoint" class="fed-share-input" value=${endpoint} onInput=${e => setEndpoint(e.target.value)} placeholder="https://192.168.1.10:8444" />
                 ${isLoopbackEndpoint(endpoint) && html`<div class="fed-warn">⚠︎ This address only works on this computer, so anyone who scans your code would reach their own machine instead. Pick this computer's address on your network below (e.g. <code>https://192.168.1.10:8444</code>).</div>`}
             </div>
             <${FedEndpointPicker} candidates=${lanCandidates} endpoint=${endpoint} onPick=${setEndpoint} />
             <button class="btn btn-primary" disabled=${busy} onClick=${() => doCreate('lan')}>${busy ? 'Working…' : 'Show my connection code'}</button>
         </div>`}
 
-        ${step === 'showqr' && session && html`<div class="fed-step">
+        ${step === 'showqr' && session && html`<div class="fed-step fed-exchange-step">
             <${FedGreenRail} />
-            <h3>Have them scan this</h3>
-            <${FedQr} text=${session.otpauth_uri} caption="Point the other computer's camera at this — tap “Make it bigger” if it won't focus." />
-            <p class="muted">Best done in the same room, or held up to a video call you trust.
-                <button class="fed-linkbtn" onClick=${editAddress}>Wrong address? Edit it</button></p>
-            <h3>Then scan their code back</h3>
-            <${FedScanInput} onValue=${doScanReturn} busy=${busy} />
+            <h2>Scan each other</h2>
+            <p class="fed-exchange-lead muted">Two quick scans, one in each direction. This confirms both computers before anything can be shared.</p>
+            <div class="fed-exchange">
+                <section class="fed-exchange-card">
+                    <div class="fed-exchange-card-head">
+                        <span class="fed-exchange-number">1</span>
+                        <div><h3>They scan this SAGE</h3><p class="muted">Show this code to your colleague.</p></div>
+                    </div>
+                    <${FedQr} size=${200} text=${session.otpauth_uri} caption="Their camera scans this first." />
+                    <button class="fed-linkbtn" onClick=${editAddress}>Wrong network address?</button>
+                </section>
+                <section class="fed-exchange-card fed-exchange-card-active">
+                    <div class="fed-exchange-card-head">
+                        <span class="fed-exchange-number">2</span>
+                        <div><h3>Scan their SAGE back</h3><p class="muted">They'll show you their return code.</p></div>
+                    </div>
+                    <${FedScanInput} onValue=${doScanReturn} busy=${busy} />
+                </section>
+            </div>
+            <p class="fed-exchange-note muted">Best done in the same room, or on a video call you placed to someone you trust.</p>
         </div>`}
 
         ${step === 'waiting' && html`<div class="fed-step">
@@ -11919,22 +12045,14 @@ function HostJoinWizard({ onExit }) {
             <div class="fed-waiting"><span class="fed-spinner"></span> Waiting for their request…</div>
         </div>`}
 
-        ${step === 'review' && view && html`<div class="fed-step">
-            <${FedGreenRail} />
-            <h3>${view.guest_name ? html`<strong>${view.guest_name}</strong> wants to connect` : html`Someone using the name "${view.guest_chain}" wants to connect`}</h3>
-            ${view.guest_name && html`<div class="muted" style="font-size:12px;margin-top:-4px;">Their network id: <code>${view.guest_chain}</code> — the name is just a label they chose; the code you check next is what proves it's really them.</div>`}
-            <h4>This step establishes identity trust only</h4>
-            <p class="muted">No domain access is granted by approving this connection. After both codes match, each computer independently chooses which existing domains the other may Read or offer for Copy. Connection-bound Write is reserved but not active yet.</p>
-            <div class="fed-step-actions">
-                <button class="btn btn-danger" onClick=${abort}>Ignore</button>
-                <button class="btn btn-primary" onClick=${() => setStep('compare')}>Next: verify their identity</button>
-            </div>
-        </div>`}
-
         ${step === 'compare' && view && html`<${FedCodeCompare}
-            title="Check their code"
-            instruction="They'll read you a code. Type exactly what you hear. This is the moment that proves it's really them."
+            title="You confirm them"
+            instruction="Compare with the code on their screen, or have them read it aloud. Type it here to make sure neither scan was swapped."
             expectedCode=${view.code_g}
+            peerName=${view.guest_name || view.guest_chain}
+            peerID=${view.guest_name ? view.guest_chain : ''}
+            trustOnly=${true}
+            tier4=${tier4}
             confirmLabel="Yes, they match - approve"
             busy=${busy}
             onConfirm=${doApprove}
@@ -11942,17 +12060,15 @@ function HostJoinWizard({ onExit }) {
 
         ${step === 'readback' && html`<div class="fed-step">
             <${FedGreenRail} />
-            <h3>Read this code back to them</h3>
+            <h3>They confirm you</h3>
             ${view && view.code_h ? html`<${BigCode} code=${view.code_h} />` : html`<div class="fed-waiting"><span class="fed-spinner"></span> Preparing…</div>`}
-            <p class="fed-read-instr">Read this code to ${(view && (view.guest_name || view.guest_chain)) || 'them'} so they can confirm it. Say it out loud - don't paste it.</p>
-            <div class="fed-waiting"><span class="fed-spinner"></span> You approved. Waiting for them (2 of 2)…</div>
-            <${TwoOfTwoMeter} n=${1} />
+            <p class="fed-read-instr">Let ${(view && (view.guest_name || view.guest_chain)) || 'them'} compare this with their screen, or read it aloud. Don't send it as a pasted message.</p>
+            <div class="fed-waiting"><span class="fed-spinner"></span> Waiting for their confirmation…</div>
         </div>`}
 
         ${step === 'done' && html`<div class="fed-step fed-done">
             <div class="fed-done-check">✓</div>
             <h2>Connected to ${view && view.guest_chain}</h2>
-            <${TwoOfTwoMeter} n=${2} />
             <h3>Trust is established</h3>
             <p class="muted">Permissions are separate from trust. Open this connection from Federation to choose which existing domains they may Read or Copy. They manage what they share back from their own computer; connection-bound Write is reserved but not active yet.</p>
             <button class="btn btn-primary" onClick=${onExit}>Done</button>
@@ -11963,6 +12079,21 @@ function HostJoinWizard({ onExit }) {
             <h3>Stopped - the codes didn't match</h3>
             <p class="fed-compare-bad">Do NOT approve. Nothing was shared and nothing was changed on your brain. Hang up and call them back on a number you trust, then start over.</p>
             <div class="fed-step-actions"><button class="btn btn-primary" onClick=${onExit}>Back to Federation</button></div>
+        </div>`}
+        ${step === 'ended' && html`<div class="fed-step">
+            <${FedGreenRail} />
+            <h3>Connection stopped</h3>
+            <p class="muted">${endedReason}</p>
+            <div class="fed-step-actions"><button class="btn btn-primary" onClick=${onExit}>Back to Federation</button></div>
+        </div>`}
+        ${step === 'interrupted' && html`<div class="fed-step">
+            <${FedGreenRail} />
+            <h3>Connection check interrupted</h3>
+            <p class="muted">${endedReason}</p>
+            <div class="fed-step-actions">
+                <button class="btn" onClick=${abort}>Cancel</button>
+                <button class="btn btn-primary" onClick=${() => { setEndedReason(''); setStep(interruptedFrom.current || 'waiting'); }}>Try again</button>
+            </div>
         </div>`}
     </div>`;
 }
@@ -12027,7 +12158,7 @@ function fedDomainMatchesFilter(domain, filter) {
 
 // FedPermissionsPanel keeps identity/trust separate from ongoing authorization.
 // Each node edits only its own grants and observes the peer's grants read-only.
-function FedPermissionsPanel({ conn }) {
+function FedPermissionsPanel({ conn, onRevoke, revokeBusy }) {
     const chain = conn.remote_chain_id;
     const peerName = conn.peer_name || chain;
     const [catalog, setCatalog] = useState(null);
@@ -12035,6 +12166,7 @@ function FedPermissionsPanel({ conn }) {
     const [draft, setDraft] = useState(null);
     const [remote, setRemote] = useState({});
     const [remoteKnown, setRemoteKnown] = useState(false);
+    const [remotePaused, setRemotePaused] = useState(false);
     const [subscribeSaved, setSubscribeSaved] = useState([]);
     const [subscribeDraft, setSubscribeDraft] = useState([]);
     const [syncKnown, setSyncKnown] = useState(false);
@@ -12064,6 +12196,7 @@ function FedPermissionsPanel({ conn }) {
                 setSaved(local); setDraft(local);
                 setRemote(normalizeFedPermissionList(p.remote_permissions));
                 setRemoteKnown(p.remote_known === true);
+                setRemotePaused(p.remote_paused === true);
             } else {
                 // PUT replaces the entire local snapshot. If GET failed, an
                 // editable empty draft could silently erase grants we never
@@ -12100,6 +12233,7 @@ function FedPermissionsPanel({ conn }) {
                 const p = permissionsResult.value || {};
                 setRemote(normalizeFedPermissionList(p.remote_permissions));
                 setRemoteKnown(p.remote_known === true);
+                setRemotePaused(p.remote_paused === true);
             }
             if (live) timer = setTimeout(poll, 8000);
         };
@@ -12189,6 +12323,7 @@ function FedPermissionsPanel({ conn }) {
             setSaved(nextLocal); setDraft(nextLocal);
             if (Array.isArray(response.remote_permissions)) setRemote(normalizeFedPermissionList(response.remote_permissions));
             if (Object.prototype.hasOwnProperty.call(response, 'remote_known')) setRemoteKnown(response.remote_known === true);
+            if (Object.prototype.hasOwnProperty.call(response, 'remote_paused')) setRemotePaused(response.remote_paused === true);
             showToast(`Permissions updated for ${peerName}`, 'success');
         } catch (e) { setErr(String(e.message || e)); }
         setBusy(false);
@@ -12230,6 +12365,7 @@ function FedPermissionsPanel({ conn }) {
             setCatalog(fedCatalogMap(catalogResponse));
             setRemote(normalizeFedPermissionList(permissionResponse.remote_permissions));
             setRemoteKnown(permissionResponse.remote_known === true);
+            setRemotePaused(permissionResponse.remote_paused === true);
             if (!subscribeDirty) {
                 const domains = normalizeFedDomainList(syncResponse && syncResponse.subscribe_domains);
                 setSubscribeSaved(domains); setSubscribeDraft(domains); setSyncKnown(true);
@@ -12248,6 +12384,9 @@ function FedPermissionsPanel({ conn }) {
         <div class="fed-permissions-intro">
             <strong>Trust and permissions are separate.</strong> The connection proves who this computer is linked to. These domain permissions decide what may cross that trusted link, and either computer can change its own grants at any time.
         </div>
+        ${conn.sharing_paused && html`<div class="fed-perm-pause-note">
+            <strong>Sharing from this SAGE is paused.</strong> The saved domain choices below are preserved and take effect again when you resume.
+        </div>`}
 
         <section class="fed-perm-section">
             <div class="fed-perm-section-head">
@@ -12269,6 +12408,7 @@ function FedPermissionsPanel({ conn }) {
                 </div>
             </div>
             <div class="fed-perm-count muted">${visibleRows.length} of ${localRows.length} domains shown. Bulk actions affect only these visible rows.</div>
+            <div class="fed-perm-table" role="table" aria-label=${`Domains this computer shares with ${peerName}`}>
             <div class="fed-perm-grid fed-perm-grid-head" role="row">
                 <span role="columnheader">Existing domain</span><span role="columnheader">Read</span><span role="columnheader">Write (not yet)</span><span role="columnheader">Copy offer</span>
             </div>
@@ -12287,7 +12427,7 @@ function FedPermissionsPanel({ conn }) {
                             ${row.meta && !row.canShare ? html`<span class="fed-perm-tag blocked">not shareable</span>` : ''}
                         </span>
                     </div>
-                    ${['read', 'write', 'copy'].map(field => html`<label class="fed-perm-cell" key=${field}>
+                    ${['read', 'write', 'copy'].map(field => html`<label class="fed-perm-cell" role="cell" key=${field}>
                         <input type="checkbox"
                             aria-label="Allow ${peerName} to ${field} ${row.domain}"
                             checked=${!!permission[field]}
@@ -12297,6 +12437,7 @@ function FedPermissionsPanel({ conn }) {
                     </label>`)}
                 </div>`;
             })}
+            </div>
             ${err && html`<div class="fed-err fed-perm-error">${err}</div>`}
             <div class="fed-perm-actions">
                 <button class="btn btn-primary" disabled=${!dirty || busy} onClick=${save}>${busy ? 'Saving…' : 'Save what I share'}</button>
@@ -12312,9 +12453,13 @@ function FedPermissionsPanel({ conn }) {
                 </div>
                 <button class="btn" disabled=${refreshing} onClick=${refresh}>${refreshing ? 'Refreshing…' : 'Refresh'}</button>
             </div>
+            ${remotePaused && html`<div class="fed-perm-pause-note">
+                <strong>${peerName} paused sharing.</strong> Effective Read and Copy access is off now. Their saved choices stay private on their SAGE and can resume when they turn sharing back on.
+            </div>`}
             ${!remoteKnown && html`<div class="fed-perm-empty muted">Their SAGE has not reported its permission set yet.</div>`}
-            ${remoteKnown && remoteRows.length === 0 && html`<div class="fed-perm-empty muted">They are not sharing any domains with this computer.</div>`}
+            ${remoteKnown && !remotePaused && remoteRows.length === 0 && html`<div class="fed-perm-empty muted">They are not sharing any domains with this computer.</div>`}
             ${remoteRows.length > 0 && html`<div>
+                <div class="fed-perm-table" role="table" aria-label=${`Domains ${peerName} shares with this computer`}>
                 <div class="fed-perm-grid fed-perm-grid-copy-choice fed-perm-grid-head" role="row">
                     <span role="columnheader">Their domain</span><span role="columnheader">Read</span><span role="columnheader">Write (not yet)</span><span role="columnheader">Copy offered</span><span role="columnheader">Save here</span>
                 </div>
@@ -12323,12 +12468,12 @@ function FedPermissionsPanel({ conn }) {
                     return html`<div class="fed-perm-grid fed-perm-grid-copy-choice fed-perm-row fed-perm-remote-row" role="row" key=${domain}>
                     <div class="fed-perm-domain" role="rowheader">
                         <strong>${domain}</strong>
-                        ${!permission.copy && subscribed && html`<span class="fed-perm-domain-meta"><span class="fed-perm-tag stale">copy no longer offered — remove only</span></span>`}
+                        ${!remotePaused && !permission.copy && subscribed && html`<span class="fed-perm-domain-meta"><span class="fed-perm-tag stale">copy no longer offered — remove only</span></span>`}
                     </div>
-                    ${['read', 'write', 'copy'].map(field => html`<span class="fed-perm-cell" key=${field} aria-label="${field} ${permission[field] ? 'allowed' : 'not allowed'}">
+                    ${['read', 'write', 'copy'].map(field => html`<span class="fed-perm-cell" role="cell" key=${field} aria-label="${field} ${permission[field] ? 'allowed' : 'not allowed'}">
                         <span class="fed-perm-state ${permission[field] ? 'on' : 'off'}">${permission[field] ? '✓' : '—'}</span>
                     </span>`)}
-                    <label class="fed-perm-cell">
+                    <label class="fed-perm-cell" role="cell">
                         <input type="checkbox"
                             aria-label="Save synchronized copies of ${domain} on this computer"
                             checked=${subscribed}
@@ -12336,11 +12481,20 @@ function FedPermissionsPanel({ conn }) {
                             onChange=${() => toggleSubscription(domain, permission.copy)} />
                     </label>
                 </div>`;})}
+                </div>
                 <div class="fed-perm-actions">
                     <button class="btn btn-primary" disabled=${!syncKnown || !subscribeDirty || syncBusy} onClick=${saveSubscriptions}>${syncBusy ? 'Saving…' : 'Save copy choices'}</button>
                     <span class="muted">${!syncKnown ? 'Copy controls unavailable' : (subscribeDirty ? 'Unsaved copy choices' : 'Saved')}</span>
                 </div>
             </div>`}
+        </section>
+
+        <section class="fed-perm-danger">
+            <div>
+                <strong>Revoke trust permanently</strong>
+                <p>This ends the trusted pairing, notifies the peer when reachable, and requires the JOIN ceremony again if you reconnect. Use Pause sharing on the connection row for a temporary stop.</p>
+            </div>
+            <button class="btn btn-danger" disabled=${revokeBusy} onClick=${onRevoke}>${revokeBusy ? 'Revoking…' : 'Revoke trust…'}</button>
         </section>
     </div>`;
 }
@@ -12523,14 +12677,49 @@ function FederationPage() {
     const [conns, setConns] = useState(null);
     const [localChain, setLocalChain] = useState('');
     const [err, setErr] = useState('');
+    const [remoteNotice, setRemoteNotice] = useState(null);
+    const lastGoodConns = useRef(null);
 
     const load = async () => {
-        try { const r = await fedConnections(); setConns(r.connections || []); setLocalChain(r.local_chain_id || ''); setErr(''); }
-        catch (e) { setErr(String(e.message || e)); setConns([]); }
+        try {
+            const r = await fedConnections();
+            const next = Array.isArray(r.connections) ? r.connections : [];
+            const previous = lastGoodConns.current;
+            if (previous) {
+                const previouslyActive = new Set(previous.filter(c => c.status === 'active' && !c.expired).map(c => c.remote_chain_id));
+                next.filter(c => c.ended_by === 'revoked_by_peer' && previouslyActive.has(c.remote_chain_id))
+                    .forEach(c => showToast(`${c.peer_name || c.remote_chain_id} revoked this connection. Access has stopped.`, 'warning'));
+            }
+            const latestRemoteRevoke = next.filter(c => c.ended_by === 'revoked_by_peer')
+                .sort((a, b) => String(b.ended_at || '').localeCompare(String(a.ended_at || '')))[0] || null;
+            if (latestRemoteRevoke) {
+                const key = `sage-fed-revoke-dismissed:${latestRemoteRevoke.remote_chain_id}:${latestRemoteRevoke.ended_at || ''}`;
+                let dismissed = false;
+                try { dismissed = localStorage.getItem(key) === '1'; } catch (e) {}
+                setRemoteNotice(dismissed ? null : { ...latestRemoteRevoke, dismissKey: key });
+            } else {
+                setRemoteNotice(null);
+            }
+            lastGoodConns.current = next;
+            setConns(next); setLocalChain(r.local_chain_id || ''); setErr('');
+        }
+        catch (e) {
+            // Keep the last good rows (and any open permission draft) mounted
+            // across a transient poll failure. The error is useful; an empty
+            // list would falsely imply every connection disappeared.
+            setErr(String(e.message || e));
+        }
     };
-    useEffect(() => { if (mode === 'landing') load(); }, [mode]);
+    useEffect(() => {
+        if (mode !== 'landing') return undefined;
+        load();
+        const timer = setInterval(() => { if (!document.hidden) load(); }, 10000);
+        return () => clearInterval(timer);
+    }, [mode]);
 
     const [openChain, setOpenChain] = useState('');
+    const [showPast, setShowPast] = useState(false);
+    const [busyChain, setBusyChain] = useState('');
     // Start hidden-until-known: keep the join cards down until the first
     // readiness result, so a fresh (warming) node never briefly shows cards
     // that would start a ceremony doomed to fail. On a ready/mature node the
@@ -12538,17 +12727,47 @@ function FederationPage() {
     // also called on a readiness error (older binary), so cards still show.
     const [warming, setWarming] = useState(true); // fork-ladder warm-up on a fresh node
     const [fedOn, setFedOn] = useState(null); // master switch: null=unknown, then bool
+    const pause = async (conn, paused) => {
+        if (paused && !await showConfirmation(
+            `Pause sharing with ${conn.peer_name || conn.remote_chain_id}? Their live Read and Copy access stops immediately. Your selected domains and trusted pairing stay saved, so Resume is one click.`,
+            { title: 'Pause sharing?', confirmLabel: 'Pause sharing', tone: 'primary' }
+        )) return;
+        setBusyChain(conn.remote_chain_id);
+        try {
+            await fedPause(conn.remote_chain_id, paused);
+            showToast(paused ? 'Sharing paused; pairing preserved' : 'Sharing resumed', 'success');
+            await load();
+        } catch (e) { showToast(String(e.message || e), 'error'); }
+        setBusyChain('');
+    };
     const revoke = async (chain) => {
         if (!await showConfirmation(
-            `Turn off the connection to ${chain}? This does NOT erase anything - it just stops the two networks from reaching each other.`,
-            { title: 'Turn off this connection?', confirmLabel: 'Turn off connection', tone: 'danger' }
+            `Permanently revoke trust with ${chain}? This stops access, notifies the peer when reachable, and requires the JOIN ceremony again if you reconnect. Use Pause sharing instead for a temporary stop.`,
+            { title: 'Revoke trust permanently?', confirmLabel: 'Revoke trust', tone: 'danger' }
         )) return;
-        try { await fedRevoke(chain); showToast(`Disconnected from ${chain}`, 'success'); load(); }
+        setBusyChain(chain);
+        try {
+            const result = await fedRevoke(chain);
+            const note = result && result.peer_notified === false ? ' Peer notification could not be delivered.' : '';
+            showToast(`Trust revoked with ${chain}.${note}`, result && result.peer_notified === false ? 'warning' : 'success');
+            setOpenChain('');
+            await load();
+        }
         catch (e) { showToast(String(e.message || e), 'error'); }
+        setBusyChain('');
+    };
+    const dismissRemoteNotice = () => {
+        if (remoteNotice && remoteNotice.dismissKey) {
+            try { localStorage.setItem(remoteNotice.dismissKey, '1'); } catch (e) {}
+        }
+        setRemoteNotice(null);
     };
 
     if (mode === 'guest') return html`<div class="page fed-page"><${GuestJoinWizard} onExit=${() => setMode('landing')} /></div>`;
     if (mode === 'host') return html`<div class="page fed-page"><${HostJoinWizard} onExit=${() => setMode('landing')} /></div>`;
+
+    const liveConns = (conns || []).filter(c => c.status === 'active' && !c.expired);
+    const pastConns = (conns || []).filter(c => c.status !== 'active' || c.expired);
 
     return html`<div class="page fed-page">
         <div class="fed-landing">
@@ -12558,6 +12777,13 @@ function FederationPage() {
             <${FederationMasterSwitch} onChange=${setFedOn} />
             ${fedOn && html`<${NetworkNameEditor} />`}
             ${err && html`<div class="fed-err">Couldn't load connections: ${err}</div>`}
+            ${remoteNotice && html`<div class="fed-peer-revoke-notice" role="status">
+                <div>
+                    <strong>${remoteNotice.peer_name || remoteNotice.remote_chain_id} ended this connection</strong>
+                    <p>${remoteNotice.ended_message || 'The other SAGE revoked the trusted link. Read and Copy access stopped immediately.'}</p>
+                </div>
+                <button class="btn" aria-label="Dismiss connection-ended notice" onClick=${dismissRemoteNotice}>Dismiss</button>
+            </div>`}
             ${fedOn === false && html`<div class="fed-off-note muted">Federation is off, so joining or hosting a connection is unavailable. Turn it on above to connect.</div>`}
             ${fedOn && html`<${FederationWarmup} onState=${(ready) => setWarming(!ready)} />`}
             ${fedOn && !warming && html`<div class="fed-roles">
@@ -12575,11 +12801,11 @@ function FederationPage() {
 
             ${(fedOn || (conns && conns.length > 0)) && html`<div class="fed-conns">
                 <h3>Your connections <${HelpTip} text="Each row is a trusted link to another SAGE. Expanding it shows two directional permission sets: what this computer grants them, and what they grant this computer. Each side controls only its own domains." /></h3>
-                ${conns && conns.length > 0 && html`<div class="fed-conns-explain muted">The scan and spoken code establish <strong>trust</strong>. Open a connection to manage the separate <strong>domain permissions</strong>: each computer independently decides which existing domains the other may Read or offer for Copy. Connection-bound Write is reserved but not active yet.</div>`}
+                ${liveConns.length > 0 && html`<div class="fed-conns-explain muted">The scan and spoken code establish <strong>trust</strong>. Open a connection to manage domain permissions. <strong>Pause</strong> temporarily stops what you share without losing the pairing; permanent revocation lives inside the connection details.</div>`}
                 ${conns === null && html`<div class="muted">Loading…</div>`}
-                ${conns && conns.length === 0 && html`
+                ${conns && liveConns.length === 0 && html`
                     <${EmptyState} icon="federation"
-                        headline="No connections yet"
+                        headline="No active connections"
                         hint=${fedOn
                             ? "Link your whole SAGE to another SAGE to share memories across networks. Join someone's network with a code they share, or host one and hand out a code."
                             : "Turn federation on above to link your whole SAGE to another SAGE and share memories across networks."}
@@ -12587,18 +12813,38 @@ function FederationPage() {
                         onAction=${fedOn ? (() => setMode('guest')) : null} />
                     ${localChain && html`<div class="muted" style="text-align:center;margin-top:4px;">Your network id: <code>${localChain}</code></div>`}
                 `}
-                ${conns && conns.map(c => html`<div class="fed-conn-wrap" key=${c.remote_chain_id}>
+                ${liveConns.map(c => html`<div class="fed-conn-wrap" key=${c.remote_chain_id}>
                     <div class="fed-conn-row">
-                        <button class="fed-conn-main fed-conn-expand" onClick=${() => setOpenChain(openChain === c.remote_chain_id ? '' : c.remote_chain_id)} disabled=${!(c.status === 'active' && !c.expired)}>
-                            <span class="fed-conn-status ${c.status === 'active' && !c.expired ? 'on' : 'off'}"></span>
+                        <button class="fed-conn-main fed-conn-expand" aria-expanded=${openChain === c.remote_chain_id}
+                            aria-controls=${`fed-connection-${c.remote_chain_id}`}
+                            onClick=${() => setOpenChain(openChain === c.remote_chain_id ? '' : c.remote_chain_id)}>
+                            <span class="fed-conn-status ${c.sharing_paused ? 'paused' : 'on'}"></span>
                             <span class="fed-conn-name" title=${c.peer_name ? c.remote_chain_id : ''}>${c.peer_name || c.remote_chain_id}</span>
-                            <span class="fed-conn-meta muted">${c.expired ? 'expired' : c.status} · ${c.status === 'active' && !c.expired ? 'manage domain permissions' : 'trust unavailable'}</span>
-                            ${c.status === 'active' && !c.expired && html`<span class="fed-conn-chev">${openChain === c.remote_chain_id ? '▾' : '▸'}</span>`}
+                            <span class="fed-conn-meta muted">${c.sharing_paused ? 'sharing paused · pairing preserved' : 'active · manage domain permissions'}</span>
+                            <span class="fed-conn-chev">${openChain === c.remote_chain_id ? '▾' : '▸'}</span>
                         </button>
-                        ${c.status === 'active' && html`<button class="btn btn-danger fed-conn-off" onClick=${() => revoke(c.remote_chain_id)}>Turn off</button>`}
+                        <button class="btn fed-conn-off ${c.sharing_paused ? 'btn-primary' : ''}"
+                            disabled=${busyChain === c.remote_chain_id}
+                            onClick=${() => pause(c, !c.sharing_paused)}>${busyChain === c.remote_chain_id ? 'Working…' : (c.sharing_paused ? 'Resume sharing' : 'Pause sharing')}</button>
                     </div>
-                    ${openChain === c.remote_chain_id && c.status === 'active' && !c.expired && html`<${FedPermissionsPanel} conn=${c} />`}
+                    ${openChain === c.remote_chain_id && html`<div id=${`fed-connection-${c.remote_chain_id}`}>
+                        <${FedPermissionsPanel} conn=${c} revokeBusy=${busyChain === c.remote_chain_id} onRevoke=${() => revoke(c.remote_chain_id)} />
+                    </div>`}
                 </div>`)}
+                ${pastConns.length > 0 && html`<div class="fed-past">
+                    <button class="fed-past-toggle" onClick=${() => setShowPast(!showPast)} aria-expanded=${showPast} aria-controls="fed-past-connections">
+                        <span>${showPast ? '▾' : '▸'}</span> Past connections (${pastConns.length})
+                    </button>
+                    ${showPast && html`<div class="fed-past-list" id="fed-past-connections">
+                        ${pastConns.map(c => html`<div class="fed-conn-row fed-conn-past" key=${c.remote_chain_id}>
+                            <span class="fed-conn-status off"></span>
+                            <span class="fed-conn-name" title=${c.peer_name ? c.remote_chain_id : ''}>${c.peer_name || c.remote_chain_id}</span>
+                            <span class="fed-conn-meta muted">${c.expired ? 'expired' : (c.ended_by === 'revoked_by_peer' ? 'revoked by peer' : 'revoked')} · audit history</span>
+                            ${c.ended_message && html`<span class="fed-past-reason muted">${c.ended_message}</span>`}
+                            ${c.ended_at && html`<time class="fed-past-time muted" datetime=${c.ended_at}>${new Date(c.ended_at).toLocaleString()}</time>`}
+                        </div>`)}
+                    </div>`}
+                </div>`}
             </div>`}
         </div>
     </div>`;

--- a/web/static/js/federation-flow.js
+++ b/web/static/js/federation-flow.js
@@ -1,0 +1,6 @@
+// Small pure helpers shared by the federation ceremony UI and its behavioral
+// tests. The Go API deliberately uses protocol constants such as "ABORTED";
+// browser decisions should not depend on their presentation casing.
+export function normalizeFederationJoinState(value) {
+    return String(value || '').trim().toLowerCase();
+}


### PR DESCRIPTION
Completes the v11.9.2 federation release: trust-only JOIN, independently managed directional Read/Copy domain RBAC, pause/resume without re-pairing, peer-visible revocation, exact generation-bound race hardening, clickable connection management, and a shorter reciprocal scan ceremony. Remote Write remains disabled. Verified locally with full store/federation/web/REST suites, the same four packages under the race detector, 92 JavaScript tests, static checks, version alignment, and three independent adversarial reviewer clears. No consensus or app-version change.