### PR TITLE
fix(shell): stop authenticode diagnostics failing the Windows smoke

### DIFF
--- a/scripts/native-shell-windows-runtime-smoke.ps1
+++ b/scripts/native-shell-windows-runtime-smoke.ps1
@@ -23,6 +23,20 @@ public static class SagePipeNative {
 }
 '@
 
+function Get-AuthenticodeStatusText([string]$Path) {
+    # Diagnostic metadata only -- it must never be able to fail the harness.
+    # Get-AuthenticodeSignature returns $null when the file is missing or is not a
+    # supported type, and under `Set-StrictMode -Version Latest` the resulting
+    # .Status read becomes a TERMINATING error: "The property 'Status' cannot be
+    # found on this object." That killed an otherwise-green lifecycle run on
+    # 2026-07-20 after every assertion had already passed.
+    $sig = $null
+    try { $sig = Get-AuthenticodeSignature -FilePath $Path -ErrorAction Stop } catch { return 'unavailable' }
+    if ($null -eq $sig) { return 'unavailable' }
+    if ($null -eq $sig.Status) { return 'unavailable' }
+    return $sig.Status.ToString()
+}
+
 function Assert-True([bool]$Condition, [string]$Message) {
     if (-not $Condition) { throw $Message }
 }
@@ -293,7 +307,7 @@ $webviewVersion = Get-WebViewVersion
     expected_version = $ExpectedVersion
     installer_path = $setup.FullName
     installer_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $setup.FullName).Hash.ToLowerInvariant()
-    authenticode = (Get-AuthenticodeSignature -FilePath $setup.FullName).Status.ToString()
+    authenticode = Get-AuthenticodeStatusText $setup.FullName
     image_os = $env:ImageOS
     image_version = $env:ImageVersion
     os_caption = $os.Caption
@@ -376,7 +390,7 @@ try {
 
     $safeStatus = [ordered]@{
         installer_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $setup.FullName).Hash.ToLowerInvariant()
-        authenticode = (Get-AuthenticodeSignature -FilePath $setup.FullName).Status.ToString()
+        authenticode = Get-AuthenticodeStatusText $setup.FullName
         daemon_version = $daemonOnly.Status.daemon_version
         state = $daemonOnly.Status.state
         ui_origin = $daemonOnly.Status.ui_origin

--- a/scripts/native-shell-windows-runtime-smoke.test.sh
+++ b/scripts/native-shell-windows-runtime-smoke.test.sh
@@ -28,10 +28,20 @@ for required in \
   '$Process.Kill($true)' \
   'taskkill.exe /PID' \
   'preserve.sentinel' \
+  'Get-AuthenticodeStatusText' \
   'reinstall reused a stale daemon generation' \
   "@('/S', \"/D=\$installRoot\")"; do
   grep -Fq "${required}" "${HARNESS}"
 done
+
+# Diagnostic metadata must never be able to fail the harness. A raw
+# (Get-AuthenticodeSignature ...).Status read is a TERMINATING error under
+# Set-StrictMode when the file is missing or unsupported, which killed an
+# otherwise-green run on 2026-07-20.
+if grep -Eq '\(Get-AuthenticodeSignature[^)]*\)\.Status' "${HARNESS}"; then
+  echo 'Windows runtime harness reads .Status directly off Get-AuthenticodeSignature' >&2
+  exit 1
+fi
 
 if grep -Eq 'taskkill\.exe[[:space:]]+/IM|Get-Process[[:space:]]+sage-gui|Stop-Process[[:space:]]+-Name' "${HARNESS}"; then
   echo 'Windows runtime harness contains broad process-name cleanup' >&2


### PR DESCRIPTION
The Windows installed-package lifecycle smoke failed on 2026-07-20 with:

```
The property 'Status' cannot be found on this object. Verify that the property exists.
```

— **after every lifecycle assertion had already passed**. A re-run of the identical commit went green; macOS and Linux were unaffected.

## The mechanism

`Read-ReadyStatus` always returns a proper `[pscustomobject]` or throws, so the SSCP `.Status` reads are safe. The remaining two are:

```powershell
authenticode = (Get-AuthenticodeSignature -FilePath $setup.FullName).Status.ToString()
```

used purely to stamp **diagnostic metadata** into the evidence JSON. `Get-AuthenticodeSignature` returns `$null` when the file is missing or is not a supported type, and under `Set-StrictMode -Version Latest` that property read is a **terminating error** rather than `$null`.

So a transient condition around the installer file kills a run whose assertions all passed — which is exactly the observed shape.

## Fix

`Get-AuthenticodeStatusText` returns `'unavailable'` instead of throwing. Collecting diagnostics must never be able to fail the harness; a missing signature string is not a lifecycle defect.

The contract test now requires the helper and **rejects any raw `(Get-AuthenticodeSignature ...).Status` read**, verified to fail when the old form is reintroduced:

```
Windows runtime harness reads .Status directly off Get-AuthenticodeSignature
```

## Caveat, stated plainly

I cannot execute PowerShell on macOS, so this is reasoned from PowerShell semantics and the failure text rather than reproduced. It removes a demonstrable way to produce that exact error. It does **not** prove that was the site — the message doesn't name the variable, and the run is not reproducible on demand.

If the same error recurs at a different site, that narrows it further rather than invalidating this change: these two reads had no business being fatal either way.