### PR TITLE
feat(shell): measure and enforce the shell RSS budget on macOS

### DIFF
--- a/.github/workflows/native-shell.yml
+++ b/.github/workflows/native-shell.yml
@@ -21,6 +21,10 @@ on:
       - "scripts/native-shell-macos-runtime-smoke.test.sh"
       - "scripts/native-shell-macos-offline-smoke.sh"
       - "scripts/native-shell-macos-offline-smoke.test.sh"
+      - "scripts/native-shell-macos-perf-smoke.sh"
+      - "scripts/native-shell-macos-perf-smoke.test.sh"
+      - "scripts/native-shell-perf-evaluate.py"
+      - "scripts/native-shell-perf-evaluate.test.sh"
       - "scripts/native-shell-windows-runtime-smoke.ps1"
       - "scripts/native-shell-windows-runtime-smoke.test.sh"
       - "scripts/acceptance-endpoint-guard.sh"
@@ -46,6 +50,10 @@ on:
       - "scripts/native-shell-macos-runtime-smoke.test.sh"
       - "scripts/native-shell-macos-offline-smoke.sh"
       - "scripts/native-shell-macos-offline-smoke.test.sh"
+      - "scripts/native-shell-macos-perf-smoke.sh"
+      - "scripts/native-shell-macos-perf-smoke.test.sh"
+      - "scripts/native-shell-perf-evaluate.py"
+      - "scripts/native-shell-perf-evaluate.test.sh"
       - "scripts/native-shell-windows-runtime-smoke.ps1"
       - "scripts/native-shell-windows-runtime-smoke.test.sh"
       - "scripts/acceptance-endpoint-guard.sh"
@@ -198,6 +206,21 @@ jobs:
           path: ${{ runner.temp }}/sage-native-shell-macos-offline.*/diagnostics
           if-no-files-found: warn
           retention-days: 7
+      - name: Measure macOS shell performance budgets
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          scripts/native-shell-macos-perf-smoke.sh \
+            desktop/sage-shell/target/${{ matrix.rust-target }}/release/bundle \
+            "${NATIVE_SHELL_VERSION}"
+      - name: Upload macOS performance evidence
+        if: runner.os == 'macOS' && always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-shell-macOS-performance-${{ matrix.rust-target }}
+          path: ${{ runner.temp }}/sage-native-shell-macos-perf.*/diagnostics
+          if-no-files-found: warn
+          retention-days: 7
       - name: Run installed Windows package lifecycle smoke
         if: runner.os == 'Windows'
         shell: pwsh
@@ -253,6 +276,8 @@ jobs:
           scripts/native-shell-linux-runtime-smoke.test.sh
           scripts/native-shell-macos-runtime-smoke.test.sh
           scripts/native-shell-macos-offline-smoke.test.sh
+          scripts/native-shell-macos-perf-smoke.test.sh
+          scripts/native-shell-perf-evaluate.test.sh
           scripts/native-shell-windows-runtime-smoke.test.sh
           test -s docs/desktop-shell-decision.md
           test -s docs/native-app-daemon-contract.md

--- a/docs/native-shell-quality-gates.md
+++ b/docs/native-shell-quality-gates.md
@@ -253,11 +253,26 @@ instrumentation that does not exist yet: the shell emits no paint, interactive,
 recovery-shown, or frame-timing signal, so they cannot be observed from outside
 the process at all. Building that instrumentation is the v11.14 hardening work.
 
-No harness measures any of these rows yet, including the RSS row that blocks
-from v11.11 — that instrumentation is still to be written. Until it exists this
-table is a set budget, not a measured one, and nothing here should be read as
-evidence that the ceilings have been met. Calibrating the ceilings against real
-numbers is a prerequisite for v11.14 making them blocking.
+macOS now measures the two rows that are observable without shell-side
+instrumentation. `native-shell-macos-perf-smoke.sh` launches the staged app
+against an isolated `SAGE_HOME`, waits for a renderable SSCP state, then samples
+every process running the exact shell executable — the daemon is identified
+separately and excluded from the budget, but recorded for context. Sampling
+starts only after the app is renderable, because these are settled-state budgets
+rather than startup peaks.
+
+**Incremental shell RSS is enforced from v11.11**; settled idle CPU is recorded
+only. The threshold logic lives in `native-shell-perf-evaluate.py` so its
+FAILING path is testable without a macOS runner: the suite drives it over the
+ceiling, exactly at it, with zero samples, and with two shell processes whose
+sum breaches it. A harness whose failure path has never executed is not
+evidence.
+
+The remaining seven rows are still unmeasured, and are blocked on
+instrumentation rather than hardware — the shell emits no paint, interactive,
+recovery-shown or frame-timing signal, so they cannot be observed from outside
+the process at all. Until that exists those rows are set budgets, not measured
+ones, and nothing here should be read as evidence that they have been met.
 
 From v11.14, three consecutive benchmark runs must pass. A regression of more
 than 10% against the last published release fails even when the absolute ceiling

--- a/scripts/native-shell-macos-perf-smoke.sh
+++ b/scripts/native-shell-macos-perf-smoke.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# Measure the v11.11 performance rows that are observable without shell-side
+# instrumentation: incremental shell RSS (blocking) and settled idle CPU
+# (recorded only).
+#
+# RSS blocks because it is the premise of the framework decision, not because it
+# is convenient: desktop-shell-decision.md rejected Electron at 358,720 KiB
+# against this exact 200 MiB ceiling and selected Tauri at 142,544 KiB. The
+# other seven budgets need paint/interactive/frame signals the shell does not
+# emit, and become blocking in v11.14. See docs/native-shell-quality-gates.md.
+#
+# Written for bash 3.2 so it runs against the system bash on an Apple runner.
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "native-shell performance smoke requires macOS" >&2
+  exit 1
+fi
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <tauri-bundle-root> <expected-version>" >&2
+  exit 1
+fi
+
+BUNDLE_ROOT=$1
+EXPECTED_VERSION=$2
+if [ ! -d "${BUNDLE_ROOT}" ]; then
+  echo "native-shell bundle root does not exist: ${BUNDLE_ROOT}" >&2
+  exit 1
+fi
+BUNDLE_ROOT=$(cd "${BUNDLE_ROOT}" && pwd -P)
+
+# 200 MiB, the ceiling that vetoed Electron in the framework decision.
+RSS_CEILING_KIB=204800
+
+list_matches() {
+  local dir=$1
+  shift
+  if [ ! -d "${dir}" ]; then
+    return 0
+  fi
+  find "${dir}" "$@" 2>/dev/null || true
+}
+
+exactly_one() {
+  local label=$1 matches=$2 count
+  count=$(printf '%s' "${matches}" | grep -c . || true)
+  if [ "${count}" -ne 1 ]; then
+    echo "expected exactly one ${label}, found ${count}" >&2
+    return 1
+  fi
+  printf '%s\n' "${matches}" | head -1
+}
+
+STAGED_APP=$(exactly_one 'staged macOS app' \
+  "$(list_matches "${BUNDLE_ROOT}/macos" -maxdepth 1 -type d -name '*.app')")
+SHELL_EXECUTABLE=$(exactly_one 'shell executable' \
+  "$(list_matches "${STAGED_APP}/Contents/MacOS" -maxdepth 1 -type f)")
+BUNDLED_DAEMON="${STAGED_APP}/Contents/Resources/binaries/sage-gui"
+test -x "${BUNDLED_DAEMON}"
+
+SMOKE_ROOT=$(cd "$(mktemp -d "${RUNNER_TEMP:-/tmp}/sage-native-shell-macos-perf.XXXXXX")" && pwd -P)
+SAGE_SMOKE_HOME="${SMOKE_ROOT}/home"
+DIAGNOSTICS="${SMOKE_ROOT}/diagnostics"
+SHELL_LOG="${DIAGNOSTICS}/shell.log"
+SAMPLES="${DIAGNOSTICS}/process-samples.txt"
+mkdir -p "${SAGE_SMOKE_HOME}" "${DIAGNOSTICS}"
+: > "${SAMPLES}"
+
+TRACKED_PIDS=""
+SAMPLER_PID=""
+
+track_pid() {
+  case " ${TRACKED_PIDS} " in
+    *" $1 "*) ;;
+    *) TRACKED_PIDS="${TRACKED_PIDS} $1" ;;
+  esac
+}
+
+process_path() {
+  ps -p "$1" -o comm= 2>/dev/null || true
+}
+
+stop_exact_pid() {
+  local pid=$1 expected=$2 actual deadline
+  if ! kill -0 "${pid}" 2>/dev/null; then
+    return 0
+  fi
+  actual=$(process_path "${pid}")
+  if [ -n "${expected}" ] && [ -n "${actual}" ] && [ "${actual}" != "${expected}" ]; then
+    echo "refusing to signal pid ${pid}: expected ${expected}, found ${actual}" >&2
+    return 1
+  fi
+  kill -TERM "${pid}" 2>/dev/null || true
+  deadline=$((SECONDS + 10))
+  while [ "${SECONDS}" -lt "${deadline}" ] && kill -0 "${pid}" 2>/dev/null; do
+    sleep 0.1
+  done
+  if kill -0 "${pid}" 2>/dev/null; then
+    kill -KILL "${pid}" 2>/dev/null || true
+  fi
+}
+
+discover_daemon_pid() {
+  python3 - "${SAGE_SMOKE_HOME}/run/shell-control.sock" 2>/dev/null <<'PY' || true
+import socket
+import sys
+
+try:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as stream:
+        stream.settimeout(2)
+        stream.connect(sys.argv[1])
+        pid = int.from_bytes(stream.getsockopt(0, 2, 4), sys.byteorder)
+        if pid > 0:
+            print(pid)
+except OSError:
+    pass
+PY
+}
+
+cleanup() {
+  local original_status=$1 pid stray
+  trap - EXIT
+  set +e
+  if [ -n "${SAMPLER_PID}" ] && kill -0 "${SAMPLER_PID}" 2>/dev/null; then
+    kill -TERM "${SAMPLER_PID}" 2>/dev/null
+  fi
+  stray=$(discover_daemon_pid)
+  if [ -n "${stray}" ]; then
+    track_pid "${stray}"
+  fi
+  for pid in ${TRACKED_PIDS}; do
+    kill -0 "${pid}" 2>/dev/null && kill -TERM "${pid}" 2>/dev/null
+  done
+  sleep 0.5
+  for pid in ${TRACKED_PIDS}; do
+    kill -0 "${pid}" 2>/dev/null && kill -KILL "${pid}" 2>/dev/null
+  done
+  echo "native-shell macOS performance evidence: ${DIAGNOSTICS}"
+  exit "${original_status}"
+}
+trap 'cleanup $?' EXIT
+trap 'exit 130' INT TERM
+
+read -r REST_PORT RPC_PORT P2P_PORT < <(python3 - <<'PY'
+import socket
+
+sockets = []
+try:
+    for _ in range(3):
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        sockets.append(listener)
+    print(*(listener.getsockname()[1] for listener in sockets))
+finally:
+    for listener in sockets:
+        listener.close()
+PY
+)
+EXPECTED_UI_ORIGIN="http://127.0.0.1:${REST_PORT}"
+
+query_status() {
+  python3 - "${SAGE_SMOKE_HOME}/run/shell-control.sock" "${EXPECTED_UI_ORIGIN}" "${EXPECTED_VERSION}" <<'PY'
+import json
+import re
+import socket
+import struct
+import sys
+import time
+
+endpoint, expected_origin, expected_version = sys.argv[1], sys.argv[2], sys.argv[3]
+request = json.dumps(
+    {"control_protocol": 1, "shell_protocol": 1, "operation": "status"},
+    separators=(",", ":"),
+).encode()
+deadline = time.monotonic() + 90
+last_error = None
+expected_fields = {
+    "control_protocol", "daemon_version", "api_schema", "min_shell_protocol",
+    "max_shell_protocol", "instance_generation", "state", "ui_origin", "startup_proof",
+}
+
+
+def validate(status):
+    if not isinstance(status, dict) or set(status) != expected_fields:
+        raise ValueError("SSCP status schema is not exact")
+    if status["daemon_version"] != expected_version:
+        raise ValueError(f"SSCP daemon version is unsupported: {status['daemon_version']!r}")
+    if not re.fullmatch(r"[A-Za-z0-9_-]{43}", status["instance_generation"]):
+        raise ValueError("SSCP generation is malformed")
+    if status["state"] not in {"ready", "degraded"}:
+        raise ValueError(f"SSCP daemon is not renderable: {status['state']!r}")
+    if status["ui_origin"] != expected_origin:
+        raise ValueError("SSCP UI origin does not match the isolated REST listener")
+
+
+def read_exact(stream, size):
+    chunks, remaining = [], size
+    while remaining:
+        chunk = stream.recv(remaining)
+        if not chunk:
+            raise RuntimeError("SSCP connection closed before the frame completed")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+while time.monotonic() < deadline:
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as stream:
+            stream.settimeout(1)
+            stream.connect(endpoint)
+            daemon_pid = int.from_bytes(stream.getsockopt(0, 2, 4), sys.byteorder)
+            stream.sendall(struct.pack(">I", len(request)) + request)
+            size = struct.unpack(">I", read_exact(stream, 4))[0]
+            status = json.loads(read_exact(stream, size))
+            validate(status)
+            print(json.dumps({"status": status, "daemon_pid": daemon_pid}, sort_keys=True))
+            raise SystemExit(0)
+    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, OSError,
+            RuntimeError, ValueError, json.JSONDecodeError) as error:
+        last_error = error
+        time.sleep(0.1)
+
+raise SystemExit(f"timed out waiting for a renderable SSCP status: {last_error}")
+PY
+}
+
+# Sample RSS and CPU for every process running the exact shell executable, and
+# separately for the exact bundled daemon so the daemon can be excluded from the
+# shell budget while still being recorded for context. Exact absolute executable
+# path only; never a process name.
+sample_processes() {
+  while :; do
+    python3 - "${SHELL_EXECUTABLE}" "${BUNDLED_DAEMON}" >> "${SAMPLES}" 2>/dev/null <<'PY' || true
+import subprocess
+import sys
+import time
+
+shell_path, daemon_path = sys.argv[1], sys.argv[2]
+try:
+    listing = subprocess.run(["ps", "-Ao", "pid=,ppid=,rss=,%cpu=,comm="],
+                             capture_output=True, text=True, timeout=5).stdout
+except Exception:
+    raise SystemExit(0)
+stamp = time.monotonic()
+for line in listing.splitlines():
+    parts = line.strip().split(None, 4)
+    if len(parts) < 5:
+        continue
+    pid, ppid, rss, cpu, path = parts
+    if path == shell_path:
+        role = "shell"
+    elif path == daemon_path:
+        role = "daemon"
+    else:
+        continue
+    print(f"{stamp:.3f}\t{role}\t{pid}\t{ppid}\t{rss}\t{cpu}")
+PY
+    sleep 0.25
+  done
+}
+
+launch_shell() {
+  env \
+    SAGE_HOME="${SAGE_SMOKE_HOME}" \
+    SAGE_NO_BROWSER=1 \
+    REST_ADDR="127.0.0.1:${REST_PORT}" \
+    SAGE_CMT_RPC_ADDR="tcp://127.0.0.1:${RPC_PORT}" \
+    SAGE_CMT_P2P_ADDR="tcp://127.0.0.1:${P2P_PORT}" \
+    "$@" >> "${SHELL_LOG}" 2>&1 &
+  LAUNCHED_PID=$!
+  track_pid "${LAUNCHED_PID}"
+}
+
+launch_shell "${SHELL_EXECUTABLE}"
+SHELL_PID=${LAUNCHED_PID}
+
+STATUS=$(query_status)
+printf '%s\n' "${STATUS}" > "${DIAGNOSTICS}/ready-status.json"
+DAEMON_PID=$(printf '%s\n' "${STATUS}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["daemon_pid"])')
+track_pid "${DAEMON_PID}"
+kill -0 "${SHELL_PID}"
+
+# Only sample once the app is renderable: the budget is a settled-state budget,
+# not a startup transient.
+sample_processes &
+SAMPLER_PID=$!
+sleep 12
+kill -TERM "${SAMPLER_PID}" 2>/dev/null || true
+wait "${SAMPLER_PID}" 2>/dev/null || true
+SAMPLER_PID=""
+
+python3 scripts/native-shell-perf-evaluate.py \
+  "${SAMPLES}" "${RSS_CEILING_KIB}" "${DIAGNOSTICS}/performance.json" \
+  "$(sw_vers -productVersion)" "$(sw_vers -buildVersion)" "$(uname -m)" "${EXPECTED_VERSION}"
+
+stop_exact_pid "${SHELL_PID}" "${SHELL_EXECUTABLE}"
+wait "${SHELL_PID}" 2>/dev/null || true
+stop_exact_pid "${DAEMON_PID}" ""
+
+echo "native-shell macOS performance smoke passed"

--- a/scripts/native-shell-macos-perf-smoke.test.sh
+++ b/scripts/native-shell-macos-perf-smoke.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+HARNESS="${ROOT}/scripts/native-shell-macos-perf-smoke.sh"
+bash -n "${HARNESS}"
+
+for required in \
+  'RSS_CEILING_KIB=204800' \
+  'native-shell-perf-evaluate.py' \
+  'sample_processes' \
+  'stop_exact_pid' \
+  'discover_daemon_pid' \
+  'SAGE_CMT_RPC_ADDR=' \
+  'process-samples.txt'; do
+  if ! grep -Fq "${required}" "${HARNESS}"; then
+    # A bare `grep -Fq` under `set -e` aborts with no output, which makes a
+    # contract failure look like a crash. Say which invariant broke.
+    echo "performance harness is missing a required invariant: ${required}" >&2
+    exit 1
+  fi
+done
+
+# 200 MiB exactly. This is the ceiling the framework decision rests on: the ADR
+# rejected Electron at 358,720 KiB against it and selected Tauri at 142,544 KiB.
+# A silently loosened ceiling would void that decision without anyone noticing.
+python3 - "${HARNESS}" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+m = re.search(r'^RSS_CEILING_KIB=(\d+)', src, re.M)
+assert m, "the RSS ceiling is not declared as a literal"
+assert int(m.group(1)) == 200 * 1024, f"ceiling is {m.group(1)} KiB, expected 204800 (200 MiB)"
+PY
+
+# Same containment rule as the other harnesses: exact executable paths only.
+if grep -Eq 'pkill|killall|/proc/' "${HARNESS}"; then
+  echo 'performance harness contains broad process-name cleanup' >&2
+  exit 1
+fi
+
+if grep -Eq '(^|[^[:alnum:]_])(mapfile|readarray)([^[:alnum:]_]|$)' "${HARNESS}"; then
+  echo 'performance harness uses bash 4 builtins unavailable on the system bash' >&2
+  exit 1
+fi
+
+if ! grep -Eq 'SMOKE_ROOT=\$\(cd "\$\(mktemp -d.*\)" && pwd -P\)' "${HARNESS}"; then
+  echo 'performance harness does not canonicalize its smoke root' >&2
+  exit 1
+fi
+
+# Sampling must start only AFTER the app is renderable: this is a settled-state
+# budget, not a startup transient, and sampling through boot would measure peak
+# allocation instead.
+python3 - "${HARNESS}" <<'PY'
+import sys
+src = open(sys.argv[1]).read()
+ready = src.index('STATUS=$(query_status)')
+sampler = src.index('sample_processes &')
+assert ready < sampler, "sampling must start after the daemon reports a renderable state"
+PY
+
+fixture=$(mktemp -d "${TMPDIR:-/tmp}/sage-perf-fixture.XXXXXX")
+trap 'rm -rf "${fixture}"' EXIT INT TERM
+if "${HARNESS}" "${fixture}" 11.11.0-contract >"${fixture}/stdout" 2>"${fixture}/stderr"; then
+  echo "performance harness unexpectedly accepted an empty bundle" >&2
+  exit 1
+fi
+if [ "$(uname -s)" = "Darwin" ]; then
+  grep -Fq 'expected exactly one staged macOS app' "${fixture}/stderr"
+else
+  grep -Fq 'requires macOS' "${fixture}/stderr"
+fi
+
+echo "native-shell macOS performance harness contract tests passed"

--- a/scripts/native-shell-perf-evaluate.py
+++ b/scripts/native-shell-perf-evaluate.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Evaluate native-shell process samples against the v11.11 performance budgets.
+
+Extracted from native-shell-macos-perf-smoke.sh so the threshold logic can be
+tested directly, including the OVER-ceiling case. A harness whose failure path
+has never executed is not evidence.
+
+Blocking: incremental shell RSS <= 200 MiB. That ceiling is the premise of the
+framework decision -- desktop-shell-decision.md rejected Electron at 358,720 KiB
+against it and selected Tauri at 142,544 KiB -- so it is the one performance
+number with a live decision riding on it.
+
+Recorded only: settled idle CPU. It becomes blocking in v11.14 and needs a named
+baseline machine, because hosted-runner variance is wider than the 1% budget.
+See docs/native-shell-quality-gates.md.
+
+usage: native-shell-perf-evaluate.py <samples> <ceiling-kib> <out-json>
+                                     <os-version> <os-build> <arch> <version>
+"""
+import json
+import sys
+from collections import defaultdict
+
+samples_path, ceiling_kib, out_path = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+os_version, os_build, arch, expected_version = sys.argv[4], sys.argv[5], sys.argv[6], sys.argv[7]
+
+by_stamp = defaultdict(lambda: {"shell_rss": 0, "shell_cpu": 0.0, "daemon_rss": 0, "shell_pids": set()})
+with open(samples_path) as handle:
+    for line in handle:
+        parts = line.rstrip("\n").split("\t")
+        if len(parts) != 6:
+            continue
+        stamp, role, pid, _ppid, rss, cpu = parts
+        bucket = by_stamp[stamp]
+        if role == "shell":
+            bucket["shell_rss"] += int(rss)
+            bucket["shell_cpu"] += float(cpu)
+            bucket["shell_pids"].add(pid)
+        else:
+            bucket["daemon_rss"] += int(rss)
+
+if not by_stamp:
+    print("no process samples were collected; the shell was never observed", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def pct(values, p):
+    ordered = sorted(values)
+    if not ordered:
+        return 0
+    index = min(len(ordered) - 1, int(round((p / 100.0) * (len(ordered) - 1))))
+    return ordered[index]
+
+
+shell_rss = [b["shell_rss"] for b in by_stamp.values()]
+shell_cpu = [b["shell_cpu"] for b in by_stamp.values()]
+daemon_rss = [b["daemon_rss"] for b in by_stamp.values()]
+process_counts = [len(b["shell_pids"]) for b in by_stamp.values()]
+
+rss_p50, rss_p95 = pct(shell_rss, 50), pct(shell_rss, 95)
+cpu_p50, cpu_p95 = pct(shell_cpu, 50), pct(shell_cpu, 95)
+
+record = {
+    "schema": "dev.sage.native-shell.macos-performance/v1",
+    "os_version": os_version,
+    "os_build": os_build,
+    "arch": arch,
+    "build_version": expected_version,
+    "samples": len(by_stamp),
+    "shell_process_count_max": max(process_counts),
+    "shell_rss_kib": {"p50": rss_p50, "p95": rss_p95, "max": max(shell_rss)},
+    "shell_idle_cpu_percent": {"p50": round(cpu_p50, 2), "p95": round(cpu_p95, 2)},
+    "daemon_rss_kib_excluded_from_budget": {"p50": pct(daemon_rss, 50), "p95": pct(daemon_rss, 95)},
+    "budgets": {
+        "shell_rss_kib_ceiling": ceiling_kib,
+        "shell_rss_blocking_from": "v11.11",
+        "idle_cpu_percent_ceiling": 1.0,
+        "idle_cpu_blocking_from": "v11.14",
+    },
+    "measurement_limits": [
+        "RSS covers processes running the exact shell executable path. macOS WebKit "
+        "content/GPU/network processes are XPC services rather than children and are "
+        "not attributed here; the ADR baseline of 142,544 KiB was likewise a single "
+        "process, so this is comparable to it but is not whole-system cost.",
+        "Idle CPU is recorded only. It becomes blocking in v11.14 and needs a named "
+        "baseline machine, because hosted runner variance is wider than the 1% budget.",
+    ],
+}
+with open(out_path, "w") as handle:
+    json.dump(record, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+
+print(json.dumps(record["shell_rss_kib"], sort_keys=True))
+print(f"samples={len(by_stamp)} shell_processes_max={max(process_counts)} "
+      f"idle_cpu_p95={cpu_p95:.2f}% daemon_rss_p95={pct(daemon_rss, 95)} KiB")
+
+if rss_p95 > ceiling_kib:
+    print(f"shell RSS p95 {rss_p95} KiB exceeds the {ceiling_kib} KiB ceiling that the "
+          f"framework decision rests on", file=sys.stderr)
+    raise SystemExit(1)
+print(f"shell RSS p95 {rss_p95} KiB is within the {ceiling_kib} KiB ceiling "
+      f"(ADR reference: Tauri 142,544 KiB, Electron rejected at 358,720 KiB)")

--- a/scripts/native-shell-perf-evaluate.test.sh
+++ b/scripts/native-shell-perf-evaluate.test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Drive the performance evaluator directly with synthetic samples, so the
+# BLOCKING path is exercised. The harness that produces these samples needs a
+# real macOS runner; the evaluator does not, so its threshold logic is tested
+# here on every platform.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+EVAL="${ROOT}/scripts/native-shell-perf-evaluate.py"
+test -x "${EVAL}"
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/sage-perf-eval.XXXXXX")
+trap 'rm -rf "${WORK}"' EXIT INT TERM
+
+# stamp \t role \t pid \t ppid \t rss \t cpu
+samples() {
+  local out=$1 shell_rss=$2
+  {
+    printf '1.000\tshell\t100\t1\t%s\t0.4\n' "${shell_rss}"
+    printf '1.000\tdaemon\t200\t100\t70000\t1.1\n'
+    printf '1.250\tshell\t100\t1\t%s\t0.5\n' "${shell_rss}"
+    printf '1.250\tdaemon\t200\t100\t70100\t1.2\n'
+  } > "${out}"
+}
+
+# --- under the ceiling: passes, and the daemon is excluded from the budget ---
+samples "${WORK}/under.txt" 142544
+python3 "${EVAL}" "${WORK}/under.txt" 204800 "${WORK}/under.json" 14.8 23J arm64 11.11.0 \
+  > "${WORK}/under.out" 2>&1
+grep -Fq "is within the 204800 KiB ceiling" "${WORK}/under.out"
+python3 - "${WORK}/under.json" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+assert r["shell_rss_kib"]["p95"] == 142544, r["shell_rss_kib"]
+assert r["daemon_rss_kib_excluded_from_budget"]["p95"] >= 70000, r
+assert r["budgets"]["shell_rss_blocking_from"] == "v11.11", r["budgets"]
+assert r["budgets"]["idle_cpu_blocking_from"] == "v11.14", r["budgets"]
+assert r["shell_process_count_max"] == 1, r
+PY
+
+# --- over the ceiling: MUST fail. This is the path that makes the gate real. ---
+samples "${WORK}/over.txt" 262144
+if python3 "${EVAL}" "${WORK}/over.txt" 204800 "${WORK}/over.json" 14.8 23J arm64 11.11.0 \
+  > "${WORK}/over.out" 2>&1; then
+  echo "evaluator accepted an RSS p95 above the ceiling" >&2
+  exit 1
+fi
+grep -Fq "exceeds the 204800 KiB ceiling" "${WORK}/over.out"
+
+# The evidence record must still be written on failure, or a breach leaves no trace.
+test -s "${WORK}/over.json"
+python3 - "${WORK}/over.json" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+assert r["shell_rss_kib"]["p95"] == 262144, r["shell_rss_kib"]
+PY
+
+# --- exactly at the ceiling passes: the budget is "<=", not "<" ---
+samples "${WORK}/edge.txt" 204800
+python3 "${EVAL}" "${WORK}/edge.txt" 204800 "${WORK}/edge.json" 14.8 23J arm64 11.11.0 >/dev/null 2>&1
+
+# --- no samples is a failure, not a silent pass ---
+: > "${WORK}/empty.txt"
+if python3 "${EVAL}" "${WORK}/empty.txt" 204800 "${WORK}/empty.json" 14.8 23J arm64 11.11.0 \
+  > "${WORK}/empty.out" 2>&1; then
+  echo "evaluator passed with zero samples; an unobserved shell is not a pass" >&2
+  exit 1
+fi
+grep -Fq "no process samples" "${WORK}/empty.out"
+
+# --- multiple shell processes are summed, not silently taking the first ---
+{
+  printf '1.000\tshell\t100\t1\t120000\t0.4\n'
+  printf '1.000\tshell\t101\t100\t100000\t0.3\n'
+} > "${WORK}/multi.txt"
+if python3 "${EVAL}" "${WORK}/multi.txt" 204800 "${WORK}/multi.json" 14.8 23J arm64 11.11.0 \
+  >/dev/null 2>&1; then
+  echo "220000 KiB across two shell processes must breach a 204800 KiB ceiling" >&2
+  exit 1
+fi
+
+echo "native-shell performance evaluator tests passed"


### PR DESCRIPTION
Adds the first actual performance measurement to the native-shell CI matrix, covering the two rows observable without shell-side instrumentation.

## Why RSS specifically

The 200 MiB ceiling is the **premise of the framework decision**, not a convenience. `desktop-shell-decision.md` rejected Electron at **358,720 KiB** against it and selected Tauri at **142,544 KiB**. If the shipped shell drifts past it, SAGE has taken on Rust and a per-platform WebView matrix — and given up Electron's stronger tooling and accessibility — for a benefit it no longer has.

That makes it the one performance number with a live decision riding on it, which is why it's **enforced from v11.11** while settled idle CPU is **recorded only** (it blocks from v11.14 and needs a named baseline machine — hosted-runner variance is wider than the 1% budget).

## What it measures

Launches the staged app against an isolated `SAGE_HOME`, waits for a renderable SSCP state, then samples every process running the exact shell executable path. The bundled daemon is identified separately — **by executable path, never by name**, matching the other harnesses — and excluded from the shell budget while still recorded for context.

Sampling starts only **after** the app is renderable, because these are settled-state budgets, not startup peaks. The contract test asserts that ordering.

## The failure path is actually tested

The threshold logic is extracted into `native-shell-perf-evaluate.py` precisely so its **failing** path can run without a macOS runner. The suite drives it:

- over the ceiling → must fail
- exactly at the ceiling → must pass (the budget is `<=`)
- with zero samples → must fail, because an unobserved shell is not a pass
- with two shell processes whose **sum** breaches → must fail
- and asserts the evidence record is still written on breach, so a violation leaves a trace rather than just an exit code

A harness whose failure path has never executed is not evidence — that's the lesson from the two release defects that shipped in code no gate could reach.

## Guarding the ceiling itself

The contract test pins it to exactly 200 MiB, so a silently loosened budget fails rather than quietly voiding the ADR. I also fixed my own test's diagnostics: a bare `grep -Fq` under `set -e` aborts with no output, which makes a contract failure look like a crash. It now names the invariant that broke.

## Doc correction

The gate record previously said no harness measured any of these rows. That was true when written and no longer is; it now states what's measured, what's enforced from when, and that the remaining seven rows are blocked on **instrumentation, not hardware** — the shell emits no paint, interactive, recovery-shown or frame-timing signal.

## Verification

End-to-end against a synthetic Tauri-shaped bundle: passes, no leaked processes or mounts. All seven native-shell contract suites pass. 98/98 frontend.

The real numbers arrive when this runs on the macOS runner — the ADR's reference point is 142,544 KiB, so there should be visible headroom under 204,800.