### PR TITLE
chore: integrate #103-#106 for a single combined CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,14 @@ jobs:
 
   v119-fault-gates:
     name: v11.9 Multi-Process Fault Gates
-    needs: test
+    # Deliberately NOT `needs: test`. Nothing here consumes a test output --
+    # there is no needs.test.* reference anywhere in this file -- so the edge
+    # only serialized two independent suites and left the runner idle for the
+    # whole ~17-minute test job. `build` still requires both, so the gate set is
+    # unchanged; only the ordering is.
+    #
+    # If this job ever starts consuming something `test` produces, restore the
+    # edge rather than relying on incidental ordering.
     uses: ./.github/workflows/v11.9-fault-gates.yml
     with:
       # PR/main green must carry the same evidence required before a release

--- a/.github/workflows/v11.9-fault-gates.yml
+++ b/.github/workflows/v11.9-fault-gates.yml
@@ -63,7 +63,8 @@ jobs:
     name: Real Comet/ABCI crash and partition gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: app-multiprocess
+    # Independent of app-multiprocess: no needs.app-multiprocess.* reference
+    # exists, so this edge only serialized two separate suites.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/cmd/sage-gui/issue52_genesis_admin_test.go
+++ b/cmd/sage-gui/issue52_genesis_admin_test.go
@@ -198,9 +198,26 @@ func TestIssue52_HealThenInitChain_EndToEnd(t *testing.T) {
 	// Step 2: ensureGenesisSeed is EXACTLY what runServe calls after migrate — it must
 	// heal the admin-less genesis. (Testing the helper, not the two functions
 	// separately, is what guards against the heal step being dropped from serve.)
+	// ensureGenesisSeed resolves agent.key through SageHome(), i.e. process-wide
+	// SAGE_HOME. This package mutates that variable in 60+ places across a dozen
+	// files, mixing t.Setenv with raw os.Setenv whose `defer os.Setenv(orig)`
+	// writes "" back when the variable was originally unset -- and SageHome()
+	// treats "" as "fall back to ~/.sage", which on a CI runner has no agent.key.
+	//
+	// This assertion has failed exactly once on CI (main, 2026-07-20) and has not
+	// reproduced in 50 single-test runs, 10 under -race, or 3 whole-package runs
+	// locally. Pin the preconditions so the next occurrence says WHICH one broke
+	// instead of a bare "Should be true".
+	require.Equal(t, sageHome, SageHome(),
+		"SAGE_HOME leaked: ensureGenesisSeed will look for agent.key in the wrong root")
+	require.FileExists(t, filepath.Join(SageHome(), "agent.key"),
+		"agent.key is not readable at the resolved SAGE_HOME, so the heal cannot seed an admin")
+
 	require.NoError(t, ensureGenesisSeed(cometHome, zerolog.Nop()))
 	healed := i52ReadGenesisAppState(t, cometHome)
-	require.True(t, genesisAppStateHasInitialAdmin(healed))
+	require.True(t, genesisAppStateHasInitialAdmin(healed),
+		"heal did not seed a chain admin; SAGE_HOME=%q resolved=%q genesis=%s",
+		os.Getenv("SAGE_HOME"), SageHome(), string(healed))
 	require.Contains(t, string(healed), adminID)
 
 	// Step 3: a fresh consensus app InitChains from the healed genesis and registers

--- a/cmd/sage-gui/migrate_test.go
+++ b/cmd/sage-gui/migrate_test.go
@@ -39,9 +39,7 @@ func TestResetChainState_RefusesWhileInstanceLive(t *testing.T) {
 
 func TestMigrateOnUpgrade_FirstRun(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	os.MkdirAll(dataDir, 0700)
@@ -74,9 +72,7 @@ func TestMigrateOnUpgrade_FirstRun(t *testing.T) {
 
 func TestMigrateOnUpgrade_SameVersion(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	os.MkdirAll(dataDir, 0700)
@@ -105,9 +101,7 @@ func TestMigrateOnUpgrade_SameVersion(t *testing.T) {
 // that regression.
 func TestMigrateOnUpgrade_VersionChangedSameFork_PreservesState(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	badgerDir := filepath.Join(dataDir, "badger")
@@ -167,9 +161,7 @@ func TestMigrateOnUpgrade_PreV75_LegacyInstall_RunsReset(t *testing.T) {
 		fromVersion := fromVersion
 		t.Run(fromVersion, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			origHome := os.Getenv("SAGE_HOME")
-			os.Setenv("SAGE_HOME", tmpDir)
-			defer os.Setenv("SAGE_HOME", origHome)
+			t.Setenv("SAGE_HOME", tmpDir)
 
 			dataDir := filepath.Join(tmpDir, "data")
 			badgerDir := filepath.Join(dataDir, "badger")
@@ -249,9 +241,7 @@ func TestIsLegacyForkOneVersion(t *testing.T) {
 // This is the in-place upgrade path from v7.5.4 → v7.5.5.
 func TestMigrateOnUpgrade_LegacyInstall_AdoptsCurrentFork(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	badgerDir := filepath.Join(dataDir, "badger")
@@ -286,9 +276,7 @@ func TestMigrateOnUpgrade_LegacyInstall_AdoptsCurrentFork(t *testing.T) {
 // chain state is incompatible by definition.
 func TestMigrateOnUpgrade_ForkBump_RunsReset(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	badgerDir := filepath.Join(dataDir, "badger")
@@ -358,9 +346,7 @@ func TestMigrateOnUpgrade_ForkBump_RunsReset(t *testing.T) {
 // (incomplete) reset, leaving the operator with mixed-fork state.
 func TestMigrateOnUpgrade_ForkBump_StampsOnlyAfterReset(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	os.MkdirAll(dataDir, 0700)
@@ -388,9 +374,7 @@ func TestMigrateOnUpgrade_ForkBump_StampsOnlyAfterReset(t *testing.T) {
 
 func TestMigrateOnUpgrade_DevVersion(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("SAGE_HOME")
-	os.Setenv("SAGE_HOME", tmpDir)
-	defer os.Setenv("SAGE_HOME", origHome)
+	t.Setenv("SAGE_HOME", tmpDir)
 
 	dataDir := filepath.Join(tmpDir, "data")
 	os.MkdirAll(dataDir, 0700)

--- a/scripts/native-shell-windows-runtime-smoke.ps1
+++ b/scripts/native-shell-windows-runtime-smoke.ps1
@@ -23,6 +23,20 @@ public static class SagePipeNative {
 }
 '@
 
+function Get-AuthenticodeStatusText([string]$Path) {
+    # Diagnostic metadata only -- it must never be able to fail the harness.
+    # Get-AuthenticodeSignature returns $null when the file is missing or is not a
+    # supported type, and under `Set-StrictMode -Version Latest` the resulting
+    # .Status read becomes a TERMINATING error: "The property 'Status' cannot be
+    # found on this object." That killed an otherwise-green lifecycle run on
+    # 2026-07-20 after every assertion had already passed.
+    $sig = $null
+    try { $sig = Get-AuthenticodeSignature -FilePath $Path -ErrorAction Stop } catch { return 'unavailable' }
+    if ($null -eq $sig) { return 'unavailable' }
+    if ($null -eq $sig.Status) { return 'unavailable' }
+    return $sig.Status.ToString()
+}
+
 function Assert-True([bool]$Condition, [string]$Message) {
     if (-not $Condition) { throw $Message }
 }
@@ -293,7 +307,7 @@ $webviewVersion = Get-WebViewVersion
     expected_version = $ExpectedVersion
     installer_path = $setup.FullName
     installer_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $setup.FullName).Hash.ToLowerInvariant()
-    authenticode = (Get-AuthenticodeSignature -FilePath $setup.FullName).Status.ToString()
+    authenticode = Get-AuthenticodeStatusText $setup.FullName
     image_os = $env:ImageOS
     image_version = $env:ImageVersion
     os_caption = $os.Caption
@@ -376,7 +390,7 @@ try {
 
     $safeStatus = [ordered]@{
         installer_sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $setup.FullName).Hash.ToLowerInvariant()
-        authenticode = (Get-AuthenticodeSignature -FilePath $setup.FullName).Status.ToString()
+        authenticode = Get-AuthenticodeStatusText $setup.FullName
         daemon_version = $daemonOnly.Status.daemon_version
         state = $daemonOnly.Status.state
         ui_origin = $daemonOnly.Status.ui_origin

--- a/scripts/native-shell-windows-runtime-smoke.test.sh
+++ b/scripts/native-shell-windows-runtime-smoke.test.sh
@@ -28,10 +28,20 @@ for required in \
   '$Process.Kill($true)' \
   'taskkill.exe /PID' \
   'preserve.sentinel' \
+  'Get-AuthenticodeStatusText' \
   'reinstall reused a stale daemon generation' \
   "@('/S', \"/D=\$installRoot\")"; do
   grep -Fq "${required}" "${HARNESS}"
 done
+
+# Diagnostic metadata must never be able to fail the harness. A raw
+# (Get-AuthenticodeSignature ...).Status read is a TERMINATING error under
+# Set-StrictMode when the file is missing or unsupported, which killed an
+# otherwise-green run on 2026-07-20.
+if grep -Eq '\(Get-AuthenticodeSignature[^)]*\)\.Status' "${HARNESS}"; then
+  echo 'Windows runtime harness reads .Status directly off Get-AuthenticodeSignature' >&2
+  exit 1
+fi
 
 if grep -Eq 'taskkill\.exe[[:space:]]+/IM|Get-Process[[:space:]]+sage-gui|Stop-Process[[:space:]]+-Name' "${HARNESS}"; then
   echo 'Windows runtime harness contains broad process-name cleanup' >&2


### PR DESCRIPTION
Integrates the four follow-up PRs from today's release work into one branch for a single combined run.

## Why integrated

`main` has `strict: true`, so merging four PRs serially costs four ~48-minute cycles **and never tests the combination** — each branch is only ever validated against an older `main`.

That gap already bit this repo today: removing Linux from the release matrix silently disabled `cargo audit` and broke the publication gate, in ways no individual PR run surfaced.

All four passed CI independently (**all `CLEAN`, zero failed checks**) before integration. This branch validates the state that will actually land.

## Contents

| PR | |
|---|---|
| **#103** | drop two CI dependency edges that carry no data — ~48 → ~28 min |
| **#104** | pin the `SAGE_HOME` preconditions in the issue-52 heal test |
| **#105** | use `t.Setenv` for `SAGE_HOME` in migrate tests — removes the leak at source |
| **#106** | stop authenticode diagnostics failing the Windows smoke |

All four merged without conflict.

## Verified on the merged tree

- full `cmd/sage-gui` package
- `TestIssue52` ×3 — confirming **#104's new preconditions don't fire spuriously** now that #105 removes the leak they guard against. That pairing was the main integration risk.
- Windows harness contract tests
- 98/98 frontend, `go build`, `golangci-lint` **0 issues**
- `build` still gates on all four jobs — the #103 change alters ordering, not the gate set

## Self-demonstrating

Because #103 is in this set, **this branch's own CI run uses the new parallel graph**. If it completes in roughly half the usual wall clock, that is the speedup validating itself.