### PR TITLE
fix: recover stale app-v23 projections on startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1083,6 +1083,52 @@ jobs:
           gh release view "${RELEASE_TAG}" --json assets --jq '.assets[].name' | sort > /tmp/remote-assets.txt
           diff -u /tmp/local-assets.txt /tmp/remote-assets.txt
 
+  verify-staged-macos-release:
+    name: Verify Staged macOS Release Assets
+    runs-on: macos-latest
+    needs: [stage-github-release, release-metadata]
+    permissions:
+      contents: read
+    steps:
+      # Artifact checks during packaging are necessary but not sufficient: this
+      # repeats the verification against the exact DMGs uploaded to the private
+      # GitHub draft, before that draft can be made public.
+      - name: Download and verify the staged signed applications
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir staged-macos
+          gh release download "${RELEASE_TAG}" \
+            --pattern "SAGE-${RELEASE_TAG}-macOS-*.dmg" \
+            --pattern "SAGE-${RELEASE_TAG}-macOS-*.dmg.sha256" \
+            --dir staged-macos
+
+          for arch in arm64 x86_64; do
+            dmg="staged-macos/SAGE-${RELEASE_TAG}-macOS-${arch}.dmg"
+            checksum="${dmg}.sha256"
+            test -s "${dmg}"
+            test -s "${checksum}"
+            (
+              cd staged-macos
+              shasum -a 256 -c "$(basename "${checksum}")"
+            )
+
+            mount_point=$(mktemp -d)
+            cleanup_mount() {
+              hdiutil detach "${mount_point}" >/dev/null 2>&1 || true
+              rmdir "${mount_point}" >/dev/null 2>&1 || true
+            }
+            trap cleanup_mount EXIT
+            hdiutil attach -readonly -nobrowse -mountpoint "${mount_point}" "${dmg}"
+            codesign --verify --deep --strict --verbose=4 "${mount_point}/SAGE.app"
+            spctl --assess --type execute --verbose=4 "${mount_point}/SAGE.app"
+            xcrun stapler validate "${dmg}"
+            cleanup_mount
+            trap - EXIT
+          done
+
   publish-docker-version:
     name: Publish Immutable Docker Version
     runs-on: ubuntu-latest
@@ -1285,7 +1331,7 @@ jobs:
   publish-github-release:
     name: Publish GitHub Release Last
     runs-on: ubuntu-latest
-    needs: [publish-docker-latest, release-metadata]
+    needs: [publish-docker-latest, verify-staged-macos-release, release-metadata]
     permissions:
       contents: write
     steps:

--- a/internal/store/appv23_agent_projection.go
+++ b/internal/store/appv23_agent_projection.go
@@ -162,14 +162,15 @@ func reconcileAppV23AgentProjections(
 				onChain.AgentID, err,
 			)
 		}
-		if onChain.Role != role.Role ||
-			onChain.Clearance != enrollment.Clearance ||
-			onChain.Capabilities != enrollment.Capabilities {
-			return projected, fmt.Errorf(
-				"committed app-v23 agent/policy projection mismatch for %s",
-				onChain.AgentID,
-			)
-		}
+		// Role, clearance, and capabilities are serving fields derived from the
+		// independently committed role and enrollment records. Older upgrade
+		// paths can retain a stale value in the duplicate agent-shaped record;
+		// that must never turn a rebuildable local projection into a node-wide
+		// startup failure. Normalize the transient source before rebuilding
+		// SQLite. This deliberately does not write BadgerDB outside consensus.
+		onChain.Role = role.Role
+		onChain.Clearance = enrollment.Clearance
+		onChain.Capabilities = enrollment.Capabilities
 
 		entry := appV23ProjectedAgentEntry(
 			onChain,

--- a/internal/store/appv23_agent_projection_test.go
+++ b/internal/store/appv23_agent_projection_test.go
@@ -24,15 +24,15 @@ func TestReconcileAppV23AgentProjectionsNormalizesStaleAgentShapedPolicy(t *test
 	// current policy; the local SQLite projection must be rebuilt from them.
 	require.NoError(t, badgerStore.update(func(txn *badger.Txn) error {
 		var stale OnChainAgent
-		if err := appV23ReadJSON(txn, agentOnChainKey(agentID), &stale); err != nil {
-			return err
+		if readErr := appV23ReadJSON(txn, agentOnChainKey(agentID), &stale); readErr != nil {
+			return readErr
 		}
 		stale.Role = AppV23RoleManager
 		stale.Clearance = 4
 		stale.Capabilities = AgentCapabilityReadAllDomains
-		data, err := appV23Marshal(stale)
-		if err != nil {
-			return err
+		data, marshalErr := appV23Marshal(stale)
+		if marshalErr != nil {
+			return marshalErr
 		}
 		return badgerStore.txnSet(txn, appV23ProjectedAgentKey(agentID), data)
 	}))

--- a/internal/store/appv23_agent_projection_test.go
+++ b/internal/store/appv23_agent_projection_test.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileAppV23AgentProjectionsNormalizesStaleAgentShapedPolicy(t *testing.T) {
+	ctx := context.Background()
+	badgerStore, err := NewBadgerStore(filepath.Join(t.TempDir(), "badger"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, badgerStore.CloseBadger()) })
+
+	rootID := appV23Register(t, badgerStore, "projection-root", AppV23RoleAdmin, 1, 0)
+	agentID := appV23Register(t, badgerStore, "projection-member", AppV23RoleMember, 2, 0)
+	require.NoError(t, badgerStore.EnsureAppV23Root("projection-reconciliation", 10))
+
+	// Simulate the legacy duplicate agent-shaped policy record left stale by an
+	// older upgrade path. The role and enrollment records are the canonical
+	// current policy; the local SQLite projection must be rebuilt from them.
+	require.NoError(t, badgerStore.update(func(txn *badger.Txn) error {
+		var stale OnChainAgent
+		if err := appV23ReadJSON(txn, agentOnChainKey(agentID), &stale); err != nil {
+			return err
+		}
+		stale.Role = AppV23RoleManager
+		stale.Clearance = 4
+		stale.Capabilities = AgentCapabilityReadAllDomains
+		data, err := appV23Marshal(stale)
+		if err != nil {
+			return err
+		}
+		return badgerStore.txnSet(txn, appV23ProjectedAgentKey(agentID), data)
+	}))
+
+	sqliteStore, err := NewSQLiteStore(ctx, filepath.Join(t.TempDir(), "projection.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sqliteStore.Close()) })
+
+	count, err := ReconcileAppV23AgentProjections(ctx, sqliteStore, badgerStore)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "CEREBRUM Root is not an ordinary agent projection")
+
+	projected, err := sqliteStore.GetAgent(ctx, agentID)
+	require.NoError(t, err)
+	require.Equal(t, AppV23RoleMember, projected.Role)
+	require.Equal(t, 1, projected.Clearance)
+	require.Zero(t, projected.Capabilities)
+	rootProjection, err := sqliteStore.GetAgent(ctx, rootID)
+	require.Error(t, err)
+	require.Nil(t, rootProjection)
+}

--- a/internal/store/appv23_local_rbac.go
+++ b/internal/store/appv23_local_rbac.go
@@ -5314,9 +5314,12 @@ func (s *BadgerStore) ValidateAppV23State() error {
 			} else if projectionErr != nil {
 				return projectionErr
 			}
-			if agent.Role != role.Role || agent.Clearance != enrollment.Clearance || agent.Capabilities != enrollment.Capabilities {
-				return fmt.Errorf("app-v23 agent projection mismatch for %s", agentID)
-			}
+			// The duplicate agent-shaped record is a historical serving
+			// projection. Role, clearance, and capability authority lives in the
+			// separately versioned role and enrollment records validated above.
+			// Older upgrade paths can leave those derived fields stale; startup
+			// rebuilds its SQLite projection from the canonical policy instead of
+			// bricking the whole node over that recoverable drift.
 			if enrollment.Active && agentID != root.PrincipalID && enrollment.Profile != AppV23ProfileReadOnly {
 				if enrollment.HomeDomain == "" &&
 					AppV23AllowsMigratedDomainless(


### PR DESCRIPTION
## What this fixes
- Prevents recoverable drift in duplicate app-v23 agent-shaped records from stopping the daemon and taking CEREBRUM offline.
- Rebuilds the local SQLite serving projection from the canonical role and enrollment records; it never rewrites chain history or Badger outside consensus.
- Adds a regression test covering the stale-projection startup case.
- Verifies the exact signed macOS DMG on the private GitHub draft before a release can be made public.

## Verification
- `go test ./internal/store -count=1`
- Reproduced the original local node failure, built the patched daemon, and confirmed the recovered node is healthy on `127.0.0.1:8080`.
- Built a Developer-ID-signed replacement `SAGE.app`; `codesign --verify --deep --strict` passed before and after installation.