### PR TITLE
fix(cerebrum): stop the optimistic kanban re-sort disagreeing with the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "check:js": "node scripts/check-static-js.mjs",
-    "test": "npm run check:js && node --test scripts/cerebrum-shell.test.mjs scripts/federation-flow.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
+    "test": "npm run check:js && node --test scripts/cerebrum-shell.test.mjs scripts/federation-flow.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/task-reorder.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/task-reorder.test.mjs
+++ b/scripts/task-reorder.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const { computeReorderedColumn, applyColumnOrder } = await import(
+    '../web/static/js/task-reorder.js'
+);
+
+const task = (id, status) => ({ memory_id: id, task_status: status });
+const ids = (list) => list.map((entry) => entry.memory_id);
+
+test('a hidden card between two visible ones does not absorb the move', () => {
+    // P2 is hidden (filtered out); the operator sees P1 above P3 and clicks up on P3.
+    const all = [task('P1', 'planned'), task('P2', 'planned'), task('P3', 'planned')];
+    const visible = [all[0], all[2]];
+
+    const ordered = computeReorderedColumn(all, visible, all[2], -1);
+    assert.deepEqual(ordered, ['P3', 'P2', 'P1'],
+        'the two VISIBLE cards must swap; the hidden card stays between them');
+
+    // Regression: indexing the step into the unfiltered array would have swapped
+    // P3 with the hidden P2, which the operator sees as nothing happening.
+    assert.notDeepEqual(ordered, ['P1', 'P3', 'P2']);
+});
+
+test('bounds come from the visible column, not the full one', () => {
+    const all = [task('P1', 'planned'), task('P2', 'planned'), task('P3', 'planned')];
+    const visible = [all[1]]; // only one card visible
+
+    assert.equal(computeReorderedColumn(all, visible, all[1], -1), null);
+    assert.equal(computeReorderedColumn(all, visible, all[1], 1), null);
+});
+
+test('an ordinary adjacent move still works', () => {
+    const all = [task('A', 'planned'), task('B', 'planned'), task('C', 'planned')];
+    assert.deepEqual(computeReorderedColumn(all, all, all[0], 1), ['B', 'A', 'C']);
+    assert.deepEqual(computeReorderedColumn(all, all, all[2], -1), ['A', 'C', 'B']);
+});
+
+test('applying an order leaves other columns untouched and non-contiguous columns correct', () => {
+    // The exact shape an optimistic status rewrite produces: the in_progress
+    // cards are NOT contiguous, because P2 was reassigned in place.
+    const all = [
+        task('I1', 'in_progress'),
+        task('I2', 'in_progress'),
+        task('P1', 'planned'),
+        task('P2', 'in_progress'),
+        task('P3', 'planned'),
+        task('D1', 'done'),
+    ];
+
+    const next = applyColumnOrder(all, 'in_progress', ['I1', 'P2', 'I2']);
+
+    // in_progress slots (indices 0, 1, 3) now hold the new order.
+    assert.deepEqual(ids(next), ['I1', 'P2', 'P1', 'I2', 'P3', 'D1']);
+    // Reading the column back gives exactly what was POSTed.
+    assert.deepEqual(
+        ids(next.filter((entry) => entry.task_status === 'in_progress')),
+        ['I1', 'P2', 'I2'],
+    );
+    // Other columns are untouched, in both position and order.
+    assert.deepEqual(ids(next.filter((entry) => entry.task_status === 'planned')), ['P1', 'P3']);
+    assert.deepEqual(ids(next.filter((entry) => entry.task_status === 'done')), ['D1']);
+});
+
+test('the old non-transitive comparator would have failed this case', () => {
+    // Kept as an executable record of the defect: sorting the whole array with a
+    // comparator that returns 0 across columns leaves out-of-run elements in
+    // place, so the board silently disagreed with what was POSTed.
+    const all = [
+        task('I1', 'in_progress'),
+        task('I2', 'in_progress'),
+        task('P1', 'planned'),
+        task('P2', 'in_progress'),
+        task('P3', 'planned'),
+    ];
+    const orderedIDs = ['I1', 'P2', 'I2'];
+    const rank = new Map(orderedIDs.map((id, index) => [id, index]));
+
+    const oldWay = ids([...all].sort((a, b) => {
+        if (a.task_status !== 'in_progress' || b.task_status !== 'in_progress') return 0;
+        return rank.get(a.memory_id) - rank.get(b.memory_id);
+    }).filter((entry) => entry.task_status === 'in_progress'));
+
+    const newWay = ids(
+        applyColumnOrder(all, 'in_progress', orderedIDs)
+            .filter((entry) => entry.task_status === 'in_progress'),
+    );
+
+    assert.deepEqual(newWay, orderedIDs, 'the fix must reproduce exactly what was POSTed');
+    assert.notDeepEqual(oldWay, orderedIDs,
+        'if this ever matches, the old comparator was not actually broken here');
+});

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -12,6 +12,7 @@ fedConnections, fedPause, fedRevoke, fedPeerStatus, fedGetNetworkName, fedSetNet
 import { mountMriBrain } from './mri-brain.js';
 import { restartBaselineBootID, requestedRestartIsReady } from './restart-proof.js';
 import { buildUpdateBanner } from './update-banner.js';
+import { computeReorderedColumn, applyColumnOrder } from './task-reorder.js';
 import { normalizeFederationJoinState } from './federation-flow.js';
 
 const { h, render, createContext } = preact;
@@ -2272,35 +2273,16 @@ function TasksPage({ sse }) {
 
     async function reorderTask(task, direction, visibleColumnTasks) {
 		if (reorderingColumn) return;
-        // Bounds and neighbours must come from the VISIBLE column, because that is
-        // what the up/down buttons are indexed against. Applying a filtered-space
-        // step of +/-1 to the unfiltered array made the move a silent no-op
-        // whenever a hidden card sat between two visible ones - which the default
-        // view hits routinely via the 7-day done retention, plus domain and agent
-        // filters.
-        const visible = Array.isArray(visibleColumnTasks) && visibleColumnTasks.length
-            ? visibleColumnTasks
-            : tasks.filter(t => t.task_status === task.task_status);
-        const visibleFrom = visible.findIndex(t => t.memory_id === task.memory_id);
-        const visibleTo = visibleFrom + direction;
-        if (visibleFrom < 0 || visibleTo < 0 || visibleTo >= visible.length) return;
-        const neighbourID = visible[visibleTo].memory_id;
-
-        // Swap the two visible cards within the FULL column ordering, leaving any
-        // hidden cards between them exactly where they are.
-        const columnTasks = tasks.filter(t => t.task_status === task.task_status);
-        const from = columnTasks.findIndex(t => t.memory_id === task.memory_id);
-        const to = columnTasks.findIndex(t => t.memory_id === neighbourID);
-        if (from < 0 || to < 0) return;
-        [columnTasks[from], columnTasks[to]] = [columnTasks[to], columnTasks[from]];
-        const orderedIDs = columnTasks.map(t => t.memory_id);
-        const rank = new Map(orderedIDs.map((id, index) => [id, index]));
+        // Index arithmetic lives in task-reorder.js so it can be unit-tested:
+        // bounds must come from the VISIBLE column (what the buttons are indexed
+        // against), and the optimistic update must rewrite only the target
+        // column's slots rather than sorting the whole array with a comparator
+        // that is non-transitive across columns.
+        const orderedIDs = computeReorderedColumn(tasks, visibleColumnTasks, task, direction);
+        if (!orderedIDs) return;
         const previousTasks = tasks;
 		setReorderingColumn(task.task_status);
-        setTasks(prev => [...prev].sort((a, b) => {
-            if (a.task_status !== task.task_status || b.task_status !== task.task_status) return 0;
-            return rank.get(a.memory_id) - rank.get(b.memory_id);
-        }));
+        setTasks(prev => applyColumnOrder(prev, task.task_status, orderedIDs));
         try {
             const res = await reorderTasks(task.task_status, orderedIDs);
             if (res && res.error) throw new Error(res.error);

--- a/web/static/js/task-reorder.js
+++ b/web/static/js/task-reorder.js
@@ -1,0 +1,56 @@
+// Pure helpers for kanban reordering, extracted so the index arithmetic is
+// unit-testable. Both bugs these guard against were live: an up/down click could
+// silently do nothing, and the optimistic board could disagree with what was
+// actually POSTed.
+
+// Compute the new full-column order when a visible card is moved one step.
+//
+// `visibleColumnTasks` is what the operator can actually see (the buttons are
+// indexed against it, and their disabled bounds come from its length), while
+// `allTasks` is the unfiltered state. Applying a filtered-space step of +/-1
+// directly to the unfiltered array made the move a no-op whenever a hidden card
+// sat between two visible ones -- which the default view hits routinely via the
+// 7-day done retention, plus domain and agent filters.
+//
+// Returns null when the move is not possible (already at an end, or the card is
+// missing), so callers can bail without mutating anything.
+export function computeReorderedColumn(allTasks, visibleColumnTasks, task, direction) {
+    const status = task.task_status;
+    const visible = Array.isArray(visibleColumnTasks) && visibleColumnTasks.length
+        ? visibleColumnTasks
+        : allTasks.filter(candidate => candidate.task_status === status);
+
+    const visibleFrom = visible.findIndex(candidate => candidate.memory_id === task.memory_id);
+    const visibleTo = visibleFrom + direction;
+    if (visibleFrom < 0 || visibleTo < 0 || visibleTo >= visible.length) return null;
+    const neighbourID = visible[visibleTo].memory_id;
+
+    // Swap the two VISIBLE cards inside the full column ordering, leaving any
+    // hidden cards between them exactly where they are.
+    const columnTasks = allTasks.filter(candidate => candidate.task_status === status);
+    const from = columnTasks.findIndex(candidate => candidate.memory_id === task.memory_id);
+    const to = columnTasks.findIndex(candidate => candidate.memory_id === neighbourID);
+    if (from < 0 || to < 0) return null;
+    [columnTasks[from], columnTasks[to]] = [columnTasks[to], columnTasks[from]];
+    return columnTasks.map(candidate => candidate.memory_id);
+}
+
+// Apply a new column order to the full task list optimistically.
+//
+// This deliberately does NOT sort. The previous implementation sorted the whole
+// array with a comparator that returned 0 for any pair involving another
+// column, which is non-transitive: V8's sort is free to leave such elements
+// unmoved, so the board could silently keep the old order while the new one had
+// already been POSTed. It only worked while every column happened to be
+// contiguous in `allTasks` -- and every optimistic status rewrite (assign, move,
+// clear-column) breaks that contiguity without relocating the element.
+//
+// Instead, rewrite only the target column's SLOTS, in the given order, leaving
+// every other card at its exact index.
+export function applyColumnOrder(allTasks, status, orderedIDs) {
+    const byID = new Map(allTasks.map(task => [task.memory_id, task]));
+    const ordered = orderedIDs.map(id => byID.get(id)).filter(Boolean);
+    let next = 0;
+    return allTasks.map(task =>
+        task.task_status === status && next < ordered.length ? ordered[next++] : task);
+}


### PR DESCRIPTION
Closes the F3 residual from the v11.11.0 audit.

## The defect

The optimistic update after a reorder sorted the **whole** task array with:

```js
if (a.task_status !== status || b.task_status !== status) return 0;
return rank.get(a.memory_id) - rank.get(b.memory_id);
```

That comparator is **non-transitive** — it returns 0 for any pair involving a card from another column, so V8's sort is free to leave those elements unmoved. It only produced the right answer while every column happened to be contiguous in the array, and every optimistic status rewrite (`doAssign`, `moveTask`, `clearColumn`) breaks that contiguity **in place**, without relocating the element.

Concretely: assign a Planned card to an agent, then reorder inside In Progress before the reload lands. The correct order is POSTed and persisted, but the board keeps showing the old one — so the card visibly doesn't move. That's the same "nothing happened" symptom the visible-index fix already removed once, arriving by a different route.

## The fix

`applyColumnOrder` doesn't sort at all. It rewrites only the target column's **slots**, in the given order, leaving every other card at its exact index.

## Testability

The index arithmetic moves to `web/static/js/task-reorder.js`, following the existing `restart-proof.js` / `update-banner.js` pattern — `app.js` is already an ES module, and `mri-layout.js` set the precedent for importing extracted logic in tests rather than string-matching it.

Five tests, including one that matters more than the others:

```js
assert.notDeepEqual(oldWay, orderedIDs,
    'if this ever matches, the old comparator was not actually broken here');
```

That asserts the **old** comparator produces the wrong answer for the same input — so the defect is recorded as executable evidence rather than described in a commit message.

103/103 frontend tests pass (98 existing + 5 new).