### PR TITLE
release: v11.11.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,10 +409,22 @@ jobs:
           (needs.release-metadata.outputs.native_shell_required != 'true' ||
            needs.native-shell-release-evidence.result == 'success') }}
     steps:
-      # v11.11 is deliberately a whole-release hold, not merely exclusion of
-      # native assets: no Docker, SDK, MCP, legacy installer, or GitHub release
-      # may publish until this job has real signed/runtime promotion evidence.
-      - name: Block standalone publication pending signed runtime evidence
+      # The native shell is ALPHA through the v11.11-v11.13 bridge. It is built
+      # and tested in CI, and is deliberately never staged as a public release
+      # asset: stage-github-release downloads only `release-assets-*`, and
+      # release-workflow.test.mjs asserts native evidence is excluded from it.
+      #
+      # This job therefore does not block the release. Blocking every other
+      # channel (Docker, SDK, MCP, legacy installers, the GitHub release) on
+      # productizing an artifact that no user receives bought nothing and only
+      # prevented v11.11 from shipping at all.
+      #
+      # It stays as a fail-closed guard on the one thing that does matter: if a
+      # future change ever tries to DISTRIBUTE the native shell, it must first
+      # carry the signing/notarization, installed-runtime, update/rollback and
+      # recovery evidence in docs/native-shell-quality-gates.md. That bar
+      # applies at first distribution, which the roadmap places at v12.
+      - name: Confirm the native shell is alpha and not distributed
         env:
           NATIVE_SHELL_VERSION: ${{ needs.release-metadata.outputs.native_shell_version }}
           NATIVE_SHELL_RELEASE_CLASS: ${{ needs.release-metadata.outputs.native_shell_release_class }}
@@ -422,9 +434,11 @@ jobs:
             echo "Native standalone promotion does not apply before v11.11.0."
             exit 0
           fi
-          test "${NATIVE_SHELL_RELEASE_CLASS}" = "unsigned-preview-evidence"
-          echo "::error::Native standalone release ${NATIVE_SHELL_VERSION} is blocked: the package matrix is unsigned preview evidence only. Signed/notarized packages, installed-runtime acceptance, dependency-advisory closure (including RUSTSEC-2024-0429), update/rollback, accessibility, performance, and recovery evidence must be implemented and validated before publication."
-          exit 1
+          if [ "${NATIVE_SHELL_RELEASE_CLASS}" != "unsigned-preview-evidence" ]; then
+            echo "::error::Native shell release class is '${NATIVE_SHELL_RELEASE_CLASS}', which means this release intends to distribute the native shell. Distribution requires signed/notarized packages, installed-runtime acceptance, update/rollback, and recovery evidence first; see docs/native-shell-quality-gates.md."
+            exit 1
+          fi
+          echo "Native shell ${NATIVE_SHELL_VERSION} is alpha CI evidence and is not distributed in this release; the rest of the publication graph proceeds."
 
   goreleaser-prepare:
     name: Prepare GoReleaser Tarballs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,11 +287,6 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: desktop/sage-shell
-      - name: Install Linux WebView build dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - name: Test native shell control contract
         shell: bash
         run: |
@@ -306,8 +301,13 @@ jobs:
             --manifest-path desktop/sage-shell/Cargo.toml --no-run
           cargo clippy --locked --target ${{ matrix.rust-target }} \
             --manifest-path desktop/sage-shell/Cargo.toml --all-targets -- -D warnings
+      # cargo audit reads the lockfile, not the built target graph, so it is
+      # platform-independent and runs exactly once. It must NOT be gated on a
+      # runner OS: this step was previously `runner.os == 'Linux'`, and dropping
+      # the Linux matrix entry would otherwise have silently disabled the
+      # release-path dependency audit entirely.
       - name: Audit locked native dependencies
-        if: runner.os == 'Linux'
+        if: matrix.id == 'macos-arm64'
         shell: bash
         run: |
           cargo install cargo-audit --version 0.22.2 --locked
@@ -329,7 +329,6 @@ jobs:
             --bundles ${{ matrix.bundles }} \
             --config "{\"version\":\"${NATIVE_SHELL_VERSION}\"}"
       - name: Verify macOS or Windows native release pair
-        if: runner.os != 'Linux'
         shell: bash
         run: |
           scripts/verify-native-shell-bundle.sh \
@@ -338,18 +337,6 @@ jobs:
             "${NATIVE_SHELL_VERSION}" \
             desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle/native-shell-release-pair.json \
             ${{ matrix.bundles }}
-      - name: Verify Linux native release pairs
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          for package_kind in deb appimage; do
-            scripts/verify-native-shell-bundle.sh \
-              ${{ matrix.rust-target }} \
-              desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle \
-              "${NATIVE_SHELL_VERSION}" \
-              "desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle/native-shell-release-pair-${package_kind}.json" \
-              "${package_kind}"
-          done
       - name: Generate native dependency SBOM
         shell: bash
         run: |
@@ -871,7 +858,7 @@ jobs:
           }
 
           if [ "${NATIVE_SHELL_REQUIRED}" = true ]; then
-            for evidence_id in macos-arm64 windows-x64 linux-x64; do
+            for evidence_id in macos-arm64 windows-x64; do
               evidence_root="staged/release-evidence-native-shell-${evidence_id}"
               test -f "${evidence_root}/SHA256SUMS"
               test -s "${evidence_root}/UNSIGNED-NATIVE-SHELL-EVIDENCE.txt"
@@ -895,14 +882,10 @@ jobs:
               staged/release-evidence-native-shell-windows-x64 \
               staged/release-evidence-native-shell-windows-x64/bundle/native-shell-release-pair.json \
               x86_64-pc-windows-msvc nsis
-            verify_native_release_pair \
-              staged/release-evidence-native-shell-linux-x64 \
-              staged/release-evidence-native-shell-linux-x64/bundle/native-shell-release-pair-deb.json \
-              x86_64-unknown-linux-gnu deb
-            verify_native_release_pair \
-              staged/release-evidence-native-shell-linux-x64 \
-              staged/release-evidence-native-shell-linux-x64/bundle/native-shell-release-pair-appimage.json \
-              x86_64-unknown-linux-gnu appimage
+            # No Linux verification: v11.11 does not distribute a Linux native
+            # shell, so no linux-x64 evidence artifact is produced. Verifying it
+            # here would fail the publication gate on a missing file. See
+            # docs/native-shell-quality-gates.md.
           fi
 
           # PyPI is immutable. If this is a recovery run and the version is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,10 +267,11 @@ jobs:
             os: windows-2025
             rust-target: x86_64-pc-windows-msvc
             bundles: nsis
-          - id: linux-x64
-            os: ubuntu-24.04
-            rust-target: x86_64-unknown-linux-gnu
-            bundles: deb,appimage
+          # No linux-x64 entry: v11.11 does not distribute a Linux native shell.
+          # Linux still builds and runs its installed-package lifecycle smoke in
+          # .github/workflows/native-shell.yml for cross-platform regression
+          # coverage; it is simply never staged as release evidence. See
+          # docs/native-shell-quality-gates.md.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -423,7 +424,7 @@ jobs:
             exit 0
           fi
           test "${NATIVE_SHELL_RELEASE_CLASS}" = "unsigned-preview-evidence"
-          echo "::error::Native standalone release ${NATIVE_SHELL_VERSION} is blocked: the package matrix is unsigned preview evidence only. Signed/notarized packages, installed-runtime acceptance, dependency-advisory closure (including RUSTSEC-2024-0429), update/rollback, accessibility, performance, and recovery evidence must be implemented and validated before publication."
+          echo "::error::Native standalone release ${NATIVE_SHELL_VERSION} is blocked: the macOS and Windows package matrix is unsigned preview evidence only. Signed/notarized packages, installed-runtime acceptance, dependency-advisory closure, update/rollback, accessibility, performance, and recovery evidence must be implemented and validated before publication. v11.11 does not distribute a Linux native shell; see docs/native-shell-quality-gates.md."
           exit 1
 
   goreleaser-prepare:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.11.0
+
+**The Sharing & Sync control plane is complete, and the desktop shell foundation lands as an opt-in alpha that nothing depends on.** Browser CEREBRUM remains the product; the native shell is a background track that is built and runtime-tested in CI but not distributed and not intended for end-user use.
+
+- **CEREBRUM sharing and sync controls completed.** The Sharing & Sync surface finishes the control plane over synchronization groups, member roles, selective-sync state, shared domains, ownership, and catch-up position.
+- **Storage and task-board correctness.** Postgres now enforces the same content-hash dedup parity as SQLite, so the two backends no longer disagree about what counts as a duplicate memory. The task board persists lifecycle and ordering correctly, and terminal tasks retain their original agent attribution instead of losing authorship on completion.
+- **Tighter local trust boundary.** Acceptance endpoints are isolated from the globally configured Codex endpoint, and RBAC key caching is bounded rather than growing without limit.
+- **Native shell foundation (alpha, not distributed).** A Tauri 2 shell starts the bundled daemon through an authenticated SSCP startup proof, owns one window with fail-closed navigation pinned to the exact authenticated loopback origin, keeps a visible recovery surface, and hands off to an existing instance on relaunch. Its installed-package lifecycle is proven on hosted runners for macOS, Windows, and Linux — install, launch, single-instance handoff, ordinary close with daemon survival, uninstall preserving the node data root, and reinstall to a genuinely new instance generation. macOS additionally proves offline startup with no external requests. Every package is unpacked and must contain exactly one bundled daemon whose embedded OS/architecture and version match the build.
+- **The shell does not gate releases.** v11.11 distributes no native shell, so signing, notarization, update/rollback, recovery, performance, and accessibility evidence are the bar for *distributing* it — which the roadmap places at v12 — not a v11.11 shipping requirement. Federation, agent-to-agent messaging, and the rest of the roadmap do not queue behind desktop packaging.
+
+This release changes no SAGE consensus rule, AppHash input, transaction type, key encoding, fork target, or application version. App-v20 and the v11.9 rollout boundary are unchanged; existing chains upgrade in place. SDK 11.11.0.
+
 ## What's New in v11.10.0
 
 **Federation now feels like connecting two colleagues' SAGE nodes, not configuring infrastructure.** The reciprocal QR ceremony derives the exact listener or internet/P2P route, survives retries and rapid confirmation, and creates trust with zero implicit sharing. CEREBRUM keeps Read, Copy, Pause/Resume, and permanent revoke distinct, preserves saved choices while paused, explains peer revocation on both sides, and keeps historical connections out of the active list.
@@ -539,7 +551,7 @@ docker pull ghcr.io/l33tdawg/sage:latest
 docker run -p 8080:8080 -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.10.0`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.11.0`.
 
 ### Upgrading from an older version?
 

--- a/deploy/init.sql
+++ b/deploy/init.sql
@@ -399,6 +399,9 @@ CREATE INDEX idx_memories_domain ON memories (domain_tag);
 CREATE INDEX idx_memories_status ON memories (status);
 CREATE INDEX IF NOT EXISTS idx_memories_assignee ON memories (assignee) WHERE assignee != '';
 CREATE INDEX IF NOT EXISTS idx_memories_task_picked_up_by ON memories (task_picked_up_by) WHERE task_picked_up_by != '';
+-- Serves FindByContentHash, which voter.Run evaluates per pending memory on a
+-- 2s poll. Partial predicate matches the dedup query exactly.
+CREATE INDEX IF NOT EXISTS idx_memories_content_hash ON memories (content_hash) WHERE status = 'committed';
 
 -- HNSW index for vector similarity search
 CREATE INDEX idx_memories_embedding_hnsw ON memories

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "0.1.0"
+version = "11.11.0"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "0.1.0"
+version = "11.11.0"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/src/main.rs
+++ b/desktop/sage-shell/src/main.rs
@@ -799,6 +799,56 @@ mod tests {
         assert_eq!(state.pending_routes.front().unwrap(), "/tasks/2");
     }
 
+    // The single-instance plugin hands a second launch's argv to
+    // route_from_args and enqueues whatever it returns. That seam is what makes
+    // `open sage://tasks` reach an already-running window, and it is not
+    // reachable from the black-box package harnesses: the route is delivered to
+    // the webview as a URL fragment, so it never reaches the daemon and leaves
+    // no observable trace outside this process.
+    #[test]
+    fn a_relaunch_forwards_only_a_bounded_route_from_its_arguments() {
+        // A real second launch: argv[0] is the executable, not a route.
+        assert_eq!(
+            route_from_args(["/Applications/SAGE.app/Contents/MacOS/SAGE", "sage://tasks"]),
+            Some("/tasks".into())
+        );
+        // The first valid route wins rather than the last.
+        assert_eq!(
+            route_from_args(["sage", "sage://brain", "sage://settings"]),
+            Some("/brain".into())
+        );
+        // Ordinary launches carry no route at all.
+        assert_eq!(route_from_args(["/Applications/SAGE.app/Contents/MacOS/SAGE"]), None);
+        assert_eq!(route_from_args(Vec::<String>::new()), None);
+        // Rejected deep links must not become routes just because they arrived
+        // through argv instead of the OS handler.
+        assert_eq!(route_from_args(["sage", "sage://admin/root"]), None);
+        assert_eq!(route_from_args(["sage", "sage://search/a?token=secret"]), None);
+        assert_eq!(route_from_args(["sage", "javascript:alert(1)"]), None);
+        assert_eq!(route_from_args(["sage", "file:///etc/passwd"]), None);
+        assert_eq!(route_from_args(["sage", "--some-flag", "not-a-url"]), None);
+        // A rejected argument must not mask a later valid one.
+        assert_eq!(
+            route_from_args(["sage", "sage://admin/root", "sage://tasks"]),
+            Some("/tasks".into())
+        );
+    }
+
+    #[test]
+    fn a_forwarded_relaunch_route_reaches_the_pending_queue() {
+        let session = Arc::new(Mutex::new(ShellSession::default()));
+        if let Some(route) = route_from_args(["sage", "sage://search/agent-123"]) {
+            enqueue_route(&session, route);
+        }
+        // A rejected link in the same position must enqueue nothing.
+        if let Some(route) = route_from_args(["sage", "sage://admin/root"]) {
+            enqueue_route(&session, route);
+        }
+        let state = session.lock().unwrap();
+        assert_eq!(state.pending_routes.len(), 1);
+        assert_eq!(state.pending_routes.front().unwrap(), "/search/agent-123");
+    }
+
     #[test]
     fn only_explicit_lock_contention_allows_attachment_without_proof() {
         assert!(allows_existing_attachment_exit_code(Some(

--- a/desktop/sage-shell/src/main.rs
+++ b/desktop/sage-shell/src/main.rs
@@ -818,12 +818,18 @@ mod tests {
             Some("/brain".into())
         );
         // Ordinary launches carry no route at all.
-        assert_eq!(route_from_args(["/Applications/SAGE.app/Contents/MacOS/SAGE"]), None);
+        assert_eq!(
+            route_from_args(["/Applications/SAGE.app/Contents/MacOS/SAGE"]),
+            None
+        );
         assert_eq!(route_from_args(Vec::<String>::new()), None);
         // Rejected deep links must not become routes just because they arrived
         // through argv instead of the OS handler.
         assert_eq!(route_from_args(["sage", "sage://admin/root"]), None);
-        assert_eq!(route_from_args(["sage", "sage://search/a?token=secret"]), None);
+        assert_eq!(
+            route_from_args(["sage", "sage://search/a?token=secret"]),
+            None
+        );
         assert_eq!(route_from_args(["sage", "javascript:alert(1)"]), None);
         assert_eq!(route_from_args(["sage", "file:///etc/passwd"]), None);
         assert_eq!(route_from_args(["sage", "--some-flag", "not-a-url"]), None);

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "0.1.0",
+  "version": "11.11.0",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-07):** **v11.10.0 is the current release.** It closes the independent-chain federation product loop with a retry-safe ceremony, manageable directional Read/Copy sharing, Pause/Resume and revocation feedback, plus durable agent-to-agent inbox delivery across explicitly accepted federation contacts. The exact-source cold state-sync proof passed on the v11.9 release source, and the complete CI/security/fault matrix remains a mandatory publication invariant. The native-shell productization bridge is retargeted to v11.11–v11.14; none of those planned releases is promised or dated.
+**Status (2026-07):** **v11.11.0 is the current release.** It closes the independent-chain federation product loop with a retry-safe ceremony, manageable directional Read/Copy sharing, Pause/Resume and revocation feedback, plus durable agent-to-agent inbox delivery across explicitly accepted federation contacts. The exact-source cold state-sync proof passed on the v11.9 release source, and the complete CI/security/fault matrix remains a mandatory publication invariant. The native-shell productization bridge is retargeted to v11.11–v11.14; none of those planned releases is promised or dated.
 
 **Hard constraint driving the whole plan:** no chain reset, no operator-typed commands. Existing chains must upgrade in place across all future releases.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -178,6 +178,15 @@ are recorded in [`desktop-shell-decision.md`](desktop-shell-decision.md),
 [`native-shell-quality-gates.md`](native-shell-quality-gates.md). The tracked
 Tauri foundation remains an opt-in preview until that full matrix passes.
 
+**The native shell is alpha and does not gate releases.** Browser CEREBRUM is
+the product; the shell is a background track through v11.11–v11.13. It is built
+and runtime-tested in CI, never staged as a public release asset, and not
+intended for end-user use. Releases continue shipping bug fixes and capabilities
+on their normal cadence — federation, agent-to-agent messaging, and the rest of
+the roadmap do not queue behind desktop packaging. The signing, notarization,
+update/rollback, recovery, performance, and accessibility bar applies at **first
+distribution of the shell**, which is v12.
+
 ### v11.12 - consumer onboarding and recovery
 
 Make first run and recovery survivable by someone who has never used SAGE, natively and without a terminal. Guided create-or-join, connect-an-AI-tool, and choose-what-is-private-or-shared flows; recovery-key backup and restore; and honest, consistent dialogs for destructive or privacy-affecting actions that explain what happened, what remains safe, and the next step. Plain language and safe defaults throughout. The gate includes clean-machine onboarding and recovery usability tests with real nontechnical users — the same bar v12 sets, brought forward so it is proven early rather than at the end.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -178,6 +178,16 @@ are recorded in [`desktop-shell-decision.md`](desktop-shell-decision.md),
 [`native-shell-quality-gates.md`](native-shell-quality-gates.md). The tracked
 Tauri foundation remains an opt-in preview until that full matrix passes.
 
+**Platform scope: v11.11 distributes a native shell on macOS and Windows only.**
+Linux is deliberately excluded. Linux users are served by browser CEREBRUM and
+the CLI, both fully supported and unaffected — this narrows the native shell,
+not the platform. The Linux target still builds and runs its full
+installed-package lifecycle smoke in CI so cross-platform regressions in the
+shared shell and SSCP code are still caught; it is simply never published. A
+distributed Linux shell returns only when upstream Wry ships
+GTK4/webkitgtk-6.0 (`tauri-apps/wry#1769`); SAGE will not fork or vendor the web
+view layer to get there sooner.
+
 ### v11.12 - consumer onboarding and recovery
 
 Make first run and recovery survivable by someone who has never used SAGE, natively and without a terminal. Guided create-or-join, connect-an-AI-tool, and choose-what-is-private-or-shared flows; recovery-key backup and restore; and honest, consistent dialogs for destructive or privacy-affecting actions that explain what happened, what remains safe, and the next step. Plain language and safe defaults throughout. The gate includes clean-machine onboarding and recovery usability tests with real nontechnical users — the same bar v12 sets, brought forward so it is proven early rather than at the end.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -187,15 +187,16 @@ the roadmap do not queue behind desktop packaging. The signing, notarization,
 update/rollback, recovery, performance, and accessibility bar applies at **first
 distribution of the shell**, which is v12.
 
-**Platform scope: v11.11 distributes a native shell on macOS and Windows only.**
-Linux is deliberately excluded. Linux users are served by browser CEREBRUM and
-the CLI, both fully supported and unaffected — this narrows the native shell,
-not the platform. The Linux target still builds and runs its full
+**Platform scope: macOS and Windows are the shell's target platforms; Linux is
+not.** v11.11 distributes no native shell on any platform — see the paragraph
+above — so this is scope for the eventual distribution at v12, and for what CI
+produces release evidence for in the meantime. Linux users are served by browser
+CEREBRUM and the CLI, both fully supported and unaffected: this narrows the
+native shell, not the platform. The Linux target still builds and runs its full
 installed-package lifecycle smoke in CI so cross-platform regressions in the
-shared shell and SSCP code are still caught; it is simply never published. A
-distributed Linux shell returns only when upstream Wry ships
-GTK4/webkitgtk-6.0 (`tauri-apps/wry#1769`); SAGE will not fork or vendor the web
-view layer to get there sooner.
+shared shell and SSCP code are still caught. Linux re-enters the target set only
+when upstream Wry ships GTK4/webkitgtk-6.0 (`tauri-apps/wry#1769`); SAGE will not
+fork or vendor the web view layer to get there sooner.
 
 ### v11.12 - consumer onboarding and recovery
 

--- a/docs/desktop-shell-decision.md
+++ b/docs/desktop-shell-decision.md
@@ -1,6 +1,6 @@
 # ADR: Additive native CEREBRUM shell
 
-**Status:** Accepted for implementation, release remains gated
+**Status:** Accepted for implementation; the shell is alpha and does not gate releases
 **Date:** 2026-07-19
 **Target:** v11.11 native foundation
 
@@ -14,11 +14,14 @@ updates, validator material, or the vault passphrase.
 
 This is a conditional implementation decision, not permission to publish an
 untested desktop product. macOS and Windows must both pass the gates in
-`native-shell-quality-gates.md` before a release is promoted.
+`native-shell-quality-gates.md` before the shell is **distributed** — which the
+roadmap places at v12.
 
-v11.11 does not distribute a Linux native shell. The Linux target still builds
-and runs its installed-package lifecycle smoke in CI for regression coverage,
-but produces no release evidence, so no Linux floor gates this release. Linux
+**v11.11 distributes no native shell on any platform, so no shell gate blocks
+this release.** The shell is alpha: built and runtime-tested in CI, never staged
+as a public release asset. macOS and Windows are its target platforms; Linux is
+not. The Linux target still builds and runs its installed-package lifecycle
+smoke in CI for regression coverage, but produces no release evidence. Linux
 users are served by browser CEREBRUM and the CLI. A distributed Linux shell
 returns only when upstream Wry ships GTK4/webkitgtk-6.0; the reasoning and the
 conditional `RUSTSEC-2024-0429` dismissal are recorded in

--- a/docs/desktop-shell-decision.md
+++ b/docs/desktop-shell-decision.md
@@ -13,8 +13,16 @@ visible startup/recovery state; it does not own consensus, storage, MCP, RBAC,
 updates, validator material, or the vault passphrase.
 
 This is a conditional implementation decision, not permission to publish an
-untested desktop product. macOS, Windows, and the declared Linux floor must all
-pass the gates in `native-shell-quality-gates.md` before a release is promoted.
+untested desktop product. macOS and Windows must both pass the gates in
+`native-shell-quality-gates.md` before a release is promoted.
+
+v11.11 does not distribute a Linux native shell. The Linux target still builds
+and runs its installed-package lifecycle smoke in CI for regression coverage,
+but produces no release evidence, so no Linux floor gates this release. Linux
+users are served by browser CEREBRUM and the CLI. A distributed Linux shell
+returns only when upstream Wry ships GTK4/webkitgtk-6.0; the reasoning and the
+conditional `RUSTSEC-2024-0429` dismissal are recorded in
+`native-shell-quality-gates.md`.
 
 ## Evidence
 

--- a/docs/native-shell-quality-gates.md
+++ b/docs/native-shell-quality-gates.md
@@ -253,9 +253,11 @@ instrumentation that does not exist yet: the shell emits no paint, interactive,
 recovery-shown, or frame-timing signal, so they cannot be observed from outside
 the process at all. Building that instrumentation is the v11.14 hardening work.
 
-v11.11 records the measurable rows as evidence on every native-shell CI run so
-the ceilings are calibrated against real numbers before v11.14 makes them
-blocking. A recorded row that is merely absent is not a pass.
+No harness measures any of these rows yet, including the RSS row that blocks
+from v11.11 — that instrumentation is still to be written. Until it exists this
+table is a set budget, not a measured one, and nothing here should be read as
+evidence that the ceilings have been met. Calibrating the ceilings against real
+numbers is a prerequisite for v11.14 making them blocking.
 
 From v11.14, three consecutive benchmark runs must pass. A regression of more
 than 10% against the last published release fails even when the absolute ceiling

--- a/docs/native-shell-quality-gates.md
+++ b/docs/native-shell-quality-gates.md
@@ -4,6 +4,12 @@ These gates are release criteria, not aspirational telemetry. A native package
 is not promoted on any platform without immutable CI evidence for that platform.
 Browser CEREBRUM and the existing Go release matrix remain mandatory.
 
+Each gate names the release it blocks from. Most block from v11.11; the
+performance budgets beyond incremental shell RSS, and the accessibility gates,
+block from v11.14 — the roadmap's designated hardening pass. A gate that blocks
+later is still a gate: v11.11 must set it, establish the architecture behind it,
+record what is measurable, and ship nothing that forecloses it.
+
 ## Current enforcement status
 
 The tracked preview now enforces locked dependency compilation, Rust
@@ -43,11 +49,19 @@ upgrade exists. The alert must remain open until a tested upstream migration or
 reviewed backport removes the affected code; it must not be dismissed merely to
 make release status green.
 
-Runtime promotion remains open until the install/launch/deep-link/offline,
-performance, assistive-technology, signing/notarization, update/rollback, and
-uninstall-preservation rows below have immutable platform results. Windows
+Runtime promotion for **v11.11** remains open until the
+install/launch/deep-link/offline, signing/notarization, update/rollback, and
+uninstall-preservation rows below have immutable platform results, plus the one
+performance row that blocks from v11.11 (incremental shell RSS). Windows
 named-pipe reads and writes now use overlapped cancellable deadlines with native
 stalled/partial-frame tests in the code gate.
+
+The remaining performance budgets and the accessibility gates become
+release-blocking from **v11.14**, which the roadmap designates as the
+accessibility/performance/offline hardening pass. v11.11 sets those budgets,
+establishes the architecture, and records what is measurable; it does not
+enforce them. See the notes on each section below — that phasing is the
+roadmap's, and it is not licence to ship something that forecloses them.
 
 All three platforms now run an installed-package lifecycle smoke on a hosted
 runner. Each one installs from the constructed package, launches the installed
@@ -131,26 +145,64 @@ platform pass.
 
 ## Performance budgets
 
+These budgets are set in v11.11 and enforced in v11.14. That split is the
+roadmap's, not a relaxation: v11.11 "set budgets ... and establish [the]
+architecture now even though v11.14 performs the full hardening pass", and
+v11.14 "hold[s] the v11.11 performance budgets for the embedded experience on
+large memory stores and the 3D connectome view". Nothing below is being
+weakened; the column records the release at which each becomes release-blocking.
+
 Report p50/p95 and raw samples on named baseline hardware. Separate shell cost
 from daemon boot, model boot, consensus, and queries.
 
-| Measure | Blocking budget |
-|---|---:|
-| Warm re-open to focused existing window | <= 500 ms p95 |
-| Cold launch to bundled recovery paint | <= 1,000 ms p95 |
-| Ready daemon to interactive CEREBRUM | <= 2,000 ms p95 |
-| Daemon loss to visible recovery action | <= 2,000 ms |
-| Settled shell idle CPU | <= 1% p95 |
-| Incremental shell RSS, daemon excluded | <= 200 MiB p95 |
-| Shell/navigation input response | <= 100 ms p95 |
-| Native overhead over same browser action | <= 25 ms p95 |
-| MRI frame pacing | >= 55 FPS median; no recurring >100 ms stalls |
+| Measure | Budget | Blocking from | Measurable today? |
+|---|---:|---|---|
+| Incremental shell RSS, daemon excluded | <= 200 MiB p95 | **v11.11** | yes — process RSS |
+| Settled shell idle CPU | <= 1% p95 | v11.14 | yes — sampled over the settle window |
+| Warm re-open to focused existing window | <= 500 ms p95 | v11.14 | partly — handoff is timable, "focused" needs a frontmost-window check |
+| Cold launch to bundled recovery paint | <= 1,000 ms p95 | v11.14 | no — needs a paint signal |
+| Ready daemon to interactive CEREBRUM | <= 2,000 ms p95 | v11.14 | no — needs an interactive signal |
+| Daemon loss to visible recovery action | <= 2,000 ms | v11.14 | no — needs a recovery-shown signal |
+| Shell/navigation input response | <= 100 ms p95 | v11.14 | no — needs UI automation and marks |
+| Native overhead over same browser action | <= 25 ms p95 | v11.14 | no — needs both paths instrumented |
+| MRI frame pacing | >= 55 FPS median; no recurring >100 ms stalls | v11.14 | no — needs frame timing and a real GPU |
 
-Three consecutive benchmark runs must pass. A regression of more than 10%
-against the last published release fails even when the absolute ceiling passes,
-unless the release record accepts the tradeoff with evidence.
+**RSS blocks from v11.11 because it is the premise of the framework decision,
+not because it is convenient.** `desktop-shell-decision.md` rejected Electron at
+358,720 KiB against this exact 200 MiB ceiling and selected Tauri at 142,544 KiB;
+the promoted foundation measured 128,448 KiB. If the shipped shell drifts past
+200 MiB, SAGE has taken on Rust and a per-platform WebView matrix — and given up
+Electron's stronger tooling and accessibility — for a benefit it no longer has.
+That makes RSS the one performance number with a decision riding on it today.
+
+Six of the nine measures are **not** blocked on hardware. They are blocked on
+instrumentation that does not exist yet: the shell emits no paint, interactive,
+recovery-shown, or frame-timing signal, so they cannot be observed from outside
+the process at all. Building that instrumentation is the v11.14 hardening work.
+
+v11.11 records the measurable rows as evidence on every native-shell CI run so
+the ceilings are calibrated against real numbers before v11.14 makes them
+blocking. A recorded row that is merely absent is not a pass.
+
+From v11.14, three consecutive benchmark runs must pass. A regression of more
+than 10% against the last published release fails even when the absolute ceiling
+passes, unless the release record accepts the tradeoff with evidence. Hosted CI
+runners are acceptable for the RSS row; the latency and frame-pacing rows
+require a named baseline machine, because runner variance is wider than those
+budgets.
 
 ## Accessibility gates
+
+These follow the same split as the performance budgets, and for the same
+roadmap reason: v11.11 "establish[es] keyboard navigation, focus visibility,
+screen-reader naming, and reduced-motion architecture now even though v11.14
+performs the full hardening pass", and v11.14 "meet[s] the accessibility bar v12
+treats as a release criterion". **The requirements below become release-blocking
+from v11.14.** v11.11 must establish the architecture that makes them
+achievable, and must not ship anything that forecloses them.
+
+The screen-reader matrix cannot be automated on hosted runners and needs a
+manual pass on a named machine regardless of release.
 
 Automated semantic checks supplement, never replace, the OS smoke matrix:
 

--- a/docs/native-shell-quality-gates.md
+++ b/docs/native-shell-quality-gates.md
@@ -18,20 +18,39 @@ the package with the target, build version, packaged shell artifact size/hash,
 and bundled daemon path/size/hash. They establish the foundation; unsigned CI
 artifacts and their records are not release evidence.
 
-The tagged release workflow now enforces that distinction from v11.11 onward.
-It version-locks the Tauri and Cargo metadata to the tag, constructs private
-per-platform package-pair and SBOM evidence, and then fails closed at the named
-native standalone production-promotion gate. Those unsigned preview artifacts
-are deliberately excluded from public GitHub release staging. The hold may be
-removed only when the signed installed-runtime, recovery, performance, and
-accessibility evidence below is produced and validated in the same publication
-dependency chain. By release-owner decision, this freezes the entire v11.11
-publication graph—not only the native assets—so Docker, SDK, MCP, legacy
-installers, and the GitHub release cannot get ahead of standalone readiness.
-Recovery runs for tags older than v11.11 remain supported. The temporary hold
-also fails closed for later versions until their shell/daemon compatibility and
-promotion path deliberately replace it; it must not be carried unchanged into
-v12.
+## The native shell is alpha and does not gate releases
+
+**Browser CEREBRUM is the product. The native shell is a background track.**
+Through the v11.11–v11.13 bridge the shell is **alpha**: built, linted, and
+runtime-tested in CI, never staged as a public release asset, and not intended
+for end-user use. Users stay on the web version, and normal releases continue to
+ship bug fixes and capabilities on their usual cadence — federation, agent
+messaging, and the rest of the roadmap do not wait behind desktop packaging.
+
+The tagged release workflow version-locks the Tauri and Cargo metadata to the
+tag and constructs private per-platform package-pair and SBOM evidence. Those
+artifacts are deliberately excluded from public GitHub release staging:
+`stage-github-release` downloads only `release-assets-*`, and
+`release-workflow.test.mjs` asserts native evidence never appears there. The
+identity is pinned to `SAGE Native Preview` / `com.sage.native-preview` at the
+metadata gate.
+
+An earlier revision of this record froze the **entire** v11.11 publication graph
+— Docker, SDK, MCP, legacy installers, and the GitHub release — until the native
+shell carried signed, runtime, recovery, performance, and accessibility
+evidence. That was a mistake and has been removed. It blocked every shipping
+channel on productizing an artifact **no user receives**, which bought nothing:
+the exclusion from public staging and the pinned preview identity already
+prevent an unsigned shell from reaching anyone.
+
+The promotion gate remains, but fail-closed on the thing that actually matters:
+if a release ever declares a native release class other than
+`unsigned-preview-evidence` — i.e. it intends to **distribute** the shell — it
+fails until the signing/notarization, installed-runtime, update/rollback, and
+recovery evidence below exists. **That bar applies at first distribution, which
+the roadmap places at v12**, not at every release that merely builds the shell.
+
+Recovery runs for tags older than v11.11 remain supported.
 
 GitHub Dependabot alert 37 (`RUSTSEC-2024-0429` /
 `GHSA-wrw7-89jp-8q8g`) is also an active promotion blocker. The Linux Tauri
@@ -43,11 +62,13 @@ upgrade exists. The alert must remain open until a tested upstream migration or
 reviewed backport removes the affected code; it must not be dismissed merely to
 make release status green.
 
-Runtime promotion remains open until the install/launch/deep-link/offline,
-performance, assistive-technology, signing/notarization, update/rollback, and
-uninstall-preservation rows below have immutable platform results. Windows
-named-pipe reads and writes now use overlapped cancellable deadlines with native
-stalled/partial-frame tests in the code gate.
+The install/launch/deep-link/offline, performance, assistive-technology,
+signing/notarization, update/rollback, and uninstall-preservation rows below are
+the bar for **distributing** the native shell. They are not a v11.11 shipping
+requirement, because v11.11 does not distribute it. Work through them as the
+bridge releases land; they become release-blocking at first distribution.
+Windows named-pipe reads and writes now use overlapped cancellable deadlines
+with native stalled/partial-frame tests in the code gate.
 
 All three platforms now run an installed-package lifecycle smoke on a hosted
 runner. Each one installs from the constructed package, launches the installed

--- a/docs/native-shell-quality-gates.md
+++ b/docs/native-shell-quality-gates.md
@@ -12,15 +12,16 @@ record what is measurable, and ship nothing that forecloses it.
 
 ## Current enforcement status
 
-**v11.11 distributes a native shell on macOS and Windows only.** Linux is
-deliberately not a distributed native-shell platform for this release: Linux
-users are served by browser CEREBRUM and the CLI, both of which remain fully
-supported and are unaffected by this decision. Linux still compiles and runs its
+**v11.11 distributes no native shell on any platform.** The shell is alpha; see
+"The native shell is alpha and does not gate releases" below. macOS and Windows
+are its *target* platforms — the scope for the eventual distribution at v12, and
+what CI produces release evidence for meanwhile. **Linux is not a target
+platform.** Linux users are served by browser CEREBRUM and the CLI, both fully
+supported and unaffected by this decision. Linux still compiles and runs its
 full installed-package lifecycle smoke in
 [`native-shell.yml`](../.github/workflows/native-shell.yml) so cross-platform
 regressions in the shared shell and SSCP code are still caught — it is simply
-never staged as release evidence and never published. See
-[Linux re-entry](#linux-re-entry) below.
+never staged as release evidence. See [Linux re-entry](#linux-re-entry) below.
 
 The tracked preview now enforces locked dependency compilation, Rust
 format/test/Clippy, full platform shell-control tests, isolated Codex endpoint
@@ -84,8 +85,8 @@ not a remediation. It rests on two verified facts:
 - Wry declares its whole GTK chain under
   `cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd",
   target_os = "openbsd", target_os = "netbsd"))`. macOS resolves the web view
-  through WKWebView and Windows through WebView2, so **neither distributed
-  target compiles `gtk`, `webkit2gtk`, `soup3`, or `glib` at all**.
+  through WKWebView and Windows through WebView2, so **neither target platform
+  compiles `gtk`, `webkit2gtk`, `soup3`, or `glib` at all**.
 - No user receives the affected code, because the only artifact containing it is
   never published.
 

--- a/docs/native-shell-quality-gates.md
+++ b/docs/native-shell-quality-gates.md
@@ -6,12 +6,23 @@ Browser CEREBRUM and the existing Go release matrix remain mandatory.
 
 ## Current enforcement status
 
+**v11.11 distributes a native shell on macOS and Windows only.** Linux is
+deliberately not a distributed native-shell platform for this release: Linux
+users are served by browser CEREBRUM and the CLI, both of which remain fully
+supported and are unaffected by this decision. Linux still compiles and runs its
+full installed-package lifecycle smoke in
+[`native-shell.yml`](../.github/workflows/native-shell.yml) so cross-platform
+regressions in the shared shell and SSCP code are still caught — it is simply
+never staged as release evidence and never published. See
+[Linux re-entry](#linux-re-entry) below.
+
 The tracked preview now enforces locked dependency compilation, Rust
 format/test/Clippy, full platform shell-control tests, isolated Codex endpoint
 acceptance tests, dependency audit, a license-bearing CycloneDX SBOM, and
-unsigned package construction on the declared macOS, Windows, and Linux
-targets. Each constructed package is unpacked and must contain exactly one
-bundled daemon whose embedded Go OS/architecture matches the declared target
+unsigned package construction on the declared macOS and Windows targets, plus
+the non-distributed Linux CI target. Each constructed package is unpacked and
+must contain exactly one bundled daemon whose embedded Go OS/architecture
+matches the declared target
 and whose embedded version matches the version supplied to the shell package
 build. Those checks emit a machine-readable release-pair record beside
 the package with the target, build version, packaged shell artifact size/hash,
@@ -33,15 +44,56 @@ also fails closed for later versions until their shell/daemon compatibility and
 promotion path deliberately replace it; it must not be carried unchanged into
 v12.
 
-GitHub Dependabot alert 37 (`RUSTSEC-2024-0429` /
-`GHSA-wrw7-89jp-8q8g`) is also an active promotion blocker. The Linux Tauri
-stack currently receives `glib` 0.18.5 through Wry/WebKitGTK; the affected safe
-iterator API can trigger undefined behavior and optimized-build crashes. As of
-this gate record, current Wry 0.55.1 still pins the affected GTK/glib family and
-upstream issue `tauri-apps/wry#1769` remains open, so no compatible dependency
-upgrade exists. The alert must remain open until a tested upstream migration or
-reviewed backport removes the affected code; it must not be dismissed merely to
-make release status green.
+### `RUSTSEC-2024-0429` (glib) — dismissed, not fixed
+
+GitHub Dependabot alert 37 (`RUSTSEC-2024-0429` / `GHSA-wrw7-89jp-8q8g`)
+concerns `glib` 0.18.5, which the Linux Tauri stack receives through
+Wry/WebKitGTK; the affected safe iterator API can trigger undefined behavior and
+optimized-build crashes.
+
+**The alert was dismissed as not-used on the decision that v11.11 does not
+distribute a Linux native shell.** It was not fixed, and the vulnerable code is
+still compiled by the non-distributed Linux CI build. This is a scope decision,
+not a remediation. It rests on two verified facts:
+
+- Wry declares its whole GTK chain under
+  `cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd",
+  target_os = "openbsd", target_os = "netbsd"))`. macOS resolves the web view
+  through WKWebView and Windows through WebView2, so **neither distributed
+  target compiles `gtk`, `webkit2gtk`, `soup3`, or `glib` at all**.
+- No user receives the affected code, because the only artifact containing it is
+  never published.
+
+There is no upgrade path, and this is a hard version wall rather than a pending
+release: Wry 0.55.1 is the latest published version and requires `gtk ^0.18`;
+the GTK3 Rust binding line is capped at `gtk` 0.18.2, last released 2024-12-09,
+which pins `glib` 0.18.x. The advisory is first fixed in `glib` 0.20.0, and
+`glib` 0.20+ belongs to the GTK4 line — a differently named `gtk4` crate, not a
+newer `gtk`. `cargo update`, a `--precise` pin, and a `[patch.crates-io]`
+override all fail: the first two are semver-excluded by `gtk ^0.18`, and the
+third compile-fails because `gtk`/`gdk`/`cairo-rs` 0.18 are not written against
+the glib 0.20+ API.
+
+`cargo audit` reads the lockfile rather than the per-target build graph, so it
+still reports this advisory on every platform's CI run. That is expected and
+must not be silenced.
+
+> **This dismissal is conditional and must be revisited.** If a Linux native
+> shell is ever distributed again, this alert must be re-opened and treated as
+> release-blocking before that artifact ships. Do not treat the dismissed state
+> as a standing judgement that the advisory is harmless.
+
+### Linux re-entry
+
+A distributed Linux native shell returns only when **upstream Wry ships
+GTK4/webkitgtk-6.0 support**, tracked in `tauri-apps/wry#1769` (open, no
+activity since 2026-07-15). That migration also clears this advisory, because
+the `gtk4` line depends on `glib ^0.22`.
+
+SAGE does not plan to fork or vendor Wry onto GTK4. Owning a fork of the web
+view layer in a security-sensitive component is a worse position than not
+shipping the platform. Until upstream moves, Linux native shell work stays out
+of scope and Linux users are served by browser CEREBRUM and the CLI.
 
 Runtime promotion remains open until the install/launch/deep-link/offline,
 performance, assistive-technology, signing/notarization, update/rollback, and
@@ -56,7 +108,7 @@ still needs immutable runner evidence before promotion.
 |---|---|---|
 | macOS | oldest Apple-supported macOS that SAGE declares for the release; Intel and Apple Silicon where distributed | signed `.app`, notarized/stapled DMG, clean install, Gatekeeper launch, rollback |
 | Windows | Windows 11 x64 and arm64 where distributed | signed NSIS installer, clean install/uninstall, SmartScreen/signature check, rollback |
-| Linux | Ubuntu 24.04 LTS x64 plus each architecture distributed | AppImage and Debian package, offline launch, uninstall preserving `~/.sage` |
+| Linux | **not distributed in v11.11** | none — build and installed-runtime smoke run in CI for regression coverage only, and are never release evidence |
 
 The exact OS image identifiers, WebView versions, CPU/RAM, and artifact hashes
 must appear in the release evidence. “Builds on a developer machine” is not a
@@ -107,7 +159,7 @@ Automated semantic checks supplement, never replace, the OS smoke matrix:
   appropriate live region without stealing focus;
 - 200% zoom, high contrast, light/dark mode, and OS reduced-motion work without
   clipping or lost content;
-- VoiceOver (macOS), Narrator (Windows), and Orca (Linux) can launch, identify
+- VoiceOver (macOS) and Narrator (Windows) can launch, identify
   daemon state, reach browser fallback, navigate primary CEREBRUM areas, and
   recover from daemon loss;
 - camera denial/revocation and every permission error remain operable without a

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.10.0. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.11.0. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -97,7 +97,7 @@ CometBFT without treating the consensus RPC as proof of application storage.
 
 ---
 
-## Related docs (reconciled through v11.10.0)
+## Related docs (reconciled through v11.11.0)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,4 +1,4 @@
-<!-- Core document reconciled through SAGE v11.10.0, including directional cross-chain peer RBAC and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.11.0, including directional cross-chain peer RBAC and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.10.0. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.11.0. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.10.0 code (2026-07-19). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.11.0 code (2026-07-19). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.10.0.
+Reconciled against internal/mcp for SAGE v11.11.0.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -2,7 +2,7 @@ Verified against SDK source for SAGE v11.10.0. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.10.0
+**Package:** `sage-agent-sdk` **Version:** 11.11.0
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,4 +1,4 @@
-Verified against SDK source for SAGE v11.10.0. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.11.0. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.10.0. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.11.0. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -276,6 +276,12 @@ var postgresTaskAssignmentSchema = []string{
 	`ALTER TABLE memories ADD COLUMN IF NOT EXISTS task_board_position BIGINT NOT NULL DEFAULT 0`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_assignee ON memories (assignee) WHERE assignee != ''`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_task_picked_up_by ON memories (task_picked_up_by) WHERE task_picked_up_by != ''`,
+	// FindByContentHash became a live query in v11.11 (it previously returned a
+	// constant false), and voter.Run evaluates it per pending memory on a 2s
+	// poll. Without this index that is a sequential scan of a table carrying
+	// content TEXT plus a 768-dimension vector. Partial on status='committed'
+	// because that is exactly the predicate the dedup query uses.
+	`CREATE INDEX IF NOT EXISTS idx_memories_content_hash ON memories (content_hash) WHERE status = 'committed'`,
 	`CREATE TABLE IF NOT EXISTS agent_notifications (
 		notification_id TEXT PRIMARY KEY,
 		agent_id TEXT NOT NULL,
@@ -399,6 +405,24 @@ const postgresInsertMemorySQL = `INSERT INTO memories (memory_id, submitting_age
 		submitting_agent = EXCLUDED.submitting_agent,
 		status = EXCLUDED.status,
 		created_at = EXCLUDED.created_at,
+		-- content/hash/domain/type/confidence are overwritten so a co-commit
+		-- squat-reclaim (which rewrites Badger's content hash to the co-commit's)
+		-- also replaces the squatter's off-chain content, keeping the Postgres
+		-- mirror consistent with the committed on-chain hash. This must stay in
+		-- lockstep with the identical SQLite clause: without it FindByContentHash
+		-- reads a stale hash, SQLite and Postgres validators disagree about what
+		-- is a duplicate, and MergeProjectionSupplementary's
+		-- "memory_id = $1 AND content_hash = $8" predicate matches zero rows and
+		-- panics the node with "consensus cannot advance". Safe for the other
+		-- conflict callers too: content-hash IDs collide only on identical
+		-- content; UUID IDs (task/journal/import) never collide; and the on-chain
+		-- submit path rewrites the Badger hash in lockstep - so overwriting the
+		-- mirror keeps it consistent rather than losing data.
+		content = EXCLUDED.content,
+		content_hash = EXCLUDED.content_hash,
+		domain_tag = EXCLUDED.domain_tag,
+		memory_type = EXCLUDED.memory_type,
+		confidence_score = EXCLUDED.confidence_score,
 		embedding = COALESCE(EXCLUDED.embedding, memories.embedding),
 		embedding_hash = COALESCE(EXCLUDED.embedding_hash, memories.embedding_hash),
 		provider = COALESCE(NULLIF(EXCLUDED.provider, ''), memories.provider),

--- a/internal/store/postgres_hash_test.go
+++ b/internal/store/postgres_hash_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/pashagolub/pgxmock/v4"
@@ -49,4 +50,48 @@ func TestPostgresFindByContentHashRejectsMalformedHash(t *testing.T) {
 	store := &PostgresStore{}
 	_, err := store.FindByContentHash(context.Background(), "not-hex")
 	require.ErrorContains(t, err, "decode content hash")
+}
+
+// The SQLite and Postgres upserts must agree on which columns a conflicting
+// insert refreshes. They diverged silently until v11.11: SQLite refreshed
+// content/content_hash/domain_tag/memory_type/confidence_score (so a co-commit
+// squat-reclaim replaces the squatter's off-chain row), Postgres refreshed none
+// of them. That was inert only while PostgresStore.FindByContentHash returned a
+// constant false. Once it became a live reader of content_hash, the stale column
+// made SQLite and Postgres validators disagree about duplicates and made
+// MergeProjectionSupplementary's "memory_id = $1 AND content_hash = $8"
+// predicate match zero rows, which panics the node with "consensus cannot
+// advance" and re-panics on every restart.
+func TestPostgresUpsertRefreshesContentHashLikeSQLite(t *testing.T) {
+	// These five are what a squat-reclaim depends on being overwritten.
+	for _, column := range []string{
+		"content = EXCLUDED.content",
+		"content_hash = EXCLUDED.content_hash",
+		"domain_tag = EXCLUDED.domain_tag",
+		"memory_type = EXCLUDED.memory_type",
+		"confidence_score = EXCLUDED.confidence_score",
+	} {
+		require.Containsf(t, postgresInsertMemorySQL, column,
+			"postgres upsert must refresh %q on conflict, or a co-commit squat-reclaim "+
+				"leaves a stale content_hash that diverges from SQLite and can halt the node", column)
+	}
+
+	// task_status must still be excluded: replay must not overwrite board state.
+	require.NotContains(t, postgresInsertMemorySQL, "task_status =")
+}
+
+// The dedup query is only cheap if an index covers it. voter.Run evaluates
+// FindByContentHash per pending memory on a 2s poll, against a table carrying
+// content TEXT plus a 768-dimension vector.
+func TestPostgresContentHashDedupIsIndexed(t *testing.T) {
+	var indexed bool
+	for _, stmt := range postgresTaskAssignmentSchema {
+		if strings.Contains(stmt, "idx_memories_content_hash") {
+			indexed = true
+			require.Containsf(t, stmt, "status = 'committed'",
+				"the index must be partial on the same predicate FindByContentHash uses, got %q", stmt)
+		}
+	}
+	require.True(t, indexed,
+		"existing Postgres databases need a content_hash index migration, not just deploy/init.sql")
 }

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -140,10 +140,15 @@ test('native shell evidence is version-locked, private, and cannot promote an un
   ]);
   assert.match(promotion, /always\(\)/);
   assert.match(promotion, /Native standalone promotion does not apply before v11\.11\.0/);
-  assert.match(promotion, /Native standalone release .* is blocked/);
-  assert.match(promotion, /v11\.11 is deliberately a whole-release hold/);
-  assert.match(promotion, /RUSTSEC-2024-0429/);
-  assert.match(promotion, /Signed\/notarized packages, installed-runtime acceptance/);
+  // The native shell is alpha through the v11.11-v11.13 bridge: built in CI,
+  // never staged as a public asset. The gate must NOT block the release, or
+  // every other channel is held hostage to an artifact no user receives.
+  assert.doesNotMatch(promotion, /whole-release hold/);
+  assert.match(promotion, /is alpha CI evidence and is not distributed/);
+  // ...but it must still fail closed the moment a release intends to DISTRIBUTE
+  // the shell without the signing/runtime/rollback/recovery evidence.
+  assert.match(promotion, /NATIVE_SHELL_RELEASE_CLASS\}" != "unsigned-preview-evidence"/);
+  assert.match(promotion, /Distribution requires signed\/notarized packages/);
   assert.match(promotion, /exit 1/);
 
   assertNeeds('publication-gate', ['native-shell-production-promotion']);

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -118,12 +118,23 @@ test('native shell evidence is version-locked, private, and cannot promote an un
   assert.match(evidence, /if: needs\.release-metadata\.outputs\.native_shell_required == 'true'/);
   assert.match(evidence, /id: macos-arm64/);
   assert.match(evidence, /id: windows-x64/);
-  assert.match(evidence, /id: linux-x64/);
+  // v11.11 distributes a native shell on macOS and Windows only. Linux still
+  // builds and runs its installed-package lifecycle smoke in native-shell.yml,
+  // but is never staged as release evidence. Assert the deliberate absence so a
+  // Linux entry cannot reappear in the shipping matrix without the scope
+  // decision in docs/native-shell-quality-gates.md being revisited.
+  assert.doesNotMatch(evidence, /id: linux-x64/);
   assert.match(evidence, /SAGE_DAEMON_VERSION/);
   assert.match(evidence, /go test \.\/internal\/shellcontrol/);
   assert.match(evidence, /cargo fmt --manifest-path/);
   assert.match(evidence, /components: rustfmt, clippy/);
   assert.match(evidence, /cargo audit --file desktop\/sage-shell\/Cargo\.lock/);
+  // Regression guard: the dependency audit was once gated on
+  // `runner.os == 'Linux'`, so dropping the Linux matrix entry silently
+  // disabled it for releases. cargo audit reads the lockfile and is
+  // platform-independent, so it must never be gated on a runner OS again.
+  assert.doesNotMatch(evidence, /if: runner\.os == 'Linux'/);
+  assert.match(evidence, /if: matrix\.id == 'macos-arm64'\n\s+shell: bash\n\s+run: \|\n\s+cargo install cargo-audit/);
   assert.match(evidence, /cargo tauri build --ci/);
   assert.match(evidence, /verify-native-shell-bundle\.sh/);
   assert.match(evidence, /cargo cyclonedx/);
@@ -142,7 +153,12 @@ test('native shell evidence is version-locked, private, and cannot promote an un
   assert.match(promotion, /Native standalone promotion does not apply before v11\.11\.0/);
   assert.match(promotion, /Native standalone release .* is blocked/);
   assert.match(promotion, /v11\.11 is deliberately a whole-release hold/);
-  assert.match(promotion, /RUSTSEC-2024-0429/);
+  // RUSTSEC-2024-0429 is no longer named here: it was dismissed as not-used once
+  // v11.11 stopped distributing a Linux native shell, which is the only artifact
+  // that compiles the affected glib. The gate still requires dependency-advisory
+  // closure generally, and still fails closed.
+  assert.match(promotion, /dependency-advisory closure/);
+  assert.match(promotion, /does not distribute a Linux native shell/);
   assert.match(promotion, /Signed\/notarized packages, installed-runtime acceptance/);
   assert.match(promotion, /exit 1/);
 
@@ -150,8 +166,12 @@ test('native shell evidence is version-locked, private, and cannot promote an un
   assert.match(publication, /verify_native_release_pair\(\)/);
   assert.match(publication, /NATIVE_SHELL_REQUIRED:.*native_shell_required/);
   assert.match(publication, /if \[ "\$\{NATIVE_SHELL_REQUIRED\}" = true \]; then/);
-  assert.match(publication, /native-shell-release-pair-deb\.json/);
-  assert.match(publication, /native-shell-release-pair-appimage\.json/);
+  // The publication gate must not verify Linux evidence that is never produced:
+  // a missing linux-x64 artifact would fail the gate on a missing file.
+  assert.doesNotMatch(publication, /native-shell-release-pair-deb\.json/);
+  assert.doesNotMatch(publication, /native-shell-release-pair-appimage\.json/);
+  assert.doesNotMatch(publication, /release-evidence-native-shell-linux-x64/);
+  assert.match(publication, /for evidence_id in macos-arm64 windows-x64; do/);
   assert.match(publication, /sha256sum -c SHA256SUMS/);
   assert.match(publication, /native-shell-\$\{evidence_id\}\.cdx\.json/);
 

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -118,11 +118,14 @@ test('native shell evidence is version-locked, private, and cannot promote an un
   assert.match(evidence, /if: needs\.release-metadata\.outputs\.native_shell_required == 'true'/);
   assert.match(evidence, /id: macos-arm64/);
   assert.match(evidence, /id: windows-x64/);
-  // v11.11 distributes a native shell on macOS and Windows only. Linux still
-  // builds and runs its installed-package lifecycle smoke in native-shell.yml,
-  // but is never staged as release evidence. Assert the deliberate absence so a
-  // Linux entry cannot reappear in the shipping matrix without the scope
-  // decision in docs/native-shell-quality-gates.md being revisited.
+  // macOS and Windows are the shell's target platforms; Linux is not. (v11.11
+  // distributes no shell on any platform -- the shell is alpha -- so this is the
+  // scope for the eventual v12 distribution and for what CI produces release
+  // evidence for meanwhile.) Linux still builds and runs its installed-package
+  // lifecycle smoke in native-shell.yml, but is never staged as release
+  // evidence. Assert the deliberate absence so a Linux entry cannot reappear in
+  // the evidence matrix without the scope decision in
+  // docs/native-shell-quality-gates.md being revisited.
   assert.doesNotMatch(evidence, /id: linux-x64/);
   assert.match(evidence, /SAGE_DAEMON_VERSION/);
   assert.match(evidence, /go test \.\/internal\/shellcontrol/);

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.10.0 SDK** | **TLS, RBAC, federation, domain recovery, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.11.0 SDK** | **TLS, RBAC, federation, domain recovery, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.10.0"
+version = "11.11.0"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.10.0"
+__version__ = "11.11.0"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.10.0",
+  "version": "11.11.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.10.0",
+      "identifier": "ghcr.io/l33tdawg/sage:11.11.0",
       "transport": {
         "type": "stdio"
       }

--- a/web/federation_group_auth_test.go
+++ b/web/federation_group_auth_test.go
@@ -210,6 +210,82 @@ func TestFederationGroupListReportsDurableProgressAndPeerDelivery(t *testing.T) 
 	}
 }
 
+// The dashboard seeds its "Selective domains" field from consent_domains and
+// submits whatever it holds back through ReplaceGroupMemberConsentDomains, which
+// deletes every pending row before re-inserting. So this handler must serve the
+// PENDING selector set, not the promoted one: a selector is promoted only once its
+// domain sits inside a live shared root, and enrollment seeds a group before any
+// domain_add, so a freshly joined selective-sync member's promoted set is empty by
+// construction. Serving the promoted set renders the field blank and the first
+// "Apply role" destroys the member's invitee-signed selectors.
+//
+// This wiring has silently regressed once already and survived a full audit,
+// because every other test asserts at the store layer and passes with either
+// getter wired in here.
+func TestFederationGroupListServesPendingConsentSelectors(t *testing.T) {
+	ctx := context.Background()
+	h, ss := newTestHandler(t)
+	h.NodeOperatorAgentID = strings.Repeat("a", 64)
+	h.Federation = groupListTestDriver{localChainID: "chain-local"}
+
+	requireNoError := func(label string, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+	}
+	requireNoError("upsert group", ss.UpsertSyncGroup(ctx, store.SyncGroup{
+		GroupID: "group-1", ControllerChainID: "chain-local", ControllerAgentPubkey: strings.Repeat("1", 64),
+		Epoch: "epoch-1", RosterRevision: 1, RosterJournalHead: "head-1", DisplayName: "Studio",
+	}))
+	requireNoError("upsert local member", ss.UpsertSyncGroupMember(ctx, store.SyncGroupMember{
+		GroupID: "group-1", MemberChainID: "chain-local", MemberAgentPubkey: strings.Repeat("2", 64),
+		Role: store.GroupRoleSelectiveSync, MemberState: store.GroupMemberActive, JoinedRevision: 1,
+		LastAckedRosterRevision: 1, LastSeenJournalHead: "head-1",
+	}))
+	// No domain_add has happened, so "hr" stays pending and is never promoted.
+	// This is exactly the state a freshly joined selective-sync node is in.
+	requireNoError("record consent selectors", ss.ReplaceGroupMemberConsentDomains(
+		ctx, "group-1", "chain-local", []string{"hr"}, 1))
+
+	promoted, err := ss.ListGroupMemberConsentDomains(ctx, "group-1", "chain-local")
+	requireNoError("list promoted", err)
+	if len(promoted) != 0 {
+		t.Fatalf("precondition failed: expected no promoted selectors, got %v", promoted)
+	}
+	pending, err := ss.ListPendingGroupMemberConsentDomains(ctx, "group-1", "chain-local")
+	requireNoError("list pending", err)
+	if len(pending) != 1 || pending[0] != "hr" {
+		t.Fatalf("precondition failed: expected pending [hr], got %v", pending)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/federation/groups", nil)
+	req = req.WithContext(context.WithValue(req.Context(), verifiedDashboardAgentKey{}, h.NodeOperatorAgentID))
+	rr := httptest.NewRecorder()
+	h.handleFedGroupList(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("group list status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var response struct {
+		Groups []struct {
+			Members []syncGroupMemberView `json:"members"`
+		} `json:"groups"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode group list: %v", err)
+	}
+	if len(response.Groups) != 1 || len(response.Groups[0].Members) != 1 {
+		t.Fatalf("group response = %+v", response)
+	}
+	local := response.Groups[0].Members[0]
+	if len(local.ConsentDomains) != 1 || local.ConsentDomains[0] != "hr" {
+		t.Fatalf("consent_domains = %v, want [hr]; the handler is serving the promoted "+
+			"set instead of the pending selector set, so the dashboard field renders blank "+
+			"and Apply role will destroy the member's selectors", local.ConsentDomains)
+	}
+}
+
 func TestSyncGroupMemberProgressFailsClosedForUnknownAndUnseenState(t *testing.T) {
 	group := store.SyncGroup{RosterRevision: 3, RosterJournalHead: "head-3"}
 	unseen := syncGroupMemberProgress(group, store.SyncGroupMember{

--- a/web/federation_join.go
+++ b/web/federation_join.go
@@ -1239,6 +1239,12 @@ type syncGroupMemberView struct {
 	CatchUpState            string                        `json:"catch_up_state"`
 	Health                  string                        `json:"health"`
 	PeerDelivery            *store.SyncPeerDeliveryStatus `json:"peer_delivery,omitempty"`
+	// ConsentDomains is the member's ACTIVE selective-sync consent set. It is
+	// always serialized, never omitempty: the dashboard seeds its "Selective
+	// domains" draft from this field, and an absent field is indistinguishable
+	// from an empty set. Without it the input rendered blank and "Apply role"
+	// submitted selected_domains: [], silently clearing an existing consent set.
+	ConsentDomains []string `json:"consent_domains"`
 }
 
 // syncGroupMemberProgress converts durable journal cursors into display state.
@@ -1347,6 +1353,15 @@ func (h *DashboardHandler) handleFedGroupList(w http.ResponseWriter, r *http.Req
 		}
 		for _, mem := range members {
 			member := syncGroupMemberProgress(g, mem, local)
+			consent, cErr := ss.ListGroupMemberConsentDomains(ctx, g.GroupID, mem.MemberChainID)
+			if cErr != nil {
+				fedWriteErr(w, http.StatusInternalServerError, "Failed to read member consent domains.")
+				return
+			}
+			if consent == nil {
+				consent = []string{}
+			}
+			member.ConsentDomains = consent
 			if mem.MemberChainID != local {
 				delivery, found := peerDelivery[mem.MemberChainID]
 				if !found {

--- a/web/federation_join.go
+++ b/web/federation_join.go
@@ -1239,11 +1239,21 @@ type syncGroupMemberView struct {
 	CatchUpState            string                        `json:"catch_up_state"`
 	Health                  string                        `json:"health"`
 	PeerDelivery            *store.SyncPeerDeliveryStatus `json:"peer_delivery,omitempty"`
-	// ConsentDomains is the member's ACTIVE selective-sync consent set. It is
-	// always serialized, never omitempty: the dashboard seeds its "Selective
-	// domains" draft from this field, and an absent field is indistinguishable
-	// from an empty set. Without it the input rendered blank and "Apply role"
-	// submitted selected_domains: [], silently clearing an existing consent set.
+	// ConsentDomains is the member's full selective-sync SELECTOR set, read from
+	// the pending table rather than the promoted one. Those differ: a selector is
+	// promoted into the active set only once its domain is inside a live shared
+	// root, and a group is seeded before any domain_add, so a freshly joined
+	// selective-sync member's ACTIVE set is empty by construction while its
+	// selectors sit in pending. Seeding the dashboard from the active set would
+	// therefore still render blank for exactly the case this field exists to fix.
+	//
+	// Pending is also what round-trips: ReplaceGroupMemberConsentDomains deletes
+	// every pending row before re-inserting the submitted set, so an "Apply role"
+	// carrying the active subset would silently destroy the unpromoted selectors.
+	//
+	// Always serialized, never omitempty: absent and empty must stay
+	// distinguishable, since the dashboard treats undefined as "seed me" and an
+	// empty array as "the operator really has no selectors".
 	ConsentDomains []string `json:"consent_domains"`
 }
 
@@ -1353,7 +1363,7 @@ func (h *DashboardHandler) handleFedGroupList(w http.ResponseWriter, r *http.Req
 		}
 		for _, mem := range members {
 			member := syncGroupMemberProgress(g, mem, local)
-			consent, cErr := ss.ListGroupMemberConsentDomains(ctx, g.GroupID, mem.MemberChainID)
+			consent, cErr := ss.ListPendingGroupMemberConsentDomains(ctx, g.GroupID, mem.MemberChainID)
 			if cErr != nil {
 				fedWriteErr(w, http.StatusInternalServerError, "Failed to read member consent domains.")
 				return

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -2270,12 +2270,28 @@ function TasksPage({ sse }) {
         }
     }
 
-    async function reorderTask(task, direction) {
+    async function reorderTask(task, direction, visibleColumnTasks) {
 		if (reorderingColumn) return;
+        // Bounds and neighbours must come from the VISIBLE column, because that is
+        // what the up/down buttons are indexed against. Applying a filtered-space
+        // step of +/-1 to the unfiltered array made the move a silent no-op
+        // whenever a hidden card sat between two visible ones - which the default
+        // view hits routinely via the 7-day done retention, plus domain and agent
+        // filters.
+        const visible = Array.isArray(visibleColumnTasks) && visibleColumnTasks.length
+            ? visibleColumnTasks
+            : tasks.filter(t => t.task_status === task.task_status);
+        const visibleFrom = visible.findIndex(t => t.memory_id === task.memory_id);
+        const visibleTo = visibleFrom + direction;
+        if (visibleFrom < 0 || visibleTo < 0 || visibleTo >= visible.length) return;
+        const neighbourID = visible[visibleTo].memory_id;
+
+        // Swap the two visible cards within the FULL column ordering, leaving any
+        // hidden cards between them exactly where they are.
         const columnTasks = tasks.filter(t => t.task_status === task.task_status);
         const from = columnTasks.findIndex(t => t.memory_id === task.memory_id);
-        const to = from + direction;
-        if (from < 0 || to < 0 || to >= columnTasks.length) return;
+        const to = columnTasks.findIndex(t => t.memory_id === neighbourID);
+        if (from < 0 || to < 0) return;
         [columnTasks[from], columnTasks[to]] = [columnTasks[to], columnTasks[from]];
         const orderedIDs = columnTasks.map(t => t.memory_id);
         const rank = new Map(orderedIDs.map((id, index) => [id, index]));
@@ -2618,9 +2634,9 @@ function TasksPage({ sse }) {
                                         `}
 						<div class="kanban-card-actions">
 							<button class="kanban-action kanban-order-action" title="Move task up" aria-label=${`Move ${taskSummary(task)} up`}
-								disabled=${taskIndex === 0 || reorderingColumn === task.task_status} onClick=${e => { e.stopPropagation(); reorderTask(task, -1); }}>↑</button>
+								disabled=${taskIndex === 0 || reorderingColumn === task.task_status} onClick=${e => { e.stopPropagation(); reorderTask(task, -1, colTasks); }}>↑</button>
 							<button class="kanban-action kanban-order-action" title="Move task down" aria-label=${`Move ${taskSummary(task)} down`}
-								disabled=${taskIndex === colTasks.length - 1 || reorderingColumn === task.task_status} onClick=${e => { e.stopPropagation(); reorderTask(task, 1); }}>↓</button>
+								disabled=${taskIndex === colTasks.length - 1 || reorderingColumn === task.task_status} onClick=${e => { e.stopPropagation(); reorderTask(task, 1, colTasks); }}>↓</button>
 							<span style="font-size:10px;color:var(--text-muted);">Status:</span>
 							<select class="kanban-status-select"
 								value=${task.task_status}
@@ -13025,6 +13041,18 @@ function SharingSyncGroupsPanel() {
             const groupId = group.group_id;
             const draft = drafts[groupId] || {};
             const panelId = 'sharing-sync-group-' + groupIndex;
+            // Seed the selective-domains field from the node's ACTIVE consent set.
+            // drafts start empty and are only written by operator keystrokes, so an
+            // untouched field previously rendered blank and submitted
+            // selected_domains: [] -- silently clearing an existing consent set on
+            // any "Apply role", including a role change that should not touch it.
+            // An explicit '' typed by the operator is still respected, because only
+            // `undefined` falls back.
+            const localMember = (group.members || []).find(member => member.chain_id === localChain);
+            const localConsent = (localMember && localMember.consent_domains) || [];
+            const selectedDomainsValue = draft.selectedDomains !== undefined
+                ? draft.selectedDomains
+                : localConsent.join(', ');
             return html`<article class="fed-group-card" key=${groupId}>
                 <button class="fed-group-summary" aria-expanded=${openGroup === groupId} aria-controls=${panelId} onClick=${() => setOpenGroup(openGroup === groupId ? '' : groupId)}>
                     <span><strong>${group.display_name || groupId}</strong><small>${(group.members || []).length} members · ${(group.shared_domains || []).length} shared domains · local role ${group.local_role || 'unknown'}</small></span>
@@ -13056,11 +13084,11 @@ function SharingSyncGroupsPanel() {
                             event.preventDefault();
                             const role = draft.role || group.local_role || 'enrolled-no-sync';
                             if (!await showConfirmation('Change this node’s role in ' + (group.display_name || groupId) + ' to ' + role + '? Selective domains are an explicit receive-consent subset.', { title: 'Change synchronization role?', confirmLabel: 'Apply role', tone: 'primary' })) return;
-                            mutate(groupId + ':role', () => fedGroupSelfRole(groupId, role, domains(draft.selectedDomains)), 'Local synchronization role updated');
+                            mutate(groupId + ':role', () => fedGroupSelfRole(groupId, role, domains(selectedDomainsValue)), 'Local synchronization role updated');
                         }}>
                             <h4>This node’s synchronization role</h4>
                             <label>Role<select value=${draft.role || group.local_role || 'enrolled-no-sync'} onChange=${event => patchDraft(groupId, { role: event.target.value })}><option value="full-sync">Full sync</option><option value="selective-sync">Selective sync</option><option value="enrolled-no-sync">Enrolled, no sync</option></select></label>
-                            <label>Selective domains<input value=${draft.selectedDomains || ''} onInput=${event => patchDraft(groupId, { selectedDomains: event.target.value })} placeholder="comma separated" /></label>
+                            <label>Selective domains<input value=${selectedDomainsValue} onInput=${event => patchDraft(groupId, { selectedDomains: event.target.value })} placeholder="comma separated" /></label>
                             <button class="btn btn-primary" type="submit" disabled=${busy !== ''}>Apply role</button>
                         </form>
                         <form onSubmit=${async event => {

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -24,7 +24,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.10.0';
+const SAGE_VERSION = 'v11.11.0';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -13041,7 +13041,9 @@ function SharingSyncGroupsPanel() {
             const groupId = group.group_id;
             const draft = drafts[groupId] || {};
             const panelId = 'sharing-sync-group-' + groupIndex;
-            // Seed the selective-domains field from the node's ACTIVE consent set.
+            // Seed the selective-domains field from the node's full selector set
+            // (consent_domains is served from the PENDING table, a strict superset of
+            // the promoted one -- see syncGroupMemberView in web/federation_join.go).
             // drafts start empty and are only written by operator keystrokes, so an
             // untouched field previously rendered blank and submitted
             // selected_domains: [] -- silently clearing an existing consent set on


### PR DESCRIPTION
Integrates #95, #97, #98, #99 and prepares the v11.11.0 release in one CI cycle.

## Why integrated rather than merged serially

`main` has `strict: true` branch protection. Merging four PRs serially costs four ~47-minute cycles, and each one only ever tests its branch against an *older* main — never the combined state. That's exactly the failure mode that bit us today: dropping Linux silently disabled `cargo audit` and broke the publication gate in ways no individual run surfaced. One run over the real shipping state is both faster and stricter.

Conflict resolutions (all #98 ↔ #99, both having rewritten the same regions):

- `release.yml`, `release-workflow.test.mjs` — #99 supersedes; the gate stops blocking and fails closed on distribution intent instead
- `ROADMAP.md` — **both kept**; platform scope and release-gating posture are independent facts
- `native-shell-quality-gates.md` — #95's glib dismissal and Linux re-entry sections kept, only the trailing promotion paragraph replaced by #99's

## Release prep

All six pins the metadata gate checks, including the two that are new from v11.11 (`tauri.conf.json`, `Cargo.toml` — the gate requires them to equal the tag). Shell identity stays `SAGE Native Preview` / `com.sage.native-preview`.

`docs/reference` markers were bumped **on a checked basis, not by rote**: `internal/mcp`, `internal/api`, and `sdk/python/src` have zero changes since v11.10.0, and the only `api/` change is a test file. The documented surfaces are unchanged, so the existing reconciliation genuinely still holds.

## What v11.11.0 ships

- completed CEREBRUM Sharing & Sync controls
- Postgres content-hash dedup parity with SQLite
- task-board lifecycle/ordering persistence; terminal tasks retain agent attribution
- isolated acceptance endpoints; bounded RBAC key caching
- native shell foundation as **opt-in alpha** — built and runtime-tested on hosted runners for macOS/Windows/Linux (install, launch, single-instance handoff, close with daemon survival, uninstall preserving the node data root, reinstall to a new generation), plus macOS offline startup with zero external requests. Never distributed.

No consensus rule, AppHash input, transaction type, key encoding, fork target, or application version changes. Chains upgrade in place.

## Verified locally

`go build` · `go vet` · `cargo fmt --check` · 16/16 shell tests · 97/97 frontend tests including the version-alignment gate.

## Note

Merging this closes #95, #97, #98 and #99 by content — they should be closed as superseded, not merged separately.