### PR TITLE
release: SAGE v11.17.13

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
           node-version: '24'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Perform CodeQL Analysis
         id: analyze
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           category: '/language:${{ matrix.language }}'
           # Analyze everything, but do not let this action upload before the
@@ -100,7 +100,7 @@ jobs:
             "$RUNNER_TEMP/codeql-filtered/upload.sarif"
 
       - name: Upload filtered CodeQL SARIF
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: '${{ runner.temp }}/codeql-filtered/upload.sarif'
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/native-shell.yml
+++ b/.github/workflows/native-shell.yml
@@ -123,6 +123,10 @@ jobs:
           cargo clippy --locked --target ${{ matrix.rust-target }} --manifest-path desktop/sage-shell/Cargo.toml --all-targets -- -D warnings
       - name: Install pinned Tauri packager
         run: cargo install tauri-cli --version 2.11.4 --locked
+      - name: Prepare verified AppImage helper cache
+        if: runner.os == 'Linux'
+        shell: bash
+        run: scripts/prepare-tauri-appimage-tools.sh
       - name: Build unsigned installable package smoke
         shell: bash
         working-directory: desktop/sage-shell

--- a/README.md
+++ b/README.md
@@ -51,6 +51,31 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.17.13
+
+**New agents now appear where operators expect them.** Agents waiting for first
+approval are separated from activated local principals and shown in a
+conditional review queue at the top of **Agents**, with the existing atomic
+approve/reject controls. **Access Controls** remains focused on activated local
+agents. Exact ordinary agents advertised by connected SAGEs now have a distinct
+**From federation** directory, including whether read-only group permissions are
+unset or already linked; permission setup opens the existing Linked readers
+control focused on that exact `agent_id@chain` pair. Federation transport,
+ceremony, and Root identities are never cast as ordinary agents.
+
+**Linux preview packaging survives transient helper outages.** The native-shell
+gate preloads every Tauri AppImage helper through a three-attempt bounded retry,
+an atomic reusable cache, and an exact SHA-256 allowlist. Partial or corrupt
+entries are rejected, retries report the helper and attempt, and persistent or
+changed upstream artifacts fail with deterministic diagnostics instead of being
+silently trusted.
+
+This patch also refreshes the pinned Go runtime dependencies and CodeQL action.
+It changes no consensus rule, AppHash input, transaction type, key encoding,
+fork target, or application version. Existing v11.17 chains upgrade in place.
+
+Container: `ghcr.io/l33tdawg/sage:11.17.13`. SDK 11.17.13.
+
 ## What's New in v11.17.12
 
 **Federation agent sharing now fails safely and explains the real policy.** The
@@ -1322,7 +1347,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.17.12`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.17.13`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.17.12
+  version: 11.17.13
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.17.12"
+version = "11.17.13"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.17.12"
+version = "11.17.13"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.17.12",
+  "version": "11.17.13",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.17.12/app-v26. -->
+<!-- Reconciled through SAGE v11.17.13/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.17.12
+# sage-gui v11.17.13
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.17.12 advertises 31 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.17.13 advertises 31 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.17.12 is the current release.** This corrective release makes federated agent sharing preflight the selected agent's inbox eligibility before mutating domain visibility, exposes the independent federated-inbox restriction as an explicit Access Controls switch, and keeps long Tasks cards from widening the four-column board beyond the viewport. It retains v11.17.11's CPU-only embedding, idle-chain governance, and long-catalog Federation fixes. Governed app-v26 adds explicit per-group `read`, `read_write`, and `read_write_modify` authority without weakening owner control or federated read-only isolation. Existing chains upgrade in place without rewriting memories, historical authors, domains, trust, or prior blocks. The complete CI/security/fault matrix remains a mandatory publication invariant, including app-v23 through app-v26 replay and state-sync checks, and the native-shell productization bridge spans v11.11–v11.17.
+**Status (2026-08):** **v11.17.13 is the current release.** This corrective release moves first-approval identities into a conditional Agents review queue, keeps Access Controls focused on activated local principals, adds an exact-identity From federation directory with a safe path to read-only Linked-reader permissions, and makes Tauri AppImage helper acquisition bounded, cached, atomic, and SHA-256 verified. It retains v11.17.12's federated-inbox preflight and responsive Tasks fixes. Governed app-v26 adds explicit per-group `read`, `read_write`, and `read_write_modify` authority without weakening owner control or federated read-only isolation. Existing chains upgrade in place without rewriting memories, historical authors, domains, trust, or prior blocks. The complete CI/security/fault matrix remains a mandatory publication invariant, including app-v23 through app-v26 replay and state-sync checks, and the native-shell productization bridge spans v11.11–v11.17.
 
 **Hard constraint driving the whole plan:** no chain reset, no operator-typed commands. Existing chains must upgrade in place across all future releases.
 
@@ -35,6 +35,13 @@ that restriction is enabled. Companion remains a least-privilege profile; the
 operator explicitly decides whether connected SAGEs may discover its inbox.
 The same patch constrains long Tasks cards to their responsive grid tracks so
 all four desktop columns remain visible without horizontal page scrolling.
+
+v11.17.13 separates lifecycle populations in CEREBRUM: pending local identities
+are reviewed on Agents, activated principals remain in Access Controls, and
+exact ordinary agents advertised by connected SAGEs appear under From
+federation with their read-only Linked-reader state. The Linux native preview
+gate also preloads Tauri's AppImage helpers through a bounded SHA-256-verified
+cache, closing [#134](https://github.com/l33tdawg/sage/issues/134).
 
 The following acceptance and follow-up boundaries remain open after the 11.17.9
 code merge; they are not implied complete by Docker or CI evidence:

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.17.12. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.17.13. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -165,7 +165,7 @@ CometBFT without treating the consensus RPC as proof of application storage.
 
 ---
 
-## Related docs (reconciled through v11.17.12)
+## Related docs (reconciled through v11.17.13)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.17.12.
+Status: implementation contract through SAGE v11.17.13.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.

--- a/docs/reference/app-v25-upgrade-recovery.md
+++ b/docs/reference/app-v25-upgrade-recovery.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.17.12: internal/abci/app.go (app-v25 gate and immutable envelope), web/appv25_memory_legacy_adoption_worker.go, web/appv25_domain_continuity_worker.go, web/appv25_memory_legacy_adoption_control.go, and internal/store/appv25_domain_continuity.go. -->
+<!-- Reconciled through SAGE v11.17.13: internal/abci/app.go (app-v25 gate and immutable envelope), web/appv25_memory_legacy_adoption_worker.go, web/appv25_domain_continuity_worker.go, web/appv25_memory_legacy_adoption_control.go, and internal/store/appv25_domain_continuity.go. -->
 
 # App-v25 Upgrade, Historical Recovery, and Domain Continuity
 

--- a/docs/reference/concepts/app-v26-access-groups.md
+++ b/docs/reference/concepts/app-v26-access-groups.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.17.12/app-v26 code (2026-08-06). Cite file:line when behavior is non-obvious. -->
+<!-- Verified against SAGE v11.17.13/app-v26 code (2026-08-06). Cite file:line when behavior is non-obvious. -->
 
 # App-v26 Access Groups and member authority
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.17.12/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.17.13/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.17.12. Legacy organization/federation sections retain
+Verified against SAGE v11.17.13. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.17.12. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.17.13. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.17.12 code (2026-08-06). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.17.13 code (2026-08-06). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.17.12.
+Reconciled against internal/mcp for SAGE v11.17.13.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.17.12. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.17.13. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.17.12
+**Package:** `sage-agent-sdk` **Version:** 11.17.13
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.17.12. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.17.13. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/scripts/cerebrum-shell.test.mjs
+++ b/scripts/cerebrum-shell.test.mjs
@@ -272,6 +272,54 @@ test('Access Controls is a first-class sidebar route', () => {
     );
 });
 
+test('pending agent activation is surfaced on Agents and excluded from Access Controls', () => {
+    const access = appSource.slice(
+        appSource.indexOf('function AppV23AccessControl()'),
+        appSource.indexOf('function NetworkPage('),
+    );
+    const agentsPage = appSource.slice(
+        appSource.indexOf('function NetworkPage('),
+        appSource.indexOf('function RemoteAccessWizard('),
+    );
+    assert.match(access, /reviewQueueOnly \? pendingEnrollment : !pendingEnrollment/);
+    assert.match(access, /Agents needing review/);
+    assert.match(access, /if \(reviewQueueOnly && localAgents\.length === 0\) return null/,
+        'the review section must disappear when there is nothing to review');
+    assert.match(agentsPage, /<\$\{AppV23AccessControl\} reviewQueueOnly=\$\{true\}/,
+        'the activation queue belongs at the top of Agents');
+    assert.ok(
+        agentsPage.indexOf('reviewQueueOnly=${true}') < agentsPage.indexOf('agent-directory-toolbar'),
+        'the conditional review queue must render before the active agent directory',
+    );
+    assert.match(agentsPage, /activeDirectoryAgents = agents\.filter\(agent => !pendingReviewIDs\.includes\(agent\.agent_id\)\)/,
+        'pending identities must not be duplicated in the active directory');
+});
+
+test('Agents has a separate exact-identity directory for federated agents', () => {
+    const federated = appSource.slice(
+        appSource.indexOf('function FederatedAgentDirectory()'),
+        appSource.indexOf('function NetworkPage('),
+    );
+    const agentsPage = appSource.slice(
+        appSource.indexOf('function NetworkPage('),
+        appSource.indexOf('function RemoteAccessWizard('),
+    );
+    assert.match(federated, /<h3 id="federated-agent-directory-title">From federation<\/h3>/);
+    assert.match(federated, /fedPipeContactsGet\(connection\.remote_chain_id, true\)/,
+        'new remote identities must come from authenticated contact discovery');
+    assert.match(federated, /fetchAppV23LinkedReaderIdentities\(\)/,
+        'already configured remote identities must remain visible while offline');
+    assert.doesNotMatch(federated, /peer_agent_id/,
+        'a federation transport or ceremony principal must never be cast as an ordinary remote agent');
+    assert.match(federated, /Permissions not set/);
+    assert.match(federated, /remote_chain: agent\.remote_chain_id[\s\S]*remote_agent: agent\.remote_agent_id/,
+        'permission setup must preserve the exact remote chain and agent identity');
+    assert.ok(
+        agentsPage.indexOf('<${FederatedAgentDirectory} />') < agentsPage.indexOf('agent-directory-toolbar'),
+        'federated identities must be categorized before the active local directory',
+    );
+});
+
 test('CEREBRUM Root is separate from agents and uses a two-stage one-time handover', () => {
     const access = appSource.slice(
         appSource.indexOf('function AppV23AccessControl()'),

--- a/scripts/native-shell-quality.sh
+++ b/scripts/native-shell-quality.sh
@@ -37,5 +37,6 @@ cargo build --locked --release --manifest-path "${MANIFEST}"
 # in the working tree, while CI's package job exercises the real bundle path.
 scripts/stage-native-shell-daemon.sh "$(rustc -vV | sed -n 's/^host: //p')"
 scripts/verify-native-shell-bundle.test.sh
+scripts/prepare-tauri-appimage-tools.test.sh
 
 bash -n scripts/acceptance-endpoint-guard.sh

--- a/scripts/prepare-tauri-appimage-tools.sh
+++ b/scripts/prepare-tauri-appimage-tools.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Populate Tauri's AppImage helper directory through a bounded, verified,
+# atomic cache. Tauri skips its own one-shot downloads when these exact files
+# exist, so transient upstream failures cannot discard an otherwise healthy
+# Linux package build.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd -P)
+TOOLS_MANIFEST=${SAGE_TAURI_APPIMAGE_MANIFEST:-${REPO_ROOT}/scripts/tauri-appimage-tools.sha256}
+TOOLS_CACHE=${SAGE_TAURI_APPIMAGE_CACHE:-${XDG_CACHE_HOME:-${HOME}/.cache}/tauri}
+CURL_BIN=${SAGE_TAURI_CURL_BIN:-curl}
+MAX_ATTEMPTS=3
+BASE_DELAY=${SAGE_TAURI_RETRY_DELAY_SECONDS:-1}
+
+case ${BASE_DELAY} in
+  ''|*[!0-9]*) echo "tauri-appimage-tools: retry delay must be an integer" >&2; exit 2 ;;
+esac
+if [ "${BASE_DELAY}" -gt 10 ]; then
+  echo "tauri-appimage-tools: retry delay must not exceed 10 seconds" >&2
+  exit 2
+fi
+if [ ! -f "${TOOLS_MANIFEST}" ]; then
+  echo "tauri-appimage-tools: manifest not found: ${TOOLS_MANIFEST}" >&2
+  exit 2
+fi
+
+mkdir -p "${TOOLS_CACHE}"
+LOCK_DIR=${TOOLS_CACHE}/.sage-appimage-tools.lock
+lock_attempt=1
+while ! mkdir "${LOCK_DIR}" 2>/dev/null; do
+  if [ "${lock_attempt}" -ge 20 ]; then
+    echo "tauri-appimage-tools: cache lock remained busy after ${lock_attempt} attempts" >&2
+    exit 1
+  fi
+  sleep 1
+  lock_attempt=$((lock_attempt + 1))
+done
+
+TEMP_FILES=()
+cleanup() {
+  for temp_file in "${TEMP_FILES[@]:-}"; do
+    rm -f -- "${temp_file}"
+  done
+  rmdir -- "${LOCK_DIR}" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+hash_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+hash_allowed() {
+  local actual=$1 allowed=$2 candidate
+  IFS=',' read -r -a candidates <<< "${allowed}"
+  for candidate in "${candidates[@]}"; do
+    if [ "${actual}" = "${candidate}" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+while IFS='|' read -r allowed_hashes helper_name helper_url; do
+  case ${allowed_hashes} in ''|'#'*) continue ;; esac
+  if [[ ! ${allowed_hashes} =~ ^[a-f0-9]{64}(,[a-f0-9]{64})*$ ]] ||
+     [[ ! ${helper_name} =~ ^[A-Za-z0-9._-]+$ ]] ||
+     [[ ! ${helper_url} =~ ^https:// ]]; then
+    echo "tauri-appimage-tools: invalid manifest entry for ${helper_name:-unknown}" >&2
+    exit 2
+  fi
+
+  target=${TOOLS_CACHE}/${helper_name}
+  if [ -f "${target}" ]; then
+    actual_hash=$(hash_file "${target}")
+    if hash_allowed "${actual_hash}" "${allowed_hashes}"; then
+      chmod 0755 "${target}"
+      echo "tauri-appimage-tools: helper=${helper_name} cache=hit sha256=${actual_hash}"
+      continue
+    fi
+    echo "tauri-appimage-tools: helper=${helper_name} cache=corrupt sha256=${actual_hash}; replacing"
+    rm -f -- "${target}"
+  else
+    echo "tauri-appimage-tools: helper=${helper_name} cache=miss"
+  fi
+
+  downloaded=false
+  attempt=1
+  while [ "${attempt}" -le "${MAX_ATTEMPTS}" ]; do
+    temp_file=$(mktemp "${TOOLS_CACHE}/.${helper_name}.download.XXXXXX")
+    TEMP_FILES+=("${temp_file}")
+    echo "tauri-appimage-tools: helper=${helper_name} attempt=${attempt}/${MAX_ATTEMPTS} downloading"
+    if "${CURL_BIN}" --location --fail --silent --show-error \
+        --connect-timeout 20 --max-time 180 \
+        --output "${temp_file}" "${helper_url}"; then
+      actual_hash=$(hash_file "${temp_file}")
+      if hash_allowed "${actual_hash}" "${allowed_hashes}"; then
+        chmod 0755 "${temp_file}"
+        mv -f -- "${temp_file}" "${target}"
+        echo "tauri-appimage-tools: helper=${helper_name} attempt=${attempt}/${MAX_ATTEMPTS} verified sha256=${actual_hash}"
+        downloaded=true
+        break
+      fi
+      echo "tauri-appimage-tools: helper=${helper_name} attempt=${attempt}/${MAX_ATTEMPTS} checksum_mismatch sha256=${actual_hash}" >&2
+    else
+      curl_status=$?
+      echo "tauri-appimage-tools: helper=${helper_name} attempt=${attempt}/${MAX_ATTEMPTS} curl_status=${curl_status}" >&2
+    fi
+    rm -f -- "${temp_file}"
+    if [ "${attempt}" -lt "${MAX_ATTEMPTS}" ] && [ "${BASE_DELAY}" -gt 0 ]; then
+      sleep $((BASE_DELAY * attempt))
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  if [ "${downloaded}" != true ]; then
+    echo "tauri-appimage-tools: helper=${helper_name} terminal_failure attempts=${MAX_ATTEMPTS} url=${helper_url}" >&2
+    exit 1
+  fi
+done < "${TOOLS_MANIFEST}"
+
+echo "tauri-appimage-tools: verified cache ready at ${TOOLS_CACHE}"

--- a/scripts/prepare-tauri-appimage-tools.test.sh
+++ b/scripts/prepare-tauri-appimage-tools.test.sh
@@ -6,6 +6,16 @@ REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd -P)
 TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/sage-tauri-appimage-tools-test.XXXXXX")
 trap 'rm -rf -- "${TEST_ROOT}"' EXIT INT TERM
 
+manifest_entries=0
+while IFS='|' read -r allowed_hashes helper_name helper_url; do
+  case ${allowed_hashes} in ''|'#'*) continue ;; esac
+  [[ ${allowed_hashes} =~ ^[a-f0-9]{64}(,[a-f0-9]{64})*$ ]]
+  [[ ${helper_name} =~ ^[A-Za-z0-9._-]+$ ]]
+  [[ ${helper_url} =~ ^https:// ]]
+  manifest_entries=$((manifest_entries + 1))
+done < "${REPO_ROOT}/scripts/tauri-appimage-tools.sha256"
+test "${manifest_entries}" = 5
+
 SOURCE=${TEST_ROOT}/source-helper
 MANIFEST=${TEST_ROOT}/manifest
 CACHE=${TEST_ROOT}/cache

--- a/scripts/prepare-tauri-appimage-tools.test.sh
+++ b/scripts/prepare-tauri-appimage-tools.test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd -P)
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/sage-tauri-appimage-tools-test.XXXXXX")
+trap 'rm -rf -- "${TEST_ROOT}"' EXIT INT TERM
+
+SOURCE=${TEST_ROOT}/source-helper
+MANIFEST=${TEST_ROOT}/manifest
+CACHE=${TEST_ROOT}/cache
+FAKE_CURL=${TEST_ROOT}/curl
+COUNT=${TEST_ROOT}/count
+printf 'verified helper bytes\n' > "${SOURCE}"
+EXPECTED=$(sha256sum "${SOURCE}" | awk '{print $1}')
+printf '%s|helper.AppImage|https://example.invalid/helper.AppImage\n' "${EXPECTED}" > "${MANIFEST}"
+
+printf '%s\n' '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'out=' \
+  'while [ "$#" -gt 0 ]; do' \
+  '  case "$1" in --output) out=$2; shift 2 ;; *) shift ;; esac' \
+  'done' \
+  'count=0; [ ! -f "${FAKE_COUNT}" ] || count=$(cat "${FAKE_COUNT}")' \
+  'count=$((count + 1)); printf "%s\n" "${count}" > "${FAKE_COUNT}"' \
+  'if [ "${FAKE_ALWAYS_FAIL:-0}" = 1 ] || { [ "${FAKE_FAIL_FIRST:-0}" = 1 ] && [ "${count}" = 1 ]; }; then exit 22; fi' \
+  'cp "${FAKE_SOURCE}" "${out}"' > "${FAKE_CURL}"
+chmod +x "${FAKE_CURL}"
+
+run_prepare() {
+  env \
+    SAGE_TAURI_APPIMAGE_MANIFEST="${MANIFEST}" \
+    SAGE_TAURI_APPIMAGE_CACHE="${CACHE}" \
+    SAGE_TAURI_CURL_BIN="${FAKE_CURL}" \
+    SAGE_TAURI_RETRY_DELAY_SECONDS=0 \
+    FAKE_COUNT="${COUNT}" \
+    FAKE_SOURCE="${SOURCE}" \
+    "$@" \
+    "${REPO_ROOT}/scripts/prepare-tauri-appimage-tools.sh"
+}
+
+run_prepare FAKE_FAIL_FIRST=1 > "${TEST_ROOT}/transient.log" 2>&1
+test "$(cat "${COUNT}")" = 2
+grep -F 'attempt=2/3 verified' "${TEST_ROOT}/transient.log" >/dev/null
+test "$(sha256sum "${CACHE}/helper.AppImage" | awk '{print $1}')" = "${EXPECTED}"
+
+run_prepare > "${TEST_ROOT}/hit.log" 2>&1
+test "$(cat "${COUNT}")" = 2
+grep -F 'cache=hit' "${TEST_ROOT}/hit.log" >/dev/null
+
+printf 'partial corrupt download' > "${CACHE}/helper.AppImage"
+run_prepare > "${TEST_ROOT}/corrupt.log" 2>&1
+test "$(cat "${COUNT}")" = 3
+grep -F 'cache=corrupt' "${TEST_ROOT}/corrupt.log" >/dev/null
+test "$(sha256sum "${CACHE}/helper.AppImage" | awk '{print $1}')" = "${EXPECTED}"
+
+rm -f -- "${CACHE}/helper.AppImage"
+if run_prepare FAKE_ALWAYS_FAIL=1 > "${TEST_ROOT}/persistent.log" 2>&1; then
+  echo 'persistent helper failure unexpectedly succeeded' >&2
+  exit 1
+fi
+test "$(cat "${COUNT}")" = 6
+grep -F 'attempt=3/3 curl_status=22' "${TEST_ROOT}/persistent.log" >/dev/null
+grep -F 'terminal_failure attempts=3' "${TEST_ROOT}/persistent.log" >/dev/null
+test ! -e "${CACHE}/helper.AppImage"
+
+echo 'Tauri AppImage helper retry/cache tests passed'

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -105,6 +105,17 @@ test('release actions stay pinned to immutable commits', () => {
   }
 });
 
+test('Linux native packaging preloads a bounded verified AppImage helper cache', () => {
+  const prepare = nativeShellWorkflow.indexOf('Prepare verified AppImage helper cache');
+  const build = nativeShellWorkflow.indexOf('Build unsigned installable package smoke');
+  assert.ok(prepare >= 0 && build >= 0 && prepare < build,
+    'verified AppImage helpers must be prepared before Tauri packaging');
+  const stepEnd = nativeShellWorkflow.indexOf('\n      - name:', prepare + 1);
+  const step = nativeShellWorkflow.slice(prepare, stepEnd);
+  assert.match(step, /if: runner\.os == 'Linux'/);
+  assert.match(step, /scripts\/prepare-tauri-appimage-tools\.sh/);
+});
+
 test('CodeQL uses the exact bundle audited by the CometBFT baseline', () => {
   const expected = `https://github.com/github/codeql-action/releases/download/codeql-bundle-v${codeqlBaseline.codeql.semanticVersion}/codeql-bundle-linux64.tar.gz`;
   const initMarkers = [...codeqlWorkflow.matchAll(/^      - name: Initialize CodeQL$/gm)];

--- a/scripts/tauri-appimage-tools.sha256
+++ b/scripts/tauri-appimage-tools.sha256
@@ -3,7 +3,7 @@
 # upstream; the pinned digest is the authority. linuxdeploy's second digest is
 # its deterministic post-download form after Tauri zeros bytes 8..10.
 f30140a43a0a59e46db21bdefdf749b9e9f2c6946e92afabbacf98b8ae73fb4f|AppRun-x86_64|https://github.com/tauri-apps/binary-releases/releases/download/apprun-old/AppRun-x86_64
-e762bea85c8eb0d4b3508d46e5c1f037f717d0f9303ae3b4aafc8b04991fa1,20eebde3c18ae2e44279bd624fc72482503aece216d5d77f10932235342f71c1|linuxdeploy-x86_64.AppImage|https://github.com/tauri-apps/binary-releases/releases/download/linuxdeploy/linuxdeploy-x86_64.AppImage
+e762bea85c8eb0d4b3508d46e5c1f037f717d0f9303ae3b4aafc8b04991fa1ef,20eebde3c18ae2e44279bd624fc72482503aece216d5d77f10932235342f71c1|linuxdeploy-x86_64.AppImage|https://github.com/tauri-apps/binary-releases/releases/download/linuxdeploy/linuxdeploy-x86_64.AppImage
 cb379f9b0733e9ad9f8bd78f8c2fa038aef2478523bb7d4c8e64ff6a1ea3501a|linuxdeploy-plugin-gtk.sh|https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
 c107b49d84edbffc6ab226ed1007e0626a4f7aa2c3a36b7782bef62351d49e94|linuxdeploy-plugin-gstreamer.sh|https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gstreamer/master/linuxdeploy-plugin-gstreamer.sh
 a45d3e227bc7f397e9cf6bfa4c9507494efa2293357b6e86690a3de2ca992e79|linuxdeploy-plugin-appimage.AppImage|https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage

--- a/scripts/tauri-appimage-tools.sha256
+++ b/scripts/tauri-appimage-tools.sha256
@@ -1,0 +1,9 @@
+# SHA-256 allowlist for the exact helper filenames tauri-bundler 2.9.4 reads
+# from ${XDG_CACHE_HOME:-$HOME/.cache}/tauri. URLs may move or be overwritten
+# upstream; the pinned digest is the authority. linuxdeploy's second digest is
+# its deterministic post-download form after Tauri zeros bytes 8..10.
+f30140a43a0a59e46db21bdefdf749b9e9f2c6946e92afabbacf98b8ae73fb4f|AppRun-x86_64|https://github.com/tauri-apps/binary-releases/releases/download/apprun-old/AppRun-x86_64
+e762bea85c8eb0d4b3508d46e5c1f037f717d0f9303ae3b4aafc8b04991fa1,20eebde3c18ae2e44279bd624fc72482503aece216d5d77f10932235342f71c1|linuxdeploy-x86_64.AppImage|https://github.com/tauri-apps/binary-releases/releases/download/linuxdeploy/linuxdeploy-x86_64.AppImage
+cb379f9b0733e9ad9f8bd78f8c2fa038aef2478523bb7d4c8e64ff6a1ea3501a|linuxdeploy-plugin-gtk.sh|https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
+c107b49d84edbffc6ab226ed1007e0626a4f7aa2c3a36b7782bef62351d49e94|linuxdeploy-plugin-gstreamer.sh|https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gstreamer/master/linuxdeploy-plugin-gstreamer.sh
+a45d3e227bc7f397e9cf6bfa4c9507494efa2293357b6e86690a3de2ca992e79|linuxdeploy-plugin-appimage.AppImage|https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -62,7 +62,7 @@ test('release-facing version metadata stays aligned', () => {
   }
 });
 
-test('v11.17.12 user and SDK guides keep canonical Messages contracts aligned', () => {
+test('v11.17.13 user and SDK guides keep canonical Messages contracts aligned', () => {
   const architecture = read('docs/ARCHITECTURE.md');
   const roadmap = read('docs/ROADMAP.md');
   const gettingStarted = read('docs/GETTING_STARTED.md');

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.17.12 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.17.13 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.17.12"
+version = "11.17.13"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.17.12"
+__version__ = "11.17.13"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.17.12",
+  "version": "11.17.13",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.17.12",
+      "identifier": "ghcr.io/l33tdawg/sage:11.17.13",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/css/sage.css
+++ b/web/static/css/sage.css
@@ -6511,6 +6511,93 @@ input[type="range"]::-moz-range-thumb {
 .v23-state-chip.active { background: var(--success-tint); color: var(--accent); }
 .v23-state-chip.pending,
 .v23-review-badge { background: var(--warning-tint); color: var(--warning); }
+
+.v23-access-shell.review-queue-only {
+    border-color: rgba(245, 158, 11, .35);
+    margin-bottom: 22px;
+}
+.v23-review-queue-heading {
+    align-items: flex-start;
+    display: flex;
+    gap: 18px;
+    justify-content: space-between;
+    padding: 20px 22px 0;
+}
+.v23-review-queue-heading h3 { margin: 2px 0 6px; }
+.v23-review-queue-heading p {
+    color: var(--text-muted);
+    font-size: 12px;
+    margin: 0;
+    max-width: 680px;
+}
+.v23-access-shell.review-queue-only .v23-access-legend,
+.v23-access-shell.review-queue-only .v23-groups-section,
+.v23-access-shell.review-queue-only .v23-root-card,
+.v23-access-shell.review-queue-only .v23-linked-readers,
+.v23-access-shell.review-queue-only .v23-linked-messages {
+    display: none;
+}
+.federated-agent-directory {
+    background: var(--bg-card);
+    border: 1px solid rgba(34, 211, 238, .28);
+    border-radius: 14px;
+    margin-bottom: 22px;
+    overflow: hidden;
+}
+.federated-agent-directory-heading {
+    align-items: flex-start;
+    display: flex;
+    gap: 18px;
+    justify-content: space-between;
+    padding: 20px 22px 14px;
+}
+.federated-agent-directory-heading h3 { margin: 2px 0 6px; }
+.federated-agent-directory-heading p {
+    color: var(--text-muted);
+    font-size: 12px;
+    margin: 0;
+    max-width: 760px;
+}
+.federated-agent-directory-heading > span {
+    background: rgba(34, 211, 238, .1);
+    border-radius: 999px;
+    color: #22d3ee;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 5px 10px;
+}
+.federated-agent-directory-list { border-top: 1px solid var(--border); }
+.federated-agent-card {
+    align-items: center;
+    display: grid;
+    gap: 14px;
+    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    padding: 14px 18px;
+}
+.federated-agent-card + .federated-agent-card { border-top: 1px solid var(--border); }
+.federated-agent-card .agent-avatar.federated {
+    color: #22d3ee;
+    font-size: 20px;
+}
+.federated-agent-card-copy {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+.federated-agent-card-copy > span { color: var(--text-muted); font-size: 12px; }
+.federated-agent-card-copy code {
+    color: var(--text-dim);
+    font-size: 10px;
+    margin-top: 3px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+@media (max-width: 760px) {
+    .federated-agent-card { grid-template-columns: auto minmax(0, 1fr); }
+    .federated-agent-card > .v23-state-chip,
+    .federated-agent-card > .btn { grid-column: 2; justify-self: start; }
+}
 .v23-policy-panel { min-width: 0; padding: 18px; }
 .v23-policy-title {
     align-items: flex-start;

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -55,7 +55,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.17.12';
+const SAGE_VERSION = 'v11.17.13';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -8858,8 +8858,15 @@ function AgentMemoryRecoveryPanel({ agent, agents, canControl }) {
 }
 
 function AppV23AccessControl() {
+    const {
+        reviewQueueOnly = false,
+        onDirectoryChanged = null,
+        onReviewQueueChanged = null,
+    } = arguments[0] || {};
     const routeQuery = new URLSearchParams((window.location.hash.split('?')[1] || ''));
     const recoveryAgentID = routeQuery.get('recovery') === '1' ? (routeQuery.get('agent') || '') : '';
+    const requestedRemoteChainID = routeQuery.get('remote_chain') || '';
+    const requestedRemoteAgentID = routeQuery.get('remote_agent') || '';
     const [state, setState] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
@@ -8920,8 +8927,15 @@ function AppV23AccessControl() {
             const next = appV23NormalizeAccessState(await fetchAppV23Access());
             setState(next);
             setError('');
-            const editable = (next.agents || [])[0];
-            setSelectedID(current => current && (next.agents || []).some(a => a.agent_id === current)
+            const candidates = (next.agents || []).filter(agent => {
+                const pendingEnrollment = agent.needs_approval && !agent.enrollment_active && !agent.needs_reauthorization;
+                return reviewQueueOnly ? pendingEnrollment : !pendingEnrollment;
+            });
+            if (reviewQueueOnly && onReviewQueueChanged) {
+                onReviewQueueChanged(candidates.map(agent => agent.agent_id));
+            }
+            const editable = candidates[0];
+            setSelectedID(current => current && candidates.some(a => a.agent_id === current)
                 ? current
                 : (editable?.agent_id || ''));
         } catch (e) {
@@ -8929,13 +8943,13 @@ function AppV23AccessControl() {
         } finally {
             setLoading(false);
         }
-    }, []);
+    }, [reviewQueueOnly]);
 
     useEffect(() => { load(); }, [load]);
 
     useEffect(() => {
         let cancelled = false;
-        if (state?.linked_readers?.status !== 'ready') {
+        if (reviewQueueOnly || state?.linked_readers?.status !== 'ready') {
             setRemoteCandidates([]);
             setSelectedRemoteKey('');
             return () => { cancelled = true; };
@@ -8993,9 +9007,14 @@ function AppV23AccessControl() {
                 const next = Array.from(discovered.values()).sort((a, b) =>
                     `${a.peer_name}/${a.label}`.localeCompare(`${b.peer_name}/${b.label}`));
                 setRemoteCandidates(next);
-                setSelectedRemoteKey(current => current && next.some(item => item.key === current)
-                    ? current
-                    : (next[0]?.key || ''));
+                const requestedKey = requestedRemoteChainID && requestedRemoteAgentID
+                    ? `${requestedRemoteChainID}\u0000${requestedRemoteAgentID}`
+                    : '';
+                setSelectedRemoteKey(current => requestedKey && next.some(item => item.key === requestedKey)
+                    ? requestedKey
+                    : current && next.some(item => item.key === current)
+                        ? current
+                        : (next[0]?.key || ''));
                 setLinkedError('');
             } catch (e) {
                 if (!cancelled) {
@@ -9006,10 +9025,22 @@ function AppV23AccessControl() {
             }
         })();
         return () => { cancelled = true; };
-    }, [state?.linked_readers?.status]);
+    }, [reviewQueueOnly, state?.linked_readers?.status, requestedRemoteChainID, requestedRemoteAgentID]);
+
+    useEffect(() => {
+        if (!requestedRemoteChainID || !requestedRemoteAgentID || !selectedRemoteKey) return;
+        const frame = requestAnimationFrame(() => {
+            document.querySelector('.v23-linked-readers')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
+        return () => cancelAnimationFrame(frame);
+    }, [requestedRemoteChainID, requestedRemoteAgentID, selectedRemoteKey]);
 
     const agents = state?.agents || [];
-    const localAgents = agents;
+    const pendingEnrollmentAgents = agents.filter(agent =>
+        agent.needs_approval && !agent.enrollment_active && !agent.needs_reauthorization);
+    const localAgents = reviewQueueOnly
+        ? pendingEnrollmentAgents
+        : agents.filter(agent => !pendingEnrollmentAgents.some(pending => pending.agent_id === agent.agent_id));
     const selected = localAgents.find(a => a.agent_id === selectedID) || null;
     const selectedRemote = remoteCandidates.find(item => item.key === selectedRemoteKey) || null;
     const selectedRemoteMaxClearance = Number(selectedRemote?.max_clearance ?? 4);
@@ -9221,6 +9252,7 @@ function AppV23AccessControl() {
                 showToast(result.projection_warning, 'info', 10000);
             }
             await load();
+            if (onDirectoryChanged) await onDirectoryChanged();
         } catch (e) {
             if (mutationMayHaveCommitted(e)) {
                 await holdPendingConfirmation(e.message);
@@ -9288,6 +9320,7 @@ function AppV23AccessControl() {
             await removeAgent(selected.agent_id, false);
             showToast('Registration rejected and removed from the review queue.', 'success');
             await load();
+            if (onDirectoryChanged) await onDirectoryChanged();
         } catch (e) {
             showToast(e.message || 'The registration could not be rejected.', 'error', 9000);
         } finally {
@@ -9774,6 +9807,7 @@ function AppV23AccessControl() {
 
     if (loading) return html`<div class="v23-access-loading">Loading consensus access policy…</div>`;
     if (error) return html`<div class="v23-access-banner danger"><strong>Access policy unavailable</strong><span>${error}</span><button class="btn" onClick=${load}>Retry</button></div>`;
+    if (reviewQueueOnly && localAgents.length === 0) return null;
 
     const brokerReady = state?.broker?.available === true;
     const mutationReady = state?.active === true && brokerReady && !saving && !renameBusy && !groupBusy && !pendingConfirmation;
@@ -9800,7 +9834,17 @@ function AppV23AccessControl() {
     };
 
     return html`
-        <section class="v23-access-shell">
+        <section class="v23-access-shell ${reviewQueueOnly ? 'review-queue-only' : ''}">
+            ${reviewQueueOnly && html`
+                <div class="v23-review-queue-heading">
+                    <div>
+                        <div class="v23-eyebrow">Activation queue</div>
+                        <h3>Agents needing review</h3>
+                        <p>These new identities have no access yet. Review, activate, or reject them before they join the active agent directory.</p>
+                    </div>
+                    <span class="v23-review-badge">${localAgents.length} pending</span>
+                </div>
+            `}
             ${!state.active && html`
                 <div class="v23-access-banner warning">
                     <strong>Upgrade required</strong>
@@ -9888,8 +9932,8 @@ function AppV23AccessControl() {
                     }}>
                     <div class="v23-section-heading">
                         <div>
-                            <div class="v23-eyebrow">Local principals</div>
-                            <h3>Agents</h3>
+                            <div class="v23-eyebrow">${reviewQueueOnly ? 'Awaiting activation' : 'Activated principals'}</div>
+                            <h3>${reviewQueueOnly ? 'Review queue' : 'Active agents'}</h3>
                         </div>
                         <span>${localAgents.length}</span>
                     </div>
@@ -9935,7 +9979,7 @@ function AppV23AccessControl() {
                                 : html`<span class="v23-state-chip active">Active</span>`}
                         </button>
                     `)}
-                    ${localAgents.length === 0 && html`<p class="v23-empty">No registered local agents.</p>`}
+                    ${localAgents.length === 0 && html`<p class="v23-empty">No activated local agents.</p>`}
                 </div>
 
                 <div class="v23-policy-panel">
@@ -10608,12 +10652,136 @@ function AppV23AccessControl() {
     `;
 }
 
+function FederatedAgentDirectory() {
+    const [remoteAgents, setRemoteAgents] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const [connectionResponse, inventoryResponse] = await Promise.all([
+                    fedConnections(),
+                    fetchAppV23LinkedReaderIdentities().catch(() => ({ identities: [] })),
+                ]);
+                const connections = Array.isArray(connectionResponse)
+                    ? connectionResponse
+                    : (connectionResponse?.connections || []);
+                const inventory = Array.isArray(inventoryResponse?.identities)
+                    ? inventoryResponse.identities
+                    : [];
+                const discovered = new Map();
+                const addRemote = (connection, agentID, label, source, linkCount = 0) => {
+                    const id = String(agentID || '').trim();
+                    const chain = String(connection?.remote_chain_id || '').trim();
+                    if (!chain || !/^[a-f0-9]{64}$/.test(id)) return;
+                    const key = `${chain}\u0000${id}`;
+                    const prior = discovered.get(key);
+                    discovered.set(key, {
+                        key,
+                        remote_chain_id: chain,
+                        remote_agent_id: id,
+                        label: label || prior?.label || `Agent ${id.slice(0, 8)}`,
+                        peer_name: connection?.peer_name || prior?.peer_name || chain,
+                        source: source || prior?.source || 'advertised',
+                        link_count: Math.max(Number(linkCount || 0), Number(prior?.link_count || 0)),
+                    });
+                };
+
+                await Promise.all(connections.map(async connection => {
+                    if (!connection?.remote_chain_id || connection.status === 'revoked') return;
+                    inventory
+                        .filter(identity => identity.remote_chain_id === connection.remote_chain_id)
+                        .forEach(identity => addRemote(
+                            connection,
+                            identity.remote_agent_id,
+                            `Known linked agent ${String(identity.remote_agent_id || '').slice(0, 8)}`,
+                            'existing_link',
+                            identity.link_count,
+                        ));
+                    try {
+                        const response = await fedPipeContactsGet(connection.remote_chain_id, true);
+                        const contacts = Array.isArray(response?.remote_contacts?.contacts)
+                            ? response.remote_contacts.contacts
+                            : [];
+                        contacts.forEach(contact => addRemote(
+                            connection,
+                            contact.agent_id,
+                            contact.display_name || contact.handle,
+                            'advertised',
+                        ));
+                    } catch (_) {
+                        // A federation connection proves a node, not an ordinary
+                        // remote agent. Only exact advertised or already-linked
+                        // identities belong in this directory.
+                    }
+                }));
+                if (!cancelled) {
+                    setRemoteAgents(Array.from(discovered.values()).sort((left, right) =>
+                        `${left.peer_name}/${left.label}`.localeCompare(`${right.peer_name}/${right.label}`)));
+                }
+            } catch (_) {
+                if (!cancelled) setRemoteAgents([]);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, []);
+
+    if (loading || remoteAgents.length === 0) return null;
+
+    const openPermissions = agent => {
+        const query = new URLSearchParams({
+            remote_chain: agent.remote_chain_id,
+            remote_agent: agent.remote_agent_id,
+        });
+        window.location.hash = `/access?${query.toString()}`;
+    };
+
+    return html`
+        <section class="federated-agent-directory" aria-labelledby="federated-agent-directory-title">
+            <div class="federated-agent-directory-heading">
+                <div>
+                    <div class="v23-eyebrow">Federated identities</div>
+                    <h3 id="federated-agent-directory-title">From federation</h3>
+                    <p>Agents advertised by connected SAGEs. They are never local members or roles; you may give an exact identity read-only access to selected local Access Groups.</p>
+                </div>
+                <span>${remoteAgents.length}</span>
+            </div>
+            <div class="federated-agent-directory-list">
+                ${remoteAgents.map(agent => html`
+                    <article class="federated-agent-card" key=${agent.key}>
+                        <div class="agent-avatar federated" aria-hidden="true">↗</div>
+                        <div class="federated-agent-card-copy">
+                            <strong>${agent.label}</strong>
+                            <span>${agent.peer_name}</span>
+                            <code title=${`${agent.remote_agent_id}@${agent.remote_chain_id}`}>
+                                ${agent.remote_agent_id.slice(0, 12)}@${agent.remote_chain_id}
+                            </code>
+                        </div>
+                        <span class="v23-state-chip ${agent.link_count > 0 ? 'active' : 'pending'}">
+                            ${agent.link_count > 0
+                                ? `${agent.link_count} linked group${agent.link_count === 1 ? '' : 's'}`
+                                : 'Permissions not set'}
+                        </span>
+                        <button class="btn ${agent.link_count > 0 ? 'ghost' : ''}" onClick=${() => openPermissions(agent)}>
+                            ${agent.link_count > 0 ? 'Manage permissions' : 'Set permissions'}
+                        </button>
+                    </article>
+                `)}
+            </div>
+        </section>
+    `;
+}
+
 // --- Network Page (Accordion) ---
 function NetworkPage({ sse, accessMode = false }) {
     const routeQuery = new URLSearchParams((window.location.hash.split('?')[1] || ''));
     const recoveryAgentID = routeQuery.get('recovery') === '1' ? (routeQuery.get('agent') || '') : '';
     const recoveryDomain = routeQuery.get('recovery') === '1' ? (routeQuery.get('domain') || '') : '';
     const [agents, setAgents] = useState([]);
+    const [pendingReviewIDs, setPendingReviewIDs] = useState([]);
     const [loading, setLoading] = useState(true);
     const [agentQuery, setAgentQuery] = useState('');
     const [agentSort, setAgentSort] = useState('last_seen');
@@ -11274,7 +11442,8 @@ function NetworkPage({ sse, accessMode = false }) {
         const value = Date.parse(agent?.[field] || '');
         return Number.isFinite(value) ? value : 0;
     };
-    const visibleAgents = agents
+    const activeDirectoryAgents = agents.filter(agent => !pendingReviewIDs.includes(agent.agent_id));
+    const visibleAgents = activeDirectoryAgents
         .filter(agent => {
             if (!normalizedAgentQuery) return true;
             return [agentDisplayName(agent), agent?.registered_name, agent?.agent_id, agent?.provider]
@@ -11357,8 +11526,13 @@ function NetworkPage({ sse, accessMode = false }) {
             <div class="network-header">
                 ${accessMode
                     ? html`<div><h2>Access Controls <${HelpTip} text="Review and change each local agent's domain permissions, clearance, and visibility. Access grants are enforced on-chain." /><${PageHelp} section="network" label="Access controls guide" /></h2><div class="network-header-sub">Select an agent to manage its access · ${agents.length} agent${agents.length !== 1 ? 's' : ''} on this node</div></div>`
-                    : html`<div><h2>Agents <${HelpTip} text="Manage the agents on your own SAGE node. Each agent is a separate participant in BFT consensus with its own permissions. Click any agent to expand its details and access. (To connect your whole node to ANOTHER SAGE, use Federation.)" /><${PageHelp} section="network" label="Agents guide" /></h2><div class="network-header-sub">${visibleAgents.length === agents.length ? agents.length : `${visibleAgents.length} of ${agents.length}`} agent${agents.length !== 1 ? 's' : ''} on this node</div></div>`}
+                    : html`<div><h2>Agents <${HelpTip} text="Manage the agents on your own SAGE node. New identities appear in the review queue before activation. Click an active agent to expand its details. (To connect your whole node to ANOTHER SAGE, use Federation.)" /><${PageHelp} section="network" label="Agents guide" /></h2><div class="network-header-sub">${visibleAgents.length === activeDirectoryAgents.length ? activeDirectoryAgents.length : `${visibleAgents.length} of ${activeDirectoryAgents.length}`} active agent${activeDirectoryAgents.length !== 1 ? 's' : ''} on this node</div></div>`}
             </div>
+
+            <${AppV23AccessControl} reviewQueueOnly=${true} onDirectoryChanged=${loadAgents}
+                onReviewQueueChanged=${setPendingReviewIDs} />
+
+            <${FederatedAgentDirectory} />
 
             <div class="agent-directory-toolbar" role="search" aria-label="Find and sort agents">
                 <label class="agent-directory-search">


### PR DESCRIPTION
## What changed

- Move pending local-agent activation reviews to a conditional queue at the top of Agents, and keep Access Controls focused on activated identities.
- Add a From federation directory for exact advertised or already-linked remote agents, with direct permission setup before local RBAC assignment.
- Make Linux AppImage helper acquisition bounded, checksum-verified, retryable, and cache-safe. Fixes #134.
- Include the current actions dependency pins from #153. The Go dependency refresh from #152 is already present on main and is part of this release baseline.
- Align release metadata and documentation at v11.17.13.

## Safety

No consensus, AppHash, transaction encoding, or fork logic changes are introduced by this PR.

## Verification

- `node --test scripts/*.test.mjs` — 211 passed
- `scripts/prepare-tauri-appimage-tools.test.sh` — passed
- `go test ./... -count=1 -timeout 30m` — passed
- `git diff --check` — clean

## Follow-ups intentionally not folded into this release

- #154 requires a coordinated updater snapshot-coherence design.
- #155 changes federation retry and route-refresh invariants.
- #135 and #137 are signed acceptance exercises rather than small code fixes.
