### PR TITLE
docs: document App-v25 recovery and caller standing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,30 +85,37 @@ Container: `ghcr.io/l33tdawg/sage:11.16.3`. SDK 11.16.3.
 
 ## What's New in v11.16.2
 
-**One historical record can no longer take CEREBRUM or every agent offline.**
-v11.16.1 still returned a global `503` when it encountered a canonical
-zero-hash record, a deterministic SQL/canonical envelope mismatch, a malformed
-record-local envelope, or a canonical record whose SQL projection was missing.
-v11.16.2 quarantines each affected record individually. Broad list/search,
-graph, timeline, stats, and dashboard-health reads continue with the readable
-set and carry an explicit partial-projection marker. Authenticated broad routes
-used by the local CEREBRUM operator also report only the aggregate hidden
-count. Public health and ordinary signed agents keep the generic warning and
-never receive that count.
+**App-v25 repairs historical continuity without rewriting history.** It is the
+strict H+1 successor to app-v24. New submissions receive an immutable
+canonical envelope: a memory ID can be replayed exactly, but cannot later be
+reused for different content, author, domain, or classification. That closes
+the old projection-overwrite path that could leave an agent able to write a
+domain but unable to read it back.
 
-`/ready` now returns HTTP `200` with status `degraded` after a complete audit
-has localized the unsafe records. It still returns `503` when the audit did not
-complete, the canonical store is unavailable, or a real infrastructure
-dependency is down. This keeps supervisors, MCP bootstrap, `sage_inception`,
-and healthy agent work online while preserving strict handling of actual
-backend failures.
+On upgrade, SAGE scans historical SQL rows against canonical state in the
+background. Complete, content-hash-verified records are adopted through
+bounded Root-authorized, validator-attested governance batches. No memory
+content, author attribution, domain, classification, or earlier block is
+rewritten. For each recovered local domain, the earliest verified historical
+writer is retained as the operational owner; every other verified local writer
+is restored into the exact local Access Group with read/write continuity. If
+the earliest writer is no longer a valid local principal, CEREBRUM Root owns
+the recovered domain rather than promoting a later writer by guesswork.
 
-Exact/detail, related, tags, task-derived views, and portable export remain
-unavailable while any requested result cannot be verified. Hidden records are
-not deleted, rewritten, or silently called verified: CEREBRUM says they remain
-preserved for governed recovery or deprecation. Existing consensus rules,
-AppHash inputs, application version 24, memories, domains, keys, and chain
-history are unchanged.
+**One bad historical row can no longer blank CEREBRUM or take agents offline.**
+v11.16.2 quarantines each unverified record individually. Broad list/search,
+graph, timeline, stats, and dashboard-health reads continue with the verified
+set and disclose a partial-projection state. A completed audit returns
+`/ready` as HTTP `200` / `degraded`; actual backend failures and incomplete
+audits remain unavailable. This keeps supervisors, MCP bootstrap,
+`sage_inception`, and healthy agent work online without pretending incomplete
+data is safe.
+
+Unreadable or conflicting records are preserved byte-for-byte. CEREBRUM Root
+can retry the evidence scan or explicitly deprecate the exact unresolved
+inventory after a typed confirmation; deprecation retires it from automatic
+repair and normal views but does not delete historical data. See
+[App-v25 upgrade and recovery](docs/reference/app-v25-upgrade-recovery.md).
 
 Container: `ghcr.io/l33tdawg/sage:11.16.2`. SDK 11.16.2.
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -25,6 +25,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/clearance-classification.md`](concepts/clearance-classification.md) | Per-record classification (0–4), the REST-vs-wire default gotcha, and the per-record query gate. |
 | [`concepts/rbac-orgs-federation.md`](concepts/rbac-orgs-federation.md) | Orgs, departments, agent clearance, cross-org federation, cross-chain peer Read/Copy RBAC, why peer Write is reserved but unavailable in v11.9, the five-gate query pipeline, and the app-v20 one-chain quorum-scope boundary. |
 | [`app-v23-access-control-design.md`](app-v23-access-control-design.md) | The v11.16.0 contract for Root, Member/Manager/Admin roles, named security profiles, Access Groups, atomic enrollment, linked federated readers, app-v24 readiness and memory integrity, migration, replay, and state sync. |
+| [`app-v25-upgrade-recovery.md`](app-v25-upgrade-recovery.md) | The v11.16.2 strict App-v25 upgrade: immutable new-memory envelopes, automatic historical repair, local writer continuity, record-local quarantine, Root retry/deprecation controls, and readiness semantics. |
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
@@ -51,6 +52,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | Discover connected SAGEs and live-read a domain they share | [`mcp-tools.md`](mcp-tools.md) — `sage_federation`, then `sage_recall` with `federated=true` |
 | Distinguish internet federation, app-v20 quorum replication, and local-vs-network snapshot recovery | [`concepts/rbac-orgs-federation.md`](concepts/rbac-orgs-federation.md) — “v11.9 quorum scopes are not cross-chain federation” |
 | Understand Root handover, local Access Groups, or why a federated agent is read-only | [`app-v23-access-control-design.md`](app-v23-access-control-design.md) + [`concepts/rbac-orgs-federation.md`](concepts/rbac-orgs-federation.md) |
+| Understand why an upgrade is repairing, partially displaying, or preserving historical memories | [`app-v25-upgrade-recovery.md`](app-v25-upgrade-recovery.md) |
 | Configure SAGE via environment variables | [`environment-variables.md`](environment-variables.md) |
 
 ---
@@ -97,6 +99,25 @@ does not apply to ordinary upgraded agents, which retain app-v23 write behavior
 while activation completes. See
 [`app-v23-access-control-design.md`](app-v23-access-control-design.md) — “App-v24
 readiness and memory-write barrier.”
+
+### App-v25 historical recovery and domain continuity
+
+App-v25 is the strict H+1 successor to app-v24. It gives every new memory ID a
+single immutable canonical envelope—content hash, author, domain, and
+classification—so an ID can be replayed exactly but cannot be repurposed into a
+different memory. During the one-time upgrade worker, sound historical evidence
+is repaired automatically through bounded, Root-authorized and
+validator-attested batches. Invalid or incomplete evidence is quarantined one
+record at a time; it does not make the whole brain empty or prevent other
+agents from working.
+
+For a recovered multi-writer local domain, SAGE restores the verified writers'
+read/write continuity through a dedicated local Access Group. The earliest
+verified historical writer remains owner; if that identity cannot safely be
+used, CEREBRUM Root owns the domain rather than guessing. Unresolved records
+remain preserved, and only current Root may retry the scan or explicitly
+deprecate the exact unresolved inventory. See
+[`app-v25-upgrade-recovery.md`](app-v25-upgrade-recovery.md).
 
 ### Clearance / classification (legacy overloaded integer)
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -569,6 +569,32 @@ eligible historical terminal rows from their unchanged canonical content and
 status. Its plan is bounded, generation-bound, atomic, and idempotent; it never
 rewrites memory content, authorship, domain ownership, or prior blocks.
 
+## App-v25 historical recovery and writer continuity
+
+App-v25 is the strict H+1 successor to app-v24. It makes the first accepted
+memory ID an immutable canonical envelope: later submissions may replay that
+exact envelope but cannot reuse the ID for different content, author, domain,
+or classification. It also introduces governed adoption of complete historical
+projection envelopes that were absent from canonical state.
+
+After activation, CEREBRUM automatically scans historical local records. A
+complete hash-verified record is adopted in a bounded Root-bound,
+validator-attested batch without changing its content, authorship, domain,
+classification, or earlier blocks. A conflicting or incomplete row is
+quarantined on its own so it cannot blank the brain or make healthy agent work
+unavailable. Root may retry the exact unresolved snapshot or explicitly retire
+it from automatic repair; neither action deletes its historical evidence.
+
+For each recovered local domain, the earliest verified historical local writer
+is the operational owner. Other verified local historical writers are enrolled
+in the exact local Access Group and receive read/write continuity for that
+domain. The recovery cutoff is immutable: a new app-v25 memory cannot expand
+the historical writer set. If the earliest writer is unavailable, CEREBRUM
+Root owns the recovered domain; a later writer is never silently promoted.
+Federated identities remain linked readers and never enter this local group.
+See [`app-v25-upgrade-recovery.md`](app-v25-upgrade-recovery.md) for the
+operator-facing recovery contract.
+
 ## Mandatory release gates
 
 The v11.16.0 release and app-v24 activation are blocked until all of the

--- a/docs/reference/app-v25-upgrade-recovery.md
+++ b/docs/reference/app-v25-upgrade-recovery.md
@@ -1,0 +1,123 @@
+<!-- Verified against SAGE v11.16.2: internal/abci/app.go (app-v25 gate and immutable envelope), web/appv25_memory_legacy_adoption_worker.go, web/appv25_domain_continuity_worker.go, web/appv25_memory_legacy_adoption_control.go, and internal/store/appv25_domain_continuity.go. -->
+
+# App-v25 Upgrade, Historical Recovery, and Domain Continuity
+
+App-v25 is SAGE v11.16.2's governed recovery upgrade. It fixes historical
+projection defects without relabeling memories, changing their content, or
+rewriting chain history.
+
+## Activation boundary
+
+App-v25 requires app-v24 as its immediate predecessor. The activation block
+uses app-v24 semantics; app-v25 rules begin strictly at the following block
+(H+1). A node never votes for an application version it cannot execute, and
+the binary's current supported ceiling is app version 25.
+
+This is a normal governed chain upgrade. Do not stop automatic advancement of
+the mandatory upgrade ladder: validators must run the exact release binary and
+let the installed governed upgrade complete together. Diverging a node around
+this boundary is not a recovery strategy.
+
+## What changes for new memories
+
+From app-v25 onward, the first accepted submission for a memory ID establishes
+one immutable canonical envelope:
+
+- content hash;
+- submitting author;
+- domain;
+- classification; and
+- lifecycle status.
+
+An exact replay is idempotent. A second submission with the same ID but a
+different envelope is rejected before either canonical or serving state can be
+mutated. This prevents the historical class of SQL-upsert/canonical-state
+mismatch that caused write/read asymmetry.
+
+## Automatic historical repair
+
+After activation, CEREBRUM scans the local serving projection against the
+canonical record inventory in the background. It only adopts a historical row
+when the evidence is complete and exact: the SQL record must match the
+canonical envelope and its content must hash to the recorded canonical hash.
+
+Eligible rows are repaired in bounded, deterministic batches. Each batch is
+bound to the current Root credential generation, re-attested by validators,
+and committed through governance. The repair preserves the memory ID, content,
+content hash, original author attribution, domain, classification, status, and
+earlier blocks. It is idempotent: retrying a completed batch does not create a
+second memory or rewrite history.
+
+The worker can make ordinary records visible again while the rest of the scan
+continues. This is intentional: a localized legacy problem is not a reason to
+blank CEREBRUM, reject healthy writes, or make all agents appear disconnected.
+
+## Local domain continuity
+
+The same verified historical inventory restores local agent authority for
+domains that predate the app-v23 enrollment model.
+
+- The earliest verified historical local writer is the recovered operational
+  domain owner.
+- Every additional verified historical local writer is placed in the same
+  dedicated local Access Group and receives read/write continuity for that
+  exact recovered domain.
+- The recovered writer set is frozen at the upgrade cutoff. New app-v25
+  submissions cannot enlarge it.
+- If the earliest writer is missing, retired, or cannot safely be activated as
+  a local principal, CEREBRUM Root owns the recovered domain. A later writer is
+  never silently promoted in its place.
+- Root and an eligible local Admin retain their normal governing authority;
+  federated agents remain linked readers and never become local group members
+  or remote writers.
+
+This restores operational access only. It never changes the immutable author
+record on a historical memory.
+
+## When a historical row cannot be repaired
+
+A row is preserved but excluded when, for example, its canonical content hash
+is absent or incorrect, its record-local envelope conflicts with canonical
+state, required identity/domain/classification evidence is absent, or its
+content cannot be decrypted. One excluded row is quarantined on its own; it
+does not invalidate the verified remainder of the local projection.
+
+Broad CEREBRUM views display verified records and a partial-projection state.
+They do not call the brain empty. Exact/detail and export operations remain
+strict for any record they would need to disclose.
+
+After an audit has completed and localized the unsafe rows, `/ready` reports
+HTTP `200` with `status: "degraded"`. It remains unavailable when the audit has
+not completed, canonical storage is unavailable, or another actual serving
+dependency is down. `degraded` therefore means normal work can continue on the
+verified set; it is not a claim that every historical row is usable.
+
+## Root resolution controls
+
+Only the current local CEREBRUM Root may control unresolved historical rows.
+The browser-only, loopback-protected recovery control exposes aggregate
+progress, not the unresolved records' content or identities.
+
+| Action | Route | Result |
+|---|---|---|
+| Inspect aggregate progress | `GET /v1/dashboard/memory/adoption-progress` | Current scan state and aggregate discovered/converted/remaining/recovery counts. |
+| Retry scan | `POST /v1/dashboard/memory/adoption-retry` | Requests a new evidence scan for the exact current unresolved snapshot. It does not erase records, receipts, or previous decisions. |
+| Explicitly deprecate unresolved snapshot | `POST /v1/dashboard/memory/adoption-deprecate` | Requires the exact snapshot revision/count plus typed `DEPRECATE <count>` confirmation. Preserves rows for audit and prevents automatic repair from retrying those exact IDs. |
+
+These controls are intentionally not ordinary REST or MCP agent operations.
+They are Root-only CEREBRUM recovery actions on localhost. An SDK client or
+agent must not fabricate a replacement envelope, re-submit an unresolved
+memory ID, or treat deprecation as deletion.
+
+## What App-v25 does not do
+
+- It does not delete memories or rewrite historical blocks.
+- It does not turn a remote/federated agent into a local writer.
+- It does not give a newly discovered agent access merely because it shares a
+  display name with a historical author.
+- It does not make a broad query's zero result proof that the global store is
+  empty; authorization and verified-projection scope still apply.
+- It does not expose Root recovery controls through a remote CEREBRUM session.
+
+For generic roles, profiles, Access Groups, Root handover, and federation
+boundaries, see [`app-v23-access-control-design.md`](app-v23-access-control-design.md).

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -2,8 +2,9 @@
 
 # RBAC, Organizations, and Federation
 
-Verified against code at SAGE v11.7.0, with the v11.9 quorum/state-sync section
-updated against the 2026-07 opt-in implementation and open release gates.
+Verified against SAGE v11.16.2. Legacy organization/federation sections retain
+their historical context; app-v23 roles, Root, Access Groups, and app-v25
+historical writer continuity are the current local-control model.
 
 ## Overview
 
@@ -106,6 +107,21 @@ When an agent submits a memory to a domain that has no registered owner and is n
 - Exact names: `general`, `self`, `meta` (`app.go:766-770`)
 - Prefix match: `sage-*` (`app.go:780-782`)
 - Any domain with on-chain `shared_domain:<name>` sentinel (set by `TxTypeDomainReassign` with `OpenToShared=true`)
+
+### App-v25 recovered historical-domain continuity
+
+Historical rows from before the app-v23 local-enrollment model are not blindly
+treated as new claims. App-v25 derives continuity only from complete, exact
+canonical evidence. The earliest verified historical local writer remains the
+operational owner; other verified local writers become members of the exact
+recovered Access Group and retain read/write authority on that domain. This is
+not a federation mechanism and it does not alter memory authorship.
+
+If the earliest writer is unavailable as a safe local principal, CEREBRUM Root
+owns the recovered domain. SAGE never promotes a later writer by inference.
+The recovered writer set is fixed at the app-v25 cutoff, so a new memory cannot
+expand it. Linked federated readers remain read-only and never become group
+members. See [`../app-v25-upgrade-recovery.md`](../app-v25-upgrade-recovery.md).
 
 ### Explicit Grants
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -12,6 +12,22 @@ signer, regardless of optional ledger state. Older vault-sealed keyed rows
 rewrap on their next successful unlocked authentication. Only
 consensus-committed memories are returned to callers.
 
+### App-v25 recovery is automatic; agents do not repair history themselves
+
+On an app-v25 node, SAGE automatically repairs complete, hash-verified
+historical memory evidence and restores verified local writer continuity in
+bounded governed batches. A malformed or conflicting old record is quarantined
+individually; it must not make a healthy agent claim that its whole memory is
+empty. `sage_status` is the caller-safe way to learn the signed identity's
+standing and usable counts. It is not a recovery control.
+
+There is intentionally no MCP tool to rewrite, re-submit, assign, or
+deprecate the preserved historical inventory. Root-only retry/deprecation is a
+localhost CEREBRUM recovery action; see
+[`app-v25-upgrade-recovery.md`](app-v25-upgrade-recovery.md). Agents should
+continue ordinary work on verified domains, report any exact read/write error,
+and never manufacture a replacement for a historical record.
+
 ---
 
 ## Boot Sequence — Read This First

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -528,7 +528,14 @@ register_agent(
 
 `POST /v1/agent/register`
 
-Registers the identity's public key on-chain. `role`: `"member"` | `"admin"` | `"observer"`.
+Registers the identity's public key on-chain. On an app-v23/app-v25 node,
+registration is discoverability—not self-promotion. A new ordinary identity
+is a Member pending CEREBRUM review unless it is a verified first-party
+bootstrap enrollment. `manager` and `admin` are Root-governed local roles;
+supplying a stronger role in a self-registration request does not grant it.
+Use `get_profile()` immediately after registration to see the caller's own
+`registration_status`, `enrollment_status`, hard capability mask, approved
+home domain, and whether CEREBRUM action is required.
 
 Returns `AgentRegistration(agent_id, name, registered_name, role, provider, status, on_chain_height, tx_hash)`.
 
@@ -560,8 +567,19 @@ Optional fields (present when the server provides them): `display_name`,
 `domains`, `accuracy` (global verdict-correctness EWMA), and — since v8.6.0 —
 `corr_count` (lifetime corroboration) and `domain_expertise`
 (`dict[str, float]`, per-domain expertise keyed by domain tag), plus
-`on_chain_height`. The new fields are `Optional` with `None` defaults, so the
-model still validates against an older server that omits them.
+`on_chain_height`. The SDK v11.16.2 also preserves the additive app-v23
+caller-standing fields: `role`, `profile`, `home_domain`,
+`enrollment_status`, `registration_status`, `approval_required`, `clearance`,
+`capabilities`, `can_read`, `can_write`, and `access_scope`. All are optional
+for compatibility with older SAGE servers. The `can_*` fields describe the
+caller on its approved home domain; they do not claim authority over every
+domain.
+
+App-v25 historical repair is deliberately not an SDK mutation API. SAGE
+repairs sound historical evidence automatically in governed batches; local
+CEREBRUM Root alone can retry or explicitly deprecate an unresolved snapshot
+through the loopback recovery screen. SDK clients should surface standing and
+normal write/read errors, never fabricate or re-submit a repair envelope.
 
 ---
 
@@ -585,7 +603,7 @@ list_agents() -> dict
 
 `GET /v1/agents`
 
-The SDK signs this request. Since v11.16/app-v24, the server returns only the
+The SDK signs this request. Since v11.16/app-v23, the server returns only the
 active ordinary local roster visible through the pipeline identity boundary;
 the endpoint is no longer an unsigned full-directory read.
 
@@ -606,7 +624,11 @@ set_agent_permission(
 
 `PUT /v1/agent/{agent_id}/permission`
 
-Admin only. All kwargs are optional — only supplied fields are sent.
+Compatibility method for pre-app-v23 nodes only. Once app-v23 is active, the
+server returns HTTP `410 app_v23_atomic_policy_required`: role, profile,
+clearance, hard restrictions, and home domain must be approved together through
+the loopback CEREBRUM policy control. Keep this SDK method only when supporting
+an older chain; do not use it to attempt self-promotion.
 
 ---
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -739,7 +739,7 @@ Register agent on-chain. Idempotent — returns existing record if already regis
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `name` | string | yes | Display name |
-| `role` | string | no | `admin`, `member`, `observer`; defaults to `member` |
+| `role` | string | no | Compatibility registration hint. On app-v23/app-v25 a self-registration is an ordinary pending Member; this field cannot self-grant `manager` or `admin`. CEREBRUM Root approves the real local role/profile/home-domain bundle atomically. |
 | `boot_bio` | string | no | Agent system prompt / bio |
 | `provider` | string | no | e.g. `claude-code`, `cursor` |
 | `p2p_address` | string | no | Peer-to-peer address |
@@ -758,6 +758,13 @@ Register agent on-chain. Idempotent — returns existing record if already regis
   "on_chain_height": 42
 }
 ```
+
+An app-v23/app-v25 client should immediately call signed `GET /v1/agent/me`.
+That caller-only response reports whether the key is `pending_review`, its
+capability restrictions, and the exact operator action still required. It is
+the supported self-diagnostic surface; `GET /v1/agents` is a signed,
+active-only visible roster and must not be used to infer a pending caller's
+standing.
 
 **Response (existing, HTTP 200):** Same shape with `"status": "already_registered"`. `on_chain_height` is populated on both paths since v6.6.0.
 
@@ -938,6 +945,9 @@ Pre-app-v23 nodes retain their legacy projection behavior.
 | `GET /v1/dashboard/network/access/linked-messages/consent?remote_chain_id=...&remote_agent_id=...&local_agent_id=...` | Read the receiver-local, default-off consent and CAS revision for one exact currently linked remote-to-local agent tuple. |
 | `PUT /v1/dashboard/network/access/linked-messages/consent` | Set `accepting` for one exact tuple using `expected_revision`; never creates a read link, contact, group membership, domain grant, role, or write authority. |
 | `POST /v1/dashboard/network/access/root/handover` | Dedicated current-Root-only credential handover with irreversible confirmation, exact phrase, and expected Root generation. Returns the replacement recovery archive once with `Cache-Control: no-store`. |
+| `GET /v1/dashboard/memory/adoption-progress` | Root/operator aggregate App-v25 historical-recovery progress. It returns counts and state only—never the hidden records' content, domains, authors, or reasons. |
+| `POST /v1/dashboard/memory/adoption-retry` | Current-Root-only request for a fresh scan of the exact unresolved App-v25 snapshot. Requires its `projection_revision` and `expected_count`; it never deletes rows or clears earlier dispositions. |
+| `POST /v1/dashboard/memory/adoption-deprecate` | Current-Root-only retirement of the exact unresolved snapshot. Requires `projection_revision`, `expected_count`, and typed `DEPRECATE <count>` confirmation. Records remain preserved for audit and are skipped by future automatic repair. |
 
 The roles are `member`, `manager`, and `admin`. Roles define verbs; consensus
 Access Groups define local scope; clearance caps readable classification; and
@@ -2306,6 +2316,14 @@ export because labeling a partial local projection as a complete backup would
 be unsafe. A receiver completed before v11.16 without this exact baseline
 remains fail-closed until the operator explicitly repairs or repeats state sync;
 startup never infers an allowlist from the receiver's current SQL contents.
+
+`app_v25_maintenance` reports the current process's one-time historical
+adoption/continuity verification. It is intentionally a readiness signal, not
+a record-disclosure API. While its state is `waiting`, `migrating`,
+`attesting`, or localized `recovery`, normal verified serving remains available
+as `degraded` (HTTP 200 by default; `?strict=1` makes it 503). An incomplete
+or unlocalized canonical projection remains `not_ready` regardless of this
+field. See [`app-v25-upgrade-recovery.md`](app-v25-upgrade-recovery.md).
 
 The embedder status is refreshed by a ~30s background watchdog (see the node's
 `startEmbedderWatchdog`).

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.16.3 SDK** | **TLS, app-v23 roles and Access Groups, app-v24 memory integrity, read-only federation, domain recovery, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.16.3 SDK** | **TLS, app-v23 roles and Access Groups, app-v24 memory integrity, app-v25 immutable envelopes and automatic historical continuity recovery, read-only federation, domain recovery, scoped governance, and per-record `classification` supported**
 
 ## Installation
 
@@ -112,7 +112,7 @@ Before an agent can participate in the SAGE network, it must register on-chain. 
 # Register on-chain (first time only — idempotent)
 reg = client.register_agent(
     name="security-analyst",       # Human-readable name
-    role="member",                 # "member", "admin", or "observer"
+    role="member",                 # self-registration never self-promotes
     boot_bio="Analyzes CVEs",      # Optional: agent description
     provider="claude-code",        # Optional: LLM provider identifier
 )
@@ -121,8 +121,9 @@ reg = client.register_agent(
 # Update your profile
 client.update_agent(name="security-analyst-v2", boot_bio="Updated bio")
 
-# Get your profile (PoE weight, vote count)
+# Get your caller-scoped profile and access standing
 profile = client.get_profile()       # GET /v1/agent/me
+print(profile.enrollment_status, profile.home_domain, profile.can_write)
 
 # Get any registered agent's info
 agent = client.get_agent("a1b2c3...")  # GET /v1/agent/{id}
@@ -131,13 +132,9 @@ agent = client.get_agent("a1b2c3...")  # GET /v1/agent/{id}
 # List active ordinary agents visible to this signed caller
 agents = client.list_agents()        # GET /v1/agents → {"agents": [...], "total": N}
 
-# Set agent permissions (admin only)
-client.set_agent_permission(
-    agent_id="a1b2c3...",
-    clearance=2,                     # 0=Public, 1=Internal, 2=Confidential, 3=Secret, 4=TopSecret
-    org_id="org-uuid",
-    dept_id="dept-uuid",
-)
+# On app-v23/app-v25, role/profile/group changes happen through the local
+# CEREBRUM Root/Admin controls. Do not call the legacy set_agent_permission()
+# endpoint: the server retires it with HTTP 410 after activation.
 ```
 
 ### Memory Operations
@@ -871,7 +868,7 @@ def hash_embed(text: str, dim: int = 768) -> list[float]:
 | `PUT` | `/v1/agent/update` | `update_agent()` |
 | `GET` | `/v1/agent/me` | `get_profile()` |
 | `GET` | `/v1/agent/{id}` | `get_agent()` |
-| `PUT` | `/v1/agent/{id}/permission` | `set_agent_permission()` |
+| `PUT` | `/v1/agent/{id}/permission` | `set_agent_permission()` — pre-app-v23 compatibility only; v11.16 returns HTTP 410 and directs policy changes to local CEREBRUM. |
 | `GET` | `/v1/agents` | `list_agents()` |
 
 ### Pipeline

--- a/sdk/python/src/sage_sdk/models.py
+++ b/sdk/python/src/sage_sdk/models.py
@@ -293,6 +293,19 @@ class AgentProfile(BaseModel):
     # present for domains the agent has actually voted in.
     domain_expertise: dict[str, float] | None = None
     on_chain_height: int | None = None
+    # App-v23 caller-scoped standing. These are intentionally additive so an
+    # SDK can still read a profile from an older server that omits them.
+    role: str | None = None
+    profile: str | None = None
+    home_domain: str | None = None
+    enrollment_status: str | None = None
+    registration_status: str | None = None
+    approval_required: bool | None = None
+    clearance: int | None = None
+    capabilities: int | None = None
+    can_read: bool | None = None
+    can_write: bool | None = None
+    access_scope: str | None = None
 
 
 class AgentRegistration(BaseModel):

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -433,3 +433,32 @@ def test_agent_profile_tolerates_old_server_omitting_poe_signals():
     assert profile.corr_count is None
     assert profile.domain_expertise is None
     assert profile.accuracy is None
+
+
+def test_agent_profile_parses_app_v23_caller_standing():
+    # A pending-review identity must be able to learn its own standing without
+    # reading a roster or probing a forbidden memory route. The SDK must retain
+    # this additive app-v23 response surface for callers to act on it.
+    from sage_sdk.models import AgentProfile
+
+    profile = AgentProfile.model_validate({
+        "agent_id": "abc123",
+        "poe_weight": 0.0,
+        "vote_count": 0,
+        "role": "member",
+        "profile": "pending_review",
+        "home_domain": "local-abc123",
+        "enrollment_status": "pending_review",
+        "registration_status": "pending_review",
+        "approval_required": True,
+        "clearance": 0,
+        "capabilities": 30,
+        "can_read": False,
+        "can_write": False,
+        "access_scope": "home_domain",
+    })
+
+    assert profile.enrollment_status == "pending_review"
+    assert profile.approval_required is True
+    assert profile.capabilities == 30
+    assert profile.can_write is False


### PR DESCRIPTION
## Summary\n- document App-v25 automatic historical repair, record-local quarantine, and recovered local writer continuity\n- clarify caller-scoped standing and post-App-v23 enrollment behavior across README, REST, MCP, and Python SDK docs\n- expose additive caller-standing fields in Python AgentProfile, with regression coverage\n\n## Verification\n- PYTHONPATH=src python3 -m pytest -q (147 passed)\n- git diff --check