### PR TITLE
ci: remove manual two-Mac release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1397,42 +1397,13 @@ jobs:
             done
           done
 
-  manual-publication-approval:
-    name: Confirm Two-Mac Private Draft Acceptance
-    runs-on: ubuntu-latest
-    needs: [stage-github-release, verify-staged-macos-release, release-metadata]
-    environment:
-      name: release-two-mac-acceptance
-    permissions:
-      actions: read
-      contents: read
-      deployments: read
-    steps:
-      - name: Fail closed unless the environment requires a reviewer
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          gh api "repos/${GH_REPO}/environments/release-two-mac-acceptance" \
-            > environment.json
-          jq -e '
-            [.protection_rules[]?
-              | select(.type == "required_reviewers")
-              | .reviewers[]?]
-            | length >= 1
-          ' environment.json > /dev/null
-
-      - name: Record protected two-Mac acceptance
-        run: echo "Protected reviewer approved the exact private draft from this workflow run"
-
   publish-docker-version:
     name: Publish Immutable Docker Version
     runs-on: ubuntu-latest
     # PyPI and MCP versions are immutable. Do not begin any public publication
     # until the exact DMGs uploaded to the private draft have passed the final
     # writable-copy, launch, signature, Team ID, and notarization checks.
-    needs: [manual-publication-approval, release-metadata]
+    needs: [verify-staged-macos-release, release-metadata]
     permissions:
       contents: read
       packages: write

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -703,14 +703,9 @@ test('the exact GoReleaser Linux archive crosses extraction and atomic updater s
 });
 
 test('public package publication waits for the exact staged macOS assets', () => {
-  const approval = job('manual-publication-approval');
-  assert.match(
-    approval,
-    /needs:\s*\[stage-github-release, verify-staged-macos-release, release-metadata\]/,
-  );
   assert.match(
     job('publish-docker-version'),
-    /needs:\s*\[manual-publication-approval, release-metadata\]/,
+    /needs:\s*\[verify-staged-macos-release, release-metadata\]/,
   );
 });
 
@@ -1037,24 +1032,9 @@ test('public mutations are serial, resumable, and downstream of the gate', () =>
   );
   assert.doesNotMatch(job('verify-staged-macos-release'), /gh release download/);
 
-  assertNeeds('manual-publication-approval', [
-    'stage-github-release',
-    'verify-staged-macos-release',
-    'release-metadata',
-  ]);
-  assert.match(
-    job('manual-publication-approval'),
-    /environment:\s*\n\s+name: release-two-mac-acceptance/,
-  );
-  assert.doesNotMatch(job('manual-publication-approval'), /workflow_dispatch|inputs\./);
-  assert.match(job('manual-publication-approval'), /actions: read/);
-  assert.match(job('manual-publication-approval'), /deployments: read/);
-  assert.match(
-    job('manual-publication-approval'),
-    /environments\/release-two-mac-acceptance/,
-  );
-  assert.match(job('manual-publication-approval'), /required_reviewers/);
-  assertNeeds('publish-docker-version', ['manual-publication-approval', 'release-metadata']);
+  assert.doesNotMatch(workflow, /^  manual-publication-approval:$/m);
+  assert.doesNotMatch(workflow, /release-two-mac-acceptance/);
+  assertNeeds('publish-docker-version', ['verify-staged-macos-release', 'release-metadata']);
   assertNeeds('publish-mcp', ['publish-docker-version', 'release-metadata']);
   assertNeeds('publish-pypi', ['publish-mcp', 'release-metadata']);
   assertNeeds('publish-docker-latest', ['publish-pypi', 'release-metadata']);


### PR DESCRIPTION
Removes the human GitHub Environment approval from the active release workflow. Public publication now proceeds directly after the exact staged macOS assets pass the existing automated writable-copy, launch, signature, Team ID, notarization, and stapling verification.\n\nValidation: node --test scripts/release-workflow.test.mjs (34/34 pass); git diff --check.