### PR TITLE
fix(docker): run the managed reranker on a glibc runtime image (Alpine→Debian)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,20 @@ ARG VERSION=dev
 ARG COMMIT=unknown
 RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" -o /sage-gui ./cmd/sage-gui
 
-FROM alpine:3.20
-RUN apk add --no-cache ca-certificates
+# Runtime is glibc (Debian), not Alpine/musl: SAGE's managed reranker
+# (internal/rerankd) downloads and execs a prebuilt llama.cpp `llama-server`
+# engine, and llama.cpp publishes only glibc/Ubuntu Linux builds — no musl or
+# fully-static asset (checked b9870 and latest). That binary's ELF interpreter
+# is /lib64/ld-linux-x86-64.so.2 and it NEEDs libstdc++.so.6, libgomp.so.1,
+# libssl.so.3 and libcrypto.so.3, none of which exist on alpine, so on the old
+# Alpine image the engine exited instantly ("llama-server exited during
+# startup") and the managed reranker was non-functional in the container.
+# sage-gui itself is CGO_ENABLED=0 static and runs unchanged on either base.
+FROM debian:bookworm-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates libstdc++6 libgomp1 libssl3 \
+ && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /sage-gui /usr/local/bin/sage-gui
 
 ENV SAGE_HOME=/root/.sage


### PR DESCRIPTION
## What

The managed reranker (`internal/rerankd` → CEREBRUM *"Set up the reranker"*) is **non-functional in the official Docker image on Linux**, independent of network/download. This switches the runtime image from Alpine/musl to `debian:bookworm-slim` so the bundled engine can actually run.

## Why

`rerankd` downloads and execs a prebuilt llama.cpp `llama-server` cross-encoder engine. For `linux/amd64` and `linux/arm64` it pins the **glibc/Ubuntu** llama.cpp build — and llama.cpp publishes **no musl or fully-static Linux asset** (I checked the pinned `b9870` and the current latest release; every Linux asset is `ubuntu-*`).

But the official runtime image is Alpine/musl (`FROM alpine:3.20`, only `ca-certificates`). The engine binary's ELF interpreter is `/lib64/ld-linux-x86-64.so.2`, and it hard-`NEEDED`s `libstdc++.so.6`, `libgomp.so.1`, `libssl.so.3` and `libcrypto.so.3` (the OpenSSL pair via `libllama-server-impl.so` / `libllama-common.so`). None exist on the Alpine image, so the kernel can't resolve the interpreter, the child exits instantly, and SAGE surfaces *"llama-server exited during startup"*.

Scope: `sage-gui` itself is `CGO_ENABLED=0` static and runs fine on Alpine — only the external engine is affected. Native installs (macOS, glibc Linux hosts) work, and the bring-your-own **Reranker URL** path (`NewHTTPReranker`) is unaffected — which is why this doesn't show up outside a container.

## How

```diff
-FROM alpine:3.20
-RUN apk add --no-cache ca-certificates
+FROM debian:bookworm-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates libstdc++6 libgomp1 libssl3 \
+ && rm -rf /var/lib/apt/lists/*
```

bookworm's glibc 2.36 / GLIBCXX 3.4.31 clear the engine's 2.34 / 3.4.21 floors. The builder stage (`golang:1.25-alpine`) is untouched — the static Go binary runs on either base. **`deploy/Dockerfile.abci` is intentionally unchanged**: it builds the `amid`-only indexer image, which never execs the reranker.

(`libssl3` is listed explicitly because the engine links OpenSSL directly; `ca-certificates` also pulls it in via `Depends: openssl`, so it's belt-and-suspenders rather than strictly required — happy to drop it if you prefer the minimal list.)

## Validation (built + run locally with podman)

- Real root Dockerfile builds on the new base; `sage-gui` boots in it.
- All four engine libs + the glibc loader are present in the shipped image (`/lib64/ld-linux-x86-64.so.2`, `libstdc++.so.6`, `libgomp.so.1`, `libssl.so.3`, `libcrypto.so.3`).
- The exact pinned `b9870` `llama-server` execs on the Debian base (fails on Alpine, as diagnosed).
- Note: no PR-triggered workflow builds the *root* `Dockerfile` (CI's Docker Build targets `deploy/Dockerfile.abci`; the root image is built only by `release.yml` on tag) — hence the local build/boot verification above.

## Cost & your call

This grows the image **~74 MB → ~153 MB (+79 MB)** — the base swap, not the packages. That's the real tradeoff, so if Alpine is a deliberate size/attack-surface choice, you may prefer a different shape. Options, in case:

1. **This PR** — `debian:bookworm-slim` + the exact libs. Robust, matches what the engine was built against.
2. **Distroless glibc** (`gcr.io/distroless/cc-*`) — smaller, but no shell (harder healthcheck/debug) and awkward to add `libgomp1`/`libssl3`.
3. **Keep Alpine + `gcompat`** — smallest change, but `gcompat` is a partial shim; a stock Ubuntu-built llama.cpp can hit GLIBC symbol-versioning/TLS issues under it, and it'd need re-testing on every engine bump. Least reliable.
4. **Keep Alpine + document** — detect musl in `Manager.Start()` and return an actionable error ("managed reranker needs a glibc image or a Reranker URL"). Honest, but doesn't enable the feature.

I went with #1 because it's the only one I could verify end-to-end, but the base-image decision is yours — glad to reshape toward any of the above.
