### PR TITLE
fix(release): stage the bundled daemon before the Rust build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,17 @@ jobs:
         run: |
           go test ./internal/shellcontrol -count=1
           go test ./cmd/sage-gui -run 'Test(LocalAgentKeyResolver|ShellStartupProof)' -count=1
+      # MUST precede the Rust build: tauri's build script resolves the
+      # bundle.resources glob "binaries/*" at compile time, so cargo test/clippy
+      # fail with "glob pattern binaries/* path not found" if the daemon has not
+      # been staged yet. native-shell.yml has always had this order; this job did
+      # not, and it went unnoticed because the job only runs for version >= 11.11,
+      # so v11.11.0 was the first tag ever to execute it.
+      - name: Stage version-matched bundled daemon
+        shell: bash
+        env:
+          SAGE_DAEMON_VERSION: ${{ env.NATIVE_SHELL_VERSION }}
+        run: scripts/stage-native-shell-daemon.sh ${{ matrix.rust-target }}
       - name: Test and lint the locked native shell
         shell: bash
         run: |
@@ -312,11 +323,6 @@ jobs:
         run: |
           cargo install cargo-audit --version 0.22.2 --locked
           cargo audit --file desktop/sage-shell/Cargo.lock
-      - name: Stage version-matched bundled daemon
-        shell: bash
-        env:
-          SAGE_DAEMON_VERSION: ${{ env.NATIVE_SHELL_VERSION }}
-        run: scripts/stage-native-shell-daemon.sh ${{ matrix.rust-target }}
       - name: Install pinned Tauri packager
         shell: bash
         run: cargo install tauri-cli --version 2.11.4 --locked

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -128,6 +128,22 @@ test('native shell evidence is version-locked, private, and cannot promote an un
   // docs/native-shell-quality-gates.md being revisited.
   assert.doesNotMatch(evidence, /id: linux-x64/);
   assert.match(evidence, /SAGE_DAEMON_VERSION/);
+  // The daemon MUST be staged before the Rust build. tauri's build script
+  // resolves the bundle.resources glob "binaries/*" at compile time, so cargo
+  // test/clippy die with "glob pattern binaries/* path not found" if staging has
+  // not run. This job only executes for version >= 11.11, so the wrong order sat
+  // latent until v11.11.0 became the first tag to run it -- and it failed both
+  // the macOS and Windows evidence builds, skipping every publication step.
+  // Nothing else exercises this path: it cannot run on a PR.
+  {
+    const staged = evidence.indexOf('Stage version-matched bundled daemon');
+    const built = evidence.indexOf('Test and lint the locked native shell');
+    assert.ok(staged >= 0 && built >= 0, 'evidence job lost a required step');
+    assert.ok(
+      staged < built,
+      'the bundled daemon must be staged before the Rust build, or tauri fails to resolve binaries/*',
+    );
+  }
   assert.match(evidence, /go test \.\/internal\/shellcontrol/);
   assert.match(evidence, /cargo fmt --manifest-path/);
   assert.match(evidence, /components: rustfmt, clippy/);


### PR DESCRIPTION
The v11.11.0 release workflow failed both native-shell evidence jobs:

```
glob pattern binaries/* path not found or didn't match any files
```

which skipped the promotion gate and **every** publication step.

## Nothing was published

`PyPI 11.11.0 → 404` · `GitHub release → not found` · `GHCR 11.11.0 → 0 versions`. Not even a draft. The two-phase publication design contained the failure to the private build phase, exactly as intended — there is no partial release to clean up.

## Cause

The evidence job ran `Test and lint the locked native shell` **before** `Stage version-matched bundled daemon`. Tauri's build script resolves the `bundle.resources` glob `binaries/*` at compile time, so `cargo test`/`clippy` fail outright if the daemon has not been staged. `native-shell.yml` has always staged first; this job never did.

## Why a fully green CI matrix missed it

`native-shell-release-evidence` only runs when `NATIVE_SHELL_REQUIRED=true`, i.e. version ≥ 11.11. Every prior release was 11.10.x, so the job was skipped. **v11.11.0 is the first tag in the repo's history to execute it**, and it is not reachable from a pull request at all — so no amount of PR CI could have caught it.

## Guard

Adds a static ordering assertion to `release-workflow.test.mjs`, verified to fail against the previous order. A string assertion is weak evidence, and I'd rather have a real run — but this path cannot execute outside a tag push, so the alternative is finding the next ordering mistake the same way we found this one: with a burned tag.

## Recovery

`v11.11.0` currently points at `ca51d1d`, which carries the broken order. Once this merges, the tag will be moved to the fixed commit and re-pushed. That is a force-move of a published ref, which is normally to be avoided — it is acceptable here *only* because the tag was provably never consumed by any channel.