### PR TITLE
ci(shell): prove macOS installed package lifecycle

### DIFF
--- a/.github/workflows/native-shell.yml
+++ b/.github/workflows/native-shell.yml
@@ -17,6 +17,8 @@ on:
       - "scripts/verify-native-shell-bundle.test.sh"
       - "scripts/native-shell-linux-runtime-smoke.sh"
       - "scripts/native-shell-linux-runtime-smoke.test.sh"
+      - "scripts/native-shell-macos-runtime-smoke.sh"
+      - "scripts/native-shell-macos-runtime-smoke.test.sh"
       - "scripts/native-shell-windows-runtime-smoke.ps1"
       - "scripts/native-shell-windows-runtime-smoke.test.sh"
       - "scripts/acceptance-endpoint-guard.sh"
@@ -38,6 +40,8 @@ on:
       - "scripts/verify-native-shell-bundle.test.sh"
       - "scripts/native-shell-linux-runtime-smoke.sh"
       - "scripts/native-shell-linux-runtime-smoke.test.sh"
+      - "scripts/native-shell-macos-runtime-smoke.sh"
+      - "scripts/native-shell-macos-runtime-smoke.test.sh"
       - "scripts/native-shell-windows-runtime-smoke.ps1"
       - "scripts/native-shell-windows-runtime-smoke.test.sh"
       - "scripts/acceptance-endpoint-guard.sh"
@@ -57,7 +61,7 @@ jobs:
         include:
           - os: macos-14
             rust-target: aarch64-apple-darwin
-            bundle: app
+            bundle: app,dmg
           - os: windows-2025
             rust-target: x86_64-pc-windows-msvc
             bundle: nsis
@@ -112,7 +116,7 @@ jobs:
             --bundles ${{ matrix.bundle }} \
             --config "{\"version\":\"${NATIVE_SHELL_VERSION}\"}"
       - name: Verify bundled daemon release pair
-        if: runner.os != 'Linux'
+        if: runner.os == 'Windows'
         shell: bash
         run: |
           scripts/verify-native-shell-bundle.sh \
@@ -121,6 +125,18 @@ jobs:
             "${NATIVE_SHELL_VERSION}" \
             desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle/native-shell-release-pair.json \
             ${{ matrix.bundle }}
+      - name: Verify macOS package release pairs
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          for package_kind in app dmg; do
+            scripts/verify-native-shell-bundle.sh \
+              ${{ matrix.rust-target }} \
+              desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle \
+              "${NATIVE_SHELL_VERSION}" \
+              "desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle/native-shell-release-pair-${package_kind}.json" \
+              "${package_kind}"
+          done
       - name: Verify Linux package release pairs
         if: runner.os == 'Linux'
         shell: bash
@@ -146,6 +162,21 @@ jobs:
         with:
           name: native-shell-Linux-runtime-diagnostics-${{ matrix.rust-target }}
           path: ${{ runner.temp }}/sage-native-shell-runtime.*
+          if-no-files-found: warn
+          retention-days: 7
+      - name: Run installed macOS package lifecycle smoke
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          scripts/native-shell-macos-runtime-smoke.sh \
+            desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle \
+            "${NATIVE_SHELL_VERSION}"
+      - name: Upload installed macOS runtime diagnostics
+        if: runner.os == 'macOS' && always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-shell-macOS-runtime-diagnostics-${{ matrix.rust-target }}
+          path: ${{ runner.temp }}/sage-native-shell-macos-runtime.*/diagnostics
           if-no-files-found: warn
           retention-days: 7
       - name: Run installed Windows package lifecycle smoke
@@ -201,6 +232,7 @@ jobs:
         run: |
           scripts/verify-native-shell-bundle.test.sh
           scripts/native-shell-linux-runtime-smoke.test.sh
+          scripts/native-shell-macos-runtime-smoke.test.sh
           scripts/native-shell-windows-runtime-smoke.test.sh
           test -s docs/desktop-shell-decision.md
           test -s docs/native-app-daemon-contract.md

--- a/docs/native-shell-quality-gates.md
+++ b/docs/native-shell-quality-gates.md
@@ -47,8 +47,35 @@ Runtime promotion remains open until the install/launch/deep-link/offline,
 performance, assistive-technology, signing/notarization, update/rollback, and
 uninstall-preservation rows below have immutable platform results. Windows
 named-pipe reads and writes now use overlapped cancellable deadlines with native
-stalled/partial-frame tests in the code gate; the Windows package/runtime row
-still needs immutable runner evidence before promotion.
+stalled/partial-frame tests in the code gate.
+
+All three platforms now run an installed-package lifecycle smoke on a hosted
+runner. Each one installs from the constructed package, launches the installed
+executable against an isolated `SAGE_HOME`, proves single-instance handoff
+(a second launch exits cleanly and the instance generation is unchanged), proves
+the daemon survives an ordinary shell close, uninstalls, confirms the node data
+root is preserved byte-for-byte, and reinstalls to a genuinely new generation.
+The macOS harness mounts the built DMG and installs by copying the app out of
+it, and derives the serving daemon PID from the control socket with
+`LOCAL_PEERPID` — the direct analogue of the Windows `GetNamedPipeServerProcessId`
+check — so cleanup only ever signals an exact, socket-derived PID whose
+executable path matches the bundled daemon. No harness matches a process by name.
+
+These runs are *constrained* evidence and must not be read as more than they are:
+
+- they are **unsigned**. They prove nothing about code signing, notarization,
+  stapling, Gatekeeper, or SmartScreen, and they are not rollback or
+  update-failure evidence;
+- macOS runs **arm64 only** on the declared runner image, installs into an
+  isolated root rather than `/Applications`, and does not exercise Intel, deep
+  links, or LaunchServices registration;
+- the Windows row remains limited to the runner image's edition and cannot
+  complete the Windows 11 / arm64 / signing / SmartScreen matrix;
+- none of them measure the performance budgets or the accessibility gates below.
+
+The exact OS build, architecture, and WebKit/WebView version observed on each run
+are recorded in the uploaded runtime diagnostics so the constraint above is
+checkable rather than asserted.
 
 ## Supported matrix
 

--- a/scripts/native-shell-macos-runtime-smoke.sh
+++ b/scripts/native-shell-macos-runtime-smoke.sh
@@ -1,0 +1,467 @@
+#!/usr/bin/env bash
+# Prove the installed macOS package lifecycle: mount the built DMG, install the
+# app by copying it out, and drive launch/relaunch/close/uninstall/reinstall
+# against an isolated SAGE_HOME. Written for bash 3.2 so it runs against the
+# system bash on an Apple runner.
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "native-shell installed runtime smoke requires macOS" >&2
+  exit 1
+fi
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <tauri-bundle-root> <expected-version>" >&2
+  exit 1
+fi
+
+BUNDLE_ROOT=$1
+EXPECTED_VERSION=$2
+if [ ! -d "${BUNDLE_ROOT}" ]; then
+  echo "native-shell bundle root does not exist: ${BUNDLE_ROOT}" >&2
+  exit 1
+fi
+BUNDLE_ROOT=$(cd "${BUNDLE_ROOT}" && pwd -P)
+
+# list_matches tolerates a missing directory: under `set -o pipefail` a failing
+# find would otherwise abort the script before any diagnostic could be printed.
+list_matches() {
+  local dir=$1
+  shift
+  if [ ! -d "${dir}" ]; then
+    return 0
+  fi
+  find "${dir}" "$@" 2>/dev/null || true
+}
+
+# exactly_one <label> <newline-separated matches>
+exactly_one() {
+  local label=$1 matches=$2 count
+  count=$(printf '%s' "${matches}" | grep -c . || true)
+  if [ "${count}" -ne 1 ]; then
+    echo "expected exactly one ${label}, found ${count}" >&2
+    return 1
+  fi
+  printf '%s\n' "${matches}" | head -1
+}
+
+DMG_PACKAGE=$(exactly_one 'DMG package' \
+  "$(list_matches "${BUNDLE_ROOT}/dmg" -maxdepth 1 -type f -name '*.dmg')")
+
+STAGED_APP=$(exactly_one 'staged macOS app' \
+  "$(list_matches "${BUNDLE_ROOT}/macos" -maxdepth 1 -type d -name '*.app')")
+
+# Canonicalize immediately: mktemp hands back the unresolved /var form while the
+# kernel reports exec'd binaries under /private/var, and the daemon-identity
+# check below compares those paths literally.
+SMOKE_ROOT=$(cd "$(mktemp -d "${RUNNER_TEMP:-/tmp}/sage-native-shell-macos-runtime.XXXXXX")" && pwd -P)
+SAGE_SMOKE_HOME="${SMOKE_ROOT}/home"
+INSTALL_ROOT="${SMOKE_ROOT}/Applications"
+MOUNT_POINT="${SMOKE_ROOT}/mnt"
+DIAGNOSTICS="${SMOKE_ROOT}/diagnostics"
+SHELL_LOG="${DIAGNOSTICS}/shell.log"
+mkdir -p "${SAGE_SMOKE_HOME}" "${INSTALL_ROOT}" "${DIAGNOSTICS}"
+printf 'native-shell-uninstall-preservation\n' > "${SAGE_SMOKE_HOME}/preserve.sentinel"
+
+MOUNTED=0
+TRACKED_PIDS=""
+
+track_pid() {
+  case " ${TRACKED_PIDS} " in
+    *" $1 "*) ;;
+    *) TRACKED_PIDS="${TRACKED_PIDS} $1" ;;
+  esac
+}
+
+process_path() {
+  ps -p "$1" -o comm= 2>/dev/null || true
+}
+
+# stop_exact_pid mirrors the Windows harness Stop-ExactTree containment rule:
+# never signal a PID whose executable path is not the exact one we launched or
+# derived from the control socket.
+stop_exact_pid() {
+  local pid=$1 expected=$2 actual deadline
+  if ! kill -0 "${pid}" 2>/dev/null; then
+    return 0
+  fi
+  actual=$(process_path "${pid}")
+  if [ -n "${expected}" ] && [ -n "${actual}" ] && [ "${actual}" != "${expected}" ]; then
+    echo "refusing to signal pid ${pid}: expected ${expected}, found ${actual}" >&2
+    return 1
+  fi
+  kill -TERM "${pid}" 2>/dev/null || true
+  deadline=$((SECONDS + 10))
+  while [ "${SECONDS}" -lt "${deadline}" ] && kill -0 "${pid}" 2>/dev/null; do
+    sleep 0.1
+  done
+  if kill -0 "${pid}" 2>/dev/null; then
+    kill -KILL "${pid}" 2>/dev/null || true
+  fi
+}
+
+detach_dmg() {
+  if [ "${MOUNTED}" -eq 1 ]; then
+    hdiutil detach "${MOUNT_POINT}" -quiet 2>/dev/null ||
+      hdiutil detach "${MOUNT_POINT}" -force -quiet 2>/dev/null || true
+    MOUNTED=0
+  fi
+}
+
+# discover_daemon_pid derives a serving daemon PID from the control socket alone,
+# with no status validation. Cleanup needs this because an early failure (the
+# daemon came up but never reported a valid status) would otherwise leak the
+# process it started: the PID is only tracked once query_status returns.
+discover_daemon_pid() {
+  python3 - "${SAGE_SMOKE_HOME}/run/shell-control.sock" 2>/dev/null <<'PY' || true
+import socket
+import sys
+
+SOL_LOCAL = 0
+LOCAL_PEERPID = 2
+try:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as stream:
+        stream.settimeout(2)
+        stream.connect(sys.argv[1])
+        pid = int.from_bytes(stream.getsockopt(SOL_LOCAL, LOCAL_PEERPID, 4), sys.byteorder)
+        if pid > 0:
+            print(pid)
+except OSError:
+    pass
+PY
+}
+
+cleanup() {
+  local original_status=$1 pid stray
+  trap - EXIT
+  set +e
+  stray=$(discover_daemon_pid)
+  if [ -n "${stray}" ]; then
+    track_pid "${stray}"
+  fi
+  for pid in ${TRACKED_PIDS}; do
+    if kill -0 "${pid}" 2>/dev/null; then
+      kill -TERM "${pid}" 2>/dev/null
+    fi
+  done
+  sleep 0.5
+  for pid in ${TRACKED_PIDS}; do
+    if kill -0 "${pid}" 2>/dev/null; then
+      kill -KILL "${pid}" 2>/dev/null
+    fi
+  done
+  detach_dmg
+  echo "native-shell macOS runtime smoke evidence: ${DIAGNOSTICS}"
+  exit "${original_status}"
+}
+trap 'cleanup $?' EXIT
+trap 'exit 130' INT TERM
+
+read -r REST_PORT RPC_PORT P2P_PORT < <(python3 - <<'PY'
+import socket
+
+sockets = []
+try:
+    for _ in range(3):
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        sockets.append(listener)
+    print(*(listener.getsockname()[1] for listener in sockets))
+finally:
+    for listener in sockets:
+        listener.close()
+PY
+)
+EXPECTED_UI_ORIGIN="http://127.0.0.1:${REST_PORT}"
+
+# query_status validates the exact SSCP status schema and additionally derives
+# the serving daemon PID from the connected socket with LOCAL_PEERPID -- the
+# macOS analogue of GetNamedPipeServerProcessId. Nothing here matches on a
+# process name.
+query_status() {
+  python3 - "${SAGE_SMOKE_HOME}/run/shell-control.sock" "${EXPECTED_UI_ORIGIN}" "${EXPECTED_VERSION}" <<'PY'
+import json
+import re
+import socket
+import struct
+import sys
+import time
+
+endpoint = sys.argv[1]
+expected_origin = sys.argv[2]
+expected_version = sys.argv[3]
+SOL_LOCAL = 0
+LOCAL_PEERPID = 2
+request = json.dumps(
+    {"control_protocol": 1, "shell_protocol": 1, "operation": "status"},
+    separators=(",", ":"),
+).encode()
+deadline = time.monotonic() + 60
+last_error = None
+expected_fields = {
+    "control_protocol",
+    "daemon_version",
+    "api_schema",
+    "min_shell_protocol",
+    "max_shell_protocol",
+    "instance_generation",
+    "state",
+    "ui_origin",
+    "startup_proof",
+}
+canonical_generation_last = set("AEIMQUYcgkosw048")
+
+
+def validate(status):
+    if not isinstance(status, dict) or set(status) != expected_fields:
+        raise ValueError("SSCP status schema is not exact")
+    if type(status["control_protocol"]) is not int or type(status["api_schema"]) is not int:
+        raise ValueError("SSCP control/API protocol has the wrong type")
+    if status["control_protocol"] != 1 or status["api_schema"] != 1:
+        raise ValueError("SSCP control/API protocol mismatch")
+    minimum = status["min_shell_protocol"]
+    maximum = status["max_shell_protocol"]
+    if type(minimum) is not int or type(maximum) is not int or not (minimum <= 1 <= maximum):
+        raise ValueError("SSCP shell protocol is incompatible")
+    if minimum > maximum:
+        raise ValueError("SSCP shell protocol range is inverted")
+    version = status["daemon_version"]
+    if not isinstance(version, str) or version != expected_version:
+        raise ValueError(f"SSCP daemon version is unsupported: {version!r}")
+    generation = status["instance_generation"]
+    if not isinstance(generation, str) or not re.fullmatch(r"[A-Za-z0-9_-]{43}", generation):
+        raise ValueError("SSCP generation is malformed")
+    if generation[-1] not in canonical_generation_last:
+        raise ValueError("SSCP generation is not canonical base64url")
+    if not isinstance(status["state"], str) or status["state"] not in {"ready", "degraded"}:
+        raise ValueError(f"SSCP daemon is not renderable: {status['state']!r}")
+    if not isinstance(status["ui_origin"], str) or status["ui_origin"] != expected_origin:
+        raise ValueError("SSCP UI origin does not match the isolated REST listener")
+    proof = status["startup_proof"]
+    if not isinstance(proof, str) or not re.fullmatch(r"[0-9a-f]{64}", proof):
+        raise ValueError("SSCP startup proof is missing or malformed")
+
+
+def read_exact(stream, size):
+    chunks = []
+    remaining = size
+    while remaining:
+        chunk = stream.recv(remaining)
+        if not chunk:
+            raise RuntimeError("SSCP connection closed before the frame completed")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+while time.monotonic() < deadline:
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as stream:
+            stream.settimeout(1)
+            stream.connect(endpoint)
+            raw_pid = stream.getsockopt(SOL_LOCAL, LOCAL_PEERPID, 4)
+            daemon_pid = int.from_bytes(raw_pid, sys.byteorder)
+            if daemon_pid <= 0:
+                raise RuntimeError("SSCP peer pid is not derivable")
+            stream.sendall(struct.pack(">I", len(request)) + request)
+            size = struct.unpack(">I", read_exact(stream, 4))[0]
+            if size > 16 * 1024:
+                raise RuntimeError(f"oversized SSCP response: {size}")
+            status = json.loads(read_exact(stream, size))
+            validate(status)
+            print(json.dumps({"status": status, "daemon_pid": daemon_pid}, sort_keys=True))
+            raise SystemExit(0)
+    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        last_error = error
+        time.sleep(0.1)
+
+raise SystemExit(f"timed out waiting for authenticated SSCP status: {last_error}")
+PY
+}
+
+status_generation() {
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["status"]["instance_generation"])'
+}
+
+status_daemon_pid() {
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["daemon_pid"])'
+}
+
+launch_shell() {
+  env \
+    SAGE_HOME="${SAGE_SMOKE_HOME}" \
+    SAGE_NO_BROWSER=1 \
+    REST_ADDR="127.0.0.1:${REST_PORT}" \
+    SAGE_CMT_RPC_ADDR="tcp://127.0.0.1:${RPC_PORT}" \
+    SAGE_CMT_P2P_ADDR="tcp://127.0.0.1:${P2P_PORT}" \
+    "$@" >> "${SHELL_LOG}" 2>&1 &
+  LAUNCHED_PID=$!
+  track_pid "${LAUNCHED_PID}"
+}
+
+require_relaunch_exit() {
+  local pid=$1 deadline=$((SECONDS + 20)) status
+  while kill -0 "${pid}" 2>/dev/null && [ "${SECONDS}" -lt "${deadline}" ]; do
+    sleep 0.1
+  done
+  if kill -0 "${pid}" 2>/dev/null; then
+    echo "second native-shell launch did not hand off to the existing instance" >&2
+    return 1
+  fi
+  set +e
+  wait "${pid}"
+  status=$?
+  set -e
+  if [ "${status}" -ne 0 ]; then
+    echo "second native-shell launch exited with status ${status}" >&2
+    return 1
+  fi
+}
+
+require_socket_gone() {
+  local deadline=$((SECONDS + 10))
+  while [ "${SECONDS}" -lt "${deadline}" ] && [ -S "${SAGE_SMOKE_HOME}/run/shell-control.sock" ]; do
+    sleep 0.1
+  done
+  if [ -S "${SAGE_SMOKE_HOME}/run/shell-control.sock" ]; then
+    echo "control socket outlived the daemon it belonged to" >&2
+    return 1
+  fi
+}
+
+app_executable() {
+  local app=$1
+  exactly_one 'installed shell executable' \
+    "$(list_matches "${app}/Contents/MacOS" -maxdepth 1 -type f)"
+}
+
+install_from_dmg() {
+  local mounted_app
+  detach_dmg
+  rm -rf "${MOUNT_POINT}"
+  mkdir -p "${MOUNT_POINT}"
+  hdiutil attach "${DMG_PACKAGE}" -nobrowse -readonly -noautoopen -mountpoint "${MOUNT_POINT}" >/dev/null
+  MOUNTED=1
+  mounted_app=$(exactly_one 'app inside the DMG' \
+    "$(list_matches "${MOUNT_POINT}" -maxdepth 1 -type d -name '*.app')")
+  rm -rf "${INSTALL_ROOT:?}/$(basename "${mounted_app}")"
+  ditto "${mounted_app}" "${INSTALL_ROOT}/$(basename "${mounted_app}")"
+  detach_dmg
+  printf '%s\n' "${INSTALL_ROOT}/$(basename "${mounted_app}")"
+}
+
+{
+  printf '{\n'
+  printf '  "schema": "dev.sage.native-shell.macos-runtime/v1",\n'
+  printf '  "os_version": "%s",\n' "$(sw_vers -productVersion)"
+  printf '  "os_build": "%s",\n' "$(sw_vers -buildVersion)"
+  printf '  "arch": "%s",\n' "$(uname -m)"
+  printf '  "webkit_system_version": "%s",\n' \
+    "$(defaults read /System/Library/Frameworks/WebKit.framework/Resources/Info.plist CFBundleVersion 2>/dev/null || echo unknown)"
+  printf '  "expected_version": "%s"\n' "${EXPECTED_VERSION}"
+  printf '}\n'
+} > "${DIAGNOSTICS}/preflight.json"
+
+INSTALLED_APP=$(install_from_dmg)
+INSTALLED_EXECUTABLE=$(app_executable "${INSTALLED_APP}")
+INSTALLED_DAEMON="${INSTALLED_APP}/Contents/Resources/binaries/sage-gui"
+test -x "${INSTALLED_DAEMON}"
+
+# --- installed DMG copy: launch, relaunch handoff, close, daemon survival ---
+launch_shell "${INSTALLED_EXECUTABLE}"
+INSTALLED_SHELL_PID=${LAUNCHED_PID}
+FIRST_STATUS=$(query_status)
+printf '%s\n' "${FIRST_STATUS}" > "${DIAGNOSTICS}/first-install.json"
+FIRST_GENERATION=$(printf '%s\n' "${FIRST_STATUS}" | status_generation)
+FIRST_DAEMON_PID=$(printf '%s\n' "${FIRST_STATUS}" | status_daemon_pid)
+track_pid "${FIRST_DAEMON_PID}"
+kill -0 "${INSTALLED_SHELL_PID}"
+
+# The socket-derived daemon must be the exact binary bundled in the installed app.
+FIRST_DAEMON_PATH=$(process_path "${FIRST_DAEMON_PID}")
+if [ "${FIRST_DAEMON_PATH}" != "${INSTALLED_DAEMON}" ]; then
+  echo "installed shell served SSCP from an unexpected daemon: ${FIRST_DAEMON_PATH}" >&2
+  exit 1
+fi
+
+test -d "${SAGE_SMOKE_HOME}/run"
+test ! -L "${SAGE_SMOKE_HOME}/run"
+test "$(stat -f '%A' "${SAGE_SMOKE_HOME}/run")" = 700
+test -S "${SAGE_SMOKE_HOME}/run/shell-control.sock"
+test ! -L "${SAGE_SMOKE_HOME}/run/shell-control.sock"
+test "$(stat -f '%A' "${SAGE_SMOKE_HOME}/run/shell-control.sock")" = 600
+
+launch_shell "${INSTALLED_EXECUTABLE}"
+require_relaunch_exit "${LAUNCHED_PID}"
+SECOND_GENERATION=$(query_status | status_generation)
+test "${SECOND_GENERATION}" = "${FIRST_GENERATION}"
+kill -0 "${INSTALLED_SHELL_PID}"
+
+stop_exact_pid "${INSTALLED_SHELL_PID}" "${INSTALLED_EXECUTABLE}"
+wait "${INSTALLED_SHELL_PID}" 2>/dev/null || true
+test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
+
+# --- uninstall: app removed, ~/.sage preserved, daemon untouched ---
+rm -rf "${INSTALLED_APP}"
+test ! -e "${INSTALLED_EXECUTABLE}"
+test ! -e "${INSTALLED_APP}"
+grep -Fxq 'native-shell-uninstall-preservation' "${SAGE_SMOKE_HOME}/preserve.sentinel"
+test "$(query_status | status_generation)" = "${FIRST_GENERATION}"
+
+stop_exact_pid "${FIRST_DAEMON_PID}" ""
+require_socket_gone
+
+# --- staged .app bundle: a distinct generation proves a genuinely new daemon ---
+STAGED_EXECUTABLE=$(app_executable "${STAGED_APP}")
+launch_shell "${STAGED_EXECUTABLE}"
+STAGED_SHELL_PID=${LAUNCHED_PID}
+STAGED_STATUS=$(query_status)
+STAGED_GENERATION=$(printf '%s\n' "${STAGED_STATUS}" | status_generation)
+STAGED_DAEMON_PID=$(printf '%s\n' "${STAGED_STATUS}" | status_daemon_pid)
+track_pid "${STAGED_DAEMON_PID}"
+kill -0 "${STAGED_SHELL_PID}"
+test "${STAGED_GENERATION}" != "${FIRST_GENERATION}"
+test "${STAGED_DAEMON_PID}" != "${FIRST_DAEMON_PID}"
+
+launch_shell "${STAGED_EXECUTABLE}"
+require_relaunch_exit "${LAUNCHED_PID}"
+test "$(query_status | status_generation)" = "${STAGED_GENERATION}"
+kill -0 "${STAGED_SHELL_PID}"
+
+stop_exact_pid "${STAGED_SHELL_PID}" "${STAGED_EXECUTABLE}"
+wait "${STAGED_SHELL_PID}" 2>/dev/null || true
+test "$(query_status | status_generation)" = "${STAGED_GENERATION}"
+stop_exact_pid "${STAGED_DAEMON_PID}" ""
+require_socket_gone
+
+# --- reinstall over preserved state ---
+REINSTALLED_APP=$(install_from_dmg)
+REINSTALLED_EXECUTABLE=$(app_executable "${REINSTALLED_APP}")
+test -x "${REINSTALLED_EXECUTABLE}"
+grep -Fxq 'native-shell-uninstall-preservation' "${SAGE_SMOKE_HOME}/preserve.sentinel"
+
+launch_shell "${REINSTALLED_EXECUTABLE}"
+REINSTALLED_SHELL_PID=${LAUNCHED_PID}
+REINSTALLED_STATUS=$(query_status)
+printf '%s\n' "${REINSTALLED_STATUS}" > "${DIAGNOSTICS}/reinstall.json"
+REINSTALLED_GENERATION=$(printf '%s\n' "${REINSTALLED_STATUS}" | status_generation)
+REINSTALLED_DAEMON_PID=$(printf '%s\n' "${REINSTALLED_STATUS}" | status_daemon_pid)
+track_pid "${REINSTALLED_DAEMON_PID}"
+kill -0 "${REINSTALLED_SHELL_PID}"
+test "${REINSTALLED_GENERATION}" != "${FIRST_GENERATION}"
+test "${REINSTALLED_GENERATION}" != "${STAGED_GENERATION}"
+
+stop_exact_pid "${REINSTALLED_SHELL_PID}" "${REINSTALLED_EXECUTABLE}"
+wait "${REINSTALLED_SHELL_PID}" 2>/dev/null || true
+test "$(query_status | status_generation)" = "${REINSTALLED_GENERATION}"
+stop_exact_pid "${REINSTALLED_DAEMON_PID}" ""
+require_socket_gone
+
+rm -rf "${REINSTALLED_APP}"
+test ! -e "${REINSTALLED_EXECUTABLE}"
+grep -Fxq 'native-shell-uninstall-preservation' "${SAGE_SMOKE_HOME}/preserve.sentinel"
+
+if [ -f "${SHELL_LOG}" ]; then
+  tail -n 400 "${SHELL_LOG}" > "${DIAGNOSTICS}/shell-tail.log"
+fi
+
+echo "native-shell macOS installed runtime smoke passed dmg=${FIRST_GENERATION} app=${STAGED_GENERATION} reinstall=${REINSTALLED_GENERATION}"

--- a/scripts/native-shell-macos-runtime-smoke.test.sh
+++ b/scripts/native-shell-macos-runtime-smoke.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+HARNESS="${ROOT}/scripts/native-shell-macos-runtime-smoke.sh"
+bash -n "${HARNESS}"
+
+for required in \
+  'hdiutil attach' \
+  'hdiutil detach' \
+  'LOCAL_PEERPID' \
+  'ditto' \
+  'SAGE_CMT_RPC_ADDR=' \
+  'SAGE_CMT_P2P_ADDR=' \
+  'SSCP status schema is not exact' \
+  'SSCP daemon is not renderable' \
+  'SSCP startup proof is missing or malformed' \
+  'SSCP peer pid is not derivable' \
+  'shell-control.sock' \
+  "stat -f '%A'" \
+  'instance_generation' \
+  'require_relaunch_exit' \
+  'require_socket_gone' \
+  'stop_exact_pid' \
+  'discover_daemon_pid' \
+  'refusing to signal pid' \
+  'preserve.sentinel' \
+  'Contents/Resources/binaries/sage-gui' \
+  'served SSCP from an unexpected daemon' \
+  'STAGED_GENERATION' \
+  'REINSTALLED_GENERATION'; do
+  grep -Fq "${required}" "${HARNESS}"
+done
+
+# Containment: the harness must never reach for a process by name, and must not
+# fall back to the Linux-only /proc environment scan.
+if grep -Eq 'pkill|killall|-o comm=[[:space:]]*\|[[:space:]]*grep|/proc/' "${HARNESS}"; then
+  echo 'macOS runtime harness contains broad process-name cleanup' >&2
+  exit 1
+fi
+
+# bash 3.2 is the system bash on an Apple runner; these builtins are not there.
+if grep -Eq '(^|[^[:alnum:]_])(mapfile|readarray)([^[:alnum:]_]|$)' "${HARNESS}"; then
+  echo 'macOS runtime harness uses bash 4 builtins unavailable on the system bash' >&2
+  exit 1
+fi
+
+# The isolated install root must never be the real /Applications.
+if grep -Eq 'INSTALL_ROOT=["'"'"']?/Applications' "${HARNESS}"; then
+  echo 'macOS runtime harness installs into the shared /Applications root' >&2
+  exit 1
+fi
+
+# Regression: mktemp reports the unresolved /var path while the kernel reports
+# exec'd binaries under /private/var, so an uncanonicalized smoke root makes the
+# daemon-identity comparison fail on every run.
+if ! grep -Eq 'SMOKE_ROOT=\$\(cd "\$\(mktemp -d.*\)" && pwd -P\)' "${HARNESS}"; then
+  echo 'macOS runtime harness does not canonicalize its smoke root' >&2
+  exit 1
+fi
+
+fixture=$(mktemp -d "${TMPDIR:-/tmp}/sage-native-macos-fixture.XXXXXX")
+trap 'rm -rf "${fixture}"' EXIT INT TERM
+if "${HARNESS}" "${fixture}" 11.11.0-contract >"${fixture}/stdout" 2>"${fixture}/stderr"; then
+  echo "runtime harness unexpectedly accepted an empty bundle" >&2
+  exit 1
+fi
+if [ "$(uname -s)" = "Darwin" ]; then
+  grep -Fq 'expected exactly one DMG package' "${fixture}/stderr"
+else
+  grep -Fq 'requires macOS' "${fixture}/stderr"
+fi
+
+echo "native-shell macOS runtime harness contract tests passed"

--- a/scripts/verify-native-shell-bundle.sh
+++ b/scripts/verify-native-shell-bundle.sh
@@ -22,7 +22,13 @@ fi
 BUNDLE_ROOT=$(cd "${BUNDLE_ROOT}" && pwd -P)
 
 EXTRACT_ROOT=
+DMG_MOUNT=
 cleanup() {
+  if [ -n "${DMG_MOUNT}" ] && [ -d "${DMG_MOUNT}" ]; then
+    hdiutil detach "${DMG_MOUNT}" -quiet 2>/dev/null ||
+      hdiutil detach "${DMG_MOUNT}" -force -quiet 2>/dev/null || true
+    DMG_MOUNT=
+  fi
   if [ -n "${EXTRACT_ROOT}" ] && [ -d "${EXTRACT_ROOT}" ]; then
     rm -rf -- "${EXTRACT_ROOT}"
   fi
@@ -31,15 +37,33 @@ trap cleanup EXIT INT TERM
 
 case "${TARGET_TRIPLE}" in
   aarch64-apple-darwin)
-    if [ -n "${PACKAGE_KIND}" ] && [ "${PACKAGE_KIND}" != app ]; then
-      echo "unsupported package kind for ${TARGET_TRIPLE}: ${PACKAGE_KIND}" >&2
-      exit 2
-    fi
     EXPECTED_GOOS=darwin
     EXPECTED_GOARCH=arm64
-    SEARCH_ROOT=${BUNDLE_ROOT}/macos
     DAEMON_NAME=sage-gui
     DAEMON_PATTERN='*/Contents/Resources/binaries/sage-gui'
+    case "${PACKAGE_KIND:-app}" in
+      app)
+        SEARCH_ROOT=${BUNDLE_ROOT}/macos
+        ;;
+      dmg)
+        command -v hdiutil >/dev/null
+        PACKAGE_COUNT=$(find "${BUNDLE_ROOT}/dmg" -maxdepth 1 -type f -name '*.dmg' 2>/dev/null | wc -l | tr -d ' ')
+        if [ "${PACKAGE_COUNT}" -ne 1 ]; then
+          echo "native-shell bundle must contain exactly one DMG; found ${PACKAGE_COUNT}" >&2
+          exit 1
+        fi
+        PACKAGE=$(find "${BUNDLE_ROOT}/dmg" -maxdepth 1 -type f -name '*.dmg' | head -1)
+        EXTRACT_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/sage-native-dmg.XXXXXX")
+        DMG_MOUNT=${EXTRACT_ROOT}/mnt
+        mkdir -p "${DMG_MOUNT}"
+        hdiutil attach "${PACKAGE}" -nobrowse -readonly -noautoopen -mountpoint "${DMG_MOUNT}" >/dev/null
+        SEARCH_ROOT=${DMG_MOUNT}
+        ;;
+      *)
+        echo "unsupported package kind for ${TARGET_TRIPLE}: ${PACKAGE_KIND}" >&2
+        exit 2
+        ;;
+    esac
     APP_COUNT=$(find "${SEARCH_ROOT}" -maxdepth 1 -type d -name '*.app' 2>/dev/null | wc -l | tr -d ' ')
     if [ "${APP_COUNT}" -ne 1 ]; then
       echo "native-shell bundle must contain exactly one macOS app; found ${APP_COUNT}" >&2
@@ -51,8 +75,13 @@ case "${TARGET_TRIPLE}" in
       echo "native-shell macOS app must contain exactly one shell executable; found ${SHELL_ARTIFACT_COUNT}" >&2
       exit 1
     fi
-    SHELL_ARTIFACT=$(find "${APP_PATH}/Contents/MacOS" -maxdepth 1 -type f | head -1)
-    SHELL_ARTIFACT_KIND=app-executable
+    if [ "${PACKAGE_KIND:-app}" = dmg ]; then
+      SHELL_ARTIFACT=${PACKAGE}
+      SHELL_ARTIFACT_KIND=dmg
+    else
+      SHELL_ARTIFACT=$(find "${APP_PATH}/Contents/MacOS" -maxdepth 1 -type f | head -1)
+      SHELL_ARTIFACT_KIND=app-executable
+    fi
     ;;
   x86_64-unknown-linux-gnu)
     EXPECTED_GOOS=linux


### PR DESCRIPTION
Completes the three-platform installed-package runtime set alongside Linux (#91) and Windows (#92). macOS was the remaining platform in the sequence.

## What it does

`scripts/native-shell-macos-runtime-smoke.sh` builds on the existing Linux/Windows harness pattern:

- mounts the constructed DMG and installs by copying the app out into an isolated root (not `/Applications`, matching the Windows harness's isolated install-root convention)
- launches the installed executable against an isolated `SAGE_HOME` with isolated REST/RPC/P2P ports
- proves single-instance handoff — a second launch exits 0 and the instance generation is unchanged
- proves the daemon survives an ordinary shell close
- uninstalls, confirms the node data root is preserved, and confirms the daemon is untouched
- runs the staged `.app` and then reinstalls, asserting **three distinct instance generations**
- asserts run-dir `700` / socket `600`, no symlinks, and socket removal after daemon stop

`scripts/verify-native-shell-bundle.sh` gains a `dmg` package kind, so both macOS artifacts emit release-pair records.

## Daemon identity and containment

The serving daemon PID is derived from the control socket via `LOCAL_PEERPID` — the direct macOS analogue of the Windows `GetNamedPipeServerProcessId` check — and compared against the exact bundled daemon path. No harness matches a process by name; the contract test fails the build if one does.

Cleanup also re-derives a serving PID from the socket, because a run that fails *before* its first valid status would otherwise leak the daemon it started. This was a real bug caught while testing the failure paths, not a hypothetical.

## Verification

Verified locally against a synthetic Tauri-shaped bundle (real Rust build is the runner's job, per the gate doc's "builds on a developer machine is not a platform pass"):

- full lifecycle passes with three distinct generations
- **negative:** daemon reporting a different version than declared → fails
- **negative:** daemon served from outside the installed app bundle → fails with the offending path
- no leaked processes or mounts after either failure

Two macOS-specific traps were found and fixed before this ever reached a runner: `pipefail` + `find` on a missing directory aborting before any diagnostic could print, and `mktemp` returning the unresolved `/var` form while the kernel reports exec'd binaries under `/private/var` (which would have failed the daemon-identity check on every single run). Both have regression assertions in the contract test.

## What this evidence is NOT

Recorded explicitly in `docs/native-shell-quality-gates.md`:

- **unsigned** — proves nothing about signing, notarization, stapling, or Gatekeeper; not rollback or update-failure evidence
- **arm64 only** on the runner image; no Intel, no deep links, no LaunchServices registration
- does not measure the performance budgets or accessibility gates

The observed OS build, architecture, and WebKit version are recorded in the uploaded diagnostics so the constraint is checkable rather than asserted.

## Does not unblock promotion

The named native standalone production-promotion gate stays failed closed, and Dependabot alert 37 (`RUSTSEC-2024-0429`, glib 0.18.5 via Wry/WebKitGTK, upstream `tauri-apps/wry#1769` still open) remains an independent blocker.