### PR TITLE
docs(security): scope glib advisory to Linux artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,7 +423,7 @@ jobs:
             exit 0
           fi
           test "${NATIVE_SHELL_RELEASE_CLASS}" = "unsigned-preview-evidence"
-          echo "::error::Native standalone release ${NATIVE_SHELL_VERSION} is blocked: the package matrix is unsigned preview evidence only. Signed/notarized packages, installed-runtime acceptance, dependency-advisory closure (including RUSTSEC-2024-0429), update/rollback, accessibility, performance, and recovery evidence must be implemented and validated before publication."
+          echo "::error::Native standalone release ${NATIVE_SHELL_VERSION} is blocked: the package matrix is unsigned preview evidence only. Signed/notarized packages, installed-runtime acceptance, dependency-advisory closure (RUSTSEC-2024-0429 is scoped to the Linux artifacts; see docs/native-shell-quality-gates.md), update/rollback, accessibility, performance, and recovery evidence must be implemented and validated before publication."
           exit 1
 
   goreleaser-prepare:

--- a/docs/native-shell-quality-gates.md
+++ b/docs/native-shell-quality-gates.md
@@ -34,14 +34,37 @@ promotion path deliberately replace it; it must not be carried unchanged into
 v12.
 
 GitHub Dependabot alert 37 (`RUSTSEC-2024-0429` /
-`GHSA-wrw7-89jp-8q8g`) is also an active promotion blocker. The Linux Tauri
-stack currently receives `glib` 0.18.5 through Wry/WebKitGTK; the affected safe
-iterator API can trigger undefined behavior and optimized-build crashes. As of
-this gate record, current Wry 0.55.1 still pins the affected GTK/glib family and
-upstream issue `tauri-apps/wry#1769` remains open, so no compatible dependency
-upgrade exists. The alert must remain open until a tested upstream migration or
-reviewed backport removes the affected code; it must not be dismissed merely to
-make release status green.
+`GHSA-wrw7-89jp-8q8g`) is an active **Linux-only** promotion blocker. The Linux
+Tauri stack receives `glib` 0.18.5 through Wry/WebKitGTK; the affected safe
+iterator API can trigger undefined behavior and optimized-build crashes.
+
+By release-owner decision this blocker is scoped to the Linux artifacts, because
+the affected code is not built into the macOS or Windows packages at all. Wry
+declares its entire GTK chain under
+`cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd",
+target_os = "openbsd", target_os = "netbsd"))`; macOS resolves the web view
+through WKWebView and Windows through WebView2, so neither target compiles
+`gtk`, `webkit2gtk`, `soup3`, or `glib`. The scoping rests on that target gate,
+not on a severity judgement — if a future Wry release brings the affected family
+onto another target, the blocker widens again automatically.
+
+No compatible dependency upgrade exists, and this is a hard version wall rather
+than a pending release: Wry 0.55.1 is the latest published version and requires
+`gtk ^0.18`; the GTK3 Rust binding line is capped at `gtk` 0.18.2, last released
+2024-12-09, which pins `glib` 0.18.x. The advisory is first fixed in `glib`
+0.20.0, and `glib` 0.20+ belongs to the GTK4 line. Escaping therefore requires
+Wry migrating to GTK4/webkitgtk-6.0, tracked upstream in `tauri-apps/wry#1769`,
+which remains open with no activity since 2026-07-15.
+
+`cargo audit` reads the lockfile rather than the per-target build graph, so it
+reports this advisory on every platform's run regardless of the scoping above.
+That is expected and must not be silenced.
+
+The alert must remain open until a tested upstream migration or reviewed
+backport removes the affected code; it must not be dismissed merely to make
+release status green. Narrowing this blocker to Linux does **not** release any
+other hold — the native standalone production-promotion gate above still fails
+closed and still freezes the entire v11.11 publication graph on its own.
 
 Runtime promotion remains open until the install/launch/deep-link/offline,
 performance, assistive-technology, signing/notarization, update/rollback, and


### PR DESCRIPTION
Dependabot alert 37 (`RUSTSEC-2024-0429` / `GHSA-wrw7-89jp-8q8g`) **stays open and stays release-blocking**. This scopes it to the Linux artifacts and records the evidence for why.

## Why Linux-only

Wry declares its entire GTK chain under a target gate:

```
gtk / webkit2gtk / webkit2gtk-sys / soup3
  → cfg(any(target_os = "linux", target_os = "dragonfly",
            target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))
```

macOS resolves the web view through WKWebView and Windows through WebView2, so **neither target compiles `gtk`, `webkit2gtk`, `soup3`, or `glib` at all**. The vulnerable code is not present in the macOS or Windows packages.

The scoping rests on that target gate, not on a severity judgement — so if a future Wry release moves the affected family onto another target, the blocker widens again on its own.

## Why there is no upgrade path

This is a hard version wall, not a pending release:

| Link | State |
|---|---|
| `wry` | 0.55.1 — latest published, we're on it; requires `gtk ^0.18` |
| `gtk` (GTK3 bindings) | capped at 0.18.2, last released **2024-12-09** |
| → pins | `glib` 0.18.x |
| advisory first fixed in | `glib` **0.20.0** (GTK4 line; upstream glib is at 0.22.8) |
| `tauri-apps/wry#1769` | **open**, no activity since 2026-07-15 |

Escaping requires Wry migrating to GTK4/webkitgtk-6.0. Nothing we can bump, pin, or `cargo update` reaches a patched glib.

## What this does not change

- the alert is **not** dismissed and must not be, merely to make release status green
- `cargo audit` reads the lockfile rather than the per-target build graph, so it will keep reporting the advisory on every platform's run — that is expected and must not be silenced
- the `release.yml` gate message is reworded to match, but **its logic is unchanged** and still `exit 1`s for every platform
- the native standalone production-promotion gate still fails closed and still freezes the entire v11.11 publication graph on its own

Narrowing this blocker releases no other hold.

## Note on merge order

Touches `docs/native-shell-quality-gates.md` in the paragraph immediately before one that #93 also edits. Whichever merges second may need a trivial doc rebase.