### PR TITLE
feat(shell): drop Linux from v11.11 native distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,11 +287,6 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: desktop/sage-shell
-      - name: Install Linux WebView build dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - name: Test native shell control contract
         shell: bash
         run: |
@@ -306,8 +301,13 @@ jobs:
             --manifest-path desktop/sage-shell/Cargo.toml --no-run
           cargo clippy --locked --target ${{ matrix.rust-target }} \
             --manifest-path desktop/sage-shell/Cargo.toml --all-targets -- -D warnings
+      # cargo audit reads the lockfile, not the built target graph, so it is
+      # platform-independent and runs exactly once. It must NOT be gated on a
+      # runner OS: this step was previously `runner.os == 'Linux'`, and dropping
+      # the Linux matrix entry would otherwise have silently disabled the
+      # release-path dependency audit entirely.
       - name: Audit locked native dependencies
-        if: runner.os == 'Linux'
+        if: matrix.id == 'macos-arm64'
         shell: bash
         run: |
           cargo install cargo-audit --version 0.22.2 --locked
@@ -329,7 +329,6 @@ jobs:
             --bundles ${{ matrix.bundles }} \
             --config "{\"version\":\"${NATIVE_SHELL_VERSION}\"}"
       - name: Verify macOS or Windows native release pair
-        if: runner.os != 'Linux'
         shell: bash
         run: |
           scripts/verify-native-shell-bundle.sh \
@@ -338,18 +337,6 @@ jobs:
             "${NATIVE_SHELL_VERSION}" \
             desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle/native-shell-release-pair.json \
             ${{ matrix.bundles }}
-      - name: Verify Linux native release pairs
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          for package_kind in deb appimage; do
-            scripts/verify-native-shell-bundle.sh \
-              ${{ matrix.rust-target }} \
-              desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle \
-              "${NATIVE_SHELL_VERSION}" \
-              "desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle/native-shell-release-pair-${package_kind}.json" \
-              "${package_kind}"
-          done
       - name: Generate native dependency SBOM
         shell: bash
         run: |
@@ -871,7 +858,7 @@ jobs:
           }
 
           if [ "${NATIVE_SHELL_REQUIRED}" = true ]; then
-            for evidence_id in macos-arm64 windows-x64 linux-x64; do
+            for evidence_id in macos-arm64 windows-x64; do
               evidence_root="staged/release-evidence-native-shell-${evidence_id}"
               test -f "${evidence_root}/SHA256SUMS"
               test -s "${evidence_root}/UNSIGNED-NATIVE-SHELL-EVIDENCE.txt"
@@ -895,14 +882,10 @@ jobs:
               staged/release-evidence-native-shell-windows-x64 \
               staged/release-evidence-native-shell-windows-x64/bundle/native-shell-release-pair.json \
               x86_64-pc-windows-msvc nsis
-            verify_native_release_pair \
-              staged/release-evidence-native-shell-linux-x64 \
-              staged/release-evidence-native-shell-linux-x64/bundle/native-shell-release-pair-deb.json \
-              x86_64-unknown-linux-gnu deb
-            verify_native_release_pair \
-              staged/release-evidence-native-shell-linux-x64 \
-              staged/release-evidence-native-shell-linux-x64/bundle/native-shell-release-pair-appimage.json \
-              x86_64-unknown-linux-gnu appimage
+            # No Linux verification: v11.11 does not distribute a Linux native
+            # shell, so no linux-x64 evidence artifact is produced. Verifying it
+            # here would fail the publication gate on a missing file. See
+            # docs/native-shell-quality-gates.md.
           fi
 
           # PyPI is immutable. If this is a recovery run and the version is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,10 +267,11 @@ jobs:
             os: windows-2025
             rust-target: x86_64-pc-windows-msvc
             bundles: nsis
-          - id: linux-x64
-            os: ubuntu-24.04
-            rust-target: x86_64-unknown-linux-gnu
-            bundles: deb,appimage
+          # No linux-x64 entry: v11.11 does not distribute a Linux native shell.
+          # Linux still builds and runs its installed-package lifecycle smoke in
+          # .github/workflows/native-shell.yml for cross-platform regression
+          # coverage; it is simply never staged as release evidence. See
+          # docs/native-shell-quality-gates.md.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -423,7 +424,7 @@ jobs:
             exit 0
           fi
           test "${NATIVE_SHELL_RELEASE_CLASS}" = "unsigned-preview-evidence"
-          echo "::error::Native standalone release ${NATIVE_SHELL_VERSION} is blocked: the package matrix is unsigned preview evidence only. Signed/notarized packages, installed-runtime acceptance, dependency-advisory closure (including RUSTSEC-2024-0429), update/rollback, accessibility, performance, and recovery evidence must be implemented and validated before publication."
+          echo "::error::Native standalone release ${NATIVE_SHELL_VERSION} is blocked: the macOS and Windows package matrix is unsigned preview evidence only. Signed/notarized packages, installed-runtime acceptance, dependency-advisory closure, update/rollback, accessibility, performance, and recovery evidence must be implemented and validated before publication. v11.11 does not distribute a Linux native shell; see docs/native-shell-quality-gates.md."
           exit 1
 
   goreleaser-prepare:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -178,6 +178,16 @@ are recorded in [`desktop-shell-decision.md`](desktop-shell-decision.md),
 [`native-shell-quality-gates.md`](native-shell-quality-gates.md). The tracked
 Tauri foundation remains an opt-in preview until that full matrix passes.
 
+**Platform scope: v11.11 distributes a native shell on macOS and Windows only.**
+Linux is deliberately excluded. Linux users are served by browser CEREBRUM and
+the CLI, both fully supported and unaffected — this narrows the native shell,
+not the platform. The Linux target still builds and runs its full
+installed-package lifecycle smoke in CI so cross-platform regressions in the
+shared shell and SSCP code are still caught; it is simply never published. A
+distributed Linux shell returns only when upstream Wry ships
+GTK4/webkitgtk-6.0 (`tauri-apps/wry#1769`); SAGE will not fork or vendor the web
+view layer to get there sooner.
+
 ### v11.12 - consumer onboarding and recovery
 
 Make first run and recovery survivable by someone who has never used SAGE, natively and without a terminal. Guided create-or-join, connect-an-AI-tool, and choose-what-is-private-or-shared flows; recovery-key backup and restore; and honest, consistent dialogs for destructive or privacy-affecting actions that explain what happened, what remains safe, and the next step. Plain language and safe defaults throughout. The gate includes clean-machine onboarding and recovery usability tests with real nontechnical users — the same bar v12 sets, brought forward so it is proven early rather than at the end.

--- a/docs/desktop-shell-decision.md
+++ b/docs/desktop-shell-decision.md
@@ -13,8 +13,16 @@ visible startup/recovery state; it does not own consensus, storage, MCP, RBAC,
 updates, validator material, or the vault passphrase.
 
 This is a conditional implementation decision, not permission to publish an
-untested desktop product. macOS, Windows, and the declared Linux floor must all
-pass the gates in `native-shell-quality-gates.md` before a release is promoted.
+untested desktop product. macOS and Windows must both pass the gates in
+`native-shell-quality-gates.md` before a release is promoted.
+
+v11.11 does not distribute a Linux native shell. The Linux target still builds
+and runs its installed-package lifecycle smoke in CI for regression coverage,
+but produces no release evidence, so no Linux floor gates this release. Linux
+users are served by browser CEREBRUM and the CLI. A distributed Linux shell
+returns only when upstream Wry ships GTK4/webkitgtk-6.0; the reasoning and the
+conditional `RUSTSEC-2024-0429` dismissal are recorded in
+`native-shell-quality-gates.md`.
 
 ## Evidence
 

--- a/docs/native-shell-quality-gates.md
+++ b/docs/native-shell-quality-gates.md
@@ -6,12 +6,23 @@ Browser CEREBRUM and the existing Go release matrix remain mandatory.
 
 ## Current enforcement status
 
+**v11.11 distributes a native shell on macOS and Windows only.** Linux is
+deliberately not a distributed native-shell platform for this release: Linux
+users are served by browser CEREBRUM and the CLI, both of which remain fully
+supported and are unaffected by this decision. Linux still compiles and runs its
+full installed-package lifecycle smoke in
+[`native-shell.yml`](../.github/workflows/native-shell.yml) so cross-platform
+regressions in the shared shell and SSCP code are still caught — it is simply
+never staged as release evidence and never published. See
+[Linux re-entry](#linux-re-entry) below.
+
 The tracked preview now enforces locked dependency compilation, Rust
 format/test/Clippy, full platform shell-control tests, isolated Codex endpoint
 acceptance tests, dependency audit, a license-bearing CycloneDX SBOM, and
-unsigned package construction on the declared macOS, Windows, and Linux
-targets. Each constructed package is unpacked and must contain exactly one
-bundled daemon whose embedded Go OS/architecture matches the declared target
+unsigned package construction on the declared macOS and Windows targets, plus
+the non-distributed Linux CI target. Each constructed package is unpacked and
+must contain exactly one bundled daemon whose embedded Go OS/architecture
+matches the declared target
 and whose embedded version matches the version supplied to the shell package
 build. Those checks emit a machine-readable release-pair record beside
 the package with the target, build version, packaged shell artifact size/hash,
@@ -33,15 +44,56 @@ also fails closed for later versions until their shell/daemon compatibility and
 promotion path deliberately replace it; it must not be carried unchanged into
 v12.
 
-GitHub Dependabot alert 37 (`RUSTSEC-2024-0429` /
-`GHSA-wrw7-89jp-8q8g`) is also an active promotion blocker. The Linux Tauri
-stack currently receives `glib` 0.18.5 through Wry/WebKitGTK; the affected safe
-iterator API can trigger undefined behavior and optimized-build crashes. As of
-this gate record, current Wry 0.55.1 still pins the affected GTK/glib family and
-upstream issue `tauri-apps/wry#1769` remains open, so no compatible dependency
-upgrade exists. The alert must remain open until a tested upstream migration or
-reviewed backport removes the affected code; it must not be dismissed merely to
-make release status green.
+### `RUSTSEC-2024-0429` (glib) — dismissed, not fixed
+
+GitHub Dependabot alert 37 (`RUSTSEC-2024-0429` / `GHSA-wrw7-89jp-8q8g`)
+concerns `glib` 0.18.5, which the Linux Tauri stack receives through
+Wry/WebKitGTK; the affected safe iterator API can trigger undefined behavior and
+optimized-build crashes.
+
+**The alert was dismissed as not-used on the decision that v11.11 does not
+distribute a Linux native shell.** It was not fixed, and the vulnerable code is
+still compiled by the non-distributed Linux CI build. This is a scope decision,
+not a remediation. It rests on two verified facts:
+
+- Wry declares its whole GTK chain under
+  `cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd",
+  target_os = "openbsd", target_os = "netbsd"))`. macOS resolves the web view
+  through WKWebView and Windows through WebView2, so **neither distributed
+  target compiles `gtk`, `webkit2gtk`, `soup3`, or `glib` at all**.
+- No user receives the affected code, because the only artifact containing it is
+  never published.
+
+There is no upgrade path, and this is a hard version wall rather than a pending
+release: Wry 0.55.1 is the latest published version and requires `gtk ^0.18`;
+the GTK3 Rust binding line is capped at `gtk` 0.18.2, last released 2024-12-09,
+which pins `glib` 0.18.x. The advisory is first fixed in `glib` 0.20.0, and
+`glib` 0.20+ belongs to the GTK4 line — a differently named `gtk4` crate, not a
+newer `gtk`. `cargo update`, a `--precise` pin, and a `[patch.crates-io]`
+override all fail: the first two are semver-excluded by `gtk ^0.18`, and the
+third compile-fails because `gtk`/`gdk`/`cairo-rs` 0.18 are not written against
+the glib 0.20+ API.
+
+`cargo audit` reads the lockfile rather than the per-target build graph, so it
+still reports this advisory on every platform's CI run. That is expected and
+must not be silenced.
+
+> **This dismissal is conditional and must be revisited.** If a Linux native
+> shell is ever distributed again, this alert must be re-opened and treated as
+> release-blocking before that artifact ships. Do not treat the dismissed state
+> as a standing judgement that the advisory is harmless.
+
+### Linux re-entry
+
+A distributed Linux native shell returns only when **upstream Wry ships
+GTK4/webkitgtk-6.0 support**, tracked in `tauri-apps/wry#1769` (open, no
+activity since 2026-07-15). That migration also clears this advisory, because
+the `gtk4` line depends on `glib ^0.22`.
+
+SAGE does not plan to fork or vendor Wry onto GTK4. Owning a fork of the web
+view layer in a security-sensitive component is a worse position than not
+shipping the platform. Until upstream moves, Linux native shell work stays out
+of scope and Linux users are served by browser CEREBRUM and the CLI.
 
 Runtime promotion remains open until the install/launch/deep-link/offline,
 performance, assistive-technology, signing/notarization, update/rollback, and
@@ -56,7 +108,7 @@ still needs immutable runner evidence before promotion.
 |---|---|---|
 | macOS | oldest Apple-supported macOS that SAGE declares for the release; Intel and Apple Silicon where distributed | signed `.app`, notarized/stapled DMG, clean install, Gatekeeper launch, rollback |
 | Windows | Windows 11 x64 and arm64 where distributed | signed NSIS installer, clean install/uninstall, SmartScreen/signature check, rollback |
-| Linux | Ubuntu 24.04 LTS x64 plus each architecture distributed | AppImage and Debian package, offline launch, uninstall preserving `~/.sage` |
+| Linux | **not distributed in v11.11** | none — build and installed-runtime smoke run in CI for regression coverage only, and are never release evidence |
 
 The exact OS image identifiers, WebView versions, CPU/RAM, and artifact hashes
 must appear in the release evidence. “Builds on a developer machine” is not a
@@ -107,7 +159,7 @@ Automated semantic checks supplement, never replace, the OS smoke matrix:
   appropriate live region without stealing focus;
 - 200% zoom, high contrast, light/dark mode, and OS reduced-motion work without
   clipping or lost content;
-- VoiceOver (macOS), Narrator (Windows), and Orca (Linux) can launch, identify
+- VoiceOver (macOS) and Narrator (Windows) can launch, identify
   daemon state, reach browser fallback, navigate primary CEREBRUM areas, and
   recover from daemon loss;
 - camera denial/revocation and every permission error remain operable without a

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -118,12 +118,23 @@ test('native shell evidence is version-locked, private, and cannot promote an un
   assert.match(evidence, /if: needs\.release-metadata\.outputs\.native_shell_required == 'true'/);
   assert.match(evidence, /id: macos-arm64/);
   assert.match(evidence, /id: windows-x64/);
-  assert.match(evidence, /id: linux-x64/);
+  // v11.11 distributes a native shell on macOS and Windows only. Linux still
+  // builds and runs its installed-package lifecycle smoke in native-shell.yml,
+  // but is never staged as release evidence. Assert the deliberate absence so a
+  // Linux entry cannot reappear in the shipping matrix without the scope
+  // decision in docs/native-shell-quality-gates.md being revisited.
+  assert.doesNotMatch(evidence, /id: linux-x64/);
   assert.match(evidence, /SAGE_DAEMON_VERSION/);
   assert.match(evidence, /go test \.\/internal\/shellcontrol/);
   assert.match(evidence, /cargo fmt --manifest-path/);
   assert.match(evidence, /components: rustfmt, clippy/);
   assert.match(evidence, /cargo audit --file desktop\/sage-shell\/Cargo\.lock/);
+  // Regression guard: the dependency audit was once gated on
+  // `runner.os == 'Linux'`, so dropping the Linux matrix entry silently
+  // disabled it for releases. cargo audit reads the lockfile and is
+  // platform-independent, so it must never be gated on a runner OS again.
+  assert.doesNotMatch(evidence, /if: runner\.os == 'Linux'/);
+  assert.match(evidence, /if: matrix\.id == 'macos-arm64'\n\s+shell: bash\n\s+run: \|\n\s+cargo install cargo-audit/);
   assert.match(evidence, /cargo tauri build --ci/);
   assert.match(evidence, /verify-native-shell-bundle\.sh/);
   assert.match(evidence, /cargo cyclonedx/);
@@ -142,7 +153,12 @@ test('native shell evidence is version-locked, private, and cannot promote an un
   assert.match(promotion, /Native standalone promotion does not apply before v11\.11\.0/);
   assert.match(promotion, /Native standalone release .* is blocked/);
   assert.match(promotion, /v11\.11 is deliberately a whole-release hold/);
-  assert.match(promotion, /RUSTSEC-2024-0429/);
+  // RUSTSEC-2024-0429 is no longer named here: it was dismissed as not-used once
+  // v11.11 stopped distributing a Linux native shell, which is the only artifact
+  // that compiles the affected glib. The gate still requires dependency-advisory
+  // closure generally, and still fails closed.
+  assert.match(promotion, /dependency-advisory closure/);
+  assert.match(promotion, /does not distribute a Linux native shell/);
   assert.match(promotion, /Signed\/notarized packages, installed-runtime acceptance/);
   assert.match(promotion, /exit 1/);
 
@@ -150,8 +166,12 @@ test('native shell evidence is version-locked, private, and cannot promote an un
   assert.match(publication, /verify_native_release_pair\(\)/);
   assert.match(publication, /NATIVE_SHELL_REQUIRED:.*native_shell_required/);
   assert.match(publication, /if \[ "\$\{NATIVE_SHELL_REQUIRED\}" = true \]; then/);
-  assert.match(publication, /native-shell-release-pair-deb\.json/);
-  assert.match(publication, /native-shell-release-pair-appimage\.json/);
+  // The publication gate must not verify Linux evidence that is never produced:
+  // a missing linux-x64 artifact would fail the gate on a missing file.
+  assert.doesNotMatch(publication, /native-shell-release-pair-deb\.json/);
+  assert.doesNotMatch(publication, /native-shell-release-pair-appimage\.json/);
+  assert.doesNotMatch(publication, /release-evidence-native-shell-linux-x64/);
+  assert.match(publication, /for evidence_id in macos-arm64 windows-x64; do/);
   assert.match(publication, /sha256sum -c SHA256SUMS/);
   assert.match(publication, /native-shell-\$\{evidence_id\}\.cdx\.json/);
 


### PR DESCRIPTION
v11.11 distributes a native shell on **macOS and Windows only**.

Linux users are served by browser CEREBRUM and the CLI, both fully supported and unaffected — **this narrows the native shell, not the platform.** The Linux daemon, CLI, and web dashboard are untouched.

Supersedes #94, whose premise (glib as a Linux-only *blocker*) no longer applies once the Linux artifact isn't shipped.

## CI keeps Linux; release drops it

| Workflow | Linux | Why |
|---|---|---|
| `native-shell.yml` (CI) | **kept**, incl. installed-package lifecycle smoke | catches cross-platform regressions in the shared shell + SSCP code; preserves #91's harness; keeps the door open |
| `release.yml` (shipping evidence) | **removed** | nothing Linux is ever staged or published |

Verified programmatically — release evidence matrix is now macOS + Windows; CI matrix still has ubuntu-24.04 with the lifecycle smoke step intact.

## RUSTSEC-2024-0429 retired by scope, not remediation

Dependabot alert 37 is dismissed as **not-used**, on the basis that no user receives the affected code:

- Wry declares its whole GTK chain under `cfg(any(target_os = "linux", dragonfly, freebsd, openbsd, netbsd))`, so macOS (WKWebView) and Windows (WebView2) **never compile `glib`**
- the only artifact that does compile it is never published

**I want to be explicit about what this is not.** The vulnerable code is still compiled by the non-distributed Linux CI build. This is a scope decision, not a fix. The gate record says so plainly and carries a blockquote stating the dismissal is **conditional** — if a Linux native shell is ever distributed again, the alert must be re-opened and treated as release-blocking before that artifact ships. The dismissal reasoning lives in the repo, not only in a GitHub dismissal comment, precisely so it can't rot silently.

`cargo audit` reads the lockfile rather than the per-target build graph, so it will keep reporting the advisory on every CI run. That's expected and documented as must-not-silence.

## Linux re-entry

Gated on **upstream Wry shipping GTK4/webkitgtk-6.0** (`tauri-apps/wry#1769`, open, no activity since 2026-07-15). That migration also clears the advisory, since the `gtk4` line depends on `glib ^0.22`.

SAGE will **not** fork or vendor Wry onto GTK4 — owning a fork of the web view layer in a security-sensitive component is a worse position than not shipping the platform.

Recorded for the next person who asks "why not just upgrade gtk": there is no `gtk` 0.2x. The GTK3 binding line is capped at `gtk` 0.18.2 (last released 2024-12-09) pinning `glib` 0.18.x; the fix landed in `glib` 0.20.0 on the separate `gtk4` crate. `cargo update`, `--precise`, and `[patch.crates-io]` all fail — the first two are semver-excluded by `gtk ^0.18`, the third compile-fails because `gtk`/`gdk`/`cairo-rs` 0.18 aren't written against the glib 0.20+ API.

## Files

- `.github/workflows/release.yml` — drop `linux-x64` from release evidence; reword the gate message. **Gate logic unchanged, still fails closed.**
- `docs/native-shell-quality-gates.md` — platform scope, dismissal record + conditional-revisit warning, Linux re-entry section, supported matrix row, Orca row removed
- `docs/desktop-shell-decision.md` — no Linux floor gates this release
- `docs/ROADMAP.md` — v11.11 platform scope

## Merge order

Touches `docs/native-shell-quality-gates.md` near paragraphs #93 also edits. Suggest merging #93 first (it's the larger diff and already green), then this.