### PR TITLE
perf(ci): drop two dependency edges that carry no data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,14 @@ jobs:
 
   v119-fault-gates:
     name: v11.9 Multi-Process Fault Gates
-    needs: test
+    # Deliberately NOT `needs: test`. Nothing here consumes a test output --
+    # there is no needs.test.* reference anywhere in this file -- so the edge
+    # only serialized two independent suites and left the runner idle for the
+    # whole ~17-minute test job. `build` still requires both, so the gate set is
+    # unchanged; only the ordering is.
+    #
+    # If this job ever starts consuming something `test` produces, restore the
+    # edge rather than relying on incidental ordering.
     uses: ./.github/workflows/v11.9-fault-gates.yml
     with:
       # PR/main green must carry the same evidence required before a release

--- a/.github/workflows/v11.9-fault-gates.yml
+++ b/.github/workflows/v11.9-fault-gates.yml
@@ -63,7 +63,8 @@ jobs:
     name: Real Comet/ABCI crash and partition gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: app-multiprocess
+    # Independent of app-multiprocess: no needs.app-multiprocess.* reference
+    # exists, so this edge only serialized two separate suites.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
CI takes ~48 minutes. **~41 of those are one serial chain**, measured from run `29750220297`:

```
   starts@     dur  job
      0.0m    0.2m  Frontend Static Checks
      0.0m    0.7m  Lint
      0.0m    0.2m  Python SDK Tests
      0.0m   16.7m  Test
     16.8m    2.6m  App-v20 subprocess fault oracle
     19.5m   24.2m  Real Comet/ABCI crash and partition gate
     43.7m    0.6m  Build
     44.3m    1.7m  Docker Build
     44.3m    3.3m  Byzantine Fault Tests
```

The three fast jobs finish inside a minute, then everything waits.

## Two edges carry no data

- **`v119-fault-gates` declared `needs: test`** — but there is no `needs.test.*` reference anywhere in `ci.yml`. The fault gates build their own images and drive their own processes; they consume nothing `test` produces. The edge purely idled a runner for the whole ~17-minute test job.
- **`real-comet-chaos` declared `needs: app-multiprocess`** — no `needs.app-multiprocess.*` reference. Separate suites.

## The gate set does not change

`build` still requires `lint`, `test`, `frontend-static`, `v119-fault-gates`; `docker` and `byzantine` still require `build`. **Nothing merges on less evidence** — only the ordering changes.

| | before | after |
|---|---|---|
| critical path | `test` → `oracle` → `comet` → `build` → `byz` | `max(test, comet)` → `build` → `byz` |
| **wall clock** | **~48 min** | **~28 min** |

## What's left

The floor becomes `real-comet-chaos` at ~24 minutes — it builds two Docker images and drives real multi-process consensus with firewall partitions, so it's genuinely expensive. Going below ~28 minutes means moving it off the PR path (merge queue or nightly), which is a real tradeoff rather than free, so I've left it alone.

## Note

If either job ever starts consuming an output of its former dependency, restore the edge explicitly rather than relying on incidental ordering — that's called out in a comment at each site.