### PR TITLE
feat(cerebrum): show which selective-sync selectors are still waiting

### DIFF
--- a/web/federation_group_auth_test.go
+++ b/web/federation_group_auth_test.go
@@ -284,6 +284,14 @@ func TestFederationGroupListServesPendingConsentSelectors(t *testing.T) {
 			"set instead of the pending selector set, so the dashboard field renders blank "+
 			"and Apply role will destroy the member's selectors", local.ConsentDomains)
 	}
+	// "hr" is selected but NOT promoted -- no domain_add has shared it -- so the
+	// active set must be empty. The dashboard subtracts active from selectors to
+	// tell the operator which choices are still waiting on the domain owner;
+	// serving the same list for both would make an inert selector look live.
+	if len(local.ActiveConsentDomains) != 0 {
+		t.Fatalf("active_consent_domains = %v, want []; an unshared domain must not "+
+			"report as actively delivering", local.ActiveConsentDomains)
+	}
 }
 
 func TestSyncGroupMemberProgressFailsClosedForUnknownAndUnseenState(t *testing.T) {

--- a/web/federation_join.go
+++ b/web/federation_join.go
@@ -1255,6 +1255,13 @@ type syncGroupMemberView struct {
 	// distinguishable, since the dashboard treats undefined as "seed me" and an
 	// empty array as "the operator really has no selectors".
 	ConsentDomains []string `json:"consent_domains"`
+	// ActiveConsentDomains is the promoted subset -- the selectors whose domain is
+	// already inside a live shared root and is therefore actually being delivered.
+	// A selector stays pending until its owner shares that domain, so without this
+	// the dashboard cannot distinguish "syncing" from "waiting", and an operator
+	// who selected a domain before it was shared sees their selector listed while
+	// receiving nothing, with no explanation anywhere in the UI.
+	ActiveConsentDomains []string `json:"active_consent_domains"`
 }
 
 // syncGroupMemberProgress converts durable journal cursors into display state.
@@ -1372,6 +1379,15 @@ func (h *DashboardHandler) handleFedGroupList(w http.ResponseWriter, r *http.Req
 				consent = []string{}
 			}
 			member.ConsentDomains = consent
+			active, aErr := ss.ListGroupMemberConsentDomains(ctx, g.GroupID, mem.MemberChainID)
+			if aErr != nil {
+				fedWriteErr(w, http.StatusInternalServerError, "Failed to read active member consent domains.")
+				return
+			}
+			if active == nil {
+				active = []string{}
+			}
+			member.ActiveConsentDomains = active
 			if mem.MemberChainID != local {
 				delivery, found := peerDelivery[mem.MemberChainID]
 				if !found {

--- a/web/static/css/sage.css
+++ b/web/static/css/sage.css
@@ -5239,3 +5239,14 @@ input[type="range"]::-moz-range-thumb {
     margin: 0 auto 14px;
     line-height: 1.5;
 }
+
+/* Selective-sync selectors that are saved but not yet delivering, because the
+   domain owner has not shared that domain with the group. Without this the
+   operator cannot distinguish a live selector from an inert one. */
+.fed-consent-pending {
+    margin: 4px 0 0;
+    font-size: 12px;
+    line-height: 1.45;
+    color: var(--text-muted);
+}
+.fed-consent-pending strong { color: var(--text); }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -13052,6 +13052,12 @@ function SharingSyncGroupsPanel() {
             // `undefined` falls back.
             const localMember = (group.members || []).find(member => member.chain_id === localChain);
             const localConsent = (localMember && localMember.consent_domains) || [];
+            // A selector only becomes ACTIVE once its domain sits inside a live
+            // shared root, so a selector chosen before the owner shares that
+            // domain is silently inert. Surfacing the difference is the only way
+            // an operator can tell "syncing" from "waiting on the owner".
+            const localActive = (localMember && localMember.active_consent_domains) || [];
+            const pendingOnly = localConsent.filter(tag => !localActive.includes(tag));
             const selectedDomainsValue = draft.selectedDomains !== undefined
                 ? draft.selectedDomains
                 : localConsent.join(', ');
@@ -13091,6 +13097,7 @@ function SharingSyncGroupsPanel() {
                             <h4>This node’s synchronization role</h4>
                             <label>Role<select value=${draft.role || group.local_role || 'enrolled-no-sync'} onChange=${event => patchDraft(groupId, { role: event.target.value })}><option value="full-sync">Full sync</option><option value="selective-sync">Selective sync</option><option value="enrolled-no-sync">Enrolled, no sync</option></select></label>
                             <label>Selective domains<input value=${selectedDomainsValue} onInput=${event => patchDraft(groupId, { selectedDomains: event.target.value })} placeholder="comma separated" /></label>
+                            ${pendingOnly.length > 0 && html`<p class="fed-consent-pending">Waiting on the domain owner: <strong>${pendingOnly.join(', ')}</strong>. These selectors are saved, but nothing is delivered for them until that domain is shared with this group.</p>`}
                             <button class="btn btn-primary" type="submit" disabled=${busy !== ''}>Apply role</button>
                         </form>
                         <form onSubmit=${async event => {


### PR DESCRIPTION
Closes the F4 residual from the v11.11.0 audit.

## The gap

A selective-sync selector only becomes **active** once its domain sits inside a live shared root (`consentTagInSharedSet`, `sync_group_tables.go:835-843`). Until the owner shares that domain, the selector is saved but **inert** — and the dashboard rendered it identically to a live one.

So an operator who selects `hr` before the owner shares `hr`:

- sees `hr` listed in Selective domains
- receives nothing for it
- has **no surface anywhere in CEREBRUM** explaining why

Earlier work fixed the field so it stops *wiping* selectors. This fixes it so the selectors it shows are honest about whether they're doing anything.

## The change

`syncGroupMemberView` now carries `active_consent_domains` (the promoted subset) alongside `consent_domains` (the full selector set). The panel subtracts one from the other and names the difference:

> Waiting on the domain owner: **hr**. These selectors are saved, but nothing is delivered for them until that domain is shared with this group.

## Test

The handler test asserts the two sets are genuinely distinct — `hr` selected with no `domain_add` must report `consent_domains: [hr]` and `active_consent_domains: []`.

Verified to fail when `active` is wrongly served from the pending table:

```
active_consent_domains = [hr], want []; an unshared domain must not report as actively delivering
```

That's the exact shape this change would regress into, given the two getters differ by one word at the call site.

`go build`, `golangci-lint` 0 issues, 98/98 frontend.