### PR TITLE
fix(release): correct the publication gate artifact kind; cut v11.11.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -894,10 +894,16 @@ jobs:
                 .metadata.component.version == $version
               ' "${evidence_root}/native-shell-${evidence_id}.cdx.json" > /dev/null
             done
+            # "app-executable", not "app": verify-native-shell-bundle.sh records
+            # the artifact KIND it measured (the .app's inner executable), which is
+            # not the same string as the tauri --bundles value. This gate had never
+            # executed before v11.11.0 -- it only runs for version >= 11.11 -- so the
+            # mismatch sat latent and failed the first real release at the
+            # publication gate, after every build had already succeeded.
             verify_native_release_pair \
               staged/release-evidence-native-shell-macos-arm64 \
               staged/release-evidence-native-shell-macos-arm64/bundle/native-shell-release-pair.json \
-              aarch64-apple-darwin app
+              aarch64-apple-darwin app-executable
             verify_native_release_pair \
               staged/release-evidence-native-shell-windows-x64 \
               staged/release-evidence-native-shell-windows-x64/bundle/native-shell-release-pair.json \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.11.1
+
+**Release-pipeline fix for v11.11.0.** v11.11.0 was tagged but never published: the release workflow's native-shell evidence and publication jobs only execute for version 11.11 and above, so v11.11.0 was the first tag in the project's history to run them, and two latent defects surfaced in a path no pull request can exercise. The bundled daemon was staged after the Rust build that consumes it, and the publication gate expected an artifact-kind string the bundle verifier never records. Both are fixed and pinned by tests. No user received v11.11.0 on any channel.
+
+Everything below shipped in this release.
+
 ## What's New in v11.11.0
 
 **The Sharing & Sync control plane is complete, and the desktop shell foundation lands as an opt-in alpha that nothing depends on.** Browser CEREBRUM remains the product; the native shell is a background track that is built and runtime-tested in CI but not distributed and not intended for end-user use.
@@ -61,7 +67,7 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 - **Native shell foundation (alpha, not distributed).** A Tauri 2 shell starts the bundled daemon through an authenticated SSCP startup proof, owns one window with fail-closed navigation pinned to the exact authenticated loopback origin, keeps a visible recovery surface, and hands off to an existing instance on relaunch. Its installed-package lifecycle is proven on hosted runners for macOS, Windows, and Linux — install, launch, single-instance handoff, ordinary close with daemon survival, uninstall preserving the node data root, and reinstall to a genuinely new instance generation. macOS additionally proves offline startup with no external requests. Every package is unpacked and must contain exactly one bundled daemon whose embedded OS/architecture and version match the build.
 - **The shell does not gate releases.** v11.11 distributes no native shell, so signing, notarization, update/rollback, recovery, performance, and accessibility evidence are the bar for *distributing* it — which the roadmap places at v12 — not a v11.11 shipping requirement. Federation, agent-to-agent messaging, and the rest of the roadmap do not queue behind desktop packaging.
 
-This release changes no SAGE consensus rule, AppHash input, transaction type, key encoding, fork target, or application version. App-v20 and the v11.9 rollout boundary are unchanged; existing chains upgrade in place. SDK 11.11.0.
+This release changes no SAGE consensus rule, AppHash input, transaction type, key encoding, fork target, or application version. App-v20 and the v11.9 rollout boundary are unchanged; existing chains upgrade in place. SDK 11.11.1.
 
 ## What's New in v11.10.0
 
@@ -551,7 +557,7 @@ docker pull ghcr.io/l33tdawg/sage:latest
 docker run -p 8080:8080 -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.11.0`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.11.1`.
 
 ### Upgrading from an older version?
 

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.11.0"
+version = "11.11.1"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.11.0"
+version = "11.11.1"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.11.0",
+  "version": "11.11.1",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-07):** **v11.11.0 is the current release.** It closes the independent-chain federation product loop with a retry-safe ceremony, manageable directional Read/Copy sharing, Pause/Resume and revocation feedback, plus durable agent-to-agent inbox delivery across explicitly accepted federation contacts. The exact-source cold state-sync proof passed on the v11.9 release source, and the complete CI/security/fault matrix remains a mandatory publication invariant. The native-shell productization bridge is retargeted to v11.11–v11.14; none of those planned releases is promised or dated.
+**Status (2026-07):** **v11.11.1 is the current release.** It closes the independent-chain federation product loop with a retry-safe ceremony, manageable directional Read/Copy sharing, Pause/Resume and revocation feedback, plus durable agent-to-agent inbox delivery across explicitly accepted federation contacts. The exact-source cold state-sync proof passed on the v11.9 release source, and the complete CI/security/fault matrix remains a mandatory publication invariant. The native-shell productization bridge is retargeted to v11.11–v11.14; none of those planned releases is promised or dated.
 
 **Hard constraint driving the whole plan:** no chain reset, no operator-typed commands. Existing chains must upgrade in place across all future releases.
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.11.0. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.11.1. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -97,7 +97,7 @@ CometBFT without treating the consensus RPC as proof of application storage.
 
 ---
 
-## Related docs (reconciled through v11.11.0)
+## Related docs (reconciled through v11.11.1)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,4 +1,4 @@
-<!-- Core document reconciled through SAGE v11.11.0, including directional cross-chain peer RBAC and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.11.1, including directional cross-chain peer RBAC and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.11.0. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.11.1. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.11.0 code (2026-07-19). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.11.1 code (2026-07-19). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.11.0.
+Reconciled against internal/mcp for SAGE v11.11.1.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.11.0. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.11.1. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.11.0
+**Package:** `sage-agent-sdk` **Version:** 11.11.1
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.11.0. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.11.1. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -17,6 +17,10 @@ const windowsInstaller = readFileSync(
   'utf8',
 );
 const rootDockerfile = readFileSync(new URL('../Dockerfile', import.meta.url), 'utf8');
+const bundleVerifier = readFileSync(
+  new URL('../scripts/verify-native-shell-bundle.sh', import.meta.url),
+  'utf8',
+);
 const v119Chaos = readFileSync(
   new URL('../deploy/scripts/run-v11.9-chaos.sh', import.meta.url),
   'utf8',
@@ -197,6 +201,34 @@ test('native shell evidence is version-locked, private, and cannot promote an un
   const publicStaging = job('stage-github-release');
   assert.match(publicStaging, /pattern: release-assets-\*/);
   assert.doesNotMatch(publicStaging, /release-evidence-native-shell/);
+});
+
+test('publication gate expects the artifact kinds the bundle verifier actually records', () => {
+  // verify-native-shell-bundle.sh writes the KIND it measured into the
+  // release-pair record; the publication gate asserts .shell_artifact.kind
+  // equals a string hard-coded in release.yml. Nothing declares those strings in
+  // one place, so they drifted: the gate expected "app" while the verifier
+  // records "app-executable" for a macOS .app. Neither file is exercised by PR
+  // CI -- the evidence and publication jobs only run for version >= 11.11 on a
+  // real tag -- so the mismatch failed the first genuine release, after every
+  // build job had already gone green.
+  const recorded = new Set(
+    [...bundleVerifier.matchAll(/SHELL_ARTIFACT_KIND=([A-Za-z0-9-]+)/g)].map((m) => m[1]),
+  );
+  assert.ok(recorded.size > 0, 'could not read any SHELL_ARTIFACT_KIND from the bundle verifier');
+
+  const publication = job('publication-gate');
+  const expected = [...publication.matchAll(/^\s+\S+ (\S+)$/gm)]
+    .map((m) => m[1])
+    .filter((token) => /^(app|app-executable|dmg|nsis|deb|appimage)$/.test(token));
+  assert.ok(expected.length > 0, 'could not read any expected artifact kind from the publication gate');
+
+  for (const kind of expected) {
+    assert.ok(
+      recorded.has(kind),
+      `publication gate expects artifact kind "${kind}", which verify-native-shell-bundle.sh never records (it records: ${[...recorded].sort().join(', ')})`,
+    );
+  }
 });
 
 test('manual release recovery checks out the immutable tag in every source job', () => {

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.11.0 SDK** | **TLS, RBAC, federation, domain recovery, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.11.1 SDK** | **TLS, RBAC, federation, domain recovery, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.11.0"
+version = "11.11.1"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.11.0"
+__version__ = "11.11.1"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.11.0",
+  "version": "11.11.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.11.0",
+      "identifier": "ghcr.io/l33tdawg/sage:11.11.1",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -24,7 +24,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.11.0';
+const SAGE_VERSION = 'v11.11.1';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
`v11.11.0` was tagged twice and published nowhere. Two latent defects sat in the release path, both in code that **only executes for version ≥ 11.11 on a real tag push** — so v11.11.0 was the first tag in the project's history to run it, and no pull request could ever have exercised it.

## Defect 2 (this PR)

With #101's step-order fix in, the run got much further: both native-shell evidence jobs **passed**, the promotion gate **passed**, and it reached `Artifact and Package Publication Gate` — which failed.

The gate asserts `.shell_artifact.kind` equals a string hard-coded in `release.yml`:

| | |
|---|---|
| `verify-native-shell-bundle.sh` **records** for darwin | `app-executable` |
| publication gate **expected** | `app` |

Confirmed against the real artifact downloaded from run `29765457774`, not inferred from reading. Windows was fine — `nsis` on both sides.

## Guard

The two files must agree on strings that nothing declares centrally, which is exactly how they drifted. The new test extracts every `SHELL_ARTIFACT_KIND` the verifier can record and asserts every kind the gate expects is among them. Verified to fail against the previous value:

```
publication gate expects artifact kind "app", which verify-native-shell-bundle.sh
never records (it records: app-executable, appimage, deb, dmg, nsis)
```

## Why v11.11.1 rather than moving the tag again

Release-owner decision. One move of a provably unconsumed tag was defensible; a second would be a habit, and moving a ref anyone might have fetched is how two different trees end up claiming to be the same version.

`v11.11.0` stays dead and unpublished — PyPI 404, no GHCR image, no GitHub release **or draft**, MCP registry empty. All six pins, the OCI identifier, the README section and Docker pin, and the eight `docs/reference` markers move to 11.11.1.

## Standing gap this exposes

The release path cannot be tested without tagging. Two static guards now cover the two defects we hit, but the publication gate still has steps that have never executed. Before v11.12 this should be smoke-tested with a throwaway prerelease tag rather than discovered on real ones — a real run is the only thing that actually proves this path.

Local gate: `go build`, `gofmt`, 98/98 frontend including the version-alignment test.