### PR TITLE
ci: restore private draft verification for v11.17.2 recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1221,7 +1221,10 @@ jobs:
     runs-on: macos-latest
     needs: [stage-github-release, release-metadata]
     permissions:
-      contents: read
+      # Draft releases are visible only to callers with push access. Keep the
+      # broader workflow read-only and elevate only this verifier so it can
+      # resolve and download the exact private assets staged by the prior job.
+      contents: write
     steps:
       # Artifact checks during packaging are necessary but not sufficient: this
       # repeats the verification against the exact DMGs uploaded to the private

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1283,6 +1283,11 @@ jobs:
             done
           done
 
+          # No GitHub API call is needed below this point. In particular, do
+          # not let a staged executable inherit repository write authority
+          # when the verifier runs its local `version` smoke check.
+          unset GH_TOKEN
+
           for arch in arm64 x86_64; do
             for dmg_name in \
               "SAGE-${RELEASE_TAG}-macOS-${arch}.dmg" \

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1077,11 +1077,12 @@ test('public mutations are serial, resumable, and downstream of the gate', () =>
   assert.doesNotMatch(workflow, /git push/);
 });
 
-test('write permissions exist only at the publication boundary', () => {
+test('write permissions exist only at the private verification and publication boundary', () => {
   assert.match(workflow, /^permissions:\n  contents: read$/m);
   assert.doesNotMatch(job('goreleaser-prepare'), /contents: write|packages: write|id-token: write/);
   assert.doesNotMatch(job('docker-image'), /contents: write|packages: write|id-token: write/);
   assert.match(job('stage-github-release'), /contents: write/);
+  assert.match(job('verify-staged-macos-release'), /contents: write/);
   assert.match(job('publish-docker-version'), /packages: write/);
   assert.match(job('publish-mcp'), /id-token: write/);
   assert.match(job('publish-docker-latest'), /packages: write/);


### PR DESCRIPTION
## Problem

The v11.17.2 release staged all 38 assets, but `Verify Staged macOS Release Assets` saw zero drafts. GitHub exposes draft releases only to callers with push access, while that job explicitly reduced its token to `contents: read`.

## Fix

Grant `contents: write` only to the staged macOS verifier. The workflow stays read-only globally, and no publication job gains additional authority.

## Recovery

After merge, dispatch the protected-main Release workflow with `release_tag=v11.17.2`. It uses the corrected workflow while checking out the immutable v11.17.2 tag for release inputs.

## Verification

- `git diff --check`
- workflow YAML parses successfully
- all build, test, app-v26, package, and draft-staging jobs in run 30866551498 passed; failure was exactly `Expected exactly one private draft for v11.17.2; found 0`.