### PR TITLE
ci(shell): prove Linux installed package lifecycle

### DIFF
--- a/.github/workflows/native-shell.yml
+++ b/.github/workflows/native-shell.yml
@@ -15,6 +15,8 @@ on:
       - "scripts/stage-native-shell-daemon.sh"
       - "scripts/verify-native-shell-bundle.sh"
       - "scripts/verify-native-shell-bundle.test.sh"
+      - "scripts/native-shell-linux-runtime-smoke.sh"
+      - "scripts/native-shell-linux-runtime-smoke.test.sh"
       - "scripts/acceptance-endpoint-guard.sh"
       - ".github/workflows/native-shell.yml"
   push:
@@ -32,6 +34,8 @@ on:
       - "scripts/stage-native-shell-daemon.sh"
       - "scripts/verify-native-shell-bundle.sh"
       - "scripts/verify-native-shell-bundle.test.sh"
+      - "scripts/native-shell-linux-runtime-smoke.sh"
+      - "scripts/native-shell-linux-runtime-smoke.test.sh"
       - "scripts/acceptance-endpoint-guard.sh"
       - ".github/workflows/native-shell.yml"
   workflow_dispatch:
@@ -75,7 +79,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xvfb dbus-x11
       - name: Go control-contract tests
         shell: bash
         run: |
@@ -125,6 +129,13 @@ jobs:
               "desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle/native-shell-release-pair-${package_kind}.json" \
               "${package_kind}"
           done
+      - name: Run installed Linux package lifecycle smoke
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          dbus-run-session -- xvfb-run -a \
+            scripts/native-shell-linux-runtime-smoke.sh \
+            desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: native-shell-${{ runner.os }}-${{ matrix.rust-target }}
@@ -164,6 +175,7 @@ jobs:
       - name: Gate records are published
         run: |
           scripts/verify-native-shell-bundle.test.sh
+          scripts/native-shell-linux-runtime-smoke.test.sh
           test -s docs/desktop-shell-decision.md
           test -s docs/native-app-daemon-contract.md
           test -s docs/native-shell-quality-gates.md

--- a/.github/workflows/native-shell.yml
+++ b/.github/workflows/native-shell.yml
@@ -136,6 +136,14 @@ jobs:
           dbus-run-session -- xvfb-run -a \
             scripts/native-shell-linux-runtime-smoke.sh \
             desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle
+      - name: Upload installed Linux runtime diagnostics
+        if: runner.os == 'Linux' && always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-shell-Linux-runtime-diagnostics-${{ matrix.rust-target }}
+          path: ${{ runner.temp }}/sage-native-shell-runtime.*
+          if-no-files-found: warn
+          retention-days: 7
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: native-shell-${{ runner.os }}-${{ matrix.rust-target }}

--- a/scripts/native-shell-linux-runtime-smoke.sh
+++ b/scripts/native-shell-linux-runtime-smoke.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "native-shell installed runtime smoke requires Linux" >&2
+  exit 1
+fi
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <tauri-bundle-root>" >&2
+  exit 1
+fi
+
+BUNDLE_ROOT=$1
+if [ ! -d "${BUNDLE_ROOT}" ]; then
+  echo "native-shell bundle root does not exist: ${BUNDLE_ROOT}" >&2
+  exit 1
+fi
+
+exactly_one() {
+  local label=$1
+  shift
+  local -a matches=("$@")
+  if [ "${#matches[@]}" -ne 1 ]; then
+    echo "expected exactly one ${label}, found ${#matches[@]}" >&2
+    return 1
+  fi
+  printf '%s\n' "${matches[0]}"
+}
+
+mapfile -d '' -t deb_matches < <(find "${BUNDLE_ROOT}" -type f -name '*.deb' -print0)
+mapfile -d '' -t appimage_matches < <(find "${BUNDLE_ROOT}" -type f -name '*.AppImage' -print0)
+DEB_PACKAGE=$(exactly_one 'Debian package' "${deb_matches[@]}")
+APPIMAGE=$(exactly_one 'AppImage package' "${appimage_matches[@]}")
+chmod +x "${APPIMAGE}"
+
+SMOKE_ROOT=$(mktemp -d "${RUNNER_TEMP:-/tmp}/sage-native-shell-runtime.XXXXXX")
+SAGE_SMOKE_HOME="${SMOKE_ROOT}/home"
+SHELL_LOG="${SMOKE_ROOT}/shell.log"
+mkdir -p "${SAGE_SMOKE_HOME}"
+printf 'native-shell-uninstall-preservation\n' > "${SAGE_SMOKE_HOME}/preserve.sentinel"
+PACKAGE_NAME=$(dpkg-deb -f "${DEB_PACKAGE}" Package)
+PACKAGE_INSTALLED=0
+
+matching_smoke_pids() {
+  local environ pid
+  for environ in /proc/[0-9]*/environ; do
+    [ -r "${environ}" ] || continue
+    if tr '\0' '\n' < "${environ}" 2>/dev/null |
+      grep -Fxq "SAGE_HOME=${SAGE_SMOKE_HOME}"; then
+      pid=${environ#/proc/}
+      printf '%s\n' "${pid%%/*}"
+    fi
+  done
+}
+
+cleanup() {
+  local pid deadline
+  while IFS= read -r pid; do
+    [ -n "${pid}" ] && kill -TERM "${pid}" 2>/dev/null || true
+  done < <(matching_smoke_pids)
+  deadline=$((SECONDS + 5))
+  while [ "${SECONDS}" -lt "${deadline}" ] && [ -n "$(matching_smoke_pids)" ]; do
+    sleep 0.1
+  done
+  while IFS= read -r pid; do
+    [ -n "${pid}" ] && kill -KILL "${pid}" 2>/dev/null || true
+  done < <(matching_smoke_pids)
+  if [ "${PACKAGE_INSTALLED}" -eq 1 ] && dpkg-query -W "${PACKAGE_NAME}" >/dev/null 2>&1; then
+    sudo dpkg --remove "${PACKAGE_NAME}" >/dev/null 2>&1 || true
+  fi
+  echo "native-shell runtime smoke evidence: ${SMOKE_ROOT}"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+query_status() {
+  python3 - "${SAGE_SMOKE_HOME}/run/shell-control.sock" <<'PY'
+import json
+import socket
+import struct
+import sys
+import time
+
+endpoint = sys.argv[1]
+request = json.dumps(
+    {"control_protocol": 1, "shell_protocol": 1, "operation": "status"},
+    separators=(",", ":"),
+).encode()
+deadline = time.monotonic() + 20
+last_error = None
+
+def read_exact(stream, size):
+    chunks = []
+    remaining = size
+    while remaining:
+        chunk = stream.recv(remaining)
+        if not chunk:
+            raise RuntimeError("SSCP connection closed before the frame completed")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+while time.monotonic() < deadline:
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as stream:
+            stream.settimeout(1)
+            stream.connect(endpoint)
+            stream.sendall(struct.pack(">I", len(request)) + request)
+            size = struct.unpack(">I", read_exact(stream, 4))[0]
+            if size > 16 * 1024:
+                raise RuntimeError(f"oversized SSCP response: {size}")
+            status = json.loads(read_exact(stream, size))
+            print(json.dumps(status, sort_keys=True))
+            raise SystemExit(0)
+    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, OSError, RuntimeError, json.JSONDecodeError) as error:
+        last_error = error
+        time.sleep(0.1)
+
+raise SystemExit(f"timed out waiting for authenticated SSCP status: {last_error}")
+PY
+}
+
+status_generation() {
+  python3 -c '
+import json, re, sys
+status = json.load(sys.stdin)
+assert status["control_protocol"] == 1
+assert status["api_schema"] == 1
+assert status["state"] in {"starting", "locked", "ready", "degraded", "draining", "failed"}
+generation = status["instance_generation"]
+assert re.fullmatch(r"[A-Za-z0-9_-]{43}", generation)
+print(generation)
+'
+}
+
+launch_shell() {
+  env SAGE_HOME="${SAGE_SMOKE_HOME}" SAGE_NO_BROWSER=1 "$@" >> "${SHELL_LOG}" 2>&1 &
+  LAUNCHED_PID=$!
+}
+
+require_relaunch_exit() {
+  local pid=$1 deadline=$((SECONDS + 10)) status
+  while kill -0 "${pid}" 2>/dev/null && [ "${SECONDS}" -lt "${deadline}" ]; do
+    sleep 0.1
+  done
+  if kill -0 "${pid}" 2>/dev/null; then
+    echo "second native-shell launch did not hand off to the existing instance" >&2
+    return 1
+  fi
+  set +e
+  wait "${pid}"
+  status=$?
+  set -e
+  if [ "${status}" -ne 0 ]; then
+    echo "second native-shell launch exited with status ${status}" >&2
+    return 1
+  fi
+}
+
+sudo dpkg -i "${DEB_PACKAGE}"
+PACKAGE_INSTALLED=1
+mapfile -t installed_executables < <(
+  dpkg -L "${PACKAGE_NAME}" |
+    while IFS= read -r candidate; do
+      if [[ "${candidate}" == /usr/bin/* ]] && [ -f "${candidate}" ] && [ -x "${candidate}" ]; then
+        printf '%s\n' "${candidate}"
+      fi
+    done
+)
+INSTALLED_EXECUTABLE=$(exactly_one 'installed native-shell executable' "${installed_executables[@]}")
+
+launch_shell "${INSTALLED_EXECUTABLE}"
+INSTALLED_SHELL_PID=${LAUNCHED_PID}
+FIRST_STATUS=$(query_status)
+FIRST_GENERATION=$(printf '%s\n' "${FIRST_STATUS}" | status_generation)
+test -d "${SAGE_SMOKE_HOME}/run"
+test ! -L "${SAGE_SMOKE_HOME}/run"
+test "$(stat -c '%a' "${SAGE_SMOKE_HOME}/run")" = 700
+test -S "${SAGE_SMOKE_HOME}/run/shell-control.sock"
+test ! -L "${SAGE_SMOKE_HOME}/run/shell-control.sock"
+test "$(stat -c '%a' "${SAGE_SMOKE_HOME}/run/shell-control.sock")" = 600
+
+launch_shell "${INSTALLED_EXECUTABLE}"
+require_relaunch_exit "${LAUNCHED_PID}"
+SECOND_GENERATION=$(query_status | status_generation)
+test "${SECOND_GENERATION}" = "${FIRST_GENERATION}"
+
+kill -TERM "${INSTALLED_SHELL_PID}"
+wait "${INSTALLED_SHELL_PID}" 2>/dev/null || true
+test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
+
+sudo dpkg --remove "${PACKAGE_NAME}"
+PACKAGE_INSTALLED=0
+grep -Fx 'native-shell-uninstall-preservation' "${SAGE_SMOKE_HOME}/preserve.sentinel"
+test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
+
+launch_shell env APPIMAGE_EXTRACT_AND_RUN=1 "${APPIMAGE}"
+APPIMAGE_SHELL_PID=${LAUNCHED_PID}
+sleep 1
+kill -0 "${APPIMAGE_SHELL_PID}"
+test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
+
+launch_shell env APPIMAGE_EXTRACT_AND_RUN=1 "${APPIMAGE}"
+require_relaunch_exit "${LAUNCHED_PID}"
+test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
+
+sudo dpkg -i "${DEB_PACKAGE}"
+PACKAGE_INSTALLED=1
+grep -Fx 'native-shell-uninstall-preservation' "${SAGE_SMOKE_HOME}/preserve.sentinel"
+test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
+
+echo "native-shell Linux installed runtime smoke passed generation=${FIRST_GENERATION}"

--- a/scripts/native-shell-linux-runtime-smoke.sh
+++ b/scripts/native-shell-linux-runtime-smoke.sh
@@ -39,7 +39,27 @@ SHELL_LOG="${SMOKE_ROOT}/shell.log"
 mkdir -p "${SAGE_SMOKE_HOME}"
 printf 'native-shell-uninstall-preservation\n' > "${SAGE_SMOKE_HOME}/preserve.sentinel"
 PACKAGE_NAME=$(dpkg-deb -f "${DEB_PACKAGE}" Package)
-PACKAGE_INSTALLED=0
+if dpkg-query -W -f='${db:Status-Abbrev}' "${PACKAGE_NAME}" 2>/dev/null | grep -q '^ii'; then
+  echo "refusing to replace an already-installed package: ${PACKAGE_NAME}" >&2
+  exit 1
+fi
+
+read -r REST_PORT RPC_PORT P2P_PORT < <(python3 - <<'PY'
+import socket
+
+sockets = []
+try:
+    for _ in range(3):
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        sockets.append(listener)
+    print(*(listener.getsockname()[1] for listener in sockets))
+finally:
+    for listener in sockets:
+        listener.close()
+PY
+)
+EXPECTED_UI_ORIGIN="http://127.0.0.1:${REST_PORT}"
 
 matching_smoke_pids() {
   local environ pid
@@ -53,7 +73,7 @@ matching_smoke_pids() {
   done
 }
 
-cleanup() {
+stop_smoke_processes() {
   local pid deadline
   while IFS= read -r pid; do
     [ -n "${pid}" ] && kill -TERM "${pid}" 2>/dev/null || true
@@ -65,29 +85,88 @@ cleanup() {
   while IFS= read -r pid; do
     [ -n "${pid}" ] && kill -KILL "${pid}" 2>/dev/null || true
   done < <(matching_smoke_pids)
-  if [ "${PACKAGE_INSTALLED}" -eq 1 ] && dpkg-query -W "${PACKAGE_NAME}" >/dev/null 2>&1; then
-    sudo dpkg --remove "${PACKAGE_NAME}" >/dev/null 2>&1 || true
+}
+
+cleanup() {
+  local original_status=$1 removal_status=0
+  trap - EXIT
+  set +e
+  stop_smoke_processes
+  if dpkg-query -W "${PACKAGE_NAME}" >/dev/null 2>&1; then
+    sudo dpkg --remove "${PACKAGE_NAME}" >/dev/null 2>&1
+    removal_status=$?
   fi
   echo "native-shell runtime smoke evidence: ${SMOKE_ROOT}"
+  if [ "${original_status}" -eq 0 ] && [ "${removal_status}" -ne 0 ]; then
+    echo "failed to remove ${PACKAGE_NAME} during native-shell runtime cleanup" >&2
+    original_status=${removal_status}
+  fi
+  exit "${original_status}"
 }
-trap cleanup EXIT
+trap 'cleanup $?' EXIT
 trap 'exit 130' INT TERM
 
 query_status() {
-  python3 - "${SAGE_SMOKE_HOME}/run/shell-control.sock" <<'PY'
+  python3 - "${SAGE_SMOKE_HOME}/run/shell-control.sock" "${EXPECTED_UI_ORIGIN}" <<'PY'
 import json
+import re
 import socket
 import struct
 import sys
 import time
 
 endpoint = sys.argv[1]
+expected_origin = sys.argv[2]
 request = json.dumps(
     {"control_protocol": 1, "shell_protocol": 1, "operation": "status"},
     separators=(",", ":"),
 ).encode()
-deadline = time.monotonic() + 20
+deadline = time.monotonic() + 60
 last_error = None
+expected_fields = {
+    "control_protocol",
+    "daemon_version",
+    "api_schema",
+    "min_shell_protocol",
+    "max_shell_protocol",
+    "instance_generation",
+    "state",
+    "ui_origin",
+    "startup_proof",
+}
+canonical_generation_last = set("AEIMQUYcgkosw048")
+
+def validate(status):
+    if not isinstance(status, dict) or set(status) != expected_fields:
+        raise ValueError("SSCP status schema is not exact")
+    if type(status["control_protocol"]) is not int or type(status["api_schema"]) is not int:
+        raise ValueError("SSCP control/API protocol has the wrong type")
+    if status["control_protocol"] != 1 or status["api_schema"] != 1:
+        raise ValueError("SSCP control/API protocol mismatch")
+    minimum = status["min_shell_protocol"]
+    maximum = status["max_shell_protocol"]
+    if type(minimum) is not int or type(maximum) is not int or not (minimum <= 1 <= maximum):
+        raise ValueError("SSCP shell protocol is incompatible")
+    if minimum > maximum:
+        raise ValueError("SSCP shell protocol range is inverted")
+    version = status["daemon_version"]
+    if not isinstance(version, str) or not re.fullmatch(
+        r"v?11\.(?:10|11)\.(?:0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?",
+        version,
+    ):
+        raise ValueError("SSCP daemon version is unsupported")
+    generation = status["instance_generation"]
+    if not isinstance(generation, str) or not re.fullmatch(r"[A-Za-z0-9_-]{43}", generation):
+        raise ValueError("SSCP generation is malformed")
+    if generation[-1] not in canonical_generation_last:
+        raise ValueError("SSCP generation is not canonical base64url")
+    if not isinstance(status["state"], str) or status["state"] not in {"ready", "degraded"}:
+        raise ValueError(f"SSCP daemon is not renderable: {status['state']!r}")
+    if not isinstance(status["ui_origin"], str) or status["ui_origin"] != expected_origin:
+        raise ValueError("SSCP UI origin does not match the isolated REST listener")
+    proof = status["startup_proof"]
+    if not isinstance(proof, str) or not re.fullmatch(r"[0-9a-f]{64}", proof):
+        raise ValueError("SSCP startup proof is missing or malformed")
 
 def read_exact(stream, size):
     chunks = []
@@ -110,9 +189,10 @@ while time.monotonic() < deadline:
             if size > 16 * 1024:
                 raise RuntimeError(f"oversized SSCP response: {size}")
             status = json.loads(read_exact(stream, size))
+            validate(status)
             print(json.dumps(status, sort_keys=True))
             raise SystemExit(0)
-    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, OSError, RuntimeError, json.JSONDecodeError) as error:
+    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
         last_error = error
         time.sleep(0.1)
 
@@ -124,17 +204,19 @@ status_generation() {
   python3 -c '
 import json, re, sys
 status = json.load(sys.stdin)
-assert status["control_protocol"] == 1
-assert status["api_schema"] == 1
-assert status["state"] in {"starting", "locked", "ready", "degraded", "draining", "failed"}
 generation = status["instance_generation"]
-assert re.fullmatch(r"[A-Za-z0-9_-]{43}", generation)
 print(generation)
 '
 }
 
 launch_shell() {
-  env SAGE_HOME="${SAGE_SMOKE_HOME}" SAGE_NO_BROWSER=1 "$@" >> "${SHELL_LOG}" 2>&1 &
+  env \
+    SAGE_HOME="${SAGE_SMOKE_HOME}" \
+    SAGE_NO_BROWSER=1 \
+    REST_ADDR="127.0.0.1:${REST_PORT}" \
+    SAGE_CMT_RPC_ADDR="tcp://127.0.0.1:${RPC_PORT}" \
+    SAGE_CMT_P2P_ADDR="tcp://127.0.0.1:${P2P_PORT}" \
+    "$@" >> "${SHELL_LOG}" 2>&1 &
   LAUNCHED_PID=$!
 }
 
@@ -158,7 +240,6 @@ require_relaunch_exit() {
 }
 
 sudo dpkg -i "${DEB_PACKAGE}"
-PACKAGE_INSTALLED=1
 mapfile -t installed_executables < <(
   dpkg -L "${PACKAGE_NAME}" |
     while IFS= read -r candidate; do
@@ -173,6 +254,7 @@ launch_shell "${INSTALLED_EXECUTABLE}"
 INSTALLED_SHELL_PID=${LAUNCHED_PID}
 FIRST_STATUS=$(query_status)
 FIRST_GENERATION=$(printf '%s\n' "${FIRST_STATUS}" | status_generation)
+kill -0 "${INSTALLED_SHELL_PID}"
 test -d "${SAGE_SMOKE_HOME}/run"
 test ! -L "${SAGE_SMOKE_HOME}/run"
 test "$(stat -c '%a' "${SAGE_SMOKE_HOME}/run")" = 700
@@ -184,29 +266,58 @@ launch_shell "${INSTALLED_EXECUTABLE}"
 require_relaunch_exit "${LAUNCHED_PID}"
 SECOND_GENERATION=$(query_status | status_generation)
 test "${SECOND_GENERATION}" = "${FIRST_GENERATION}"
+kill -0 "${INSTALLED_SHELL_PID}"
 
 kill -TERM "${INSTALLED_SHELL_PID}"
 wait "${INSTALLED_SHELL_PID}" 2>/dev/null || true
 test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
 
 sudo dpkg --remove "${PACKAGE_NAME}"
-PACKAGE_INSTALLED=0
+test ! -e "${INSTALLED_EXECUTABLE}"
+if dpkg-query -W -f='${db:Status-Abbrev}' "${PACKAGE_NAME}" 2>/dev/null | grep -q '^ii'; then
+  echo "Debian package remained installed after removal: ${PACKAGE_NAME}" >&2
+  exit 1
+fi
 grep -Fx 'native-shell-uninstall-preservation' "${SAGE_SMOKE_HOME}/preserve.sentinel"
 test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
+
+stop_smoke_processes
+test ! -S "${SAGE_SMOKE_HOME}/run/shell-control.sock"
 
 launch_shell env APPIMAGE_EXTRACT_AND_RUN=1 "${APPIMAGE}"
 APPIMAGE_SHELL_PID=${LAUNCHED_PID}
-sleep 1
+APPIMAGE_GENERATION=$(query_status | status_generation)
 kill -0 "${APPIMAGE_SHELL_PID}"
-test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
+test "${APPIMAGE_GENERATION}" != "${FIRST_GENERATION}"
 
 launch_shell env APPIMAGE_EXTRACT_AND_RUN=1 "${APPIMAGE}"
 require_relaunch_exit "${LAUNCHED_PID}"
-test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
+test "$(query_status | status_generation)" = "${APPIMAGE_GENERATION}"
+kill -0 "${APPIMAGE_SHELL_PID}"
+
+kill -TERM "${APPIMAGE_SHELL_PID}"
+wait "${APPIMAGE_SHELL_PID}" 2>/dev/null || true
+test "$(query_status | status_generation)" = "${APPIMAGE_GENERATION}"
+stop_smoke_processes
+test ! -S "${SAGE_SMOKE_HOME}/run/shell-control.sock"
 
 sudo dpkg -i "${DEB_PACKAGE}"
-PACKAGE_INSTALLED=1
+test -x "${INSTALLED_EXECUTABLE}"
 grep -Fx 'native-shell-uninstall-preservation' "${SAGE_SMOKE_HOME}/preserve.sentinel"
-test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
+launch_shell "${INSTALLED_EXECUTABLE}"
+REINSTALLED_SHELL_PID=${LAUNCHED_PID}
+REINSTALLED_GENERATION=$(query_status | status_generation)
+kill -0 "${REINSTALLED_SHELL_PID}"
+test "${REINSTALLED_GENERATION}" != "${FIRST_GENERATION}"
+test "${REINSTALLED_GENERATION}" != "${APPIMAGE_GENERATION}"
 
-echo "native-shell Linux installed runtime smoke passed generation=${FIRST_GENERATION}"
+kill -TERM "${REINSTALLED_SHELL_PID}"
+wait "${REINSTALLED_SHELL_PID}" 2>/dev/null || true
+test "$(query_status | status_generation)" = "${REINSTALLED_GENERATION}"
+stop_smoke_processes
+test ! -S "${SAGE_SMOKE_HOME}/run/shell-control.sock"
+sudo dpkg --remove "${PACKAGE_NAME}"
+test ! -e "${INSTALLED_EXECUTABLE}"
+grep -Fx 'native-shell-uninstall-preservation' "${SAGE_SMOKE_HOME}/preserve.sentinel"
+
+echo "native-shell Linux installed runtime smoke passed deb=${FIRST_GENERATION} appimage=${APPIMAGE_GENERATION} reinstall=${REINSTALLED_GENERATION}"

--- a/scripts/native-shell-linux-runtime-smoke.test.sh
+++ b/scripts/native-shell-linux-runtime-smoke.test.sh
@@ -9,12 +9,19 @@ for required in \
   'sudo dpkg -i' \
   'sudo dpkg --remove' \
   'APPIMAGE_EXTRACT_AND_RUN=1' \
+  'SAGE_CMT_RPC_ADDR=' \
+  'SAGE_CMT_P2P_ADDR=' \
+  'SSCP status schema is not exact' \
+  'SSCP daemon is not renderable' \
+  'SSCP startup proof is missing or malformed' \
   'shell-control.sock' \
   "stat -c '%a'" \
   'instance_generation' \
   'require_relaunch_exit' \
   'preserve.sentinel' \
-  'matching_smoke_pids'; do
+  'matching_smoke_pids' \
+  'APPIMAGE_GENERATION' \
+  'REINSTALLED_GENERATION'; do
   grep -Fq "${required}" "${HARNESS}"
 done
 

--- a/scripts/native-shell-linux-runtime-smoke.test.sh
+++ b/scripts/native-shell-linux-runtime-smoke.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+HARNESS="${ROOT}/scripts/native-shell-linux-runtime-smoke.sh"
+bash -n "${HARNESS}"
+
+for required in \
+  'sudo dpkg -i' \
+  'sudo dpkg --remove' \
+  'APPIMAGE_EXTRACT_AND_RUN=1' \
+  'shell-control.sock' \
+  "stat -c '%a'" \
+  'instance_generation' \
+  'require_relaunch_exit' \
+  'preserve.sentinel' \
+  'matching_smoke_pids'; do
+  grep -Fq "${required}" "${HARNESS}"
+done
+
+fixture=$(mktemp -d "${TMPDIR:-/tmp}/sage-native-runtime-fixture.XXXXXX")
+trap 'rm -rf "${fixture}"' EXIT INT TERM
+if "${HARNESS}" "${fixture}" >"${fixture}/stdout" 2>"${fixture}/stderr"; then
+  echo "runtime harness unexpectedly accepted an empty bundle" >&2
+  exit 1
+fi
+if [ "$(uname -s)" = "Linux" ]; then
+  grep -Fq 'expected exactly one Debian package' "${fixture}/stderr"
+else
+  grep -Fq 'requires Linux' "${fixture}/stderr"
+fi
+
+echo "native-shell Linux runtime harness contract tests passed"


### PR DESCRIPTION
## Summary
- install the actual Tauri Debian package under Xvfb/DBus with a disposable SAGE home
- prove the installed shell starts the bundled daemon and exposes authenticated SSCP with protected endpoint permissions
- prove relaunch hands off to one shell/daemon generation, window exit leaves daemon ownership intact, and package removal preserves SAGE state
- launch and relaunch the actual AppImage against the surviving daemon, then reinstall the Debian package without losing state
- terminate only processes carrying the exact disposable SAGE_HOME

## Verification
- scripts/native-shell-linux-runtime-smoke.test.sh
- bash -n scripts/native-shell-linux-runtime-smoke.sh
- actionlint v1.7.7 .github/workflows/native-shell.yml
- git diff --check

## Scope
This closes one automatable Linux installed-runtime slice. It does not claim signing, offline, update/rollback, accessibility, performance, macOS, or Windows promotion readiness, and it does not create a release tag.