### PR TITLE
test(sage-gui): use t.Setenv for SAGE_HOME in migrate tests

### DIFF
--- a/cmd/sage-gui/migrate_test.go
+++ b/cmd/sage-gui/migrate_test.go
@@ -39,9 +39,7 @@ func TestResetChainState_RefusesWhileInstanceLive(t *testing.T) {
 
 func TestMigrateOnUpgrade_FirstRun(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	os.MkdirAll(dataDir, 0700)
@@ -74,9 +72,7 @@ func TestMigrateOnUpgrade_FirstRun(t *testing.T) {
 
 func TestMigrateOnUpgrade_SameVersion(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	os.MkdirAll(dataDir, 0700)
@@ -105,9 +101,7 @@ func TestMigrateOnUpgrade_SameVersion(t *testing.T) {
 // that regression.
 func TestMigrateOnUpgrade_VersionChangedSameFork_PreservesState(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	badgerDir := filepath.Join(dataDir, "badger")
@@ -167,9 +161,7 @@ func TestMigrateOnUpgrade_PreV75_LegacyInstall_RunsReset(t *testing.T) {
 		fromVersion := fromVersion
 		t.Run(fromVersion, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			origHome := os.Getenv("SAGE_HOME")
-			os.Setenv("SAGE_HOME", tmpDir)
-			defer os.Setenv("SAGE_HOME", origHome)
+			t.Setenv("SAGE_HOME", tmpDir)
 
 			dataDir := filepath.Join(tmpDir, "data")
 			badgerDir := filepath.Join(dataDir, "badger")
@@ -249,9 +241,7 @@ func TestIsLegacyForkOneVersion(t *testing.T) {
 // This is the in-place upgrade path from v7.5.4 → v7.5.5.
 func TestMigrateOnUpgrade_LegacyInstall_AdoptsCurrentFork(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	badgerDir := filepath.Join(dataDir, "badger")
@@ -286,9 +276,7 @@ func TestMigrateOnUpgrade_LegacyInstall_AdoptsCurrentFork(t *testing.T) {
 // chain state is incompatible by definition.
 func TestMigrateOnUpgrade_ForkBump_RunsReset(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	badgerDir := filepath.Join(dataDir, "badger")
@@ -358,9 +346,7 @@ func TestMigrateOnUpgrade_ForkBump_RunsReset(t *testing.T) {
 // (incomplete) reset, leaving the operator with mixed-fork state.
 func TestMigrateOnUpgrade_ForkBump_StampsOnlyAfterReset(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	os.MkdirAll(dataDir, 0700)
@@ -388,9 +374,7 @@ func TestMigrateOnUpgrade_ForkBump_StampsOnlyAfterReset(t *testing.T) {
 
 func TestMigrateOnUpgrade_DevVersion(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	os.MkdirAll(dataDir, 0700)


### PR DESCRIPTION
Removes the leak class behind the `TestIssue52_HealThenInitChain_EndToEnd` CI flake, at its source.

## The pattern

`migrate_test.go` held the package's only raw `os.Setenv` restore for `SAGE_HOME` — eight copies of:

```go
origHome := os.Getenv("SAGE_HOME")
os.Setenv("SAGE_HOME", tmpDir)
defer os.Setenv("SAGE_HOME", origHome)
```

When `SAGE_HOME` was originally **unset**, `origHome` is `""` and the deferred call writes `""` back instead of unsetting. `SageHome()` treats `""` as *fall back to `~/.sage`*.

## Why that produced a CI-only failure

| | fallback resolves to | `agent.key`? | outcome |
|---|---|---|---|
| CI runner | `/home/runner/.sage` | no | heal seeds no admin → the exact assertion that failed |
| dev machine | `~/.sage` | yes (real node) | heal succeeds → invisible |

`t.Setenv` restores prior state correctly — **including unsetting a variable that was previously unset** — and panics if the test is parallel. No test in this file calls `t.Parallel()`; verified.

## Honesty about what this proves

This removes the mechanism. It does **not** prove the flake is gone — that failure has never reproduced locally, so I can't demonstrate a before/after. The diagnostic preconditions in #104 are deliberately kept for exactly that reason: if it recurs, the failure will now name which precondition broke rather than reporting `Should be true`.

Full package run 3× locally after the change, plus `go vet`.