### PR TITLE
fix: make fresh federation enrollment usable across real route sets

### DIFF
--- a/cmd/sage-gui/config_test.go
+++ b/cmd/sage-gui/config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/rand"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -76,6 +77,21 @@ func TestSelectFederationRouteAddressesKeepsMultipleRelayCandidates(t *testing.T
 	selected, err := selectFederationRouteAddresses(addrs)
 	require.NoError(t, err)
 	assert.Equal(t, addrs, selected)
+}
+
+func TestSelectFederationRouteAddressesNeverExceedsEnrollmentLimit(t *testing.T) {
+	addrs := make([]string, 0, 10)
+	for i := 0; i < 5; i++ {
+		addrs = append(addrs, fmt.Sprintf("/ip4/10.0.0.%d/tcp/1/p2p/destination", i+1))
+	}
+	for i := 0; i < 5; i++ {
+		addrs = append(addrs, fmt.Sprintf("/ip4/198.51.100.%d/tcp/2/p2p/relay-%d/p2p-circuit/p2p/destination", i+1, i+1))
+	}
+	selected, err := selectFederationRouteAddresses(addrs)
+	require.NoError(t, err)
+	assert.Len(t, selected, maxFederationDirectRoutes+maxFederationRelayRoutes)
+	assert.Equal(t, addrs[:maxFederationDirectRoutes], selected[:maxFederationDirectRoutes])
+	assert.Equal(t, addrs[5:5+maxFederationRelayRoutes], selected[maxFederationDirectRoutes:])
 }
 
 func TestSelectFederationRouteAddressesAllowsDirectWithoutRelay(t *testing.T) {

--- a/cmd/sage-gui/federation_routes.go
+++ b/cmd/sage-gui/federation_routes.go
@@ -10,9 +10,14 @@ import (
 
 	"github.com/l33tdawg/sage/internal/federation"
 	sagep2p "github.com/l33tdawg/sage/internal/p2p"
+	"github.com/l33tdawg/sage/internal/totp"
 )
 
-const federationP2PCandidateTimeout = 2 * time.Second
+const (
+	federationP2PCandidateTimeout = 2 * time.Second
+	maxFederationDirectRoutes     = 4
+	maxFederationRelayRoutes      = totp.MaxEnrollmentRouteCount - maxFederationDirectRoutes
+)
 
 func localFederationRouteBundle(transport *sagep2p.Transport) (federation.JoinP2PBundle, error) {
 	if transport == nil {
@@ -29,8 +34,8 @@ func localFederationRouteBundle(transport *sagep2p.Transport) (federation.JoinP2
 }
 
 func selectFederationRouteAddresses(all []string) ([]string, error) {
-	direct := make([]string, 0, 4)
-	relay := make([]string, 0, 4)
+	direct := make([]string, 0, maxFederationDirectRoutes)
+	relay := make([]string, 0, maxFederationRelayRoutes)
 	seen := make(map[string]struct{})
 	for _, addr := range all {
 		if addr == "" {
@@ -41,10 +46,10 @@ func selectFederationRouteAddresses(all []string) ([]string, error) {
 		}
 		seen[addr] = struct{}{}
 		if strings.Contains(addr, "/p2p-circuit/") {
-			if len(relay) < 4 {
+			if len(relay) < maxFederationRelayRoutes {
 				relay = append(relay, addr)
 			}
-		} else if len(direct) < 4 {
+		} else if len(direct) < maxFederationDirectRoutes {
 			direct = append(direct, addr)
 		}
 	}

--- a/cmd/sage-gui/federation_routes.go
+++ b/cmd/sage-gui/federation_routes.go
@@ -112,8 +112,17 @@ func dialFederationP2PRouteTargets(ctx context.Context, targets []string, dial f
 			defer attemptCancel()
 			start := time.Now()
 			conn, err := dial(attemptCtx, target)
+			selectedTarget := target
+			if actualTarget, limited, ok := sagep2p.InspectConnectionRoute(conn); ok {
+				selectedTarget = actualTarget
+				if limited {
+					kind = federation.RouteKindRelay
+				} else {
+					kind = federation.RouteKindP2PDirect
+				}
+			}
 			result := federation.PeerRouteDialResult{
-				Conn: conn, Kind: kind, Target: target, Latency: time.Since(start),
+				Conn: conn, Kind: kind, Target: selectedTarget, Latency: time.Since(start),
 			}
 			if authenticate != nil {
 				result, err = authenticate(attemptCtx, result, err)

--- a/cmd/sage-gui/federation_routes_test.go
+++ b/cmd/sage-gui/federation_routes_test.go
@@ -30,6 +30,14 @@ func (c *trackedRouteConn) Close() error {
 	return c.Conn.Close()
 }
 
+type routedTestConn struct {
+	*trackedRouteConn
+	target  string
+	limited bool
+}
+
+func (c *routedTestConn) P2PRoute() (string, bool) { return c.target, c.limited }
+
 func TestDialFederationP2PRouteTargetsClosesConcurrentLoser(t *testing.T) {
 	first, firstPeer := net.Pipe()
 	second, secondPeer := net.Pipe()
@@ -128,6 +136,28 @@ func TestDialFederationP2PRouteTargetsAuthenticatesBeforeChoosingWinner(t *testi
 	assert.Same(t, goodTracked, winner.Conn)
 	assert.True(t, winner.Authenticated)
 	require.Eventually(t, badTracked.closed.Load, time.Second, 5*time.Millisecond)
+	require.NoError(t, winner.Conn.Close())
+}
+
+func TestDialFederationP2PRouteTargetsReportsReusedLiveRelay(t *testing.T) {
+	raw, peerConn := net.Pipe()
+	t.Cleanup(func() { _ = peerConn.Close() })
+	tracked := &trackedRouteConn{Conn: raw}
+	conn := &routedTestConn{
+		trackedRouteConn: tracked,
+		target:           "/ip4/192.0.2.9/tcp/4001/p2p/relay/p2p-circuit/p2p/peer",
+		limited:          true,
+	}
+	winner, handled, err := dialFederationP2PRouteTargets(
+		context.Background(),
+		[]string{"/ip4/127.0.0.1/tcp/4002/p2p/peer"},
+		func(context.Context, string) (net.Conn, error) { return conn, nil },
+		nil,
+	)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, federation.RouteKindRelay, winner.Kind)
+	assert.Equal(t, conn.target, winner.Target)
 	require.NoError(t, winner.Conn.Close())
 }
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1678,6 +1678,13 @@ scope and every ballot whose pinned roster contains it is terminal.
 
 **Response** (HTTP 200): `{"scopes": [...], "count": 1}`
 
+The local CEREBRUM UI reads the same canonical projection through
+`GET /v1/dashboard/chain/scopes`. That dashboard route requires an
+authenticated same-machine operator session; it is not a replacement signed
+agents can use remotely. Browser code must not call `/v1/scopes` directly,
+because a dashboard session cannot manufacture the Ed25519 request signature
+required by the agent REST surface.
+
 ---
 
 ### `GET /v1/scopes/{scope_id}`

--- a/internal/federation/join_ceremony_test.go
+++ b/internal/federation/join_ceremony_test.go
@@ -332,7 +332,7 @@ func TestAutoHostJoinWindowAcceptsDirectCAFetchFromLegacyGuest(t *testing.T) {
 	legacyURL, err := url.Parse(create.OTPAuthURI)
 	require.NoError(t, err)
 	query := legacyURL.Query()
-	for _, key := range []string{"x_sage_transport", "x_sage_proto", "x_sage_peer", "x_sage_addrs"} {
+	for _, key := range []string{"x_sage_transport", "x_sage_proto", "x_sage_peer", "x_sage_addr"} {
 		query.Del(key)
 	}
 	legacyURL.RawQuery = query.Encode()
@@ -344,13 +344,24 @@ func TestAutoHostJoinWindowAcceptsDirectCAFetchFromLegacyGuest(t *testing.T) {
 func TestHostCreateAutoUsesPreparedDirectBundle(t *testing.T) {
 	host := newCeremonyNode(t, "host-auto-direct")
 	bundle := testDirectRouteBundle(t, "192.168.1.25")
+	calls := 0
 	host.mgr.SetJoinP2PHooks(JoinP2PHooks{
-		LocalBundle: func() (JoinP2PBundle, error) { return bundle, nil },
+		LocalBundle: func() (JoinP2PBundle, error) {
+			calls++
+			if calls > 1 {
+				return JoinP2PBundle{}, errors.New("live route snapshot changed")
+			}
+			return bundle, nil
+		},
 	})
 	create, err := host.mgr.HostCreateAuto("https://192.168.1.20:8444")
 	require.NoError(t, err)
 	assert.Equal(t, "p2p", create.Transport)
 	assert.Contains(t, create.OTPAuthURI, "x_sage_transport=p2p")
+	assert.Equal(t, 1, calls, "HostCreateAuto must emit the exact bundle it validated")
+	enrollment, err := totp.ParseEnrollment(create.OTPAuthURI, false)
+	require.NoError(t, err, "a generated direct-only QR must be accepted by the current parser")
+	assert.Equal(t, bundle.Addrs, enrollment.P2PAddrs)
 }
 
 func TestHostCreateAutoFallsBackToLegacyDirectForOldPeers(t *testing.T) {

--- a/internal/federation/join_ceremony_test.go
+++ b/internal/federation/join_ceremony_test.go
@@ -302,6 +302,45 @@ func TestHostCreateAutoUsesPreparedRelayBundle(t *testing.T) {
 	assert.Contains(t, create.OTPAuthURI, "x_sage_transport=p2p")
 }
 
+// TestAutoHostJoinWindowAcceptsDirectCAFetchFromLegacyGuest covers the mixed
+// route shape used by the dashboard compatibility path: a current host opens
+// one auto/P2P-capable ceremony, while an older/direct-only guest consumes the
+// same code without the optional P2P fields and fetches the host CA over the
+// advertised LAN listener. The host TLS verifier must consult the same live
+// JoinStore populated by HostCreateAuto; otherwise the bootstrap handshake is
+// rejected as "remote error: tls: bad certificate" before HTTP sees the
+// session id.
+func TestAutoHostJoinWindowAcceptsDirectCAFetchFromLegacyGuest(t *testing.T) {
+	host := newCeremonyNode(t, "host-auto-direct")
+	guest := newCeremonyNode(t, "guest-auto-direct")
+	bundle := testRouteBundle(t, "203.0.113.82")
+	host.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LocalBundle: func() (JoinP2PBundle, error) { return bundle, nil },
+	})
+
+	hostTLS, err := host.mgr.ServerTLSConfig()
+	require.NoError(t, err)
+	srv := httptest.NewUnstartedServer(host.mgr.Router())
+	srv.TLS = hostTLS
+	srv.StartTLS()
+	defer srv.Close()
+
+	create, err := host.mgr.HostCreateAuto(srv.URL)
+	require.NoError(t, err)
+	require.Equal(t, "p2p", create.Transport)
+
+	legacyURL, err := url.Parse(create.OTPAuthURI)
+	require.NoError(t, err)
+	query := legacyURL.Query()
+	for _, key := range []string{"x_sage_transport", "x_sage_proto", "x_sage_peer", "x_sage_addrs"} {
+		query.Del(key)
+	}
+	legacyURL.RawQuery = query.Encode()
+
+	_, err = guest.mgr.GuestScan(context.Background(), legacyURL.String(), "https://127.0.0.1:19444")
+	require.NoError(t, err)
+}
+
 func TestHostCreateAutoUsesPreparedDirectBundle(t *testing.T) {
 	host := newCeremonyNode(t, "host-auto-direct")
 	bundle := testDirectRouteBundle(t, "192.168.1.25")

--- a/internal/federation/join_routes.go
+++ b/internal/federation/join_routes.go
@@ -681,7 +681,7 @@ type HostCreateResult struct {
 // HostCreate opens a join session, generates the shared seed, and returns the
 // enrollment QR string (rendered client-side).
 func (m *Manager) HostCreate(hostEndpoint string) (*HostCreateResult, error) {
-	return m.HostCreateMode(hostEndpoint, false)
+	return m.hostCreateWithBundle(hostEndpoint, nil)
 }
 
 // HostCreateAuto is the single product intent. When a direct or relay-backed
@@ -692,9 +692,10 @@ func (m *Manager) HostCreateAuto(hostEndpoint string) (*HostCreateResult, error)
 	hooks := m.joinP2PHooks()
 	if hooks.LocalBundle != nil {
 		if bundle, err := hooks.LocalBundle(); err == nil {
+			bundle.Addrs = append([]string(nil), bundle.Addrs...)
 			bundle = m.prepareLocalRouteBundle(bundle)
 			if validateP2PBundle(bundle) == nil {
-				return m.HostCreateMode(hostEndpoint, true)
+				return m.hostCreateWithBundle(hostEndpoint, &bundle)
 			}
 		}
 	}
@@ -709,10 +710,33 @@ func (m *Manager) HostCreateAuto(hostEndpoint string) (*HostCreateResult, error)
 // exchange roaming routes over authenticated mTLS only after the agreement is
 // active.
 func (m *Manager) HostCreateMode(hostEndpoint string, requireP2P bool) (*HostCreateResult, error) {
+	if !requireP2P {
+		return m.hostCreateWithBundle(hostEndpoint, nil)
+	}
+	hooks := m.joinP2PHooks()
+	if hooks.LocalBundle == nil {
+		return nil, fmt.Errorf("internet connection is not ready: enable P2P and wait for a direct or relay route")
+	}
+	bundle, err := hooks.LocalBundle()
+	if err != nil {
+		return nil, fmt.Errorf("internet connection is not ready: enable P2P and wait for a direct or relay route")
+	}
+	bundle.Addrs = append([]string(nil), bundle.Addrs...)
+	bundle = m.prepareLocalRouteBundle(bundle)
+	if err := validateP2PBundle(bundle); err != nil {
+		return nil, fmt.Errorf("internet connection is not ready: enable P2P and wait for a direct or relay route")
+	}
+	return m.hostCreateWithBundle(hostEndpoint, &bundle)
+}
+
+// hostCreateWithBundle emits exactly the prepared bundle the caller validated.
+// Re-reading live transport addresses here can produce a different QR payload
+// from the one that passed validation a moment earlier.
+func (m *Manager) hostCreateWithBundle(hostEndpoint string, p2pBundle *JoinP2PBundle) (*HostCreateResult, error) {
 	if !m.transportIsEnabled() {
 		return nil, fmt.Errorf("federation transport is disabled")
 	}
-	if requireP2P && hostEndpoint == "" {
+	if p2pBundle != nil && hostEndpoint == "" {
 		hostEndpoint = joinP2POnlyEndpoint
 	}
 	if err := validateJoinEndpoint(hostEndpoint); err != nil {
@@ -734,23 +758,16 @@ func (m *Manager) HostCreateMode(hostEndpoint string, requireP2P bool) (*HostCre
 	uri := totp.ProvisioningURI(seed, m.localChainID, "SAGE", ownPin, hostEndpoint, sidForQR(js.ID), "host")
 	transport := ""
 	hooks := m.joinP2PHooks()
-	if requireP2P && hooks.LocalBundle != nil {
-		if bundle, bundleErr := hooks.LocalBundle(); bundleErr == nil && bundle.PeerID != "" && len(bundle.Addrs) > 0 {
-			bundle = m.prepareLocalRouteBundle(bundle)
-			if setErr := m.joins.SetHostP2P(js.ID, bundle.PeerID, bundle.Addrs); setErr != nil {
-				return nil, setErr
-			}
-			uri = totp.ProvisioningURIWithP2P(seed, m.localChainID, "SAGE", ownPin, hostEndpoint,
-				sidForQR(js.ID), "host", bundle.Protocol, bundle.PeerID, bundle.Addrs)
-			transport = "p2p"
-			if hooks.Begin != nil {
-				hooks.Begin(js.ID, js.ExpiresAt)
-			}
+	if p2pBundle != nil {
+		if setErr := m.joins.SetHostP2P(js.ID, p2pBundle.PeerID, p2pBundle.Addrs); setErr != nil {
+			return nil, setErr
 		}
-	}
-	if requireP2P && transport != "p2p" {
-		_ = m.joins.Abort(js.ID)
-		return nil, fmt.Errorf("internet connection is not ready: enable P2P and wait for a direct or relay route")
+		uri = totp.ProvisioningURIWithP2P(seed, m.localChainID, "SAGE", ownPin, hostEndpoint,
+			sidForQR(js.ID), "host", p2pBundle.Protocol, p2pBundle.PeerID, p2pBundle.Addrs)
+		transport = "p2p"
+		if hooks.Begin != nil {
+			hooks.Begin(js.ID, js.ExpiresAt)
+		}
 	}
 	return &HostCreateResult{
 		SessionID:  js.ID,

--- a/internal/federation/p2p_routes.go
+++ b/internal/federation/p2p_routes.go
@@ -12,6 +12,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/totp"
 )
 
 // p2pRouteBinding is the immutable JOIN generation that authenticated a route
@@ -77,15 +78,17 @@ func (m *Manager) currentP2PRouteBinding(ctx context.Context, remoteChainID stri
 }
 
 func validateP2PBundle(bundle JoinP2PBundle) error {
-	if bundle.Protocol != "/sage/fed/1.0.0" || len(bundle.Addrs) == 0 || len(bundle.Addrs) > 8 {
+	if bundle.Protocol != "/sage/fed/1.0.0" || len(bundle.Addrs) == 0 || len(bundle.Addrs) > totp.MaxEnrollmentRouteCount {
 		return fmt.Errorf("invalid p2p route bundle")
 	}
 	declared, err := peer.Decode(bundle.PeerID)
 	if err != nil {
 		return fmt.Errorf("invalid p2p peer id")
 	}
+	total := 0
 	for _, raw := range bundle.Addrs {
-		if len(raw) == 0 || len(raw) > 512 {
+		total += len(raw)
+		if len(raw) == 0 || len(raw) > totp.MaxEnrollmentRouteLength || total > totp.MaxEnrollmentRouteBytes {
 			return fmt.Errorf("invalid p2p route")
 		}
 		addr, err := ma.NewMultiaddr(raw)

--- a/internal/federation/p2p_routes_test.go
+++ b/internal/federation/p2p_routes_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/totp"
 )
 
 func testRouteBundle(t *testing.T, ip string) JoinP2PBundle {
@@ -50,6 +51,32 @@ func testDirectRouteBundle(t *testing.T, ip string) JoinP2PBundle {
 
 func TestValidateP2PBundleAllowsDirectOnlyRoute(t *testing.T) {
 	require.NoError(t, validateP2PBundle(testDirectRouteBundle(t, "192.168.1.25")))
+}
+
+func TestValidateP2PBundleMatchesEnrollmentBounds(t *testing.T) {
+	bundle := testRouteBundle(t, "203.0.113.90")
+	relayRoute := bundle.Addrs[0]
+
+	bundle.Addrs = make([]string, totp.MaxEnrollmentRouteCount)
+	for i := range bundle.Addrs {
+		bundle.Addrs[i] = relayRoute
+	}
+	require.NoError(t, validateP2PBundle(bundle), "the enrollment route-count ceiling must be accepted")
+
+	bundle.Addrs = append(bundle.Addrs, relayRoute)
+	require.ErrorContains(t, validateP2PBundle(bundle), "invalid p2p route bundle")
+
+	longHost := strings.TrimSuffix(strings.Repeat("abcdefghij.", 18), ".") + ".example"
+	longRoute := strings.Replace(relayRoute, "/ip4/203.0.113.90", "/dns4/"+longHost, 1)
+	require.LessOrEqual(t, len(longRoute), totp.MaxEnrollmentRouteLength)
+	bundle.Addrs = make([]string, 0, totp.MaxEnrollmentRouteCount)
+	total := 0
+	for total <= totp.MaxEnrollmentRouteBytes {
+		bundle.Addrs = append(bundle.Addrs, longRoute)
+		total += len(longRoute)
+	}
+	require.LessOrEqual(t, len(bundle.Addrs), totp.MaxEnrollmentRouteCount)
+	require.ErrorContains(t, validateP2PBundle(bundle), "invalid p2p route")
 }
 
 func bindP2PRouteControl(t *testing.T, m *Manager, remoteChainID, peerAgentID, epoch string) *store.CrossFedRecord {

--- a/internal/p2p/conn.go
+++ b/internal/p2p/conn.go
@@ -49,6 +49,28 @@ func (c *streamConn) RemoteAddr() net.Addr {
 	return streamAddr{value: withPeer(conn.RemoteMultiaddr(), conn.RemotePeer().String())}
 }
 
+// P2PRoute reports the connection libp2p actually selected for this stream.
+// The requested candidate is not authoritative: Host.Connect may reuse an
+// already-open direct or limited relay connection to the same peer.
+func (c *streamConn) P2PRoute() (target string, limited bool) {
+	conn := c.Conn()
+	return withPeer(conn.RemoteMultiaddr(), conn.RemotePeer().String()), conn.Stat().Limited
+}
+
+// InspectConnectionRoute returns the live libp2p route behind a net.Conn.
+// Non-libp2p connections deliberately return ok=false so generic dial seams
+// retain their caller-supplied route metadata.
+func InspectConnectionRoute(conn net.Conn) (target string, limited bool, ok bool) {
+	routed, ok := conn.(interface {
+		P2PRoute() (string, bool)
+	})
+	if !ok {
+		return "", false, false
+	}
+	target, limited = routed.P2PRoute()
+	return target, limited, target != ""
+}
+
 func (c *streamConn) SetDeadline(deadline time.Time) error {
 	return c.Stream.SetDeadline(deadline)
 }

--- a/internal/p2p/relay_test.go
+++ b/internal/p2p/relay_test.go
@@ -143,6 +143,10 @@ func TestDialContextOverRelayLimitedConnection(t *testing.T) {
 		t.Fatalf("DialContext through relay: %v", err)
 	}
 	defer conn.Close()
+	actualTarget, limitedRoute, ok := InspectConnectionRoute(conn)
+	if !ok || !limitedRoute || !strings.Contains(actualTarget, "/p2p-circuit/") {
+		t.Fatalf("InspectConnectionRoute = target %q limited=%v ok=%v, want live relay circuit", actualTarget, limitedRoute, ok)
+	}
 
 	var limited bool
 	for _, networkConn := range source.Host().Network().ConnsToPeer(destination.Host().ID()) {

--- a/internal/store/appv25_domain_continuity.go
+++ b/internal/store/appv25_domain_continuity.go
@@ -1477,6 +1477,48 @@ func (s *BadgerStore) GetAppV25DomainContinuity(
 	return &record, nil
 }
 
+// AppV25DomainContinuityWouldDisplaceOwner reports the narrow permanent
+// conflict that the continuity worker can safely omit before broadcasting a
+// proposal: current canonical policy assigns the domain to neither Root nor
+// any historically proven writer. It is a read-only mirror of the consensus
+// apply guard; returning true never changes or transfers ownership.
+func (s *BadgerStore) AppV25DomainContinuityWouldDisplaceOwner(
+	domain string,
+	writers []string,
+) (bool, error) {
+	if err := ValidateAppV23DomainName(domain); err != nil {
+		return false, err
+	}
+	if len(writers) == 0 {
+		return false, errors.New("domain continuity requires at least one writer")
+	}
+	writers = append([]string(nil), writers...)
+	sort.Strings(writers)
+	conflicted := false
+	err := s.view(func(txn *badger.Txn) error {
+		var root AppV23RootState
+		if readErr := appV23ReadJSON(txn, appV23RootKey(), &root); readErr != nil {
+			return readErr
+		}
+		value, readErr := s.appV23ReadEffectiveValueTxn(txn, domainKey(domain))
+		if errors.Is(readErr, badger.ErrKeyNotFound) {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+		currentOwner, _, decodeErr := decodeString(value, 0)
+		if decodeErr != nil {
+			return decodeErr
+		}
+		index := sort.SearchStrings(writers, currentOwner)
+		writerOwns := index < len(writers) && writers[index] == currentOwner
+		conflicted = currentOwner != "" && currentOwner != root.PrincipalID && !writerOwns
+		return nil
+	})
+	return conflicted, err
+}
+
 func (s *BadgerStore) appV25ContinuityActivationMatchesTxn(
 	txn *badger.Txn,
 	enrollment AppV23LocalEnrollment,

--- a/internal/store/appv25_domain_continuity_test.go
+++ b/internal/store/appv25_domain_continuity_test.go
@@ -490,6 +490,16 @@ func TestAppV25DomainContinuityRejectsConflictingOwnerBeforeMutation(t *testing.
 	ownerID := appV23Register(t, s, "continuity-conflict-owner", AppV23RoleMember, 3, 0)
 	require.NoError(t, s.RegisterDomain("continuity-owned-elsewhere", ownerID, "", 4))
 	require.NoError(t, s.EnsureAppV23Root("continuity-conflict", 100))
+	wouldDisplace, err := s.AppV25DomainContinuityWouldDisplaceOwner(
+		"continuity-owned-elsewhere", []string{writerID},
+	)
+	require.NoError(t, err)
+	require.True(t, wouldDisplace)
+	wouldDisplace, err = s.AppV25DomainContinuityWouldDisplaceOwner(
+		"continuity-owned-elsewhere", []string{ownerID, writerID},
+	)
+	require.NoError(t, err)
+	require.False(t, wouldDisplace)
 
 	plan := sha256.Sum256([]byte("conflicting-owner-plan"))
 	before, err := s.ComputeAppHash()

--- a/internal/totp/totp.go
+++ b/internal/totp/totp.go
@@ -42,6 +42,14 @@ const (
 	PinLen = 32
 	// MinSessionIDBits is the RT-3 entropy floor for the join session id.
 	MinSessionIDBits = 40
+	// MaxEnrollmentRouteCount matches the live federation bundle: at most four
+	// direct candidates plus four relay fallbacks. The byte limits below remain
+	// the primary bound on QR size and parser work.
+	MaxEnrollmentRouteCount = 8
+	// MaxEnrollmentRouteLength bounds any single encoded multiaddr.
+	MaxEnrollmentRouteLength = 512
+	// MaxEnrollmentRouteBytes bounds all encoded multiaddrs in one bundle.
+	MaxEnrollmentRouteBytes = 1536
 )
 
 // b32 is the RFC-4648 base32 (no padding) codec used for otpauth secret + ids,
@@ -209,14 +217,14 @@ func ParseEnrollment(uri string, allowPinOnly bool) (*Enrollment, error) {
 			return nil, fmt.Errorf("this isn't a SAGE connection code (bad peer id)")
 		}
 		addrs := q["x_sage_addr"]
-		if len(addrs) == 0 || len(addrs) > 4 {
+		if len(addrs) == 0 || len(addrs) > MaxEnrollmentRouteCount {
 			return nil, fmt.Errorf("this isn't a SAGE connection code (bad route count)")
 		}
 		hasCircuit := false
 		total := 0
 		for _, raw := range addrs {
 			total += len(raw)
-			if len(raw) == 0 || len(raw) > 512 || total > 1536 {
+			if len(raw) == 0 || len(raw) > MaxEnrollmentRouteLength || total > MaxEnrollmentRouteBytes {
 				return nil, fmt.Errorf("this isn't a SAGE connection code (route too large)")
 			}
 			addr, addrErr := ma.NewMultiaddr(raw)

--- a/internal/totp/totp.go
+++ b/internal/totp/totp.go
@@ -220,7 +220,6 @@ func ParseEnrollment(uri string, allowPinOnly bool) (*Enrollment, error) {
 		if len(addrs) == 0 || len(addrs) > MaxEnrollmentRouteCount {
 			return nil, fmt.Errorf("this isn't a SAGE connection code (bad route count)")
 		}
-		hasCircuit := false
 		total := 0
 		for _, raw := range addrs {
 			total += len(raw)
@@ -235,12 +234,6 @@ func ParseEnrollment(uri string, allowPinOnly bool) (*Enrollment, error) {
 			if infoErr != nil || info.ID != declared {
 				return nil, fmt.Errorf("this isn't a SAGE connection code (route peer mismatch)")
 			}
-			if strings.Contains(raw, "/p2p-circuit/") {
-				hasCircuit = true
-			}
-		}
-		if !hasCircuit {
-			return nil, fmt.Errorf("this isn't a SAGE connection code (no relay route)")
 		}
 		e.Transport = transport
 		e.Protocol = q.Get("x_sage_proto")

--- a/internal/totp/totp_test.go
+++ b/internal/totp/totp_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
+	"strings"
 	"testing"
 
 	libcrypto "github.com/libp2p/go-libp2p/core/crypto"
@@ -70,6 +72,61 @@ func TestProvisioningP2PRoundTripAndPeerBinding(t *testing.T) {
 		"host", "/sage/fed/1.0.0", otherID.String(), []string{relay})
 	if _, err := ParseEnrollment(bad, false); err == nil {
 		t.Fatal("accepted route whose terminal peer differs from x_sage_peer")
+	}
+}
+
+func TestProvisioningP2PAcceptsLiveSixRouteBundleAndRejectsOverLimit(t *testing.T) {
+	priv, _, err := libcrypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := peer.IDFromPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	relayPriv, _, err := libcrypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	relayID, err := peer.IDFromPrivateKey(relayPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination := "/p2p/" + id.String()
+	addrs := []string{
+		"/ip4/127.0.0.1/tcp/4001" + destination,
+		"/ip4/127.0.0.1/udp/4001/quic-v1" + destination,
+		"/ip4/192.0.2.10/tcp/4001" + destination,
+		"/ip4/192.0.2.10/udp/4001/quic-v1" + destination,
+		"/ip4/198.51.100.10/tcp/4001/p2p/" + relayID.String() + "/p2p-circuit" + destination,
+		"/ip4/198.51.100.10/udp/4001/quic-v1/p2p/" + relayID.String() + "/p2p-circuit" + destination,
+	}
+	seed, err := NewSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pin := sha256.Sum256([]byte("host-ca-spki-six-routes"))
+	sid := b32.EncodeToString([]byte{1, 2, 3, 4, 5, 6})
+	uri := ProvisioningURIWithP2P(seed, "six-route-chain", "SAGE", pin[:], "https://host:8444", sid,
+		"host", "/sage/fed/1.0.0", id.String(), addrs)
+	enrollment, err := ParseEnrollment(uri, false)
+	if err != nil {
+		t.Fatalf("live six-route bundle must parse: %v", err)
+	}
+	if len(enrollment.P2PAddrs) != len(addrs) {
+		t.Fatalf("parsed %d routes, want %d", len(enrollment.P2PAddrs), len(addrs))
+	}
+
+	overLimit := make([]string, MaxEnrollmentRouteCount+1)
+	for i := range overLimit {
+		overLimit[i] = fmt.Sprintf("/ip4/192.0.2.%d/tcp/4001%s", i+1, destination)
+	}
+	// Preserve the relay requirement so this exercises only the count bound.
+	overLimit[len(overLimit)-1] = addrs[len(addrs)-1]
+	tooManyURI := ProvisioningURIWithP2P(seed, "too-many-routes", "SAGE", pin[:], "https://host:8444", sid,
+		"host", "/sage/fed/1.0.0", id.String(), overLimit)
+	if _, err := ParseEnrollment(tooManyURI, false); err == nil || !strings.Contains(err.Error(), "bad route count") {
+		t.Fatalf("over-limit route bundle error = %v, want bad route count", err)
 	}
 }
 

--- a/internal/totp/totp_test.go
+++ b/internal/totp/totp_test.go
@@ -121,12 +121,27 @@ func TestProvisioningP2PAcceptsLiveSixRouteBundleAndRejectsOverLimit(t *testing.
 	for i := range overLimit {
 		overLimit[i] = fmt.Sprintf("/ip4/192.0.2.%d/tcp/4001%s", i+1, destination)
 	}
-	// Preserve the relay requirement so this exercises only the count bound.
+	// Keep one live relay-shaped candidate while exercising only the count bound.
 	overLimit[len(overLimit)-1] = addrs[len(addrs)-1]
 	tooManyURI := ProvisioningURIWithP2P(seed, "too-many-routes", "SAGE", pin[:], "https://host:8444", sid,
 		"host", "/sage/fed/1.0.0", id.String(), overLimit)
 	if _, err := ParseEnrollment(tooManyURI, false); err == nil || !strings.Contains(err.Error(), "bad route count") {
 		t.Fatalf("over-limit route bundle error = %v, want bad route count", err)
+	}
+
+	longHost := strings.TrimSuffix(strings.Repeat("abcdefghij.", 18), ".") + ".example"
+	longRoute := "/dns4/" + longHost + "/tcp/4001" + destination
+	if len(longRoute) > MaxEnrollmentRouteLength {
+		t.Fatalf("test route length = %d, want <= %d", len(longRoute), MaxEnrollmentRouteLength)
+	}
+	overBytes := make([]string, MaxEnrollmentRouteCount)
+	for i := range overBytes {
+		overBytes[i] = longRoute
+	}
+	overBytesURI := ProvisioningURIWithP2P(seed, "too-many-route-bytes", "SAGE", pin[:], "https://host:8444", sid,
+		"host", "/sage/fed/1.0.0", id.String(), overBytes)
+	if _, err := ParseEnrollment(overBytesURI, false); err == nil || !strings.Contains(err.Error(), "route too large") {
+		t.Fatalf("over-byte route bundle error = %v, want route too large", err)
 	}
 }
 

--- a/scripts/cerebrum-shell.test.mjs
+++ b/scripts/cerebrum-shell.test.mjs
@@ -811,6 +811,8 @@ test('federation endpoint discovery uses the node listener as the signed source 
 
 test('federation ceremony presents one clear two-way scan flow without dropping the safety check', () => {
     const hostWizard = appSource.slice(appSource.indexOf('function HostJoinWizard('), appSource.indexOf('function fedCatalogMap('));
+    assert.match(hostWizard, /\['showqr', 'waiting', 'compare', 'readback'\]\.includes\(step\)/,
+        'the visible host QR must keep polling so an expired backend join window cannot look open');
     assert.match(hostWizard, /fed-wizard-wide/);
     assert.match(hostWizard, /class="fed-exchange"/);
     assert.match(hostWizard, /They scan this SAGE/);

--- a/web/appv25_domain_continuity_worker.go
+++ b/web/appv25_domain_continuity_worker.go
@@ -382,6 +382,27 @@ func (h *DashboardHandler) runAppV25DomainContinuityPassWithRun(
 	if !broker.Available || root == nil || len(rootKey) != ed25519.PrivateKeySize {
 		return false, fmt.Errorf("current Root signing path is unavailable: %s", broker.ReasonCode)
 	}
+	eligible := make([]appV25DomainContinuityEntry, 0, len(run.plan.Entries))
+	for _, entry := range run.plan.Entries {
+		conflicted, conflictErr := h.BadgerStore.AppV25DomainContinuityWouldDisplaceOwner(
+			entry.Domain, entry.Writers,
+		)
+		if conflictErr != nil {
+			return false, conflictErr
+		}
+		if conflicted {
+			domainDigest := sha256.Sum256([]byte(entry.Domain))
+			logger.Warn().
+				Str("domain_digest", fmt.Sprintf("%x", domainDigest[:8])).
+				Msg("app-v25 domain-continuity evidence skipped because current policy has an unrelated owner")
+			continue
+		}
+		eligible = append(eligible, entry)
+	}
+	run.plan.Entries = eligible
+	if len(run.plan.Entries) == 0 {
+		return false, nil
+	}
 	if !h.canAutomaticallyProposeAppV25Maintenance() {
 		return false, nil
 	}

--- a/web/appv25_domain_continuity_worker_test.go
+++ b/web/appv25_domain_continuity_worker_test.go
@@ -509,3 +509,39 @@ func TestAppV25ExecutedRepairWithPreexistingStaleGrantsIsReplayed(t *testing.T) 
 	require.Empty(t, run.plan.Entries,
 		"executed repair is complete only after exact grant authorization succeeds")
 }
+
+func TestAppV25ContinuityWorkerDoesNotProposeOverUnrelatedCurrentOwner(t *testing.T) {
+	ctx := context.Background()
+	fixture := newAppV23AccessFixture(t)
+	sqlite, err := store.NewSQLiteStore(ctx, filepath.Join(t.TempDir(), "memories.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, sqlite.Close()) }()
+	progress := store.LegacyMemoryAdoptionProgress{State: "complete"}
+	require.NoError(t, sqlite.PublishLegacyMemoryAdoptionProgress(ctx, progress))
+	_, signingKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	handler := NewDashboardHandler(sqlite, "test")
+	handler.BadgerStore = fixture.badger
+	handler.SigningKey = signingKey
+	handler.AdminSigningKey = fixture.rootKey
+	handler.CometBFTRPC = "http://unused.invalid"
+	handler.ConfigureAppV25Maintenance(true)
+	handler.noteAppV25MaintenanceProgress(progress)
+
+	run := &appV25DomainContinuityRun{plan: &appV25DomainContinuityPlan{
+		Entries: []appV25DomainContinuityEntry{{
+			Domain: "companion-home", Owner: "historical-writer",
+			Writers: []string{"historical-writer"},
+		}},
+	}}
+	more, err := handler.runAppV25DomainContinuityPassWithRun(
+		ctx, zerolog.Nop(), run,
+	)
+	require.NoError(t, err)
+	require.False(t, more)
+	require.Empty(t, run.plan.Entries,
+		"historical recovery must never propose displacement of current policy ownership")
+	owner, err := fixture.badger.GetDomainOwner("companion-home")
+	require.NoError(t, err)
+	require.Equal(t, fixture.agentID, owner)
+}

--- a/web/handler.go
+++ b/web/handler.go
@@ -1313,6 +1313,8 @@ func (h *DashboardHandler) RegisterRoutes(r chi.Router) {
 
 			r.With(h.cerebrumOperatorGate).
 				Get("/v1/dashboard/memory/list", h.handleListMemories)
+			r.With(h.cerebrumOperatorGate).
+				Get("/v1/dashboard/chain/scopes", h.handleChainScopes)
 			r.With(h.cerebrumOperatorGate).Get("/v1/dashboard/export", h.handleExport)
 			r.With(h.cerebrumOperatorGate, h.appV23ProjectionBroadReadGate).
 				Get("/v1/dashboard/memory/timeline", h.handleTimeline)

--- a/web/scope_handler.go
+++ b/web/scope_handler.go
@@ -1,0 +1,148 @@
+package web
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"sort"
+
+	"github.com/l33tdawg/sage/internal/scope"
+)
+
+type dashboardScopeDomainResponse struct {
+	Name    string `json:"name"`
+	Subtree bool   `json:"subtree"`
+}
+
+type dashboardScopeMemberResponse struct {
+	ValidatorID             string `json:"validator_id"`
+	AssignedWeight          uint64 `json:"assigned_weight"`
+	JoinedRevision          uint64 `json:"joined_revision"`
+	Active                  bool   `json:"active"`
+	PendingBallotCount      int    `json:"pending_ballot_count"`
+	ValidatorRemovalBlocked bool   `json:"validator_removal_blocked"`
+}
+
+type dashboardScopeDrainResponse struct {
+	PendingBallotCount   int      `json:"pending_ballot_count"`
+	PendingMemoryIDs     []string `json:"pending_memory_ids"`
+	BlockingValidatorIDs []string `json:"blocking_validator_ids"`
+}
+
+type dashboardScopeRecordResponse struct {
+	ScopeID               string                         `json:"scope_id"`
+	Revision              uint64                         `json:"revision"`
+	RevisionHash          string                         `json:"revision_hash"`
+	State                 string                         `json:"state"`
+	ControllerValidatorID string                         `json:"controller_validator_id"`
+	CreatedHeight         int64                          `json:"created_height"`
+	UpdatedHeight         int64                          `json:"updated_height"`
+	Domains               []dashboardScopeDomainResponse `json:"domains"`
+	Members               []dashboardScopeMemberResponse `json:"members"`
+	Drain                 dashboardScopeDrainResponse    `json:"drain"`
+}
+
+// handleChainScopes exposes canonical scope topology to the authenticated,
+// same-machine CEREBRUM operator. The browser cannot sign the operator/admin
+// REST contract at /v1/scopes, and that agent API must remain signed.
+func (h *DashboardHandler) handleChainScopes(w http.ResponseWriter, _ *http.Request) {
+	if h.BadgerStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "canonical scope storage is not configured")
+		return
+	}
+	records, err := h.BadgerStore.ListScopeRecords()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	pending, err := h.BadgerStore.ListPendingScopeBallots()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	views := make([]dashboardScopeRecordResponse, 0, len(records))
+	for i := range records {
+		view, viewErr := h.dashboardScopeRecordView(&records[i], pending)
+		if viewErr != nil {
+			writeError(w, http.StatusInternalServerError, viewErr.Error())
+			return
+		}
+		views = append(views, view)
+	}
+	writeJSONResp(w, http.StatusOK, map[string]any{"scopes": views, "count": len(views)})
+}
+
+func (h *DashboardHandler) dashboardScopeRecordView(
+	record *scope.Record,
+	pending []scope.Ballot,
+) (dashboardScopeRecordResponse, error) {
+	digest, err := h.BadgerStore.GetScopeRevisionHash(record.ScopeID, record.Revision)
+	if err != nil {
+		return dashboardScopeRecordResponse{}, err
+	}
+	if len(digest) != sha256.Size {
+		return dashboardScopeRecordResponse{}, fmt.Errorf(
+			"scope %q revision %d is missing its audit anchor", record.ScopeID, record.Revision,
+		)
+	}
+	domains := make([]dashboardScopeDomainResponse, 0, len(record.Domains))
+	for _, domain := range record.Domains {
+		domains = append(domains, dashboardScopeDomainResponse{Name: domain.Name, Subtree: domain.Subtree})
+	}
+	pendingByValidator := make(map[string]int)
+	pendingMemoryIDs := make([]string, 0)
+	blockingValidators := make(map[string]struct{})
+	for _, ballot := range pending {
+		if ballot.ScopeID != record.ScopeID {
+			continue
+		}
+		pendingMemoryIDs = append(pendingMemoryIDs, ballot.MemoryID)
+		for _, member := range ballot.Members {
+			pendingByValidator[member.ValidatorID]++
+			blockingValidators[member.ValidatorID] = struct{}{}
+		}
+	}
+	members := make([]dashboardScopeMemberResponse, 0, len(record.Members))
+	for _, member := range record.Members {
+		if record.State != scope.StateRetired && member.Active {
+			blockingValidators[member.ValidatorID] = struct{}{}
+		}
+		members = append(members, dashboardScopeMemberResponse{
+			ValidatorID: member.ValidatorID, AssignedWeight: member.AssignedWeight,
+			JoinedRevision: member.JoinedRevision, Active: member.Active,
+			PendingBallotCount: pendingByValidator[member.ValidatorID],
+			ValidatorRemovalBlocked: (record.State != scope.StateRetired && member.Active) ||
+				pendingByValidator[member.ValidatorID] > 0,
+		})
+	}
+	blockingValidatorIDs := make([]string, 0, len(blockingValidators))
+	for validatorID := range blockingValidators {
+		blockingValidatorIDs = append(blockingValidatorIDs, validatorID)
+	}
+	sort.Strings(blockingValidatorIDs)
+	return dashboardScopeRecordResponse{
+		ScopeID: record.ScopeID, Revision: record.Revision,
+		RevisionHash: hex.EncodeToString(digest), State: dashboardScopeStateString(record.State),
+		ControllerValidatorID: record.ControllerValidatorID,
+		CreatedHeight:         record.CreatedHeight, UpdatedHeight: record.UpdatedHeight,
+		Domains: domains, Members: members,
+		Drain: dashboardScopeDrainResponse{
+			PendingBallotCount: len(pendingMemoryIDs), PendingMemoryIDs: pendingMemoryIDs,
+			BlockingValidatorIDs: blockingValidatorIDs,
+		},
+	}, nil
+}
+
+func dashboardScopeStateString(state scope.State) string {
+	switch state {
+	case scope.StateActive:
+		return "active"
+	case scope.StatePaused:
+		return "paused"
+	case scope.StateRetired:
+		return "retired"
+	default:
+		return "unknown"
+	}
+}

--- a/web/scope_handler_test.go
+++ b/web/scope_handler_test.go
@@ -1,0 +1,84 @@
+package web
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/scope"
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+func TestDashboardScopeProjectionUsesLocalOperatorBoundary(t *testing.T) {
+	h, _ := newTestHandler(t)
+	badgerStore, err := store.NewBadgerStore(filepath.Join(t.TempDir(), "badger"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, badgerStore.CloseBadger()) })
+	h.BadgerStore = badgerStore
+
+	record := scope.Record{
+		ScopeID: "scope-a", Revision: 1, State: scope.StateActive,
+		ControllerValidatorID: "validator-a", CreatedHeight: 10, UpdatedHeight: 10,
+		Domains: []scope.Domain{{Name: "research"}},
+		Members: []scope.Member{{
+			ValidatorID: "validator-a", AssignedWeight: 7,
+			JoinedRevision: 1, Active: true,
+		}},
+	}
+	require.NoError(t, badgerStore.SetScopeRecord(record))
+	contentHash := sha256.Sum256([]byte("pending scoped memory"))
+	require.NoError(t, badgerStore.SetScopedMemorySubmission(scope.Ballot{
+		MemoryID: "memory-a", ScopeID: "scope-a", ScopeRevision: 1,
+		SubmittedHeight: 11, State: scope.BallotPending,
+		Members:     []scope.BallotMember{{ValidatorID: "validator-a", EffectiveWeight: 7}},
+		TotalWeight: 7,
+	}, scope.Content{
+		MemoryID: "memory-a", ScopeID: "scope-a", ScopeRevision: 1,
+		SubmittingAgentID: "agent-a", ContentHash: contentHash[:],
+		MemoryType: 1, Domain: "research", ConfidenceScore: 0.9,
+		Content: "pending scoped memory", SubmittedHeight: 11, SubmittedUnix: 100,
+	}))
+	router := testRouter(h)
+
+	localReq := httptest.NewRequest(http.MethodGet, "/v1/dashboard/chain/scopes", nil)
+	markLocalCEREBRUM(h, localReq)
+	local := httptest.NewRecorder()
+	router.ServeHTTP(local, localReq)
+	require.Equal(t, http.StatusOK, local.Code, local.Body.String())
+	var response struct {
+		Scopes []dashboardScopeRecordResponse `json:"scopes"`
+		Count  int                            `json:"count"`
+	}
+	require.NoError(t, json.Unmarshal(local.Body.Bytes(), &response))
+	require.Equal(t, 1, response.Count)
+	require.Len(t, response.Scopes, 1)
+	assert.Equal(t, "scope-a", response.Scopes[0].ScopeID)
+	assert.Len(t, response.Scopes[0].RevisionHash, 64)
+	assert.Equal(t, []string{"memory-a"}, response.Scopes[0].Drain.PendingMemoryIDs)
+	assert.Equal(t, []string{"validator-a"}, response.Scopes[0].Drain.BlockingValidatorIDs)
+
+	remoteReq := httptest.NewRequest(http.MethodGet, "/v1/dashboard/chain/scopes", nil)
+	remoteReq.RemoteAddr = "192.0.2.20:54321"
+	remoteReq.Host = "192.0.2.10:8080"
+	remote := httptest.NewRecorder()
+	router.ServeHTTP(remote, remoteReq)
+	assert.Equal(t, http.StatusUnauthorized, remote.Code)
+}
+
+func TestConsensusUIUsesDashboardScopeProjection(t *testing.T) {
+	apiBytes, err := os.ReadFile("static/js/api.js")
+	require.NoError(t, err)
+	api := string(apiBytes)
+
+	assert.Contains(t, api, "`${API_BASE}/v1/dashboard/chain/scopes`")
+	assert.NotContains(t, api, "`${API_BASE}/v1/scopes`")
+	assert.Equal(t, 1, strings.Count(api, "/v1/dashboard/chain/scopes"))
+}

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -142,7 +142,7 @@ export async function fetchValidators() {
 }
 
 export async function fetchScopes() {
-	const res = await fetch(`${API_BASE}/v1/scopes`);
+	const res = await fetch(`${API_BASE}/v1/dashboard/chain/scopes`);
 	if (!res.ok) throw new Error('scopes fetch failed');
 	return res.json();
 }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -15760,10 +15760,12 @@ function HostJoinWizard({ onExit }) {
         setStep('aborted');
     };
 
-    // Poll every in-flight host screen so a guest-side Stop, expiry, or network
-    // failure always becomes visible instead of leaving a dead spinner/card.
+    // Poll every in-flight host screen, including the initial QR. Without the
+    // showqr state here an expired/aborted backend session kept looking usable
+    // indefinitely while the mTLS listener correctly closed its join window;
+    // the guest then saw only a misleading "bad certificate" handshake error.
     useEffect(() => {
-        if (!session || !['waiting', 'compare', 'readback'].includes(step)) return;
+        if (!session || !['showqr', 'waiting', 'compare', 'readback'].includes(step)) return;
         let live = true;
         let misses = 0;
         const tick = async () => {


### PR DESCRIPTION
## Summary
- accept the live direct + relay route bundle size emitted by SAGE while preserving route byte bounds and terminal peer binding
- validate and emit one immutable enrollment bundle snapshot
- accept secure direct-only same-LAN bundles consistently
- expire stale host QR state in CEREBRUM when the backend join window closes
- cover the observed six-route Mac-to-Mac shape, route limits, direct-only round trips, and mixed current-host/legacy-guest TLS bootstrap

## Validation
- go test ./internal/totp ./internal/federation ./cmd/sage-gui
- exact mixed-version TLS compatibility test 20/20
- exact linked-message revocation case 20/20 (follow-up to one unrelated full-suite failure)
- node --test scripts/cerebrum-shell.test.mjs (56/56)
- node scripts/check-static-js.mjs (23 files)
- independent adversarial review: APPROVE after two blockers were fixed

## Release scope
Draft for v11.17.3. Do not merge into the in-flight v11.17.2 release. Live two-Mac pairing/RBAC/messaging verification still follows after installable builds are available.