### PR TITLE
docs: reconcile v11.17.8 and repair Windows shell smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ upgraded to their patched releases in both the SAGE and Natter modules. Recall
 result slices no longer use caller-derived allocation hints, app-v23 migration
 keys avoid length-arithmetic preallocation, and the CEREBRUM inline-script
 contract recognizes HTML tag case without a fragile sanitizer-style regexp.
+The roadmap, architecture, federation guide, onboarding guide, and Python SDK
+docs are reconciled to the canonical Messages API, 24-hour default TTL,
+deprecated hidden `sage_pipe*` aliases, app-v26 authority names, signed macOS
+in-place updater, and the remaining physical acceptance boundaries.
 
 Container: `ghcr.io/l33tdawg/sage:11.17.8`. SDK 11.17.8.
 

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.17.1/app-v26. -->
+<!-- Reconciled through SAGE v11.17.8/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must
@@ -36,7 +36,7 @@ The full consensus rules are in
 5. In **Access Controls**, select the exact signer, choose role, operating mode,
    clearance, and a non-shared home domain, then approve the atomic policy.
 6. Put local agents into Access Groups to share governed domain access. Group
-   authority is explicit (`read`, `read-write`, or `manage`) and removing an
+   authority is explicit (`read`, `read_write`, or `read_write_modify`) and removing an
    agent removes only group-derived access; its own home domain remains intact.
 
 The agent can inspect its own standing and bounded domain samples with

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -758,13 +758,22 @@ This is an atomic operation — if any step fails, the entire rotation is rolled
 
 ---
 
-## Pipeline Architecture (Agent-to-Agent Messaging)
+## Messages Architecture (Agent-to-Agent Messaging)
 
-Introduced in v5.0.1, the pipeline is a direct messaging system between agents. Unlike shared memories (which are broadcast knowledge), pipeline messages are routed point-to-point — one agent sends a message to a specific agent (by ID) or to any agent matching a provider (e.g., `"claude-code"`).
+SAGE v11.17 exposes one canonical Messages/Inbox workflow. Unlike shared
+memories, a message is point-to-point work addressed to one exact active local
+or caller-authorized federated agent. The older pipeline rows and federation
+wire protocol remain the storage/transport substrate; `sage_pipe*` MCP names
+are hidden deprecated compatibility aliases and are not advertised to new
+clients.
 
 ### How It Works
 
-The pipeline provides structured, asynchronous communication between agents without polluting the shared memory pool. Messages default to a 24-hour TTL so an offline agent has a full day to collect inbox work; callers may choose a shorter lifetime. They are designed for coordination, not permanent knowledge storage.
+Messages provide structured asynchronous coordination without polluting the
+shared memory pool. New sends default to the maximum supported 24-hour TTL;
+callers may explicitly choose 1–1440 minutes. The current expiry-bound inbox is
+not permanent email storage. Pending/claimed rows also have a 48-hour stale-row
+backstop, and terminal rows are retained for 24 hours before cleanup.
 
 ### Message Lifecycle
 
@@ -773,37 +782,43 @@ send → pending → claimed → completed
                     ↘ expired (TTL exceeded)
 ```
 
-1. **Send** — Agent A posts a message via `POST /v1/pipe/send`, targeting a specific `agent_id` or `provider`. The message enters `pending` status.
-2. **Pending** — The message sits in the recipient's inbox. Recipients poll via `GET /v1/pipe/inbox` to discover new messages.
-3. **Claimed** — The recipient claims the message via `PUT /v1/pipe/{id}/claim`, signaling that work has begun. This prevents other agents from claiming the same message.
-4. **Completed** — The recipient posts a result via `PUT /v1/pipe/{id}/result`. The sender can retrieve results via `GET /v1/pipe/results`.
-5. **Expired** — If the TTL elapses before the message is claimed or completed, it transitions to `expired` and is no longer actionable.
+1. **Send** — `POST /v1/messages` requires an exact recipient and a caller-scoped idempotency key. Exact retries return the original message; key reuse with different content conflicts.
+2. **Pending** — The durable row waits in the exact recipient's inbox. A federated send may remain safely queued while the trusted peer is offline.
+3. **Claimed/read** — `POST /v1/messages/receive` claims one ordered batch using a replayable receive token. Exact-recipient read acknowledgement is separate evidence and never means comprehension.
+4. **Completed** — The exact recipient replies through `POST /v1/messages/{id}/reply`. The sender reads payload-free transport, read, and workflow dimensions from the status projection.
+5. **Expired** — If the explicit TTL elapses first, the row is no longer actionable. Expiry is independent of delivery/read evidence.
 
-### Auto-Journaling
-
-When a pipeline message reaches `completed` status, SAGE automatically creates a memory entry (memory_type `journal`) capturing the exchange. This means significant inter-agent coordination is preserved in the knowledge base without agents needing to manually record it.
+Legacy local `pipe_result` completion can create a summary journal. Canonical
+Messages and foreign work do not silently turn untrusted message content into
+governed memory; an agent must remember durable knowledge explicitly.
 
 ### TTL and Expiry
 
-- **Default TTL:** 60 minutes
+- **Default TTL:** 1440 minutes (24 hours)
 - **Maximum TTL:** 1440 minutes (24 hours)
-- Senders can set a custom TTL per message within these bounds
-- Expired messages are soft-deleted — they remain queryable by ID but are excluded from inbox results
+- Senders can explicitly choose 1–1440 minutes
+- Receive-token replay metadata is retained for 48 hours and capped per agent
+- Expired rows leave the actionable inbox; retained history remains bounded by cleanup policy
 
 ### REST Endpoints
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/v1/pipe/send` | Send a message to a target agent or provider |
-| `GET` | `/v1/pipe/inbox` | List pending messages for the authenticated agent |
-| `PUT` | `/v1/pipe/{id}/claim` | Claim a pending message (marks it in-progress) |
-| `PUT` | `/v1/pipe/{id}/result` | Post a result for a claimed message |
-| `GET` | `/v1/pipe/{id}` | Get a specific message by ID (any status) |
-| `GET` | `/v1/pipe/results` | List completed messages with results for the sender |
+| `POST` | `/v1/messages` | Idempotently send to one exact local agent |
+| `POST` | `/v1/messages/receive` | Claim/replay one exact ordered recipient batch |
+| `POST` | `/v1/messages/{id}/reply` | Exact-recipient idempotent reply |
+| `PUT` | `/v1/messages/{id}/read` | Exact-recipient read acknowledgement |
+| `PUT` | `/v1/messages/read-batch` | Independently acknowledge up to 20 fetched messages |
+| `GET` | `/v1/messages/{id}/status` | Exact-sender payload-free transport/read/workflow state |
+
+The `/v1/pipe/*` routes remain the compatibility and federated transport
+surface. MCP clients should use `sage_find_agent`, `sage_message_send`,
+`sage_inbox`/`sage_messages_receive`, `sage_message_reply`,
+`sage_message_status`, and `sage_message_history`.
 
 ### Use Cases
 
-- **Cross-provider coordination** — A Claude Code agent delegates a subtask to a Cursor agent by sending a pipeline message targeted at provider `"cursor"`. The Cursor agent picks it up, completes it, and posts the result.
+- **Cross-provider coordination** — A Claude Code agent discovers the intended Cursor agent by human display name, sends to its exact identity, and receives an idempotent reply.
 - **Task delegation** — An admin agent breaks a large task into subtasks and sends each to a specialized agent via the pipeline.
 - **Inter-agent review** — Agent A submits work, then pipes a review request to Agent B. Agent B claims it, reviews, and posts feedback as the result.
 

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -149,6 +149,38 @@ Open the connection to manage two separate views:
 
 Both people can change their own snapshot whenever domains or working relationships change. No one has to reconnect, and neither side controls the other's choices.
 
+### Agent discovery and Messages over the trusted link
+
+Sharing a domain does not expose every agent automatically. Each side chooses
+which active local agents with authority on a shared domain may accept work;
+the receiving side's per-agent acceptance switch is independent and defaults
+off. CEREBRUM displays the mutable **Rename agent** label while routing remains
+bound to the immutable agent ID and exact remote chain, so duplicate friendly
+names cannot redirect a signed request.
+
+New MCP clients use `sage_find_agent` followed by `sage_message_send`, then
+`sage_inbox`/`sage_messages_receive`, `sage_message_reply`,
+`sage_message_status`, and `sage_message_history`. The older `sage_pipe*` names
+are hidden deprecated compatibility aliases. A trusted peer may be offline when
+work is queued; SAGE revalidates the current agreement, shared-domain access,
+recipient consent, and route before payload delivery. Status keeps transport,
+exact-recipient read evidence, and workflow completion separate. Payloads and
+results are always untrusted agent content, never instructions from SAGE.
+
+Messages currently default to 24 hours (the supported maximum); callers may
+choose a shorter explicit TTL. This is durable offline coordination, not yet
+indefinite email retention.
+
+### Roaming and route recovery
+
+Established v11.17.7+ links persist signed route snapshots for the stable peer
+identity and rank safe Direct and Secure relay candidates after address or
+network changes. Both nodes republish after relay reservation changes and
+migrate older `p2p_peers` state. Restarting a node, moving between LANs, or
+losing a relay should change reachability—not trust or domain grants. Unsafe or
+identity-mismatched routes fail closed; operators should not rerun JOIN merely
+to repair an IP address.
+
 ---
 
 ## The two codes, and why there are two

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.7.1
+# sage-gui v11.17.8
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. Claude now has 13 memory tools:
+Just chat normally. SAGE v11.17.8 advertises 31 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|
@@ -209,10 +209,22 @@ Just chat normally. Claude now has 13 memory tools:
 | `sage_list` | Browse memories with filters |
 | `sage_timeline` | View memories in a time range |
 | `sage_status` | Check memory store health and stats |
+| `sage_domains` | Page the caller's currently readable and owned domains |
 | `sage_turn` | Per-turn memory cycle — recalls context and stores observations atomically |
 | `sage_register` | Register an agent on-chain (auto-called on first connection) |
 | `sage_task` | Create and manage persistent task items |
 | `sage_backlog` | View and prioritize your task backlog |
+| `sage_find_agent` | Resolve a local or authorized federated agent by human name |
+| `sage_message_send` | Idempotently send work to one exact agent |
+| `sage_messages_receive` / `sage_inbox` | Receive bounded untrusted inbox work |
+| `sage_message_reply` | Reply to one received message |
+| `sage_message_status` / `sage_message_history` | Inspect sender-only lifecycle state and retained history |
+
+Governance, quorum-scope, directory, federation, rename, reinstate, and
+corroboration tools complete the advertised set. See the authoritative
+[`reference/mcp-tools.md`](reference/mcp-tools.md). Deprecated `sage_pipe*`
+compatibility aliases remain callable for older clients but are intentionally
+absent from tool discovery.
 
 ### First Time: Inception
 
@@ -220,7 +232,7 @@ The very first time your AI connects to SAGE, tell it:
 
 > **You:** Call sage_inception to initialize your memory.
 
-This seeds your AI's brain with foundational memories about how to use its memory system. From then on, the MCP server's initialization instructions tell the AI to automatically:
+This seeds your AI's brain with foundational memories about how to use its memory system. From then on, the MCP server's initialization instructions adapt the recommended lifecycle to the configured memory mode:
 1. **Recall** relevant context at the start of every task
 2. **Remember** important learnings during work
 3. **Reflect** on what went right and wrong after tasks complete
@@ -247,7 +259,11 @@ Both make the AI better. The `sage_reflect` tool captures this at the end of eac
 
 ### Upgrading from an older version?
 
-If you installed SAGE before v4.5 and your AI isn't calling `sage_turn` every turn or `sage_inception` on startup, you're likely missing the **Claude Code hooks** that were added in later versions. These hooks enforce the memory lifecycle automatically — no manual prompting needed.
+If you installed SAGE before v4.5 and your AI is not receiving the current
+`sage_inception` boot guidance, you may be missing the **Claude Code hooks**
+added in later versions. The hooks preserve session context and expose the
+configured full, bookend, or on-demand memory mode; the server does not block
+unrelated work merely because `sage_turn` was not called.
 
 Re-run the installer in each project directory where you use SAGE:
 
@@ -260,7 +276,7 @@ This is safe to run on existing installs — it won't overwrite your `.mcp.json`
 
 **What the hooks do:**
 - **Boot hook** (`SessionStart`) — tells the AI to call `sage_inception` at the start of every session
-- **Turn hook** (`PreCompact`, `Stop`, `PostToolUse`) — reminds the AI to call `sage_turn` so memories are flushed before context loss
+- **Turn hooks** (`PreCompact`, `Stop`, `PostToolUse`) — preserve useful bookend context before compaction/session end when the configured memory mode calls for it
 - **Permissions** — auto-allows all SAGE MCP tools so the AI doesn't need to ask permission each time
 
 ---
@@ -302,12 +318,12 @@ Once you have SAGE running for yourself, you can add more agents — other machi
 
 ### Adding an agent via the CEREBRUM dashboard
 
-Open `http://localhost:8080/ui/` and go to the Network tab. The wizard walks you through four steps:
+Open `http://localhost:8080/ui/` and go to **Access Controls**. The governed flow is:
 
-1. **Name & Role** — Give the agent a name (e.g., "Work Laptop") and pick a role: Admin, Validator, Writer, Reader, or Observer
-2. **Clearance Level** — Set the clearance tier (Guest through Top Secret) to control how much the agent can see and do
-3. **Domain Access** — Use the visual matrix to toggle read/write access per knowledge domain (e.g., "security" read+write, "personal" read-only)
-4. **Confirm** — Review the config and click Create. The agent gets its own Ed25519 identity automatically
+1. **Register the real client identity** — connect the tool so it self-registers its own Ed25519 signer; do not create or share a generic identity for several clients.
+2. **Approve policy** — In **Access Controls**, choose Member, Manager, or Admin, then Standard, Companion, or Read-only operating mode and clearance 0–4.
+3. **Approve a home domain** — Each ordinary local agent owns one non-shared home domain. The immutable agent ID and registered name stay fixed; **Rename agent** changes only its display label.
+4. **Add Access Groups when needed** — Choose exact members, domains, and one explicit authority: Read, Read + write, or Read + write + modify. Ownership never moves merely because a group changes.
 
 ### LAN pairing quick setup
 
@@ -320,19 +336,23 @@ The fastest way to connect a new machine:
 
 No port forwarding, no config files to copy, no keys to email around. Everything happens over your local network.
 
-### Domain access configuration
+### Access Group configuration
 
-Domains are the knowledge categories your agents work with (e.g., "security", "finance", "personal", "code"). For each agent, you control:
+Domains are the knowledge categories your agents work with (e.g., "security", "finance", "personal", "code"). An agent always retains ownership of its home domain. Cross-agent access is additive and comes from exact Access Group membership:
 
-- **Read access** — Can the agent query memories in this domain?
-- **Write access** — Can the agent propose new memories to this domain?
+- **Read** — Members can query the selected group domains.
+- **Read + write** — Members can also propose memories without changing ownership.
+- **Read + write + modify** — Members can also use governed modify/deprecate workflows.
 
-Set these per-domain from the Access Control tab on any agent's card in the dashboard. Changes take effect immediately — no restart needed.
+Set these in **Access Controls**. Removing a member revokes only group-derived
+authority and does not move or erase its home domain. Federated linked readers
+remain a separate read-only principal kind and can never become local group
+members through federation.
 
 A few practical examples:
-- Your personal laptop: full read+write on everything
-- A shared family machine: read+write on "household", read-only on "work"
-- A guest device: read-only on "public", no access to anything else
+- Your personal agent: owns and fully controls its home domain.
+- A household group: Read + write on the exact `household` domains selected by their owners.
+- A guest agent: Read-only profile plus group Read on an exact public domain.
 
 ### On-Chain Agent Identity (v3.5)
 
@@ -340,7 +360,7 @@ Starting in v3.5, agent identity is a first-class on-chain concept. When you add
 
 **What this means for you:**
 - Every agent registration is cryptographically signed and committed to the chain
-- Identity changes (name, bio, permissions) are auditable on-chain
+- Display-name, bio, and governed policy changes are auditable on-chain; immutable registration name and agent ID do not change
 - Agents auto-register on their first MCP connection — no manual setup required
 - Agents self-register through `POST /v1/agent/register`; the local human then
   approves or changes role, operating mode, clearance, home domain, and Access
@@ -348,7 +368,9 @@ Starting in v3.5, agent identity is a first-class on-chain concept. When you add
   permission mutation route is retired on governed nodes.
 - Existing agents from pre-v3.5 are automatically migrated to on-chain identity on first boot
 
-**Visible Agents:** You can restrict which agents' memories are visible to a given agent. Set this in the agent's Access Control tab on the Network page. By default, all agents can see all memories (open model). Set specific agent IDs to restrict visibility.
+Caller-visible memory is derived from current ownership, exact Access Groups,
+legacy direct grants where still supported, clearance/classification, and hard
+profile restrictions. There is no current “all agents see everything” default.
 
 ### Using Custom Identity Paths (Multiple Agents on the same machine)
 
@@ -422,21 +444,18 @@ generate a different key if this file is missing or corrupt.
 
 ### Backup
 
-```bash
-# Backup your memories
-cp ~/.sage/data/sage.db ~/sage-backup-$(date +%Y%m%d).db
+Use **Settings > Maintenance > Export backup** for a portable memory export.
+For disaster recovery of the entire node, stop SAGE and copy the complete
+`~/.sage` directory—including Badger, CometBFT history, SQLite projections,
+keys, certificates, and configuration—as one consistent backup. Copying only a
+live `sage.db` file is not a chain backup.
 
-# Backup everything
-tar czf ~/sage-backup-$(date +%Y%m%d).tar.gz ~/.sage/
-```
+### Start over safely
 
-### Reset
-
-```bash
-# Remove all data and start fresh
-rm -rf ~/.sage/data/
-sage-gui serve  # Reinitializes automatically
-```
+Do not delete `~/.sage/data` on a lived-in node: that discards consensus history
+and is not an upgrade or repair procedure. Export first. If you intentionally
+want an unrelated fresh SAGE, create it under a new empty `SAGE_HOME`; restore
+the complete stopped-node backup when you intend to recover the existing SAGE.
 
 ---
 
@@ -445,15 +464,18 @@ sage-gui serve  # Reinitializes automatically
 Under the hood, SAGE Personal runs a real BFT consensus engine (CometBFT) with a per-node memory auto-voter that signs votes with the node's own consensus key. Every memory goes through the full governance pipeline:
 
 1. **Propose** — memory submitted via MCP or REST API
-2. **Pre-Validate** — 4 application validators vote independently:
-   - **Sentinel** — baseline accept (ensures liveness)
-   - **Dedup** — rejects duplicate content by SHA-256 hash
-   - **Quality** — rejects noise (greeting observations, short content, empty headers)
-   - **Consistency** — enforces confidence thresholds and required fields
-3. **BFT Quorum** — 3 of 4 validators must accept (meets 2/3 BFT threshold)
-4. **Commit** — each validator signs a vote transaction broadcast through CometBFT, memory written to SQLite with on-chain hash in BadgerDB
+2. **Pre-Validate** — deterministic application checks reject malformed,
+   duplicate, low-quality, or policy-invalid content before voting.
+3. **Vote** — each SAGE node's memory auto-voter casts one signed validator
+   vote. A personal node is one node/one vote; adding consensus validators adds
+   independent voting power under the governed validator set.
+4. **BFT quorum and commit** — CometBFT orders the signed transactions; SAGE
+   reaches its weighted threshold, commits canonical state to BadgerDB, and
+   updates SQLite/PostgreSQL serving projections.
 
-This means your personal SAGE instance uses the exact same consensus protocol as a multi-validator production deployment, with real quality gates preventing noise from accumulating. If you later want to upgrade to a team setup with additional validators, your data and tooling are already compatible.
+This means a personal SAGE uses the same consensus application and transaction
+path as a multi-validator deployment without pretending that four in-process
+checks are four independent nodes.
 
 ### Upgrading from v3.x
 
@@ -467,13 +489,11 @@ history-preserving migration or restoration of a complete stopped-node backup.
 
 ## Migrating to Full SAGE
 
-When you outgrow personal mode and need multi-agent BFT consensus:
-
-1. Export your memories: they're in standard SQLite
-2. Set up the full 4-node deployment: `make init && make up`
-3. Import memories into the PostgreSQL-backed production cluster
-
-See the main [README](../README.md) for the full multi-node deployment guide.
+When you outgrow personal mode, use the authenticated same-chain node-join and
+governed validator-management flows. Do not export SQLite and initialize an
+unrelated four-node chain as an “upgrade”; existing chains advance in place and
+retain their canonical history. See the main [README](../README.md) and
+[`ARCHITECTURE.md`](ARCHITECTURE.md).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,40 @@
 
 **Hard constraint driving the whole plan:** no chain reset, no operator-typed commands. Existing chains must upgrade in place across all future releases.
 
+## v11.17.x completion ledger
+
+The 11.17 line has shipped the app-v23 through app-v26 governed upgrade path,
+historical-memory recovery controls, responsive Access Controls, authenticated
+Consensus loading, mutable agent display names, canonical Messages, deprecated
+hidden `sage_pipe*` compatibility aliases, 24-hour default message TTL, signed
+in-place macOS update support, roaming Direct/relay federation routes, and a
+Docker lane covering LAN, isolated-network/relay, address churn, restart, and
+offline inbox recovery. v11.17.8 additionally clears the tracked DTLS/STUN and
+CodeQL security backlog without dismissing genuine alerts.
+
+The following acceptance and follow-up boundaries remain open after the 11.17.8
+code merge; they are not implied complete by Docker or CI evidence:
+
+- [#137](https://github.com/l33tdawg/sage/issues/137): repeat the complete MBP ↔
+  Mac Mini matrix on the official signed build—same-LAN Direct, forced
+  relay/internet, address change, one/both-node restart, retained trust and
+  grants, bidirectional renamed-agent discovery, shared-domain reads, durable
+  inbox/reply/receipt history, and the updater path.
+- [#135](https://github.com/l33tdawg/sage/issues/135): capture deterministic
+  signed-browser evidence for Home, Tasks reload, and Access Controls.
+- [#134](https://github.com/l33tdawg/sage/issues/134): close native-shell
+  packaging retry/cache and Windows normal-close lifecycle evidence.
+- [#117](https://github.com/l33tdawg/sage/issues/117): benchmark and improve the
+  CPU-only embedding path.
+- Complete product acceptance for the signed macOS in-place updater, make
+  unread/unclaimed Messages email-like rather than expiry-bound, add a bounded
+  or metadata-only `sage_turn` inbox mode for small models, verify unscoped
+  `sage_list`/bounded-domain projection semantics, and reproduce or close the
+  historical broad authorization-scan budget report.
+
+These are separate acceptance boundaries. A published patch, green CI, or a
+Docker pass must not silently close physical-machine or signed-artifact work.
+
 ---
 
 ## v11 - shipped (the sovereign-UX + federation release)
@@ -36,7 +70,7 @@ v11 is the "zero-terminal, sovereign" release. It takes SAGE from "works if you 
 - **Reading panel** collapses to the domain lobes by default (newest 30, most-recently-active first) with an expandable "how to read".
 - **Live task board** with agent-vs-human authorship and atomic claim/ownership; the agent message bus merged in as a Messages tab.
 - **Real search** (FTS with keyword fallback), bulk curation, status and tag filters, and corroboration counts on list + detail.
-- **Settings reorganized** into focused tabs (Overview, Connection, Recall, Security, Maintenance, Updates), with verified update discovery and node restart. Linux supports in-place replacement; macOS downloads the signed DMG until a recovery helper can live safely outside the replaceable app bundle.
+- **Settings reorganized** into focused tabs (Overview, Connection, Recall, Security, Maintenance, Updates), with verified update discovery and node restart. Linux supports verified in-place replacement. On macOS, CEREBRUM downloads and verifies the architecture-specific signed DMG, stages the replacement, hands activation to a helper outside the replaceable bundle, restarts into the new app, and rolls back on bounded readiness failure; manual DMG installation remains the explicit fallback.
 
 ---
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -2,7 +2,7 @@
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.16.2. Legacy organization/federation sections retain
+Verified against SAGE v11.17.8. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -709,7 +709,13 @@ Returns `EpochInfo(epoch_num, block_height, scores: list[ValidatorScore])`. Each
 
 ---
 
-### Pipeline (Agent-to-Agent Messaging)
+### Compatibility pipeline (agent-to-agent transport)
+
+The `pipe_*` methods remain public for older integrations and for the internal
+federated transport/receipt surface. New same-node integrations should prefer
+the canonical `message_*` / `messages_*` methods below. New MCP integrations
+should use the canonical `sage_message_*` workflow; deprecated `sage_pipe*`
+tool names are hidden from MCP discovery.
 
 #### `pipe_resolve()`
 

--- a/scripts/native-shell-windows-runtime-smoke.ps1
+++ b/scripts/native-shell-windows-runtime-smoke.ps1
@@ -164,6 +164,21 @@ function Read-ReadyStatus([string]$PipeName, [string]$ExpectedOrigin, [string]$E
     throw "timed out waiting for renderable verified SSCP status: $lastError"
 }
 
+function Get-ReadyStatusResult([string]$PipeName, [string]$ExpectedOrigin, [string]$ExpectedDaemon, [bool]$RequireStartupProof = $true, [int]$TimeoutSeconds = 60) {
+    # PowerShell may surface incidental pipeline output from native/.NET calls
+    # made while probing a named pipe. Treat only the deliberately shaped
+    # Status/ServerPid record as the function result. This keeps StrictMode from
+    # trying `.ServerPid` on an Object[] while retaining exact-count evidence if
+    # the probe ever emits zero or multiple valid result records.
+    $candidates = @(Read-ReadyStatus $PipeName $ExpectedOrigin $ExpectedDaemon $RequireStartupProof $TimeoutSeconds)
+    $results = @($candidates | Where-Object {
+        $null -ne $_ -and
+        $null -ne $_.PSObject.Properties['Status'] -and
+        $null -ne $_.PSObject.Properties['ServerPid']
+    })
+    return Get-One $results 'verified SSCP status result'
+}
+
 function Get-ExecutablePath([int]$ProcessId) {
     $process = Get-CimInstance Win32_Process -Filter "ProcessId = $ProcessId"
     if (-not $process -or -not $process.ExecutablePath) { throw "cannot resolve executable path for PID $ProcessId" }
@@ -351,7 +366,7 @@ try {
 
     $first = Start-Shell $shellExe.FullName $nodeDataRoot $ports
     $shellProcesses.Add($first)
-    $firstResult = Read-ReadyStatus $pipeName $origin $ExpectedVersion
+    $firstResult = Get-ReadyStatusResult $pipeName $origin $ExpectedVersion
     Assert-True (-not $first.HasExited) 'installed native shell exited before attachment evidence'
     Assert-ServerPath $firstResult $daemonPath
     $firstDaemon = Get-ExactProcessHandle $firstResult.ServerPid $daemonPath 'installed bundled daemon'
@@ -370,7 +385,7 @@ try {
     )
     $profileBDaemon = Start-Daemon $daemonPath $profileBHome $profileBPorts
     $daemonProcesses.Add($profileBDaemon)
-    $profileBResult = Read-ReadyStatus $profileBPipe $profileBOrigin $ExpectedVersion $false
+    $profileBResult = Get-ReadyStatusResult $profileBPipe $profileBOrigin $ExpectedVersion $false
     Assert-True ($profileBResult.ServerPid -eq $profileBDaemon.Id) 'profile-B SSCP server PID did not match the directly launched daemon'
     Assert-ServerPath $profileBResult $daemonPath
     Assert-True ($profileBResult.Status.instance_generation -cne $firstGeneration) 'distinct profiles reused one daemon generation'
@@ -380,14 +395,14 @@ try {
     $shellProcesses.Add($second)
     Assert-True ($second.WaitForExit(10000)) 'second native-shell launch did not hand off to the existing instance'
     Assert-True ($second.ExitCode -eq 0) "second native-shell launch exited with status $($second.ExitCode)"
-    $secondResult = Read-ReadyStatus $pipeName $origin $ExpectedVersion
+    $secondResult = Get-ReadyStatusResult $pipeName $origin $ExpectedVersion
     Assert-True ($secondResult.Status.instance_generation -ceq $firstGeneration) 'second launch changed the daemon generation'
     Assert-True ($secondResult.ServerPid -eq $firstResult.ServerPid) 'second launch changed the daemon PID'
     Assert-True (-not $first.HasExited) 'primary native shell exited during second-instance handoff'
 
     Assert-True ($first.CloseMainWindow()) 'installed shell did not expose a closeable main window'
     Assert-True ($first.WaitForExit(10000)) 'installed shell did not exit after normal window close'
-    $daemonOnly = Read-ReadyStatus $pipeName $origin $ExpectedVersion
+    $daemonOnly = Get-ReadyStatusResult $pipeName $origin $ExpectedVersion
     Assert-True ($daemonOnly.Status.instance_generation -ceq $firstGeneration) 'window close changed the daemon generation'
     Assert-True ($daemonOnly.ServerPid -eq $firstResult.ServerPid) 'window close changed the daemon PID'
     Assert-ServerPath $daemonOnly $daemonPath
@@ -424,7 +439,7 @@ try {
     $daemonPath = (Get-One (Get-ChildItem -LiteralPath $installRoot -Recurse -File -Filter 'sage-gui.exe' | Where-Object FullName -Match '(?i)[\\/]binaries[\\/]sage-gui\.exe$') 'reinstalled bundled daemon').FullName
     $reinstalled = Start-Shell $shellExe.FullName $nodeDataRoot $ports
     $shellProcesses.Add($reinstalled)
-    $reinstallResult = Read-ReadyStatus $pipeName $origin $ExpectedVersion
+    $reinstallResult = Get-ReadyStatusResult $pipeName $origin $ExpectedVersion
     Assert-True (-not $reinstalled.HasExited) 'reinstalled native shell exited before attachment evidence'
     Assert-ServerPath $reinstallResult $daemonPath
     $reinstallDaemon = Get-ExactProcessHandle $reinstallResult.ServerPid $daemonPath 'reinstalled bundled daemon'

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -45,6 +45,7 @@ test('release-facing version metadata stays aligned', () => {
     ['docs/reference/rest-api.md', `Reconciled through SAGE v${version}`],
     ['docs/reference/concepts/rbac-orgs-federation.md', `reconciled through SAGE v${version}`],
     ['docs/reference/app-v23-access-control-design.md', `SAGE v${version}`],
+    ['docs/ADMIN_BOOTSTRAP.md', `Reconciled through SAGE v${version}/app-v26`],
     ['docs/reference/app-v23-access-control-design.md', '## App-v24 readiness and memory-write barrier'],
     ['docs/reference/mcp-tools.md', 'A level-2 grant is never a remedy for a hard'],
     ['docs/reference/mcp-tools.md', 'never be substituted for this caller-scoped projection'],
@@ -59,6 +60,22 @@ test('release-facing version metadata stays aligned', () => {
   for (const [path, marker] of exact) {
     assert.ok(read(path).includes(marker), `${path} is missing current version marker: ${marker}`);
   }
+});
+
+test('v11.17.8 user and SDK guides keep canonical Messages contracts aligned', () => {
+  const architecture = read('docs/ARCHITECTURE.md');
+  const roadmap = read('docs/ROADMAP.md');
+  const gettingStarted = read('docs/GETTING_STARTED.md');
+  const sdkReadme = read('sdk/python/README.md');
+
+  assert.match(architecture, /Default TTL:\*\* 1440 minutes \(24 hours\)/);
+  assert.doesNotMatch(architecture, /Default TTL:\*\* 60 minutes/);
+  assert.match(architecture, /sage_message_send/);
+  assert.match(roadmap, /v11\.17\.x completion ledger/);
+  assert.match(roadmap, /helper outside the replaceable bundle/);
+  assert.match(gettingStarted, /advertises 31 MCP tools/);
+  assert.match(gettingStarted, /Deprecated `sage_pipe\*`\s+compatibility/);
+  assert.match(sdkReadme, /Compatibility pipeline/);
 });
 
 test('v11.17 app-v23 through app-v26 public contract markers stay release-visible', () => {

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -334,9 +334,15 @@ epoch = client.get_epoch()
 # Returns: EpochInfo(epoch_num, block_height, scores=[{validator_id, current_weight, ...}])
 ```
 
-### Pipeline (Agent-to-Agent Messaging)
+### Compatibility pipeline (agent-to-agent transport)
 
-The pipeline enables direct messaging between agents. Messages are routed by agent ID or provider name, with automatic expiry and journaling.
+The `pipe_*` SDK methods remain for existing integrations and federated
+transport/receipt compatibility. New same-node SDK integrations should use the
+canonical `message_*` / `messages_*` methods below. New MCP clients should use
+the canonical `sage_message_*` workflow; `sage_pipe*` MCP names are deprecated
+and hidden from tool discovery. Legacy local pipe completion may journal a
+summary, while foreign work and canonical Messages are never silently promoted
+into governed memory.
 
 ```python
 # Send a message to another agent


### PR DESCRIPTION
## Summary
- reconcile roadmap, architecture, federation, onboarding, admin, MCP-facing, and Python SDK guidance to the v11.17.8 contracts
- record shipped 11.17 work separately from remaining physical/signed-artifact acceptance
- correct canonical Messages, 24-hour TTL, app-v26 authority, renamed-agent, roaming federation, and macOS updater guidance
- harden the Windows installed-runtime smoke against incidental PowerShell pipeline output while preserving exact SSCP result validation

## Validation
- node --test scripts/version-alignment.test.mjs
- npm test (201 tests)
- git diff --check

## CI failure addressed
Main run 30968981013 failed only in the Windows installed package lifecycle smoke with StrictMode: property ServerPid missing on an Object[]; the new helper selects exactly one deliberately shaped Status/ServerPid result and fails if zero or multiple valid results exist.