### PR TITLE
test(shell): cover the relaunch deep-link forwarding seam

### DIFF
--- a/desktop/sage-shell/src/main.rs
+++ b/desktop/sage-shell/src/main.rs
@@ -799,6 +799,56 @@ mod tests {
         assert_eq!(state.pending_routes.front().unwrap(), "/tasks/2");
     }
 
+    // The single-instance plugin hands a second launch's argv to
+    // route_from_args and enqueues whatever it returns. That seam is what makes
+    // `open sage://tasks` reach an already-running window, and it is not
+    // reachable from the black-box package harnesses: the route is delivered to
+    // the webview as a URL fragment, so it never reaches the daemon and leaves
+    // no observable trace outside this process.
+    #[test]
+    fn a_relaunch_forwards_only_a_bounded_route_from_its_arguments() {
+        // A real second launch: argv[0] is the executable, not a route.
+        assert_eq!(
+            route_from_args(["/Applications/SAGE.app/Contents/MacOS/SAGE", "sage://tasks"]),
+            Some("/tasks".into())
+        );
+        // The first valid route wins rather than the last.
+        assert_eq!(
+            route_from_args(["sage", "sage://brain", "sage://settings"]),
+            Some("/brain".into())
+        );
+        // Ordinary launches carry no route at all.
+        assert_eq!(route_from_args(["/Applications/SAGE.app/Contents/MacOS/SAGE"]), None);
+        assert_eq!(route_from_args(Vec::<String>::new()), None);
+        // Rejected deep links must not become routes just because they arrived
+        // through argv instead of the OS handler.
+        assert_eq!(route_from_args(["sage", "sage://admin/root"]), None);
+        assert_eq!(route_from_args(["sage", "sage://search/a?token=secret"]), None);
+        assert_eq!(route_from_args(["sage", "javascript:alert(1)"]), None);
+        assert_eq!(route_from_args(["sage", "file:///etc/passwd"]), None);
+        assert_eq!(route_from_args(["sage", "--some-flag", "not-a-url"]), None);
+        // A rejected argument must not mask a later valid one.
+        assert_eq!(
+            route_from_args(["sage", "sage://admin/root", "sage://tasks"]),
+            Some("/tasks".into())
+        );
+    }
+
+    #[test]
+    fn a_forwarded_relaunch_route_reaches_the_pending_queue() {
+        let session = Arc::new(Mutex::new(ShellSession::default()));
+        if let Some(route) = route_from_args(["sage", "sage://search/agent-123"]) {
+            enqueue_route(&session, route);
+        }
+        // A rejected link in the same position must enqueue nothing.
+        if let Some(route) = route_from_args(["sage", "sage://admin/root"]) {
+            enqueue_route(&session, route);
+        }
+        let state = session.lock().unwrap();
+        assert_eq!(state.pending_routes.len(), 1);
+        assert_eq!(state.pending_routes.front().unwrap(), "/search/agent-123");
+    }
+
     #[test]
     fn only_explicit_lock_contention_allows_attachment_without_proof() {
         assert!(allows_existing_attachment_exit_code(Some(

--- a/desktop/sage-shell/src/main.rs
+++ b/desktop/sage-shell/src/main.rs
@@ -818,12 +818,18 @@ mod tests {
             Some("/brain".into())
         );
         // Ordinary launches carry no route at all.
-        assert_eq!(route_from_args(["/Applications/SAGE.app/Contents/MacOS/SAGE"]), None);
+        assert_eq!(
+            route_from_args(["/Applications/SAGE.app/Contents/MacOS/SAGE"]),
+            None
+        );
         assert_eq!(route_from_args(Vec::<String>::new()), None);
         // Rejected deep links must not become routes just because they arrived
         // through argv instead of the OS handler.
         assert_eq!(route_from_args(["sage", "sage://admin/root"]), None);
-        assert_eq!(route_from_args(["sage", "sage://search/a?token=secret"]), None);
+        assert_eq!(
+            route_from_args(["sage", "sage://search/a?token=secret"]),
+            None
+        );
         assert_eq!(route_from_args(["sage", "javascript:alert(1)"]), None);
         assert_eq!(route_from_args(["sage", "file:///etc/passwd"]), None);
         assert_eq!(route_from_args(["sage", "--some-flag", "not-a-url"]), None);


### PR DESCRIPTION
Adds direct coverage for the single-instance → `route_from_args` → `enqueue_route` seam. That path is what makes `open sage://tasks` reach an already-running window, and it had no direct test: existing tests cover `parse_deep_link` and the pending-route queue, but not the path between them.

## Why this can't be a package-harness check

The route is delivered to the webview as a **URL fragment** (`pinned_ui_url` calls `url.set_fragment`). Fragments are never transmitted, so the daemon sees an identical `GET /ui/` whether a deep link fired or not. `enqueue_route` only mutates in-memory state, and SSCP's status schema can't carry a route field — all three package harnesses assert the schema exactly, so adding one breaks Linux and Windows.

A black-box harness therefore cannot distinguish a delivered route from a dropped one. Rust is the only level where this seam is observable.

## Covered

- `argv[0]` (the executable path) is not mistaken for a route
- first valid route wins, not the last
- ordinary launches and empty argv carry no route
- rejected links don't become routes just because they arrived via argv rather than the OS handler: `sage://admin/root`, `?token=secret`, `javascript:`, `file:///etc/passwd`, non-URL flags
- a rejected argument doesn't mask a later valid one
- a forwarded route actually lands in the pending queue, and a rejected one enqueues nothing

## What this does NOT do

**It does not close the deep-link promotion row.** OS-level LaunchServices delivery is still unproven. Closing that needs either shell-side observability (a route-accepted log line, which I deliberately did not add here — see below) or a documented manual sign-off alongside the VoiceOver/Narrator rows.

I considered adding a log line for accepted routes to make the row harness-testable, and decided against it for now: nothing consumes it yet, and it's product code in a security-sensitive component added purely for a test that doesn't exist. If we do add it, it should log only the validated host segment (a fixed 5-value enum) and route length — never the path, since routes like `sage://search/agent-123` carry identifiers.

## Verification note

**This is the one change in this series I could not run locally** — there's no Rust toolchain on my machine, and installing one plus building 465 Tauri crates wasn't a proportionate trade for a test-only change. The generic bounds (`I: IntoIterator<Item = S>, S: AsRef<str>`) accept both the array literals and `Vec<String>` used here, and the idioms match existing tests in the same module. The `Rust test and lint` step runs early in the job, before the expensive Tauri build, so a compile error surfaces in minutes rather than at the end.