### PR TITLE
docs: add the upgrade guide, and the tools it tells operators to run

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -103,8 +103,7 @@
       "mcp__sage__sage_register",
       "mcp__sage__sage_timeline",
       "mcp__sage__sage_reinstate",
-      "mcp__sage__sage_rename",
-      "mcp__sage__sage_red_pill"
+      "mcp__sage__sage_rename"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ docs/*
 !docs/ADMIN_BOOTSTRAP.md
 !docs/HOOKS.md
 !docs/ISSUE_52_RECOVERY.md
+!docs/UPGRADING.md
 # v11 user guides (Dhillon-approved for publication 2026-07-04; docs/README.md links them)
 !docs/BRAIN.md
 !docs/FEDERATION.md

--- a/README.md
+++ b/README.md
@@ -1416,6 +1416,14 @@ not an unauthenticated MCP endpoint.
 
 ### Upgrading from an older version?
 
+**Upgrading an existing node — including the v10.x → v11 jump — is
+[docs/UPGRADING.md](docs/UPGRADING.md).** Short version: install the new binary,
+stop the node, `sage-gui backup --full`, `sage-gui upgrade preflight`, then start
+it. (The binary comes first because it is what provides those two commands.)
+Your chain advances in place; a personal node climbs the consensus fork ladder by
+itself. Read the guide before a multi-admin chain crosses app-v23 — that
+activation re-derives administrator authority.
+
 If you installed SAGE before v5.0 and your AI isn't doing turn-by-turn memory updates, re-run the installer in your project directory:
 
 ```bash
@@ -1433,6 +1441,7 @@ This installs Claude Code hooks that enforce the memory lifecycle (boot, turn, r
 |-----|-------------|
 | [Architecture & Deployment](docs/ARCHITECTURE.md) | Multi-agent networks, BFT, RBAC, federation, API reference |
 | [Getting Started](docs/GETTING_STARTED.md) | Setup walkthrough, embedding providers, multi-agent network guide |
+| [Upgrading](docs/UPGRADING.md) | Moving an existing node to a new release, including v10.x → v11: backup, preflight, the app-version ladder, and what app-v23 does to your admins |
 | [Security FAQ](SECURITY_FAQ.md) | Threat model, encryption, auth, signature scheme |
 | [Connect Your AI](https://l33tdawg.github.io/sage/connect.html) | Interactive setup wizard for any provider |
 

--- a/cmd/sage-gui/backup_full.go
+++ b/cmd/sage-gui/backup_full.go
@@ -309,19 +309,20 @@ func resolveRoot(path string) (string, error) {
 // backups directory itself is skipped: archiving prior archives balloons the
 // output and serves no recovery purpose. torn counts files whose size changed
 // mid-read — the most reliable evidence the node was not actually stopped.
-func writeBackupArchive(archivePath string, roots []string, manifest backupManifest) (size int64, torn int, err error) {
-	f, err := os.OpenFile(archivePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
-	if err != nil {
-		return 0, 0, fmt.Errorf("create archive: %w", err)
+func writeBackupArchive(archivePath string, roots []string, manifest backupManifest) (int64, int, error) {
+	torn := 0
+	f, openErr := os.OpenFile(archivePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if openErr != nil {
+		return 0, 0, fmt.Errorf("create archive: %w", openErr)
 	}
 	defer func() { _ = f.Close() }()
 
 	gz := gzip.NewWriter(f)
 	tw := tar.NewWriter(gz)
 
-	payload, err := json.MarshalIndent(manifest, "", "  ")
-	if err != nil {
-		return 0, 0, fmt.Errorf("encode manifest: %w", err)
+	payload, marshalErr := json.MarshalIndent(manifest, "", "  ")
+	if marshalErr != nil {
+		return 0, 0, fmt.Errorf("encode manifest: %w", marshalErr)
 	}
 	if err := tw.WriteHeader(&tar.Header{
 		Name: backupManifestName, Mode: 0600,
@@ -351,9 +352,9 @@ func writeBackupArchive(archivePath string, roots []string, manifest backupManif
 	if err := f.Sync(); err != nil {
 		return 0, 0, fmt.Errorf("sync archive: %w", err)
 	}
-	info, err := f.Stat()
-	if err != nil {
-		return 0, 0, fmt.Errorf("stat archive: %w", err)
+	info, statErr := f.Stat()
+	if statErr != nil {
+		return 0, 0, fmt.Errorf("stat archive: %w", statErr)
 	}
 	return info.Size(), torn, nil
 }
@@ -428,8 +429,8 @@ func archiveTree(tw *tar.Writer, root, prefix, skipDir string) (int, error) {
 				return fmt.Errorf("header %s: %w", path, err)
 			}
 			hdr.Name = name
-			if err := tw.WriteHeader(hdr); err != nil {
-				return fmt.Errorf("write header %s: %w", path, err)
+			if headerErr := tw.WriteHeader(hdr); headerErr != nil {
+				return fmt.Errorf("write header %s: %w", path, headerErr)
 			}
 			src, err := os.Open(path) //nolint:gosec // path comes from walking the operator's own SAGE home
 			if err != nil {

--- a/cmd/sage-gui/backup_full.go
+++ b/cmd/sage-gui/backup_full.go
@@ -886,10 +886,24 @@ func extractBackupArchive(path string, targets []string) error {
 			continue
 		}
 		root := cleanTargets[idx]
-		dest := filepath.Join(root, filepath.FromSlash(rel))
 
-		// Path traversal guard: a crafted archive must never write outside its
-		// target root.
+		// Sanitize the archive-supplied path into a value BEFORE it becomes a
+		// filesystem path. filepath.IsLocal rejects absolute paths, volume names,
+		// and every ".." escape, so nothing derived from the header can address
+		// anything outside root. Guarding the joined path afterwards would be
+		// equally safe at runtime but leaves the untrusted string flowing into
+		// the sink, which is both harder to audit and unprovable to a scanner.
+		safeRel := filepath.Clean(filepath.FromSlash(rel))
+		if safeRel == "." {
+			continue
+		}
+		if !filepath.IsLocal(safeRel) {
+			return fmt.Errorf("archive entry %q escapes its restore root", hdr.Name)
+		}
+		dest := filepath.Join(root, safeRel)
+
+		// Defence in depth: the join above cannot escape a local path, but keep
+		// the containment assertion so a future refactor cannot quietly remove it.
 		if !pathWithin(dest, root) {
 			return fmt.Errorf("archive entry %q escapes its restore root", hdr.Name)
 		}
@@ -902,16 +916,18 @@ func extractBackupArchive(path string, targets []string) error {
 		case tar.TypeSymlink:
 			// A symlink whose target escapes the root turns every LATER file
 			// entry into an arbitrary write: extracting "root0/link/file" would
-			// follow the link out of the tree. Validate the target, not just the
-			// entry name.
-			if err := validateSymlinkTarget(hdr.Linkname, dest, root); err != nil {
-				return err
+			// follow the link out of the tree. Sanitize the target into a new
+			// value and create THAT — the archive's own string never reaches
+			// os.Symlink.
+			safeLink, linkErr := sanitizeSymlinkTarget(hdr.Linkname, safeRel)
+			if linkErr != nil {
+				return fmt.Errorf("archive symlink %q: %w", hdr.Name, linkErr)
 			}
 			if err := os.MkdirAll(filepath.Dir(dest), 0700); err != nil {
 				return fmt.Errorf("create parent of %s: %w", dest, err)
 			}
 			_ = os.Remove(dest)
-			if err := os.Symlink(hdr.Linkname, dest); err != nil {
+			if err := os.Symlink(safeLink, dest); err != nil {
 				return fmt.Errorf("symlink %s: %w", dest, err)
 			}
 		case tar.TypeReg:
@@ -945,20 +961,32 @@ func extractBackupArchive(path string, targets []string) error {
 	}
 }
 
-// validateSymlinkTarget rejects absolute targets and relative targets that
-// resolve outside the restore root.
-func validateSymlinkTarget(linkname, dest, root string) error {
+// sanitizeSymlinkTarget validates an archive-supplied symlink target and returns
+// the exact relative target to create.
+//
+// It deliberately returns a RECOMPUTED value rather than echoing the header
+// field back: the untrusted string must never reach os.Symlink. entryRel is the
+// link's own already-sanitized path relative to the restore root, so resolving
+// the target against its directory and requiring the result to stay local is
+// sufficient — an escaping link would otherwise turn every later file entry into
+// an arbitrary write.
+func sanitizeSymlinkTarget(linkname, entryRel string) (string, error) {
 	if linkname == "" {
-		return fmt.Errorf("archive contains a symlink with an empty target at %q", dest)
+		return "", errors.New("empty target")
 	}
 	if filepath.IsAbs(linkname) {
-		return fmt.Errorf("archive symlink %q points to an absolute path %q; refusing to restore it", dest, linkname)
+		return "", fmt.Errorf("target %q is an absolute path", linkname)
 	}
-	resolved := filepath.Clean(filepath.Join(filepath.Dir(dest), linkname))
-	if !pathWithin(resolved, root) {
-		return fmt.Errorf("archive symlink %q points outside the restore root (%q)", dest, linkname)
+	linkDir := filepath.Dir(entryRel)
+	resolved := filepath.Join(linkDir, filepath.Clean(filepath.FromSlash(linkname)))
+	if !filepath.IsLocal(resolved) {
+		return "", fmt.Errorf("target %q points outside the restore root", linkname)
 	}
-	return nil
+	safe, err := filepath.Rel(linkDir, resolved)
+	if err != nil {
+		return "", fmt.Errorf("target %q could not be made relative: %w", linkname, err)
+	}
+	return safe, nil
 }
 
 // splitRootPrefix parses the "rootN/rest" entry naming written by the archiver.

--- a/cmd/sage-gui/backup_full.go
+++ b/cmd/sage-gui/backup_full.go
@@ -859,40 +859,53 @@ func extractBackupArchive(path string, targets []string) error {
 	}
 	defer func() { _ = gz.Close() }()
 
-	cleanTargets := make([]string, len(targets))
-	for i, t := range targets {
-		abs, absErr := filepath.Abs(t)
-		if absErr != nil {
-			return fmt.Errorf("resolve restore target %s: %w", t, absErr)
+	// Open each restore target as an os.Root and perform EVERY filesystem
+	// operation below through that handle. os.Root resolves each name inside the
+	// root and refuses anything that leaves it — including a traversal through a
+	// symlink an earlier archive entry planted. That is strictly stronger than
+	// validating a path and then calling the plain os functions: the check and
+	// the use are the same operation, so there is no window between them, and no
+	// archive-derived string is ever passed to an unscoped filesystem call.
+	roots := make([]*os.Root, len(targets))
+	defer func() {
+		for _, r := range roots {
+			if r != nil {
+				_ = r.Close()
+			}
 		}
-		cleanTargets[i] = abs
+	}()
+	for i, t := range targets {
+		if mkErr := os.MkdirAll(t, 0700); mkErr != nil {
+			return fmt.Errorf("create restore target %s: %w", t, mkErr)
+		}
+		r, openErr := os.OpenRoot(t)
+		if openErr != nil {
+			return fmt.Errorf("open restore target %s: %w", t, openErr)
+		}
+		roots[i] = r
 	}
 
 	tr := tar.NewReader(gz)
 	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
+		hdr, nextErr := tr.Next()
+		if nextErr == io.EOF {
 			return nil
 		}
-		if err != nil {
-			return fmt.Errorf("read archive: %w", err)
+		if nextErr != nil {
+			return fmt.Errorf("read archive: %w", nextErr)
 		}
 		if hdr.Name == backupManifestName {
 			continue
 		}
 
 		idx, rel, ok := splitRootPrefix(hdr.Name)
-		if !ok || idx >= len(cleanTargets) {
+		if !ok || idx >= len(roots) {
 			continue
 		}
-		root := cleanTargets[idx]
+		root := roots[idx]
 
-		// Sanitize the archive-supplied path into a value BEFORE it becomes a
-		// filesystem path. filepath.IsLocal rejects absolute paths, volume names,
-		// and every ".." escape, so nothing derived from the header can address
-		// anything outside root. Guarding the joined path afterwards would be
-		// equally safe at runtime but leaves the untrusted string flowing into
-		// the sink, which is both harder to audit and unprovable to a scanner.
+		// Reject non-local entry paths up front so a malformed archive fails with
+		// a message naming the entry, rather than as an opaque root-scope error.
 		safeRel := filepath.Clean(filepath.FromSlash(rel))
 		if safeRel == "." {
 			continue
@@ -900,61 +913,61 @@ func extractBackupArchive(path string, targets []string) error {
 		if !filepath.IsLocal(safeRel) {
 			return fmt.Errorf("archive entry %q escapes its restore root", hdr.Name)
 		}
-		dest := filepath.Join(root, safeRel)
-
-		// Defence in depth: the join above cannot escape a local path, but keep
-		// the containment assertion so a future refactor cannot quietly remove it.
-		if !pathWithin(dest, root) {
-			return fmt.Errorf("archive entry %q escapes its restore root", hdr.Name)
-		}
+		parent := filepath.Dir(safeRel)
 
 		switch hdr.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(dest, os.FileMode(hdr.Mode)&os.ModePerm); err != nil { //nolint:gosec // mode from the operator's own backup
-				return fmt.Errorf("create %s: %w", dest, err)
+			if mkErr := root.MkdirAll(safeRel, os.FileMode(hdr.Mode)&os.ModePerm); mkErr != nil { //nolint:gosec // mode from the operator's own backup
+				return fmt.Errorf("create %s: %w", hdr.Name, mkErr)
 			}
+
 		case tar.TypeSymlink:
-			// A symlink whose target escapes the root turns every LATER file
-			// entry into an arbitrary write: extracting "root0/link/file" would
-			// follow the link out of the tree. Sanitize the target into a new
-			// value and create THAT — the archive's own string never reaches
-			// os.Symlink.
+			// The link is created inside the root, and every later entry is also
+			// resolved through the root, so an escaping link cannot become a
+			// write primitive. Reject one anyway: restoring a link that points
+			// out of the tree would hand the operator a node whose paths lie.
 			safeLink, linkErr := sanitizeSymlinkTarget(hdr.Linkname, safeRel)
 			if linkErr != nil {
 				return fmt.Errorf("archive symlink %q: %w", hdr.Name, linkErr)
 			}
-			if err := os.MkdirAll(filepath.Dir(dest), 0700); err != nil {
-				return fmt.Errorf("create parent of %s: %w", dest, err)
-			}
-			_ = os.Remove(dest)
-			if err := os.Symlink(safeLink, dest); err != nil {
-				return fmt.Errorf("symlink %s: %w", dest, err)
-			}
-		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(dest), 0700); err != nil {
-				return fmt.Errorf("create parent of %s: %w", dest, err)
-			}
-			// Even with target validation, never write THROUGH a symlink planted
-			// at the destination itself. os.O_NOFOLLOW is not portable (undefined
-			// on Windows), so drop any existing symlink first and create fresh.
-			if info, lstatErr := os.Lstat(dest); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
-				if rmErr := os.Remove(dest); rmErr != nil {
-					return fmt.Errorf("remove symlink at %s before restoring a file there: %w", dest, rmErr)
+			if parent != "." {
+				if mkErr := root.MkdirAll(parent, 0700); mkErr != nil {
+					return fmt.Errorf("create parent of %s: %w", hdr.Name, mkErr)
 				}
 			}
-			out, err := os.OpenFile(dest, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode)&os.ModePerm) //nolint:gosec // mode from the operator's own backup
-			if err != nil {
-				return fmt.Errorf("create %s: %w", dest, err)
+			_ = root.Remove(safeRel)
+			if symErr := root.Symlink(safeLink, safeRel); symErr != nil {
+				return fmt.Errorf("symlink %s: %w", hdr.Name, symErr)
+			}
+
+		case tar.TypeReg:
+			if parent != "." {
+				if mkErr := root.MkdirAll(parent, 0700); mkErr != nil {
+					return fmt.Errorf("create parent of %s: %w", hdr.Name, mkErr)
+				}
+			}
+			// Never write through a symlink sitting at the destination. Opening
+			// through the root already refuses to follow one out of the tree;
+			// dropping it keeps an in-tree link from being clobbered by content.
+			if info, lstatErr := root.Lstat(safeRel); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+				if rmErr := root.Remove(safeRel); rmErr != nil {
+					return fmt.Errorf("remove symlink at %s before restoring a file there: %w", hdr.Name, rmErr)
+				}
+			}
+			out, openErr := root.OpenFile(safeRel, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode)&os.ModePerm) //nolint:gosec // mode from the operator's own backup
+			if openErr != nil {
+				return fmt.Errorf("create %s: %w", hdr.Name, openErr)
 			}
 			// Copy exactly the declared size: an unbounded io.Copy on a hostile
 			// archive is a decompression-bomb sink.
-			if _, err := io.CopyN(out, tr, hdr.Size); err != nil && err != io.EOF {
+			if _, copyErr := io.CopyN(out, tr, hdr.Size); copyErr != nil && copyErr != io.EOF {
 				_ = out.Close()
-				return fmt.Errorf("write %s: %w", dest, err)
+				return fmt.Errorf("write %s: %w", hdr.Name, copyErr)
 			}
-			if err := out.Close(); err != nil {
-				return fmt.Errorf("close %s: %w", dest, err)
+			if closeErr := out.Close(); closeErr != nil {
+				return fmt.Errorf("close %s: %w", hdr.Name, closeErr)
 			}
+
 		default:
 			continue
 		}

--- a/cmd/sage-gui/backup_full.go
+++ b/cmd/sage-gui/backup_full.go
@@ -1,0 +1,995 @@
+// backup_full.go implements the complete stopped-node backup and its matching
+// restore.
+//
+// Why this exists: `sage-gui backup` copies only data/sage.db, the SQLite
+// SERVING PROJECTION. Badger and CometBFT hold the canonical consensus state —
+// memories, RBAC, governance, agent identities, block history — and none of it
+// is in that file. Every recovery instruction in the docs asks for a "complete
+// stopped-node backup", and until now no command produced one. A .db copy taken
+// before an upgrade looks like insurance and is not: restoring it cannot rebuild
+// a chain.
+//
+// The archive is deliberately a plain tar.gz of the on-disk tree rather than a
+// logical export. A consensus database restored from a logical dump is a
+// different chain; a byte-identical tree is the same node. Correspondingly the
+// node MUST be stopped: a tar of a live Badger LSM tree is a torn read, and the
+// restore that follows would fail its AppHash.
+//
+// Liveness is decided by SAGE's own instance lock, not by a Badger probe. A
+// read-only Badger open is unusable as a cross-platform liveness signal because
+// badger refuses read-only opens outright on Windows (ErrWindowsNotSupported),
+// which would make both commands permanent brick walls on a shipped platform.
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	sageabci "github.com/l33tdawg/sage/internal/abci"
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+// backupManifest is written into the archive as sage-backup-manifest.json and
+// alongside it as a sidecar, so an operator can identify an archive without
+// unpacking it and restore can refuse an incompatible one.
+type backupManifest struct {
+	Kind            string    `json:"kind"`
+	CreatedAt       time.Time `json:"created_at"`
+	BinaryVersion   string    `json:"binary_version"`
+	ForkVersion     int       `json:"fork_version"`
+	AppVersion      uint64    `json:"app_version,omitempty"`
+	PersistedHeight int64     `json:"persisted_height"`
+	SageHome        string    `json:"sage_home"`
+	DataDir         string    `json:"data_dir"`
+	// DataDirLink is the path INSIDE SAGE_HOME that symlinked to DataDir, when
+	// data_dir was reached through a symlink. The link itself cannot be archived
+	// (it points outside the tree), so restore recreates it — otherwise the
+	// restored node's config names a data_dir that no longer exists.
+	DataDirLink   string   `json:"data_dir_link,omitempty"`
+	DataDirNested bool     `json:"data_dir_nested"`
+	Roots         []string `json:"roots"`
+}
+
+const (
+	backupKindFull     = "sage-complete-stopped-node-backup-v1"
+	backupManifestName = "sage-backup-manifest.json"
+)
+
+// extractFullBackupFlag reports whether --full appears anywhere in args and
+// returns the remaining arguments for the full-backup flag set. Order
+// independence is deliberate: the failure mode of positional-only matching is a
+// silent downgrade to the SQLite-only backup, which is exactly the false
+// confidence this command exists to remove. The `--full=false` form is honoured
+// rather than ignored, so an explicit opt-out means what it says.
+func extractFullBackupFlag(args []string) ([]string, bool, error) {
+	rest := make([]string, 0, len(args))
+	full := false
+	for _, a := range args {
+		switch {
+		case a == "--full" || a == "-full":
+			full = true
+		case strings.HasPrefix(a, "--full=") || strings.HasPrefix(a, "-full="):
+			raw := a[strings.IndexByte(a, '=')+1:]
+			parsed, err := strconv.ParseBool(raw)
+			if err != nil {
+				return nil, false, fmt.Errorf("invalid boolean value %q for --full", raw)
+			}
+			full = parsed
+		default:
+			rest = append(rest, a)
+		}
+	}
+	return rest, full, nil
+}
+
+// runBackupFull archives the complete node: SAGE_HOME (config, agent keys,
+// vault key) plus the data directory (badger, cometbft, sqlite) when it lives
+// outside SAGE_HOME.
+func runBackupFull(args []string) error {
+	fs := flag.NewFlagSet("backup --full", flag.ContinueOnError)
+	out := fs.String("out", "", "archive path to write (default: <SAGE_HOME>/backups/sage-full-<timestamp>.tar.gz)")
+	force := fs.Bool("force", false, "archive even if the node appears to be running (produces a TORN, unrestorable copy — do not use)")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	home := SageHome()
+	dataDir := cfg.DataDir
+
+	if probeErr := requireStoppedNode(home); probeErr != nil {
+		if !*force {
+			return fmt.Errorf("%w\n\n"+
+				"A complete backup requires a stopped node: archiving a live Badger LSM tree\n"+
+				"captures a torn state that will not restore. Stop SAGE and run this again.\n"+
+				"(--force overrides this and produces a backup you should not rely on.)", probeErr)
+		}
+		fmt.Fprintf(os.Stderr, "WARNING: %v\n", probeErr)
+		fmt.Fprintln(os.Stderr, "WARNING: --force given; this archive may be torn and unrestorable.")
+	}
+
+	height, appVersion := readNodeMetadata(filepath.Join(dataDir, "badger"))
+
+	roots, nested, err := backupRoots(home, dataDir)
+	if err != nil {
+		return err
+	}
+	// Record the RESOLVED data root, matching what roots holds. Persisting the
+	// unresolved cfg.DataDir here would make restore place the second tree at
+	// the symlink path, which overlaps SAGE_HOME and gets refused — i.e. backup
+	// would print a restore command that can never succeed.
+	manifestDataDir := dataDir
+	manifestDataDirLink := ""
+	if !nested && len(roots) > 1 {
+		manifestDataDir = roots[1]
+		// data_dir was reached through a symlink out of SAGE_HOME; remember the
+		// link so restore can put it back.
+		if absDataDir, absErr := filepath.Abs(dataDir); absErr == nil && absDataDir != roots[1] {
+			manifestDataDirLink = absDataDir
+		}
+	}
+
+	archivePath := *out
+	if archivePath == "" {
+		backupDir := filepath.Join(home, "backups")
+		if mkErr := os.MkdirAll(backupDir, 0700); mkErr != nil {
+			return fmt.Errorf("create backup dir: %w", mkErr)
+		}
+		stamp := time.Now().UTC().Format("2006-01-02T15-04-05")
+		archivePath = filepath.Join(backupDir, fmt.Sprintf("sage-full-%s.tar.gz", stamp))
+	} else if mkErr := os.MkdirAll(filepath.Dir(archivePath), 0700); mkErr != nil {
+		// An explicit --out into a not-yet-existing directory is normal (the
+		// documented Docker invocation does exactly this).
+		return fmt.Errorf("create directory for %s: %w", archivePath, mkErr)
+	}
+	if _, statErr := os.Stat(archivePath); statErr == nil {
+		return fmt.Errorf("refusing to overwrite existing archive %s", archivePath)
+	}
+
+	manifest := backupManifest{
+		Kind:            backupKindFull,
+		CreatedAt:       time.Now().UTC(),
+		BinaryVersion:   version,
+		ForkVersion:     ConsensusForkVersion,
+		AppVersion:      appVersion,
+		PersistedHeight: height,
+		SageHome:        home,
+		DataDir:         manifestDataDir,
+		DataDirLink:     manifestDataDirLink,
+		DataDirNested:   nested,
+		Roots:           roots,
+	}
+
+	fmt.Printf("Archiving complete stopped-node backup\n")
+	for _, r := range roots {
+		fmt.Printf("  including : %s\n", r)
+	}
+	fmt.Printf("  height    : %d\n", height)
+	if appVersion > 0 {
+		fmt.Printf("  app version: app-v%d\n", appVersion)
+	}
+
+	written, torn, err := writeBackupArchive(archivePath, roots, manifest)
+	if err != nil {
+		// Never leave a half-written archive that looks like a good backup.
+		_ = os.Remove(archivePath)
+		return err
+	}
+	if torn > 0 && !*force {
+		_ = os.Remove(archivePath)
+		return fmt.Errorf("%d file(s) changed size while being archived — the node is almost "+
+			"certainly still running and this archive would not restore. Stop SAGE and retry "+
+			"(--force accepts a torn archive)", torn)
+	}
+
+	// A "complete" backup with no consensus database in it is the single most
+	// dangerous outcome here: it looks like insurance and restores nothing.
+	if err := verifyArchiveHasConsensusState(archivePath); err != nil {
+		if !*force {
+			_ = os.Remove(archivePath)
+			return fmt.Errorf("%w\n\nRefusing to report a complete backup that contains no "+
+				"consensus state. Check that data_dir (%s) is correct", err, dataDir)
+		}
+		fmt.Fprintf(os.Stderr, "WARNING: %v\n", err)
+	}
+
+	sidecar := archivePath + ".manifest.json"
+	payload, _ := json.MarshalIndent(manifest, "", "  ")
+	if writeErr := os.WriteFile(sidecar, payload, 0600); writeErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not write manifest sidecar: %v\n", writeErr)
+	}
+
+	fmt.Printf("\nBackup written: %s (%s)\n", archivePath, humanBytes(written))
+	fmt.Printf("Manifest      : %s\n", sidecar)
+	fmt.Println("\nThis archive is UNENCRYPTED and contains agent keys, the vault key, TLS keys,")
+	fmt.Println("and MCP tokens. Treat it as a secret: keep it on an encrypted volume.")
+	fmt.Printf("\nRestore with: sage-gui restore --from %s --force\n", archivePath)
+	return nil
+}
+
+// requireStoppedNode reports an error when a SAGE node currently owns the
+// instance lock. This is the authoritative, cross-platform liveness signal: the
+// serve process holds it exclusively for its whole lifetime.
+func requireStoppedNode(sageHome string) error {
+	lock, err := acquireInstanceLock(sageHome)
+	if err != nil {
+		if errors.Is(err, errInstanceLockHeld) {
+			return fmt.Errorf("SAGE is running (it owns %s)",
+				filepath.Join(sageHome, "sage.instance.lock"))
+		}
+		// Could not evaluate the lock at all (permissions, unwritable home).
+		// Fail closed rather than assume the node is stopped.
+		return fmt.Errorf("cannot determine whether SAGE is running: %w", err)
+	}
+	// Release immediately: this process is not the node.
+	_ = lock.Close()
+	return nil
+}
+
+// readNodeMetadata best-effort reads the height and highest applied app version
+// for the manifest. It must never block a backup: Badger refuses read-only opens
+// on Windows entirely, and an unclean shutdown needs a replay this command will
+// not perform. Zero values simply mean "unknown".
+func readNodeMetadata(badgerPath string) (height int64, appVersion uint64) {
+	if _, statErr := os.Stat(badgerPath); statErr != nil {
+		return 0, 0
+	}
+	bs, openErr := store.OpenBadgerStoreReadOnly(badgerPath)
+	if openErr != nil {
+		return 0, 0
+	}
+	defer func() { _ = bs.CloseBadger() }()
+
+	if state, stateErr := sageabci.LoadState(bs); stateErr == nil && state != nil {
+		height = state.Height
+	}
+	appVersion = highestAppliedVersion(bs, sageabci.MaxSupportedAppVersion())
+	return height, appVersion
+}
+
+// backupRoots returns the directories to archive. When data_dir has been moved
+// outside SAGE_HOME both trees are captured; otherwise SAGE_HOME alone covers
+// everything. Symlinks are resolved first: a symlinked data_dir would otherwise
+// be archived as a one-line link entry, producing a "complete" backup holding no
+// consensus state at all.
+func backupRoots(home, dataDir string) (roots []string, nested bool, err error) {
+	absHome, err := resolveRoot(home)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve SAGE home: %w", err)
+	}
+	absData, err := resolveRoot(dataDir)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve data dir: %w", err)
+	}
+	if _, statErr := os.Stat(absHome); statErr != nil {
+		return nil, false, fmt.Errorf("SAGE home %s not found (is this node initialized?)", absHome)
+	}
+	nested = absData == absHome ||
+		strings.HasPrefix(absData+string(os.PathSeparator), absHome+string(os.PathSeparator))
+	roots = []string{absHome}
+	if !nested {
+		if _, statErr := os.Stat(absData); statErr == nil {
+			roots = append(roots, absData)
+		}
+	}
+	return roots, nested, nil
+}
+
+// resolveRoot makes a path absolute and follows symlinks when the target exists,
+// so nesting decisions compare real locations.
+func resolveRoot(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if resolved, evalErr := filepath.EvalSymlinks(abs); evalErr == nil {
+		return resolved, nil
+	}
+	return abs, nil
+}
+
+// writeBackupArchive streams roots into a tar.gz. Entries are stored under a
+// per-root prefix so restore can place each tree back where it belongs. The
+// backups directory itself is skipped: archiving prior archives balloons the
+// output and serves no recovery purpose. torn counts files whose size changed
+// mid-read — the most reliable evidence the node was not actually stopped.
+func writeBackupArchive(archivePath string, roots []string, manifest backupManifest) (size int64, torn int, err error) {
+	f, err := os.OpenFile(archivePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		return 0, 0, fmt.Errorf("create archive: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+
+	payload, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return 0, 0, fmt.Errorf("encode manifest: %w", err)
+	}
+	if err := tw.WriteHeader(&tar.Header{
+		Name: backupManifestName, Mode: 0600,
+		Size: int64(len(payload)), ModTime: manifest.CreatedAt, Typeflag: tar.TypeReg,
+	}); err != nil {
+		return 0, 0, fmt.Errorf("write manifest header: %w", err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		return 0, 0, fmt.Errorf("write manifest: %w", err)
+	}
+
+	for i, root := range roots {
+		prefix := fmt.Sprintf("root%d", i)
+		n, treeErr := archiveTree(tw, root, prefix, filepath.Join(root, "backups"))
+		if treeErr != nil {
+			return 0, 0, treeErr
+		}
+		torn += n
+	}
+
+	if err := tw.Close(); err != nil {
+		return 0, 0, fmt.Errorf("finalize tar: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return 0, 0, fmt.Errorf("finalize gzip: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return 0, 0, fmt.Errorf("sync archive: %w", err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return 0, 0, fmt.Errorf("stat archive: %w", err)
+	}
+	return info.Size(), torn, nil
+}
+
+// archiveTree walks root and writes regular files, directories, and symlinks.
+// Sockets, pipes, and devices are skipped — a live node's control socket is not
+// part of the consensus state and cannot be tarred meaningfully. It returns the
+// number of files whose size changed between the header stat and the read.
+func archiveTree(tw *tar.Writer, root, prefix, skipDir string) (int, error) {
+	torn := 0
+	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			// A vanished temp file must not abort an otherwise-good backup.
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+			return fmt.Errorf("walk %s: %w", path, walkErr)
+		}
+		if skipDir != "" && path == skipDir {
+			return filepath.SkipDir
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return fmt.Errorf("relativize %s: %w", path, relErr)
+		}
+		if rel == "." {
+			return nil
+		}
+		name := filepath.ToSlash(filepath.Join(prefix, rel))
+
+		switch {
+		case info.Mode().IsDir():
+			hdr, err := tar.FileInfoHeader(info, "")
+			if err != nil {
+				return fmt.Errorf("header %s: %w", path, err)
+			}
+			hdr.Name = name + "/"
+			return tw.WriteHeader(hdr)
+
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return fmt.Errorf("readlink %s: %w", path, err)
+			}
+			// Restore accepts only relative link targets that stay inside the
+			// root, because anything else lets a later file entry write outside
+			// it. Archiving a link restore would reject produces a backup our
+			// own restore refuses, so normalize here instead:
+			//   - target resolves INSIDE the root -> store it root-relative
+			//     (an absolute in-tree target is perfectly restorable once
+			//     rewritten, so dropping it would silently lose the link)
+			//   - target escapes the root -> skip it. The common case is a
+			//     symlinked data_dir, whose real contents are already captured
+			//     as their own archive root, so nothing is lost.
+			linkname, ok := normalizeSymlinkTarget(target, path, root)
+			if !ok {
+				fmt.Fprintf(os.Stderr,
+					"note: skipping symlink %s -> %s (target is outside the archived tree; "+
+						"its contents are archived separately if they are part of this node)\n", path, target)
+				return nil
+			}
+			hdr, err := tar.FileInfoHeader(info, linkname)
+			if err != nil {
+				return fmt.Errorf("header %s: %w", path, err)
+			}
+			hdr.Name = name
+			return tw.WriteHeader(hdr)
+
+		case info.Mode().IsRegular():
+			hdr, err := tar.FileInfoHeader(info, "")
+			if err != nil {
+				return fmt.Errorf("header %s: %w", path, err)
+			}
+			hdr.Name = name
+			if err := tw.WriteHeader(hdr); err != nil {
+				return fmt.Errorf("write header %s: %w", path, err)
+			}
+			src, err := os.Open(path) //nolint:gosec // path comes from walking the operator's own SAGE home
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return fmt.Errorf("open %s: %w", path, err)
+			}
+			defer func() { _ = src.Close() }()
+			// tar demands exactly hdr.Size bytes. Bound the copy: a file that
+			// GREW would otherwise overrun the declared size and abort the whole
+			// archive, and one that SHRANK would leave the stream short.
+			written, err := io.CopyN(tw, src, hdr.Size)
+			if err != nil && err != io.EOF {
+				return fmt.Errorf("copy %s: %w", path, err)
+			}
+			if written < hdr.Size {
+				pad := make([]byte, hdr.Size-written)
+				if _, err := tw.Write(pad); err != nil {
+					return fmt.Errorf("pad %s: %w", path, err)
+				}
+			}
+			if written != hdr.Size {
+				torn++
+				fmt.Fprintf(os.Stderr, "warning: %s changed size while being archived\n", path)
+			}
+			return nil
+
+		default:
+			// Sockets/pipes/devices: nothing to preserve.
+			return nil
+		}
+	})
+	return torn, err
+}
+
+// normalizeSymlinkTarget converts a symlink target into the form restore
+// accepts — relative, and resolving inside root — or reports that it escapes.
+//
+// An absolute target that happens to point back inside the archived tree is
+// restorable once rewritten relative to the link's own directory, so it is
+// normalized rather than dropped. Only genuinely escaping targets are refused,
+// which keeps backup and validateSymlinkTarget in exact agreement.
+func normalizeSymlinkTarget(target, linkPath, root string) (string, bool) {
+	if target == "" {
+		return "", false
+	}
+	resolved := target
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(filepath.Dir(linkPath), target)
+	}
+	resolved = filepath.Clean(resolved)
+	if !pathWithin(resolved, root) {
+		return "", false
+	}
+	rel, err := filepath.Rel(filepath.Dir(linkPath), resolved)
+	if err != nil {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
+}
+
+// verifyArchiveHasConsensusState refuses to call an archive complete unless it
+// actually contains a Badger database.
+func verifyArchiveHasConsensusState(archivePath string) error {
+	f, err := os.Open(archivePath) //nolint:gosec // path this command just wrote
+	if err != nil {
+		return fmt.Errorf("reopen archive for verification: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("verify archive: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return errors.New("archive contains no badger/ consensus database")
+		}
+		if err != nil {
+			return fmt.Errorf("verify archive: %w", err)
+		}
+		if strings.Contains(hdr.Name, "/badger/") && hdr.Typeflag == tar.TypeReg {
+			return nil
+		}
+	}
+}
+
+// runRestore unpacks a complete backup produced by `backup --full`.
+func runRestore(args []string) error {
+	fs := flag.NewFlagSet("restore", flag.ContinueOnError)
+	from := fs.String("from", "", "path to a sage-full-*.tar.gz archive")
+	force := fs.Bool("force", false, "restore over an existing SAGE home (the current tree is moved aside, never deleted)")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if *from == "" {
+		return fmt.Errorf("usage: sage-gui restore --from <archive.tar.gz> [--force]")
+	}
+
+	manifest, err := readArchiveManifest(*from)
+	if err != nil {
+		return err
+	}
+	if manifest.Kind != backupKindFull {
+		return fmt.Errorf("%s is not a complete SAGE backup (kind %q)", *from, manifest.Kind)
+	}
+	if manifest.ForkVersion != ConsensusForkVersion {
+		return fmt.Errorf("archive was taken at consensus fork %d but this binary is fork %d — "+
+			"restoring across a fork boundary requires a history-preserving migration, not a restore",
+			manifest.ForkVersion, ConsensusForkVersion)
+	}
+
+	home := SageHome()
+	// Whether SAGE_HOME exists must be decided BEFORE the liveness probe: the
+	// instance-lock check creates the directory as a side effect, which would
+	// otherwise make a restore onto a fresh machine report "already exists".
+	homeExisted := true
+	if _, statErr := os.Stat(home); statErr != nil {
+		homeExisted = false
+	}
+	if probeErr := requireStoppedNode(home); probeErr != nil {
+		return fmt.Errorf("%w\n\nStop SAGE before restoring", probeErr)
+	}
+
+	// The restore layout comes from the MANIFEST, not from the current config.
+	// Deriving it from config would let a machine whose data_dir has since moved
+	// rename a tree aside that the archive never repopulates.
+	targets, err := restoreTargets(home, manifest)
+	if err != nil {
+		return err
+	}
+
+	// An archive living inside a tree we are about to rename would disappear
+	// mid-restore. The default backup location is inside SAGE_HOME, so this is
+	// the NORMAL case, not an exotic one — copy the archive somewhere safe and
+	// restore from the copy rather than refusing the command backup just printed.
+	absFrom, err := filepath.Abs(*from)
+	if err != nil {
+		return fmt.Errorf("resolve archive path: %w", err)
+	}
+	for _, target := range targets {
+		if !pathWithin(absFrom, target) {
+			continue
+		}
+		staged, stageErr := stageArchiveOutsideTargets(absFrom, targets)
+		if stageErr != nil {
+			return stageErr
+		}
+		defer func() { _ = os.RemoveAll(filepath.Dir(staged)) }()
+		fmt.Printf("Archive lives inside %s; using a temporary copy at %s\n", target, staged)
+		absFrom = staged
+		break
+	}
+
+	fmt.Printf("Restoring %s\n", *from)
+	fmt.Printf("  taken     : %s by sage-gui %s\n", manifest.CreatedAt.Format(time.RFC3339), manifest.BinaryVersion)
+	fmt.Printf("  height    : %d\n", manifest.PersistedHeight)
+	if manifest.AppVersion > 0 {
+		fmt.Printf("  app version: app-v%d\n", manifest.AppVersion)
+	}
+	for i, t := range targets {
+		fmt.Printf("  target %d  : %s\n", i, t)
+	}
+	if manifest.SageHome != "" && manifest.SageHome != targets[0] {
+		fmt.Printf("\nNOTE: the archive was taken under SAGE_HOME %s but is being restored to %s.\n",
+			manifest.SageHome, targets[0])
+		fmt.Println("Check data_dir in the restored config.yaml before starting the node.")
+	}
+
+	stamp := time.Now().UTC().Format("2006-01-02T15-04-05")
+	if !*force {
+		for i, target := range targets {
+			// Target 0 is SAGE_HOME, which the liveness probe may have just
+			// created; homeExisted records the truth from before that.
+			exists := homeExisted
+			if i > 0 {
+				_, statErr := os.Stat(target)
+				exists = statErr == nil
+			}
+			if exists {
+				return fmt.Errorf("%s already exists — pass --force to restore over it "+
+					"(the existing tree is moved to %s.pre-restore-%s, never deleted)",
+					target, target, stamp)
+			}
+		}
+	}
+
+	// Extract into staging directories first, then swap. A failure part-way
+	// through must never leave a half-populated tree at the live path.
+	staging := make([]string, len(targets))
+	for i, target := range targets {
+		staging[i] = fmt.Sprintf("%s.restore-%s", target, stamp)
+		if _, statErr := os.Stat(staging[i]); statErr == nil {
+			return fmt.Errorf("staging path %s already exists", staging[i])
+		}
+	}
+	cleanupStaging := func() {
+		for _, s := range staging {
+			_ = os.RemoveAll(s)
+		}
+	}
+	if err := extractBackupArchive(absFrom, staging); err != nil {
+		cleanupStaging()
+		return err
+	}
+
+	for i, target := range targets {
+		if _, statErr := os.Stat(target); statErr == nil {
+			aside := fmt.Sprintf("%s.pre-restore-%s", target, stamp)
+			if renameErr := os.Rename(target, aside); renameErr != nil {
+				cleanupStaging()
+				return fmt.Errorf("move existing %s aside: %w", target, renameErr)
+			}
+			fmt.Printf("  moved aside: %s -> %s\n", target, aside)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0700); err != nil {
+			return fmt.Errorf("create parent of %s: %w", target, err)
+		}
+		if renameErr := os.Rename(staging[i], target); renameErr != nil {
+			return fmt.Errorf("move restored tree into place at %s: %w (the restored data is at %s)",
+				target, renameErr, staging[i])
+		}
+	}
+
+	if err := restoreDataDirLink(manifest, targets); err != nil {
+		// The trees are already in place; a missing link is recoverable by hand,
+		// so report it loudly rather than failing the whole restore.
+		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+	}
+
+	fmt.Printf("\nRestored %d tree(s).\n", len(targets))
+	fmt.Println("Verify before serving traffic:  sage-gui upgrade preflight")
+	return nil
+}
+
+// restoreDataDirLink recreates the SAGE_HOME symlink that pointed at an
+// out-of-tree data directory. The link cannot travel inside the archive (restore
+// rejects escaping link targets, for good reason), so it is rebuilt from the
+// manifest instead. Without it the restored config.yaml names a data_dir that
+// does not exist and the node comes up with no chain.
+func restoreDataDirLink(manifest backupManifest, targets []string) error {
+	if manifest.DataDirLink == "" || len(targets) < 2 {
+		return nil
+	}
+	linkPath := manifest.DataDirLink
+	// Rebase the link into the restored home if SAGE_HOME moved.
+	if manifest.SageHome != "" && manifest.SageHome != targets[0] {
+		rel, err := filepath.Rel(manifest.SageHome, manifest.DataDirLink)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return fmt.Errorf("cannot place the data_dir symlink %s under %s; "+
+				"point data_dir at %s in config.yaml before starting the node",
+				manifest.DataDirLink, targets[0], targets[1])
+		}
+		linkPath = filepath.Join(targets[0], rel)
+	}
+	if _, statErr := os.Lstat(linkPath); statErr == nil {
+		return nil // something already occupies the path; do not clobber it
+	}
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0700); err != nil {
+		return fmt.Errorf("create parent for the data_dir symlink %s: %w", linkPath, err)
+	}
+	if err := os.Symlink(targets[1], linkPath); err != nil {
+		return fmt.Errorf("recreate the data_dir symlink %s -> %s: %w (create it by hand "+
+			"before starting the node)", linkPath, targets[1], err)
+	}
+	fmt.Printf("  recreated data_dir symlink: %s -> %s\n", linkPath, targets[1])
+	return nil
+}
+
+// restoreTargets decides where each archived root goes, using the archive's own
+// layout. Roots beyond the first are data directories that lived outside
+// SAGE_HOME when the backup was taken.
+func restoreTargets(home string, manifest backupManifest) ([]string, error) {
+	absHome, err := filepath.Abs(home)
+	if err != nil {
+		return nil, fmt.Errorf("resolve SAGE home: %w", err)
+	}
+	count := len(manifest.Roots)
+	if count == 0 {
+		count = 1
+	}
+	targets := []string{absHome}
+	if count > 1 {
+		// Roots[1] is the absolute, symlink-resolved path the data tree actually
+		// occupied. Prefer it over DataDir, which older archives may record as
+		// an unresolved symlink path that overlaps SAGE_HOME.
+		dataTarget := manifest.DataDir
+		if len(manifest.Roots) > 1 && filepath.IsAbs(manifest.Roots[1]) {
+			dataTarget = manifest.Roots[1]
+		}
+		if dataTarget == "" {
+			return nil, fmt.Errorf("archive records %d roots but no data_dir — cannot place the second tree", count)
+		}
+		absData, absErr := filepath.Abs(dataTarget)
+		if absErr != nil {
+			return nil, fmt.Errorf("resolve archived data dir: %w", absErr)
+		}
+		targets = append(targets, absData)
+	}
+	if len(targets) != count {
+		return nil, fmt.Errorf("archive records %d roots but this machine's layout resolves %d targets",
+			count, len(targets))
+	}
+	// The archive's roots were disjoint when it was taken. If this machine's
+	// SAGE_HOME makes them overlap, restoring the home tree would clobber (or be
+	// clobbered by) the data tree. Refuse rather than silently destroy one.
+	for i, a := range targets {
+		for j, b := range targets {
+			if i != j && pathWithin(b, a) {
+				return nil, fmt.Errorf("restore targets overlap on this machine (%s is inside %s) "+
+					"but were separate when the backup was taken — set SAGE_HOME to a layout that "+
+					"keeps them apart, then retry", b, a)
+			}
+		}
+	}
+	return targets, nil
+}
+
+// stageArchiveOutsideTargets copies an archive that lives inside a restore
+// target to a temporary directory, so renaming the target aside cannot make the
+// archive vanish mid-restore. The default backup location is inside SAGE_HOME,
+// so this is the ordinary path, not an edge case.
+func stageArchiveOutsideTargets(archivePath string, targets []string) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "sage-restore-")
+	if err != nil {
+		return "", fmt.Errorf("create staging dir for the archive: %w", err)
+	}
+	for _, t := range targets {
+		if pathWithin(tmpDir, t) {
+			_ = os.RemoveAll(tmpDir)
+			return "", fmt.Errorf("temporary directory %s is inside restore target %s; "+
+				"set TMPDIR outside it and retry", tmpDir, t)
+		}
+	}
+	dest := filepath.Join(tmpDir, filepath.Base(archivePath))
+	src, err := os.Open(archivePath) //nolint:gosec // operator-supplied archive path
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("open archive to stage it: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("create staged archive: %w", err)
+	}
+	if _, copyErr := io.Copy(out, src); copyErr != nil {
+		_ = out.Close()
+		_ = os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("stage archive: %w", copyErr)
+	}
+	if closeErr := out.Close(); closeErr != nil {
+		_ = os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("close staged archive: %w", closeErr)
+	}
+	return dest, nil
+}
+
+// pathWithin reports whether candidate sits inside root.
+func pathWithin(candidate, root string) bool {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	return candidate == absRoot ||
+		strings.HasPrefix(candidate, absRoot+string(os.PathSeparator))
+}
+
+// readArchiveManifest reads the manifest entry without extracting the archive.
+func readArchiveManifest(path string) (backupManifest, error) {
+	var manifest backupManifest
+	f, err := os.Open(path) //nolint:gosec // operator-supplied archive path
+	if err != nil {
+		return manifest, fmt.Errorf("open archive: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return manifest, fmt.Errorf("read archive (not a gzip file?): %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return manifest, fmt.Errorf("archive has no %s — not a SAGE complete backup", backupManifestName)
+		}
+		if err != nil {
+			return manifest, fmt.Errorf("read archive: %w", err)
+		}
+		if hdr.Name != backupManifestName {
+			continue
+		}
+		// Bounded read: the manifest is a few hundred bytes.
+		payload, err := io.ReadAll(io.LimitReader(tr, 1<<20))
+		if err != nil {
+			return manifest, fmt.Errorf("read manifest: %w", err)
+		}
+		if err := json.Unmarshal(payload, &manifest); err != nil {
+			return manifest, fmt.Errorf("decode manifest: %w", err)
+		}
+		return manifest, nil
+	}
+}
+
+// extractBackupArchive unpacks rootN/ prefixes into the corresponding targets.
+func extractBackupArchive(path string, targets []string) error {
+	f, err := os.Open(path) //nolint:gosec // operator-supplied archive path
+	if err != nil {
+		return fmt.Errorf("open archive: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("read archive: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	cleanTargets := make([]string, len(targets))
+	for i, t := range targets {
+		abs, absErr := filepath.Abs(t)
+		if absErr != nil {
+			return fmt.Errorf("resolve restore target %s: %w", t, absErr)
+		}
+		cleanTargets[i] = abs
+	}
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read archive: %w", err)
+		}
+		if hdr.Name == backupManifestName {
+			continue
+		}
+
+		idx, rel, ok := splitRootPrefix(hdr.Name)
+		if !ok || idx >= len(cleanTargets) {
+			continue
+		}
+		root := cleanTargets[idx]
+		dest := filepath.Join(root, filepath.FromSlash(rel))
+
+		// Path traversal guard: a crafted archive must never write outside its
+		// target root.
+		if !pathWithin(dest, root) {
+			return fmt.Errorf("archive entry %q escapes its restore root", hdr.Name)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(dest, os.FileMode(hdr.Mode)&os.ModePerm); err != nil { //nolint:gosec // mode from the operator's own backup
+				return fmt.Errorf("create %s: %w", dest, err)
+			}
+		case tar.TypeSymlink:
+			// A symlink whose target escapes the root turns every LATER file
+			// entry into an arbitrary write: extracting "root0/link/file" would
+			// follow the link out of the tree. Validate the target, not just the
+			// entry name.
+			if err := validateSymlinkTarget(hdr.Linkname, dest, root); err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(dest), 0700); err != nil {
+				return fmt.Errorf("create parent of %s: %w", dest, err)
+			}
+			_ = os.Remove(dest)
+			if err := os.Symlink(hdr.Linkname, dest); err != nil {
+				return fmt.Errorf("symlink %s: %w", dest, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(dest), 0700); err != nil {
+				return fmt.Errorf("create parent of %s: %w", dest, err)
+			}
+			// Even with target validation, never write THROUGH a symlink planted
+			// at the destination itself. os.O_NOFOLLOW is not portable (undefined
+			// on Windows), so drop any existing symlink first and create fresh.
+			if info, lstatErr := os.Lstat(dest); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+				if rmErr := os.Remove(dest); rmErr != nil {
+					return fmt.Errorf("remove symlink at %s before restoring a file there: %w", dest, rmErr)
+				}
+			}
+			out, err := os.OpenFile(dest, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode)&os.ModePerm) //nolint:gosec // mode from the operator's own backup
+			if err != nil {
+				return fmt.Errorf("create %s: %w", dest, err)
+			}
+			// Copy exactly the declared size: an unbounded io.Copy on a hostile
+			// archive is a decompression-bomb sink.
+			if _, err := io.CopyN(out, tr, hdr.Size); err != nil && err != io.EOF {
+				_ = out.Close()
+				return fmt.Errorf("write %s: %w", dest, err)
+			}
+			if err := out.Close(); err != nil {
+				return fmt.Errorf("close %s: %w", dest, err)
+			}
+		default:
+			continue
+		}
+	}
+}
+
+// validateSymlinkTarget rejects absolute targets and relative targets that
+// resolve outside the restore root.
+func validateSymlinkTarget(linkname, dest, root string) error {
+	if linkname == "" {
+		return fmt.Errorf("archive contains a symlink with an empty target at %q", dest)
+	}
+	if filepath.IsAbs(linkname) {
+		return fmt.Errorf("archive symlink %q points to an absolute path %q; refusing to restore it", dest, linkname)
+	}
+	resolved := filepath.Clean(filepath.Join(filepath.Dir(dest), linkname))
+	if !pathWithin(resolved, root) {
+		return fmt.Errorf("archive symlink %q points outside the restore root (%q)", dest, linkname)
+	}
+	return nil
+}
+
+// splitRootPrefix parses the "rootN/rest" entry naming written by the archiver.
+func splitRootPrefix(name string) (int, string, bool) {
+	slash := strings.IndexByte(name, '/')
+	if slash <= 0 {
+		return 0, "", false
+	}
+	head := name[:slash]
+	if !strings.HasPrefix(head, "root") {
+		return 0, "", false
+	}
+	idx, err := strconv.Atoi(head[len("root"):])
+	if err != nil || idx < 0 {
+		return 0, "", false
+	}
+	rest := strings.TrimSuffix(name[slash+1:], "/")
+	if rest == "" {
+		return idx, ".", true
+	}
+	return idx, rest, true
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/sage-gui/backup_full_test.go
+++ b/cmd/sage-gui/backup_full_test.go
@@ -741,3 +741,94 @@ func TestRestoreDataDirLinkDoesNotClobber(t *testing.T) {
 		t.Fatalf("existing directory at the link path was clobbered: %v", err)
 	}
 }
+
+// sanitizeSymlinkTarget is the restore-side sink guard: it must return a
+// recomputed relative target and refuse anything that leaves the restore root.
+// An escaping link is not merely a bad link — it turns every LATER file entry in
+// the archive into an arbitrary write.
+func TestSanitizeSymlinkTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		linkname string
+		entryRel string
+		want     string
+		wantErr  bool
+	}{
+		{"sibling", "sibling", "a/link", "sibling", false},
+		{"nested", "sub/file", "a/link", "sub/file", false},
+		{"up-but-still-inside", "../b/file", "a/link", "../b/file", false},
+		{"escapes-root", "../../outside", "a/link", "", true},
+		{"escapes-root-deep", "../../../etc/passwd", "a/b/link", "", true},
+		{"absolute", "/etc/passwd", "a/link", "", true},
+		{"empty", "", "a/link", "", true},
+		{"dot-dot-only", "..", "link", "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sanitizeSymlinkTarget(tc.linkname, tc.entryRel)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("linkname %q from %q was accepted, got %q", tc.linkname, tc.entryRel, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("linkname %q from %q rejected: %v", tc.linkname, tc.entryRel, err)
+			}
+			if filepath.ToSlash(got) != tc.want {
+				t.Fatalf("sanitized = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The sanitized target must resolve to the same place the original did, for
+// every target that is legitimately inside the root — sanitizing must not
+// silently redirect a valid link.
+func TestSanitizeSymlinkTargetPreservesResolution(t *testing.T) {
+	entryRel := filepath.Join("a", "link")
+	got, err := sanitizeSymlinkTarget("../b/file", entryRel)
+	if err != nil {
+		t.Fatalf("sanitize: %v", err)
+	}
+	origin := filepath.Join(filepath.Dir(entryRel), "../b/file")
+	sanitized := filepath.Join(filepath.Dir(entryRel), got)
+	if filepath.Clean(origin) != filepath.Clean(sanitized) {
+		t.Fatalf("sanitized target resolves to %q, original resolved to %q", sanitized, origin)
+	}
+}
+
+// An archive entry name that escapes must be refused before it becomes a path.
+func TestExtractRejectsNonLocalEntryName(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "abs-entry.tar.gz")
+	f, createErr := os.Create(archive)
+	if createErr != nil {
+		t.Fatalf("create: %v", createErr)
+	}
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	payload := []byte("x")
+	if headerErr := tw.WriteHeader(&tar.Header{
+		Name: "root0/../../escape.txt", Mode: 0600,
+		Size: int64(len(payload)), Typeflag: tar.TypeReg,
+	}); headerErr != nil {
+		t.Fatalf("header: %v", headerErr)
+	}
+	if _, writeErr := tw.Write(payload); writeErr != nil {
+		t.Fatalf("write: %v", writeErr)
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+	_ = f.Close()
+
+	dest := filepath.Join(t.TempDir(), "target")
+	if mkdirErr := os.MkdirAll(dest, 0700); mkdirErr != nil {
+		t.Fatalf("mkdir: %v", mkdirErr)
+	}
+	err := extractBackupArchive(archive, []string{dest})
+	if err == nil {
+		t.Fatal("entry name escaping the root was accepted")
+	}
+	if !strings.Contains(err.Error(), "escapes") {
+		t.Fatalf("unexpected error %v", err)
+	}
+}

--- a/cmd/sage-gui/backup_full_test.go
+++ b/cmd/sage-gui/backup_full_test.go
@@ -832,3 +832,88 @@ func TestExtractRejectsNonLocalEntryName(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 }
+
+// The attack a check-then-use guard cannot stop: a symlinked DIRECTORY already
+// sitting in the restore target. Validating the entry path proves only that the
+// string is in-tree; the write still follows the link out. Extraction goes
+// through os.Root, which refuses to traverse a link that leaves the root, so the
+// write must fail rather than land outside.
+func TestExtractRefusesTraversalThroughPlantedSymlinkDir(t *testing.T) {
+	base := t.TempDir()
+	dest := filepath.Join(base, "target")
+	outside := filepath.Join(base, "outside")
+	for _, d := range []string{dest, outside} {
+		if err := os.MkdirAll(d, 0700); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	// Pre-plant the hostile link, as a partial earlier extraction might leave.
+	if err := os.Symlink(outside, filepath.Join(dest, "sub")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	archive := filepath.Join(t.TempDir(), "traverse.tar.gz")
+	f, createErr := os.Create(archive)
+	if createErr != nil {
+		t.Fatalf("create: %v", createErr)
+	}
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	payload := []byte("PWNED")
+	// The entry name is entirely local — no "..", nothing a path check rejects.
+	if headerErr := tw.WriteHeader(&tar.Header{
+		Name: "root0/sub/evil.txt", Mode: 0600,
+		Size: int64(len(payload)), Typeflag: tar.TypeReg,
+	}); headerErr != nil {
+		t.Fatalf("header: %v", headerErr)
+	}
+	if _, writeErr := tw.Write(payload); writeErr != nil {
+		t.Fatalf("write: %v", writeErr)
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+	_ = f.Close()
+
+	err := extractBackupArchive(archive, []string{dest})
+
+	// The decisive assertion is not the error — it is that nothing was written
+	// outside the restore root.
+	if _, statErr := os.Stat(filepath.Join(outside, "evil.txt")); statErr == nil {
+		t.Fatal("archive wrote through a planted symlink to outside the restore root")
+	}
+	if err == nil {
+		t.Fatal("traversal through a planted symlink directory was accepted")
+	}
+}
+
+// A legitimate in-tree tree still extracts through the root handle unchanged —
+// the hardening must not cost ordinary restores.
+func TestExtractThroughRootHandlesNestedTree(t *testing.T) {
+	src := t.TempDir()
+	writeTree(t, src, map[string]string{
+		"config.yaml":             "c",
+		"a/b/c/deep.txt":          "deep",
+		"data/badger/000000.vlog": "v",
+	})
+	archive := filepath.Join(t.TempDir(), "nested.tar.gz")
+	if _, _, err := writeBackupArchive(archive, []string{src}, backupManifest{
+		Kind: backupKindFull, ForkVersion: ConsensusForkVersion, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("writeBackupArchive: %v", err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "restored")
+	if err := extractBackupArchive(archive, []string{dest}); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for rel, want := range map[string]string{
+		"config.yaml":             "c",
+		"a/b/c/deep.txt":          "deep",
+		"data/badger/000000.vlog": "v",
+	} {
+		b, readErr := os.ReadFile(filepath.Join(dest, filepath.FromSlash(rel)))
+		if readErr != nil || string(b) != want {
+			t.Fatalf("%s: got %q err %v, want %q", rel, b, readErr, want)
+		}
+	}
+}

--- a/cmd/sage-gui/backup_full_test.go
+++ b/cmd/sage-gui/backup_full_test.go
@@ -1,0 +1,743 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTree materializes a small file tree for archive round-trips.
+func writeTree(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0700); err != nil {
+			t.Fatalf("mkdir %s: %v", full, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0600); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+}
+
+func TestBackupArchiveRoundTrip(t *testing.T) {
+	src := t.TempDir()
+	writeTree(t, src, map[string]string{
+		"config.yaml":         "data_dir: data\n",
+		"agents/a/agent.key":  "SEED-A",
+		"data/badger/000.sst": "badger-bytes",
+		"data/sage.db":        "sqlite-bytes",
+	})
+	// A prior archive under backups/ must not be swept into the new one.
+	writeTree(t, src, map[string]string{"backups/old-full.tar.gz": "stale"})
+
+	archive := filepath.Join(t.TempDir(), "out.tar.gz")
+	manifest := backupManifest{
+		Kind:          backupKindFull,
+		CreatedAt:     time.Now().UTC(),
+		BinaryVersion: "test",
+		ForkVersion:   ConsensusForkVersion,
+		Roots:         []string{src},
+	}
+	if _, _, err := writeBackupArchive(archive, []string{src}, manifest); err != nil {
+		t.Fatalf("writeBackupArchive: %v", err)
+	}
+
+	got, err := readArchiveManifest(archive)
+	if err != nil {
+		t.Fatalf("readArchiveManifest: %v", err)
+	}
+	if got.Kind != backupKindFull || got.ForkVersion != ConsensusForkVersion {
+		t.Fatalf("manifest round-trip mismatch: %+v", got)
+	}
+
+	dest := filepath.Join(t.TempDir(), "restored")
+	if err := extractBackupArchive(archive, []string{dest}); err != nil {
+		t.Fatalf("extractBackupArchive: %v", err)
+	}
+
+	for rel, want := range map[string]string{
+		"config.yaml":         "data_dir: data\n",
+		"agents/a/agent.key":  "SEED-A",
+		"data/badger/000.sst": "badger-bytes",
+		"data/sage.db":        "sqlite-bytes",
+	} {
+		b, readErr := os.ReadFile(filepath.Join(dest, filepath.FromSlash(rel)))
+		if readErr != nil {
+			t.Fatalf("restored %s missing: %v", rel, readErr)
+		}
+		if string(b) != want {
+			t.Fatalf("restored %s = %q, want %q", rel, b, want)
+		}
+	}
+
+	// The backups directory is deliberately excluded — archiving prior archives
+	// balloons the output and serves no recovery purpose.
+	if _, statErr := os.Stat(filepath.Join(dest, "backups", "old-full.tar.gz")); statErr == nil {
+		t.Fatal("backups/ was archived; it must be skipped")
+	}
+}
+
+// Two roots (SAGE_HOME plus an out-of-tree data_dir) must land back in their
+// own targets, not be merged.
+func TestBackupArchiveSeparatesMultipleRoots(t *testing.T) {
+	homeSrc := t.TempDir()
+	dataSrc := t.TempDir()
+	writeTree(t, homeSrc, map[string]string{"config.yaml": "home"})
+	writeTree(t, dataSrc, map[string]string{"badger/000.sst": "data"})
+
+	archive := filepath.Join(t.TempDir(), "multi.tar.gz")
+	if _, _, err := writeBackupArchive(archive, []string{homeSrc, dataSrc}, backupManifest{
+		Kind: backupKindFull, ForkVersion: ConsensusForkVersion, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("writeBackupArchive: %v", err)
+	}
+
+	outHome := filepath.Join(t.TempDir(), "home")
+	outData := filepath.Join(t.TempDir(), "data")
+	if err := extractBackupArchive(archive, []string{outHome, outData}); err != nil {
+		t.Fatalf("extractBackupArchive: %v", err)
+	}
+
+	if b, err := os.ReadFile(filepath.Join(outHome, "config.yaml")); err != nil || string(b) != "home" {
+		t.Fatalf("home root not restored: %v %q", err, b)
+	}
+	if b, err := os.ReadFile(filepath.Join(outData, "badger", "000.sst")); err != nil || string(b) != "data" {
+		t.Fatalf("data root not restored: %v %q", err, b)
+	}
+	if _, err := os.Stat(filepath.Join(outHome, "badger")); err == nil {
+		t.Fatal("data root leaked into the home target")
+	}
+}
+
+// A crafted archive must never write outside its restore root.
+func TestExtractBackupArchiveRejectsPathTraversal(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "evil.tar.gz")
+	f, err := os.Create(archive)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	payload := []byte("pwned")
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "root0/../../escaped.txt", Mode: 0600,
+		Size: int64(len(payload)), Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatalf("header: %v", err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+	_ = f.Close()
+
+	dest := filepath.Join(t.TempDir(), "target")
+	if err := os.MkdirAll(dest, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	err = extractBackupArchive(archive, []string{dest})
+	if err == nil {
+		t.Fatal("path-traversal entry was accepted")
+	}
+	if !strings.Contains(err.Error(), "escapes") {
+		t.Fatalf("unexpected error %v, want an escape refusal", err)
+	}
+}
+
+// Liveness is decided by SAGE's own instance lock rather than a Badger probe:
+// Badger refuses read-only opens outright on Windows, which would make backup
+// and restore permanent brick walls there. Assert the lock actually gates.
+func TestRequireStoppedNodeRefusesWhileInstanceLockHeld(t *testing.T) {
+	home := t.TempDir()
+	lock, err := acquireInstanceLock(home)
+	if err != nil {
+		t.Fatalf("acquire instance lock: %v", err)
+	}
+	defer func() { _ = lock.Close() }()
+
+	if err := requireStoppedNode(home); err == nil {
+		t.Fatal("requireStoppedNode reported a stopped node while the instance lock was held")
+	}
+}
+
+// With no node running the probe must succeed and must not leave the lock held,
+// or a second call (and the real node) would be locked out.
+func TestRequireStoppedNodeAllowsStoppedNodeRepeatedly(t *testing.T) {
+	home := t.TempDir()
+	for i := 0; i < 2; i++ {
+		if err := requireStoppedNode(home); err != nil {
+			t.Fatalf("call %d: stopped node refused: %v", i, err)
+		}
+	}
+	lock, err := acquireInstanceLock(home)
+	if err != nil {
+		t.Fatalf("instance lock still held after probe: %v", err)
+	}
+	_ = lock.Close()
+}
+
+func TestBackupRootsDetectsNestedDataDir(t *testing.T) {
+	home := t.TempDir()
+	nestedData := filepath.Join(home, "data")
+	if err := os.MkdirAll(nestedData, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	roots, nested, err := backupRoots(home, nestedData)
+	if err != nil {
+		t.Fatalf("backupRoots: %v", err)
+	}
+	if !nested {
+		t.Fatal("data dir under SAGE home was not detected as nested")
+	}
+	if len(roots) != 1 {
+		t.Fatalf("roots = %v, want just the home tree", roots)
+	}
+}
+
+func TestBackupRootsCapturesExternalDataDir(t *testing.T) {
+	home := t.TempDir()
+	external := t.TempDir()
+
+	roots, nested, err := backupRoots(home, external)
+	if err != nil {
+		t.Fatalf("backupRoots: %v", err)
+	}
+	if nested {
+		t.Fatal("an out-of-tree data dir was reported as nested")
+	}
+	if len(roots) != 2 {
+		t.Fatalf("roots = %v, want home and data trees", roots)
+	}
+}
+
+// A sibling directory sharing a prefix with SAGE_HOME is not inside it. Without
+// a separator-aware check, "/x/.sage-old" would be treated as nested under
+// "/x/.sage" and silently dropped from the backup.
+func TestBackupRootsPrefixSiblingIsNotNested(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, ".sage")
+	sibling := filepath.Join(base, ".sage-old")
+	for _, d := range []string{home, sibling} {
+		if err := os.MkdirAll(d, 0700); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	roots, nested, err := backupRoots(home, sibling)
+	if err != nil {
+		t.Fatalf("backupRoots: %v", err)
+	}
+	if nested {
+		t.Fatal("prefix-sharing sibling was misdetected as nested")
+	}
+	if len(roots) != 2 {
+		t.Fatalf("roots = %v, want both trees", roots)
+	}
+}
+
+func TestSplitRootPrefix(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantIdx int
+		wantRel string
+		wantOK  bool
+	}{
+		{"root0/config.yaml", 0, "config.yaml", true},
+		{"root2/a/b/c.txt", 2, "a/b/c.txt", true},
+		{"root1/", 1, ".", true},
+		{"sage-backup-manifest.json", 0, "", false},
+		{"notaroot/x", 0, "", false},
+	}
+	for _, tc := range cases {
+		idx, rel, ok := splitRootPrefix(tc.name)
+		if ok != tc.wantOK {
+			t.Fatalf("%q: ok = %v, want %v", tc.name, ok, tc.wantOK)
+		}
+		if !ok {
+			continue
+		}
+		if idx != tc.wantIdx || rel != tc.wantRel {
+			t.Fatalf("%q: got (%d,%q), want (%d,%q)", tc.name, idx, rel, tc.wantIdx, tc.wantRel)
+		}
+	}
+}
+
+func TestReadArchiveManifestRejectsNonBackup(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "plain.tar.gz")
+	f, err := os.Create(archive)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: "hello.txt", Mode: 0600, Size: 0, Typeflag: tar.TypeReg}); err != nil {
+		t.Fatalf("header: %v", err)
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+	_ = f.Close()
+
+	if _, err := readArchiveManifest(archive); err == nil {
+		t.Fatal("archive without a manifest was accepted as a SAGE backup")
+	}
+}
+
+func TestHumanBytes(t *testing.T) {
+	cases := map[int64]string{
+		512:             "512 B",
+		2048:            "2.0 KB",
+		5 * 1024 * 1024: "5.0 MB",
+	}
+	for in, want := range cases {
+		if got := humanBytes(in); got != want {
+			t.Fatalf("humanBytes(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// --full must be honoured wherever it appears, and the =-form must be parsed
+// rather than passed through. Both failure modes silently downgrade to the
+// SQLite-only projection copy while the operator believes they hold a complete
+// pre-upgrade backup.
+func TestExtractFullBackupFlagIsOrderIndependent(t *testing.T) {
+	cases := []struct {
+		args     []string
+		wantFull bool
+		wantRest []string
+	}{
+		{[]string{"--full"}, true, []string{}},
+		{[]string{"--full", "--out", "x"}, true, []string{"--out", "x"}},
+		{[]string{"--out", "x", "--full"}, true, []string{"--out", "x"}},
+		{[]string{"--full=true"}, true, []string{}},
+		{[]string{"--full=false"}, false, []string{}},
+		{[]string{"--out", "x"}, false, []string{"--out", "x"}},
+		{[]string{}, false, []string{}},
+	}
+	for _, tc := range cases {
+		rest, full, err := extractFullBackupFlag(tc.args)
+		if err != nil {
+			t.Fatalf("%v: unexpected error %v", tc.args, err)
+		}
+		if full != tc.wantFull {
+			t.Fatalf("%v: full = %v, want %v", tc.args, full, tc.wantFull)
+		}
+		if strings.Join(rest, " ") != strings.Join(tc.wantRest, " ") {
+			t.Fatalf("%v: rest = %v, want %v", tc.args, rest, tc.wantRest)
+		}
+	}
+}
+
+func TestExtractFullBackupFlagRejectsGarbageBoolean(t *testing.T) {
+	if _, _, err := extractFullBackupFlag([]string{"--full=yes-please"}); err == nil {
+		t.Fatal("garbage --full value was accepted")
+	}
+}
+
+// A symlinked data_dir must be followed, not archived as a one-line link entry.
+// Otherwise the archive contains zero consensus state and still reports success.
+func TestBackupRootsFollowsSymlinkedDataDir(t *testing.T) {
+	home := t.TempDir()
+	real := t.TempDir()
+	link := filepath.Join(home, "data")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	roots, nested, err := backupRoots(home, link)
+	if err != nil {
+		t.Fatalf("backupRoots: %v", err)
+	}
+	if nested {
+		t.Fatal("a data_dir symlinked outside SAGE home was reported as nested")
+	}
+	if len(roots) != 2 {
+		t.Fatalf("roots = %v, want the home tree and the resolved data tree", roots)
+	}
+}
+
+// A symlink entry whose target escapes the root turns every later file entry
+// into an arbitrary write. Reject the symlink itself.
+func TestExtractBackupArchiveRejectsEscapingSymlink(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "hatch.tar.gz")
+	f, err := os.Create(archive)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "root0/hatch", Linkname: "../../outside", Typeflag: tar.TypeSymlink, Mode: 0777,
+	}); err != nil {
+		t.Fatalf("header: %v", err)
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+	_ = f.Close()
+
+	dest := filepath.Join(t.TempDir(), "target")
+	if err := os.MkdirAll(dest, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	err = extractBackupArchive(archive, []string{dest})
+	if err == nil {
+		t.Fatal("escaping symlink entry was accepted")
+	}
+	if !strings.Contains(err.Error(), "outside the restore root") {
+		t.Fatalf("unexpected error %v", err)
+	}
+}
+
+func TestExtractBackupArchiveRejectsAbsoluteSymlink(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "abs.tar.gz")
+	f, err := os.Create(archive)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "root0/hatch", Linkname: "/etc", Typeflag: tar.TypeSymlink, Mode: 0777,
+	}); err != nil {
+		t.Fatalf("header: %v", err)
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+	_ = f.Close()
+
+	dest := filepath.Join(t.TempDir(), "target")
+	if err := os.MkdirAll(dest, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := extractBackupArchive(archive, []string{dest}); err == nil {
+		t.Fatal("absolute symlink entry was accepted")
+	}
+}
+
+// Restore layout must come from the manifest. Deriving it from the current
+// config lets a machine whose data_dir has since moved rename a tree aside that
+// the archive never repopulates.
+func TestRestoreTargetsUseManifestLayout(t *testing.T) {
+	home := t.TempDir()
+
+	single, err := restoreTargets(home, backupManifest{Roots: []string{"/old/home"}, DataDirNested: true})
+	if err != nil {
+		t.Fatalf("single-root: %v", err)
+	}
+	if len(single) != 1 {
+		t.Fatalf("single-root targets = %v, want 1", single)
+	}
+
+	external := filepath.Join(t.TempDir(), "external-data")
+	multi, err := restoreTargets(home, backupManifest{
+		Roots: []string{"/old/home", external}, DataDir: external,
+	})
+	if err != nil {
+		t.Fatalf("two-root: %v", err)
+	}
+	if len(multi) != 2 || multi[1] != external {
+		t.Fatalf("two-root targets = %v, want the archived data dir second", multi)
+	}
+}
+
+// An archive that records two roots but carries neither an absolute second root
+// nor a data_dir cannot be placed; refusing beats renaming a tree aside and
+// never repopulating it.
+func TestRestoreTargetsRefusesUnplaceableLayout(t *testing.T) {
+	_, err := restoreTargets(t.TempDir(), backupManifest{Roots: []string{"/a", "relative-root"}})
+	if err == nil {
+		t.Fatal("archive with an unplaceable second root was accepted")
+	}
+}
+
+func TestVerifyArchiveHasConsensusState(t *testing.T) {
+	src := t.TempDir()
+	writeTree(t, src, map[string]string{"config.yaml": "no chain here"})
+	empty := filepath.Join(t.TempDir(), "empty.tar.gz")
+	if _, _, err := writeBackupArchive(empty, []string{src}, backupManifest{
+		Kind: backupKindFull, ForkVersion: ConsensusForkVersion, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("writeBackupArchive: %v", err)
+	}
+	if err := verifyArchiveHasConsensusState(empty); err == nil {
+		t.Fatal("archive without a badger tree passed consensus-state verification")
+	}
+
+	writeTree(t, src, map[string]string{"data/badger/MANIFEST": "x"})
+	good := filepath.Join(t.TempDir(), "good.tar.gz")
+	if _, _, err := writeBackupArchive(good, []string{src}, backupManifest{
+		Kind: backupKindFull, ForkVersion: ConsensusForkVersion, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("writeBackupArchive: %v", err)
+	}
+	if err := verifyArchiveHasConsensusState(good); err != nil {
+		t.Fatalf("archive with a badger tree was rejected: %v", err)
+	}
+}
+
+// F6/F7 collided: backupRoots resolved a symlinked data_dir into its own root,
+// but archiveTree still emitted the link itself with an absolute target, which
+// validateSymlinkTarget then rejected — producing an archive our own restore
+// refused. Backup must never write an entry restore will not accept.
+func TestBackupSkipsSymlinksRestoreWouldReject(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	external := filepath.Join(base, "external")
+	if err := os.MkdirAll(filepath.Join(external, "badger"), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(home, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "badger", "MANIFEST"), []byte("m"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte("c"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(home, "data")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	roots, _, err := backupRoots(home, filepath.Join(home, "data"))
+	if err != nil {
+		t.Fatalf("backupRoots: %v", err)
+	}
+	archive := filepath.Join(t.TempDir(), "sym.tar.gz")
+	if _, _, err := writeBackupArchive(archive, roots, backupManifest{
+		Kind: backupKindFull, ForkVersion: ConsensusForkVersion,
+		CreatedAt: time.Now().UTC(), Roots: roots, DataDir: external,
+	}); err != nil {
+		t.Fatalf("writeBackupArchive: %v", err)
+	}
+
+	// The round trip must succeed: this is the archive backup just produced.
+	outs := []string{filepath.Join(t.TempDir(), "h"), filepath.Join(t.TempDir(), "d")}
+	if err := extractBackupArchive(archive, outs); err != nil {
+		t.Fatalf("restore rejected an archive this backup produced: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outs[1], "badger", "MANIFEST")); err != nil {
+		t.Fatalf("external data tree not restored: %v", err)
+	}
+}
+
+func TestNormalizeSymlinkTarget(t *testing.T) {
+	root := "/srv/sage"
+
+	if _, ok := normalizeSymlinkTarget("/elsewhere", "/srv/sage/data", root); ok {
+		t.Fatal("absolute target outside the root accepted")
+	}
+	if _, ok := normalizeSymlinkTarget("../../etc", "/srv/sage/a/b", root); ok {
+		t.Fatal("escaping relative target accepted")
+	}
+	if rel, ok := normalizeSymlinkTarget("sibling", "/srv/sage/a/b", root); !ok || rel != "sibling" {
+		t.Fatalf("in-tree relative target = (%q,%v), want (\"sibling\",true)", rel, ok)
+	}
+	// An absolute target pointing back inside the tree is restorable once made
+	// relative; dropping it would silently lose the link and leave the restored
+	// node pointing at a path that no longer exists.
+	rel, ok := normalizeSymlinkTarget("/srv/sage/realdata", "/srv/sage/data", root)
+	if !ok {
+		t.Fatal("absolute in-tree target was dropped instead of normalized")
+	}
+	if rel != "realdata" {
+		t.Fatalf("normalized target = %q, want \"realdata\"", rel)
+	}
+}
+
+// An absolute symlink pointing back inside SAGE_HOME must survive the round
+// trip: dropping it left the restored node with a config naming a data_dir that
+// no longer existed.
+func TestBackupPreservesInTreeAbsoluteSymlink(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "realdata", "badger"), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "realdata", "badger", "MANIFEST"), []byte("m"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(home, "realdata"), filepath.Join(home, "data")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	archive := filepath.Join(t.TempDir(), "in-tree.tar.gz")
+	if _, _, err := writeBackupArchive(archive, []string{home}, backupManifest{
+		Kind: backupKindFull, ForkVersion: ConsensusForkVersion, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("writeBackupArchive: %v", err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "restored")
+	if err := extractBackupArchive(archive, []string{dest}); err != nil {
+		t.Fatalf("restore rejected an archive this backup produced: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dest, "data")); err != nil {
+		t.Fatalf("in-tree symlink was not restored: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "data", "badger", "MANIFEST")); err != nil {
+		t.Fatalf("restored symlink does not resolve to the data tree: %v", err)
+	}
+}
+
+// The manifest must record the RESOLVED data root. Recording the symlink path
+// made restoreTargets produce overlapping targets and refuse the very archive
+// backup had just written.
+func TestSymlinkedDataDirRoundTripsThroughRestoreTargets(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	external := filepath.Join(base, "bigvol")
+	if err := os.MkdirAll(external, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(home, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	link := filepath.Join(home, "data")
+	if err := os.Symlink(external, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	roots, nested, err := backupRoots(home, link)
+	if err != nil {
+		t.Fatalf("backupRoots: %v", err)
+	}
+	if nested || len(roots) != 2 {
+		t.Fatalf("roots = %v nested = %v, want two disjoint roots", roots, nested)
+	}
+	// Mirror exactly what runBackupFull persists.
+	manifestDataDir := link
+	if !nested && len(roots) > 1 {
+		manifestDataDir = roots[1]
+	}
+	targets, err := restoreTargets(home, backupManifest{
+		Roots: roots, DataDir: manifestDataDir, DataDirNested: nested,
+	})
+	if err != nil {
+		t.Fatalf("restore refused an archive this backup would produce: %v", err)
+	}
+	if len(targets) != 2 || pathWithin(targets[1], targets[0]) {
+		t.Fatalf("targets = %v, want two disjoint paths", targets)
+	}
+}
+
+// Restore targets that overlap on this machine would clobber one another. They
+// were disjoint when the backup was taken, so refuse rather than destroy.
+func TestRestoreTargetsRefusesOverlappingLayout(t *testing.T) {
+	// A manifest whose second root genuinely lands inside this machine's
+	// SAGE_HOME — e.g. restoring an archive taken as SAGE_HOME=/old with
+	// data at /old/data under a SAGE_HOME of /old's parent.
+	home := t.TempDir()
+	nested := filepath.Join(home, "data")
+	_, err := restoreTargets(home, backupManifest{
+		Roots: []string{filepath.Join(home, "old"), nested}, DataDir: nested,
+	})
+	if err == nil {
+		t.Fatal("overlapping restore targets were accepted")
+	}
+	if !strings.Contains(err.Error(), "overlap") {
+		t.Fatalf("unexpected error %v", err)
+	}
+}
+
+// The default backup lives inside SAGE_HOME, which restore replaces. Staging it
+// outside must make the command backup prints actually work.
+func TestStageArchiveOutsideTargets(t *testing.T) {
+	home := t.TempDir()
+	inside := filepath.Join(home, "backups")
+	if err := os.MkdirAll(inside, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	archive := filepath.Join(inside, "a.tar.gz")
+	if err := os.WriteFile(archive, []byte("payload"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	staged, err := stageArchiveOutsideTargets(archive, []string{home})
+	if err != nil {
+		t.Fatalf("stageArchiveOutsideTargets: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(filepath.Dir(staged)) }()
+
+	if pathWithin(staged, home) {
+		t.Fatalf("staged archive %s is still inside the restore target %s", staged, home)
+	}
+	b, err := os.ReadFile(staged)
+	if err != nil || string(b) != "payload" {
+		t.Fatalf("staged copy is wrong: %v %q", err, b)
+	}
+}
+
+// The symlink that points SAGE_HOME/data at an external volume cannot travel
+// inside the archive (restore rejects escaping link targets). Restore must
+// rebuild it from the manifest, or the restored node's config.yaml names a
+// data_dir that no longer exists and it comes up with no chain.
+func TestRestoreRecreatesExternalDataDirLink(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	external := filepath.Join(base, "bigvol")
+	for _, d := range []string{home, external} {
+		if err := os.MkdirAll(d, 0700); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	link := filepath.Join(home, "data")
+
+	manifest := backupManifest{
+		Kind: backupKindFull, ForkVersion: ConsensusForkVersion,
+		SageHome: home, DataDir: external, DataDirLink: link,
+		Roots: []string{home, external},
+	}
+	if err := restoreDataDirLink(manifest, []string{home, external}); err != nil {
+		t.Fatalf("restoreDataDirLink: %v", err)
+	}
+
+	got, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("data_dir symlink was not recreated: %v", err)
+	}
+	if got != external {
+		t.Fatalf("symlink target = %q, want %q", got, external)
+	}
+}
+
+// A nested (non-symlinked) data_dir records no link, so nothing is recreated.
+func TestRestoreDataDirLinkNoopWithoutLink(t *testing.T) {
+	home := t.TempDir()
+	if err := restoreDataDirLink(backupManifest{SageHome: home}, []string{home}); err != nil {
+		t.Fatalf("no-link manifest produced an error: %v", err)
+	}
+}
+
+// Restore must never clobber something already sitting at the link path.
+func TestRestoreDataDirLinkDoesNotClobber(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	external := filepath.Join(base, "bigvol")
+	for _, d := range []string{home, external} {
+		if err := os.MkdirAll(d, 0700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	link := filepath.Join(home, "data")
+	if err := os.MkdirAll(link, 0700); err != nil {
+		t.Fatalf("mkdir link path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(link, "keep"), []byte("x"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := restoreDataDirLink(backupManifest{
+		SageHome: home, DataDir: external, DataDirLink: link, Roots: []string{home, external},
+	}, []string{home, external}); err != nil {
+		t.Fatalf("restoreDataDirLink: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(link, "keep")); err != nil {
+		t.Fatalf("existing directory at the link path was clobbered: %v", err)
+	}
+}

--- a/cmd/sage-gui/backup_full_test.go
+++ b/cmd/sage-gui/backup_full_test.go
@@ -117,9 +117,9 @@ func TestBackupArchiveSeparatesMultipleRoots(t *testing.T) {
 // A crafted archive must never write outside its restore root.
 func TestExtractBackupArchiveRejectsPathTraversal(t *testing.T) {
 	archive := filepath.Join(t.TempDir(), "evil.tar.gz")
-	f, err := os.Create(archive)
-	if err != nil {
-		t.Fatalf("create: %v", err)
+	f, createErr := os.Create(archive)
+	if createErr != nil {
+		t.Fatalf("create: %v", createErr)
 	}
 	gz := gzip.NewWriter(f)
 	tw := tar.NewWriter(gz)
@@ -141,7 +141,7 @@ func TestExtractBackupArchiveRejectsPathTraversal(t *testing.T) {
 	if err := os.MkdirAll(dest, 0700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	err = extractBackupArchive(archive, []string{dest})
+	err := extractBackupArchive(archive, []string{dest})
 	if err == nil {
 		t.Fatal("path-traversal entry was accepted")
 	}
@@ -271,9 +271,9 @@ func TestSplitRootPrefix(t *testing.T) {
 
 func TestReadArchiveManifestRejectsNonBackup(t *testing.T) {
 	archive := filepath.Join(t.TempDir(), "plain.tar.gz")
-	f, err := os.Create(archive)
-	if err != nil {
-		t.Fatalf("create: %v", err)
+	f, createErr := os.Create(archive)
+	if createErr != nil {
+		t.Fatalf("create: %v", createErr)
 	}
 	gz := gzip.NewWriter(f)
 	tw := tar.NewWriter(gz)
@@ -366,9 +366,9 @@ func TestBackupRootsFollowsSymlinkedDataDir(t *testing.T) {
 // into an arbitrary write. Reject the symlink itself.
 func TestExtractBackupArchiveRejectsEscapingSymlink(t *testing.T) {
 	archive := filepath.Join(t.TempDir(), "hatch.tar.gz")
-	f, err := os.Create(archive)
-	if err != nil {
-		t.Fatalf("create: %v", err)
+	f, createErr := os.Create(archive)
+	if createErr != nil {
+		t.Fatalf("create: %v", createErr)
 	}
 	gz := gzip.NewWriter(f)
 	tw := tar.NewWriter(gz)
@@ -385,7 +385,7 @@ func TestExtractBackupArchiveRejectsEscapingSymlink(t *testing.T) {
 	if err := os.MkdirAll(dest, 0700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	err = extractBackupArchive(archive, []string{dest})
+	err := extractBackupArchive(archive, []string{dest})
 	if err == nil {
 		t.Fatal("escaping symlink entry was accepted")
 	}
@@ -396,9 +396,9 @@ func TestExtractBackupArchiveRejectsEscapingSymlink(t *testing.T) {
 
 func TestExtractBackupArchiveRejectsAbsoluteSymlink(t *testing.T) {
 	archive := filepath.Join(t.TempDir(), "abs.tar.gz")
-	f, err := os.Create(archive)
-	if err != nil {
-		t.Fatalf("create: %v", err)
+	f, createErr := os.Create(archive)
+	if createErr != nil {
+		t.Fatalf("create: %v", createErr)
 	}
 	gz := gzip.NewWriter(f)
 	tw := tar.NewWriter(gz)

--- a/cmd/sage-gui/main.go
+++ b/cmd/sage-gui/main.go
@@ -141,7 +141,28 @@ func main() {
 	case "import":
 		err = runImport()
 	case "backup":
-		err = runBackup()
+		// `backup` alone copies only the SQLite projection (data/sage.db).
+		// `backup --full` takes the complete stopped-node archive that every
+		// recovery and upgrade procedure actually requires.
+		//
+		// --full is matched anywhere in the argument list, not just first:
+		// `backup --out X --full` silently falling through to the SQLite-only
+		// path would hand the operator a backup they believe is complete, right
+		// before an irreversible consensus upgrade.
+		if rest, full, flagErr := extractFullBackupFlag(os.Args[2:]); flagErr != nil {
+			err = flagErr
+		} else if full {
+			err = runBackupFull(rest)
+		} else if len(rest) > 0 {
+			// Silently ignoring a mistyped argument here would hand back a
+			// SQLite-only copy while the operator believes they asked for the
+			// complete archive.
+			err = fmt.Errorf("unknown argument %q for backup — did you mean \"sage-gui backup --full\"? (see: sage-gui help)", rest[0])
+		} else {
+			err = runBackup()
+		}
+	case "restore":
+		err = runRestore(os.Args[2:])
 	case "snapshot":
 		err = runSnapshot(os.Args[2:])
 	case "upgrade":
@@ -246,9 +267,13 @@ Commands:
   seed      Seed memories from a text/JSON file (bootstrap your AI's brain)
   export    Export memories to a .vault file (optionally encrypted)
   import    Import memories from a .vault file
-  backup    Create a timestamped backup of the memory database
+  backup    Back up the SQLite memory projection (timestamped copy of data/sage.db)
+  backup --full  Complete stopped-node archive (Badger + CometBFT + keys + config).
+            This is the backup every upgrade and recovery procedure requires;
+            a plain "backup" cannot rebuild a chain. See docs/UPGRADING.md
+  restore   Restore a complete backup (sage-gui restore --from <archive.tar.gz>)
   snapshot  List or prune on-disk chain snapshots (list | prune [--keep N])
-  upgrade   Activate app-version consensus forks (status | propose --target N)
+  upgrade   Activate app-version consensus forks (status | preflight | propose --target N)
   recover   Reset vault passphrase using your recovery key
   repair-chain  Disabled: SQLite cannot reconstruct canonical chain history; restore a complete stopped-node backup
   quorum-init   Initialize a quorum network (generates shared genesis)

--- a/cmd/sage-gui/upgrade.go
+++ b/cmd/sage-gui/upgrade.go
@@ -64,6 +64,8 @@ func runUpgrade(args []string) error {
 		return runUpgradePropose(args[1:])
 	case "status":
 		return runUpgradeStatus(args[1:])
+	case "preflight":
+		return runUpgradePreflight(args[1:])
 	case "help", "--help", "-h":
 		printUpgradeUsage()
 		return nil
@@ -88,6 +90,9 @@ The voting/processing already exists; this submits the plan an operator needs.
 
 Subcommands:
   status                       Show the chain's app version and the next fork
+  preflight                    Read-only pre-upgrade check on a STOPPED node: verifies the
+                               app-v22/app-v23 predecessor-ladder invariant and previews the
+                               app-v23 Root election. Run this before adopting a new binary.
   propose --target <N>         Propose activation of app-v<N> (must be current+1)
 
 propose flags:

--- a/cmd/sage-gui/upgrade_preflight.go
+++ b/cmd/sage-gui/upgrade_preflight.go
@@ -1,0 +1,452 @@
+// upgrade_preflight.go implements `sage-gui upgrade preflight`: the read-only
+// check an operator runs BEFORE climbing the app-version ladder on an existing
+// chain (typically a v10.x node adopting a current v11 binary).
+//
+// It exists because the two hardest upgrade failures are both discovered far
+// too late without it:
+//
+//	(1) The app-v22/app-v23 predecessor-ladder invariant. Those two activations
+//	    refuse unless consensus storage holds a canonical applied-upgrade record
+//	    for app-v6 and every independent version from app-v7 up, in strictly
+//	    increasing activation-height order. A chain with a historical gap climbs
+//	    happily to app-v21 and only then fails closed — mid-ladder, after the
+//	    operator has already committed to the upgrade.
+//
+//	(2) The app-v23 authority migration. The earliest legacy Admin by
+//	    RegisteredAt (canonical Agent ID as tie-breaker) becomes the singleton
+//	    CEREBRUM Root; every other legacy Admin is demoted to Member pending an
+//	    explicit Root-attested review. Operators need to know which key that is
+//	    while they can still plan for it, not after activation.
+//
+// CRITICAL SCOPING RULE: the ladder invariant is only meaningful up to the
+// version the chain has ACTUALLY REACHED. Activation records are written as each
+// rung activates (internal/abci/app.go MarkUpgradeApplied), and consensus only
+// consults the ladder when app-v22/app-v23 is proposed, executed, or restored —
+// which requires currentAppVersion()==21/22 respectively. A healthy chain at
+// app-v14 therefore has records for app-v6..v14 and legitimately none above.
+// Demanding the full app-v6..v21 range unconditionally would report a false
+// "unrepairable gap" for every chain below app-v21 — that is, for the entire
+// audience this command was written for.
+//
+// Read-only wherever the platform allows it: it opens BadgerDB with
+// WithReadOnly(true) and never proposes or mutates consensus state. Windows is
+// the exception — badger refuses read-only opens there — so on that platform it
+// first proves through SAGE's instance lock that no node is running, then opens
+// normally. Either way the node must be stopped.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	sageabci "github.com/l33tdawg/sage/internal/abci"
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+// appV22LadderFloor and appV22LadderCeiling bound the predecessor evidence
+// app-v22 requires. They mirror the loop in
+// abci.validatePersistedAppV22PredecessorLadder: the canonical persisted app-v6
+// record is the single compatibility proof for the historical cumulative app-v2
+// through app-v5 activation, and app-v7 through app-v21 must each carry their
+// own record. Keep these in lockstep with that validator.
+const (
+	appV22LadderFloor   uint64 = 6
+	appV22LadderCeiling uint64 = 21
+)
+
+// ladderRung is one version's persisted activation evidence.
+type ladderRung struct {
+	Version uint64
+	Name    string
+	Height  int64
+	Present bool
+	NotYet  bool   // above the chain's current version — nothing is wrong
+	Problem string // non-empty when this rung fails the consensus invariant
+}
+
+// runUpgradePreflight is the `upgrade preflight` entry point.
+func runUpgradePreflight(args []string) error {
+	fs := flag.NewFlagSet("upgrade preflight", flag.ContinueOnError)
+	dataDir := fs.String("data-dir", "", "SAGE data directory holding badger/ (default: the configured data_dir)")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	resolvedDataDir := *dataDir
+	if resolvedDataDir == "" {
+		cfg, err := LoadConfig()
+		if err != nil {
+			return fmt.Errorf("load config (pass --data-dir to check a specific node): %w", err)
+		}
+		resolvedDataDir = cfg.DataDir
+	}
+	badgerPath := filepath.Join(resolvedDataDir, "badger")
+	if _, statErr := os.Stat(badgerPath); statErr != nil {
+		return fmt.Errorf("no consensus database at %s (wrong --data-dir, or this node was never initialized)", badgerPath)
+	}
+
+	bs, err := openConsensusStoreForInspection(badgerPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = bs.CloseBadger() }()
+
+	state, err := sageabci.LoadState(bs)
+	if err != nil {
+		return fmt.Errorf("read persisted app state: %w", err)
+	}
+	maxSupported := sageabci.MaxSupportedAppVersion()
+
+	fmt.Printf("SAGE upgrade preflight\n")
+	fmt.Printf("  data dir        : %s\n", resolvedDataDir)
+	fmt.Printf("  persisted height: %d\n", state.Height)
+	fmt.Printf("  binary supports : up to app-v%d\n", maxSupported)
+	fmt.Printf("  this binary     : sage-gui %s\n\n", version)
+
+	// A chain born directly at app-v23 has no app-v6..v21 history and consensus
+	// explicitly exempts it (internal/abci/appv23_local_rbac.go validateAppV23Prerequisite
+	// returns early on appV23GenesisActive). Applying the ladder to it would be
+	// a pure false alarm.
+	genesis, genesisErr := bs.GetAppV23GenesisActivation()
+	if genesisErr == nil && genesis != nil {
+		return reportDirectV23Genesis(bs, maxSupported)
+	}
+
+	reached := highestAppliedVersion(bs, maxSupported)
+	fmt.Printf("Highest applied activation record: app-v%d\n\n", reached)
+
+	rungs := inspectLadder(bs, state.Height, reached)
+	printLadderTable(rungs)
+
+	ladderOK, firstProblem := ladderVerdict(rungs)
+	admins, adminErr := listLegacyAdmins(bs)
+
+	fmt.Println()
+	switch {
+	case !ladderOK:
+		fmt.Println("VERDICT: this chain CANNOT reach app-v22.")
+		fmt.Printf("  %s\n", firstProblem)
+		fmt.Println("  app-v22 and app-v23 refuse to be proposed, approved, activated, or restored")
+		fmt.Println("  without complete, strictly ordered predecessor evidence. The climb will stop")
+		fmt.Println("  at app-v21 and fail closed there.")
+		fmt.Println()
+		fmt.Println("  This is not repairable by proposing again: the evidence is missing from")
+		fmt.Println("  consensus storage, and synthesized records are rejected. Restore a complete")
+		fmt.Println("  stopped-node backup taken before the gap, or open an issue with this output —")
+		fmt.Println("  do NOT delete the data directory, that discards all canonical history.")
+	case adminErr == nil && reached < 23 && len(admins) == 0:
+		// app-v23 elects its singleton Root from the legacy Admin roster. With
+		// an empty roster there is nobody to promote, so the activation cannot
+		// complete. Surfacing this as a footnote under a green verdict would be
+		// exactly the manufactured confidence this command exists to prevent.
+		fmt.Println("VERDICT: this chain CANNOT safely activate app-v23.")
+		fmt.Println("  No agent holds Role==admin on chain, so the migration has no legacy Admin")
+		fmt.Println("  to promote to the singleton CEREBRUM Root.")
+		fmt.Println("  Register or materialize an admin agent before starting the climb.")
+	case reached >= maxSupported:
+		fmt.Printf("VERDICT: nothing to do — the chain is already at app-v%d, this binary's ceiling.\n", maxSupported)
+	default:
+		fmt.Printf("VERDICT: clear to climb from app-v%d to app-v%d.\n", reached, maxSupported)
+		fmt.Printf("  %d fork activation(s) remain. Each waits out a governance delay of at least\n", maxSupported-reached)
+		fmt.Println("  200 blocks, so the full climb takes a while — see docs/UPGRADING.md.")
+	}
+
+	// The authority preview reads only the agent registry, so it is meaningful
+	// even when the ladder verdict is negative — an operator facing a gap still
+	// benefits from knowing what app-v23 would do.
+	if reached < 23 {
+		fmt.Println()
+		if adminErr != nil {
+			fmt.Printf("app-v23 authority preview unavailable: %v\n", adminErr)
+		} else {
+			printAppV23Preview(admins)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Full procedure: docs/UPGRADING.md")
+	return nil
+}
+
+// openConsensusStoreForInspection opens the chain database for reading.
+//
+// The read-only open is preferred everywhere it works, because a diagnostic must
+// not mutate consensus state. It is NOT available on Windows: badger refuses
+// read-only opens outright there (ErrWindowsNotSupported), returned before it
+// touches any data. Failing there would make preflight — a mandatory step in
+// docs/UPGRADING.md — a permanent brick wall on a shipped platform, and the
+// error text would send the operator into a restart-and-replay loop that can
+// never succeed.
+//
+// So on Windows, having first proven through SAGE's own instance lock that no
+// node is running, fall back to a plain open. That path performs badger's normal
+// recovery but runs no SAGE migrations, which is the same treatment a restored
+// state-sync database gets.
+func openConsensusStoreForInspection(badgerPath string) (*store.BadgerStore, error) {
+	bs, err := store.OpenBadgerStoreReadOnly(badgerPath)
+	if err == nil {
+		return bs, nil
+	}
+	if runtime.GOOS != "windows" {
+		return nil, explainBadgerOpenFailure(badgerPath, err)
+	}
+	if lockErr := requireStoppedNode(SageHome()); lockErr != nil {
+		return nil, fmt.Errorf("%w\n\nStop SAGE, then re-run preflight", lockErr)
+	}
+	bs, fallbackErr := store.OpenBadgerStoreWithoutMigrations(badgerPath)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("open %s for inspection: %w", badgerPath, fallbackErr)
+	}
+	return bs, nil
+}
+
+// explainBadgerOpenFailure separates "the node is running" from "this database
+// needs recovery". Both surface as an open failure, but they need opposite
+// operator actions, and telling someone with an unclean shutdown to "stop SAGE"
+// sends them looking for a process that is not there.
+func explainBadgerOpenFailure(badgerPath string, err error) error {
+	msg := err.Error()
+	if strings.Contains(msg, "directory lock") || strings.Contains(msg, "Another process") {
+		return fmt.Errorf("open %s read-only: %w\n\n"+
+			"SAGE is still running — preflight reads the consensus database directly.\n"+
+			"Stop the node, then: sage-gui backup --full, sage-gui upgrade preflight", badgerPath, err)
+	}
+	return fmt.Errorf("open %s read-only: %w\n\n"+
+		"This does not look like a running node — the database needs recovery before it can\n"+
+		"be read read-only (an unclean shutdown leaves a value log to replay). Start the node\n"+
+		"once so it replays, stop it cleanly, then re-run preflight.", badgerPath, err)
+}
+
+// reportDirectV23Genesis handles chains born at app-v23, which have no
+// app-v6..v21 lineage by design.
+func reportDirectV23Genesis(bs *store.BadgerStore, maxSupported uint64) error {
+	reached := highestAppliedVersion(bs, maxSupported)
+	if reached < 23 {
+		reached = 23
+	}
+	fmt.Println("This chain was born directly at app-v23 (direct genesis).")
+	fmt.Println("The app-v22 predecessor ladder does not apply to it — consensus exempts")
+	fmt.Println("direct-v23 genesis chains from that invariant.")
+	fmt.Printf("\nHighest applied activation record: app-v%d\n\n", reached)
+	if reached >= maxSupported {
+		fmt.Printf("VERDICT: nothing to do — the chain is already at app-v%d, this binary's ceiling.\n", maxSupported)
+	} else {
+		fmt.Printf("VERDICT: clear to climb from app-v%d to app-v%d.\n", reached, maxSupported)
+	}
+	fmt.Println()
+	fmt.Println("Full procedure: docs/UPGRADING.md")
+	return nil
+}
+
+// inspectLadder evaluates the predecessor evidence, applying the consensus rules
+// only to rungs at or below the chain's current version. Rungs above `reached`
+// are marked NotYet: the binary will create them as it climbs.
+func inspectLadder(bs *store.BadgerStore, persistedHeight int64, reached uint64) []ladderRung {
+	ceiling := appV22LadderCeiling
+	// Once the chain is at app-v22 or beyond, that rung's own record is part of
+	// the evidence app-v23 requires, so include it.
+	if reached >= 22 {
+		ceiling = 22
+	}
+	rungs := make([]ladderRung, 0, ceiling-appV22LadderFloor+1)
+	var previousHeight int64
+	for v := appV22LadderFloor; v <= ceiling; v++ {
+		if v > reached {
+			rungs = append(rungs, ladderRung{Version: v, Name: tx.CanonicalUpgradeName(v), NotYet: true})
+			continue
+		}
+		rung := inspectRung(bs, v, persistedHeight, previousHeight)
+		rungs = append(rungs, rung)
+		if rung.Present && rung.Problem == "" {
+			previousHeight = rung.Height
+		}
+	}
+	return rungs
+}
+
+// inspectRung evaluates a single version's record against previousHeight, using
+// the same rules as abci.validatePersistedAppV22PredecessorLadder.
+func inspectRung(bs *store.BadgerStore, v uint64, persistedHeight, previousHeight int64) ladderRung {
+	name := tx.CanonicalUpgradeName(v)
+	rung := ladderRung{Version: v, Name: name}
+
+	rec, err := bs.GetAppliedUpgrade(name)
+	if err != nil {
+		rung.Problem = fmt.Sprintf("cannot read applied %s record: %v", name, err)
+		return rung
+	}
+	if rec == nil {
+		rung.Problem = fmt.Sprintf("missing canonical applied %s record", name)
+		return rung
+	}
+
+	rung.Present = true
+	rung.Height = rec.AppliedHeight
+	switch {
+	case rec.Name != name:
+		rung.Problem = fmt.Sprintf("record is named %q, want %q", rec.Name, name)
+	case rec.TargetAppVersion != v:
+		rung.Problem = fmt.Sprintf("record targets app version %d, want %d", rec.TargetAppVersion, v)
+	case rec.AppliedHeight <= 0:
+		rung.Problem = fmt.Sprintf("non-positive activation height %d", rec.AppliedHeight)
+	case previousHeight > 0 && rec.AppliedHeight <= previousHeight:
+		rung.Problem = fmt.Sprintf("height %d is not after the previous rung's height %d", rec.AppliedHeight, previousHeight)
+	case rec.AppliedHeight > persistedHeight+1:
+		rung.Problem = fmt.Sprintf("height %d is ahead of the persisted app height %d", rec.AppliedHeight, persistedHeight)
+	}
+	return rung
+}
+
+// highestAppliedVersion reports the highest version with a VALID activation
+// record. A present-but-invalid record must not count as reached: treating it as
+// progress is what turns a corrupt app-v22 record into a "clear to climb".
+func highestAppliedVersion(bs *store.BadgerStore, maxSupported uint64) uint64 {
+	var highest uint64
+	for v := appV22LadderFloor; v <= maxSupported; v++ {
+		rec, err := bs.GetAppliedUpgrade(tx.CanonicalUpgradeName(v))
+		if err != nil || rec == nil {
+			continue
+		}
+		if rec.TargetAppVersion != v || rec.AppliedHeight <= 0 {
+			continue
+		}
+		if v > highest {
+			highest = v
+		}
+	}
+	return highest
+}
+
+// ladderVerdict reports whether every evaluated rung is sound, and the first
+// problem otherwise. NotYet rungs are skipped — they are not evidence of a gap.
+func ladderVerdict(rungs []ladderRung) (bool, string) {
+	for _, r := range rungs {
+		if r.NotYet {
+			continue
+		}
+		if r.Problem != "" {
+			return false, fmt.Sprintf("app-v%d: %s", r.Version, r.Problem)
+		}
+	}
+	return true, ""
+}
+
+func printLadderTable(rungs []ladderRung) {
+	fmt.Println("Predecessor ladder evidence (required by app-v22 and app-v23):")
+	for _, r := range rungs {
+		label := fmt.Sprintf("  app-v%-2d", r.Version)
+		switch {
+		case r.NotYet:
+			fmt.Printf("%s  --        not activated yet; this binary will climb it\n", label)
+		case !r.Present:
+			fmt.Printf("%s  MISSING   %s\n", label, r.Problem)
+		case r.Problem != "":
+			fmt.Printf("%s  INVALID   height %d — %s\n", label, r.Height, r.Problem)
+		default:
+			fmt.Printf("%s  ok        activated at height %d\n", label, r.Height)
+		}
+	}
+	fmt.Println("  (app-v6's record is the canonical compatibility proof for the cumulative")
+	fmt.Println("   app-v2 through app-v5 activation; app-v7+ each need their own record.)")
+}
+
+// listLegacyAdmins returns the on-chain agents app-v23 will consider for Root
+// election, in the migration's deterministic order. The role comparison is exact
+// (store.AppV23RoleAdmin), matching consensus rather than approximating it.
+func listLegacyAdmins(bs *store.BadgerStore) ([]store.OnChainAgent, error) {
+	agents, err := bs.ListRegisteredAgents()
+	if err != nil {
+		return nil, fmt.Errorf("list registered agents: %w", err)
+	}
+	admins := make([]store.OnChainAgent, 0, len(agents))
+	for _, a := range agents {
+		if a.Role == store.AppV23RoleAdmin {
+			admins = append(admins, a)
+		}
+	}
+	sortAppV23AdminOrder(admins)
+	return admins, nil
+}
+
+// sortAppV23AdminOrder puts legacy Admins into the migration's deterministic
+// Root-election order: earliest RegisteredAt first, canonical Agent ID breaking
+// ties.
+func sortAppV23AdminOrder(admins []store.OnChainAgent) {
+	sort.Slice(admins, func(i, j int) bool {
+		if admins[i].RegisteredAt != admins[j].RegisteredAt {
+			return admins[i].RegisteredAt < admins[j].RegisteredAt
+		}
+		return admins[i].AgentID < admins[j].AgentID
+	})
+}
+
+// electAppV23Root returns the legacy Admin that app-v23 activation will promote
+// to the singleton CEREBRUM Root.
+func electAppV23Root(admins []store.OnChainAgent) store.OnChainAgent {
+	if len(admins) == 0 {
+		return store.OnChainAgent{}
+	}
+	ordered := append([]store.OnChainAgent{}, admins...)
+	sortAppV23AdminOrder(ordered)
+	return ordered[0]
+}
+
+// printAppV23Preview reports which legacy Admin app-v23 will elect as the
+// singleton CEREBRUM Root and which Admins will be demoted pending review.
+func printAppV23Preview(admins []store.OnChainAgent) {
+	if len(admins) == 0 {
+		fmt.Println("app-v23 authority preview: no agent holds Role==admin on chain, so the")
+		fmt.Println("migration has no legacy Admin to promote to Root. Fix this before climbing.")
+		return
+	}
+
+	root := admins[0]
+	fmt.Println("app-v23 authority preview (what activation will do to your admins):")
+	fmt.Printf("  becomes CEREBRUM Root : %s\n", describeAgent(root))
+	fmt.Printf("                          registered at height %d\n", root.RegisteredAt)
+	if len(admins) == 1 {
+		fmt.Println("  demoted to Member     : none — this chain has a single Admin.")
+		fmt.Println()
+		fmt.Println("  Keep that agent's key material on this machine. After app-v23 the upgrade")
+		fmt.Println("  proposals themselves are signed with the CEREBRUM Root credential, not the")
+		fmt.Println("  operator agent.key.")
+		return
+	}
+
+	fmt.Printf("  demoted to Member     : %d other Admin(s), each becoming an active Member with the\n", len(admins)-1)
+	fmt.Println("                          migration-only legacy_restricted profile and disposition")
+	fmt.Println("                          legacy_admin_review:")
+	for _, a := range admins[1:] {
+		fmt.Printf("                            - %s (height %d)\n", describeAgent(a), a.RegisteredAt)
+	}
+	fmt.Println()
+	fmt.Println("  No historical Admin is re-promoted automatically. Restoring any of them to")
+	fmt.Println("  Admin requires an explicit review attested by the current Root in CEREBRUM.")
+	fmt.Println("  The complete old Admin roster is retained as immutable audit evidence.")
+}
+
+// describeAgent renders the most identifying label available for an agent.
+func describeAgent(a store.OnChainAgent) string {
+	name := a.RegisteredName
+	if name == "" {
+		name = a.Name
+	}
+	shortID := a.AgentID
+	if len(shortID) > 16 {
+		shortID = shortID[:16] + "…"
+	}
+	if name == "" {
+		return shortID
+	}
+	return fmt.Sprintf("%s (%s)", name, shortID)
+}

--- a/cmd/sage-gui/upgrade_preflight.go
+++ b/cmd/sage-gui/upgrade_preflight.go
@@ -224,7 +224,7 @@ func explainBadgerOpenFailure(badgerPath string, err error) error {
 	return fmt.Errorf("open %s read-only: %w\n\n"+
 		"This does not look like a running node — the database needs recovery before it can\n"+
 		"be read read-only (an unclean shutdown leaves a value log to replay). Start the node\n"+
-		"once so it replays, stop it cleanly, then re-run preflight.", badgerPath, err)
+		"once so it replays, stop it cleanly, then re-run preflight", badgerPath, err)
 }
 
 // reportDirectV23Genesis handles chains born at app-v23, which have no

--- a/cmd/sage-gui/upgrade_preflight_test.go
+++ b/cmd/sage-gui/upgrade_preflight_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sageabci "github.com/l33tdawg/sage/internal/abci"
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+// newPreflightStore builds a writable Badger store for ladder fixtures.
+func newPreflightStore(t *testing.T) (*store.BadgerStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "badger")
+	bs, err := store.NewBadgerStore(path)
+	if err != nil {
+		t.Fatalf("open badger: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.CloseBadger() })
+	return bs, path
+}
+
+// seedLadder writes canonical applied-upgrade records for [floor, ceiling] with
+// strictly increasing heights, skipping any version in omit.
+func seedLadder(t *testing.T, bs *store.BadgerStore, floor, ceiling uint64, omit map[uint64]bool) {
+	t.Helper()
+	height := int64(10)
+	for v := floor; v <= ceiling; v++ {
+		height += 10
+		if omit[v] {
+			continue
+		}
+		if err := bs.MarkUpgradeApplied(tx.CanonicalUpgradeName(v), v, height); err != nil {
+			t.Fatalf("mark app-v%d applied: %v", v, err)
+		}
+	}
+}
+
+// THE regression test. A healthy v10.7 chain sits at app-v14 with records for
+// app-v6..v14 and legitimately none above — the climb creates those. Requiring
+// the full app-v6..v21 range unconditionally reported "this chain CANNOT reach
+// app-v22 ... not repairable" to every chain below app-v21, i.e. to the entire
+// audience of docs/UPGRADING.md.
+func TestLadderAcceptsChainThatHasNotClimbedYet(t *testing.T) {
+	bs, _ := newPreflightStore(t)
+	seedLadder(t, bs, appV22LadderFloor, 14, nil)
+
+	reached := highestAppliedVersion(bs, sageabci.MaxSupportedAppVersion())
+	if reached != 14 {
+		t.Fatalf("reached = %d, want 14", reached)
+	}
+
+	rungs := inspectLadder(bs, 10_000, reached)
+	ok, problem := ladderVerdict(rungs)
+	if !ok {
+		t.Fatalf("healthy app-v14 chain was reported as broken: %s", problem)
+	}
+	for _, r := range rungs {
+		if r.Version > reached && !r.NotYet {
+			t.Fatalf("app-v%d above the chain's version was not marked not-yet-reached", r.Version)
+		}
+		if r.Version <= reached && r.NotYet {
+			t.Fatalf("app-v%d at or below the chain's version was wrongly skipped", r.Version)
+		}
+	}
+}
+
+func TestInspectLadderAcceptsCompleteEvidence(t *testing.T) {
+	bs, _ := newPreflightStore(t)
+	seedLadder(t, bs, appV22LadderFloor, appV22LadderCeiling, nil)
+
+	rungs := inspectLadder(bs, 10_000, appV22LadderCeiling)
+	ok, problem := ladderVerdict(rungs)
+	if !ok {
+		t.Fatalf("complete ladder rejected: %s", problem)
+	}
+}
+
+// A genuine historical gap BELOW the chain's current version is the real defect
+// this command exists to catch, and it must still fail closed.
+func TestInspectLadderRejectsGapBelowReachedVersion(t *testing.T) {
+	bs, _ := newPreflightStore(t)
+	seedLadder(t, bs, appV22LadderFloor, appV22LadderCeiling, map[uint64]bool{17: true})
+
+	reached := highestAppliedVersion(bs, sageabci.MaxSupportedAppVersion())
+	rungs := inspectLadder(bs, 10_000, reached)
+	ok, problem := ladderVerdict(rungs)
+	if ok {
+		t.Fatal("ladder with a missing app-v17 record was accepted")
+	}
+	if !strings.Contains(problem, "app-v17") {
+		t.Fatalf("problem %q does not name app-v17", problem)
+	}
+}
+
+// Out-of-order activation heights must fail exactly as the consensus validator
+// fails them: strictly increasing is the rule, not merely present.
+func TestInspectLadderRejectsOutOfOrderHeights(t *testing.T) {
+	bs, _ := newPreflightStore(t)
+	seedLadder(t, bs, appV22LadderFloor, appV22LadderCeiling, nil)
+	if err := bs.MarkUpgradeApplied(tx.CanonicalUpgradeName(15), 15, 11); err != nil {
+		t.Fatalf("rewrite app-v15: %v", err)
+	}
+
+	rungs := inspectLadder(bs, 10_000, appV22LadderCeiling)
+	if ok, _ := ladderVerdict(rungs); ok {
+		t.Fatal("out-of-order ladder was accepted")
+	}
+}
+
+// A record ahead of the persisted app height is corruption, not progress. The
+// consensus validator allows exactly +1 for the FinalizeBlock/Commit crash
+// window; preflight must mirror that boundary rather than approximate it.
+func TestInspectRungHeightAheadOfPersistedState(t *testing.T) {
+	bs, _ := newPreflightStore(t)
+	if err := bs.MarkUpgradeApplied(tx.CanonicalUpgradeName(9), 9, 100); err != nil {
+		t.Fatalf("mark applied: %v", err)
+	}
+
+	if rung := inspectRung(bs, 9, 99, 0); rung.Problem != "" {
+		t.Fatalf("crash-window height rejected: %s", rung.Problem)
+	}
+	if rung := inspectRung(bs, 9, 98, 0); rung.Problem == "" {
+		t.Fatal("height ahead of persisted app state was accepted")
+	}
+}
+
+func TestInspectRungRejectsMismatchedTarget(t *testing.T) {
+	bs, _ := newPreflightStore(t)
+	if err := bs.MarkUpgradeApplied(tx.CanonicalUpgradeName(12), 11, 50); err != nil {
+		t.Fatalf("mark applied: %v", err)
+	}
+	if rung := inspectRung(bs, 12, 10_000, 0); rung.Problem == "" {
+		t.Fatal("record with a mismatched target app version was accepted")
+	}
+}
+
+// An invalid record must not count as progress. Counting it would let a corrupt
+// app-v22 record produce "clear to climb" — the exact manufactured confidence
+// this command exists to prevent.
+func TestHighestAppliedVersionIgnoresInvalidRecords(t *testing.T) {
+	bs, _ := newPreflightStore(t)
+	seedLadder(t, bs, appV22LadderFloor, 14, nil)
+	if err := bs.MarkUpgradeApplied(tx.CanonicalUpgradeName(15), 11, 500); err != nil {
+		t.Fatalf("seed mismatched record: %v", err)
+	}
+
+	if got := highestAppliedVersion(bs, sageabci.MaxSupportedAppVersion()); got != 14 {
+		t.Fatalf("highestAppliedVersion = %d, want 14 (the invalid app-v15 record must not count)", got)
+	}
+}
+
+// highestAppliedVersion must be self-sufficient across the whole range, not just
+// app-v23 and above: the backup manifest relies on it for pre-v23 chains.
+func TestHighestAppliedVersionCoversPreV23Chains(t *testing.T) {
+	bs, _ := newPreflightStore(t)
+	seedLadder(t, bs, appV22LadderFloor, 11, nil)
+
+	if got := highestAppliedVersion(bs, sageabci.MaxSupportedAppVersion()); got != 11 {
+		t.Fatalf("highestAppliedVersion = %d, want 11", got)
+	}
+}
+
+func TestHighestAppliedVersionScansPastLadder(t *testing.T) {
+	bs, _ := newPreflightStore(t)
+	seedLadder(t, bs, appV22LadderFloor, 24, nil)
+
+	if got := highestAppliedVersion(bs, sageabci.MaxSupportedAppVersion()); got != 24 {
+		t.Fatalf("highestAppliedVersion = %d, want 24", got)
+	}
+}
+
+// Once the chain is at app-v22, that rung's own record becomes part of the
+// evidence app-v23 requires, so it must be evaluated rather than skipped.
+func TestInspectLadderIncludesAppV22OnceReached(t *testing.T) {
+	bs, _ := newPreflightStore(t)
+	seedLadder(t, bs, appV22LadderFloor, 22, nil)
+
+	rungs := inspectLadder(bs, 10_000, 22)
+	last := rungs[len(rungs)-1]
+	if last.Version != 22 {
+		t.Fatalf("last rung = app-v%d, want app-v22", last.Version)
+	}
+	if last.NotYet || !last.Present {
+		t.Fatalf("app-v22 record was not evaluated: %+v", last)
+	}
+}
+
+func TestLadderVerdictSkipsNotYetRungs(t *testing.T) {
+	rungs := []ladderRung{
+		{Version: 6, Height: 10, Present: true},
+		{Version: 7, NotYet: true, Problem: "should be ignored"},
+	}
+	if ok, problem := ladderVerdict(rungs); !ok {
+		t.Fatalf("not-yet-reached rung produced a failure: %s", problem)
+	}
+}
+
+// The app-v23 Root election is deterministic: earliest RegisteredAt wins, with
+// the canonical Agent ID as tie-breaker.
+func TestAppV23RootElectionOrdering(t *testing.T) {
+	admins := []store.OnChainAgent{
+		{AgentID: "ffff", Role: store.AppV23RoleAdmin, RegisteredAt: 50},
+		{AgentID: "bbbb", Role: store.AppV23RoleAdmin, RegisteredAt: 10},
+		{AgentID: "aaaa", Role: store.AppV23RoleAdmin, RegisteredAt: 10},
+	}
+	if root := electAppV23Root(admins); root.AgentID != "aaaa" {
+		t.Fatalf("root = %s, want aaaa (earliest height, lowest ID tie-break)", root.AgentID)
+	}
+}
+
+// The preview's candidate set must be byte-identical to the migration's, which
+// compares the role exactly. A case-insensitive match would preview a Root that
+// consensus would never elect.
+func TestListLegacyAdminsMatchesRoleExactly(t *testing.T) {
+	bs, _ := newPreflightStore(t)
+	if err := bs.RegisterAgent("aaaa", "real", store.AppV23RoleAdmin, "", "", "", 10); err != nil {
+		t.Fatalf("register admin: %v", err)
+	}
+	if err := bs.RegisterAgent("bbbb", "casing", "Admin", "", "", "", 5); err != nil {
+		t.Fatalf("register mixed-case role: %v", err)
+	}
+
+	admins, err := listLegacyAdmins(bs)
+	if err != nil {
+		t.Fatalf("listLegacyAdmins: %v", err)
+	}
+	for _, a := range admins {
+		if a.Role != store.AppV23RoleAdmin {
+			t.Fatalf("non-exact role %q was included as a Root candidate", a.Role)
+		}
+	}
+	for _, a := range admins {
+		if a.AgentID == "bbbb" {
+			t.Fatal("mixed-case \"Admin\" was treated as a Root candidate; consensus compares exactly")
+		}
+	}
+}
+
+func TestDescribeAgentPrefersRegisteredName(t *testing.T) {
+	a := store.OnChainAgent{
+		AgentID:        "0123456789abcdef0123456789abcdef",
+		Name:           "mutable",
+		RegisteredName: "canonical",
+	}
+	got := describeAgent(a)
+	if !strings.Contains(got, "canonical") {
+		t.Fatalf("describeAgent = %q, want it to name the registered name", got)
+	}
+	if strings.Contains(got, a.AgentID) {
+		t.Fatalf("describeAgent = %q, want the agent ID truncated", got)
+	}
+}
+
+// A running node and a database needing recovery both surface as an open
+// failure, but they need opposite operator actions. Telling someone with an
+// unclean shutdown to "stop SAGE" sends them hunting a process that is not there.
+func TestExplainBadgerOpenFailureDistinguishesLockFromCorruption(t *testing.T) {
+	lockErr := explainBadgerOpenFailure("/x/badger",
+		errTest("Cannot acquire directory lock on \"/x/badger\""))
+	if !strings.Contains(lockErr.Error(), "SAGE is still running") {
+		t.Fatalf("lock failure not identified as a running node: %v", lockErr)
+	}
+
+	replayErr := explainBadgerOpenFailure("/x/badger", errTest("value log truncate required"))
+	if strings.Contains(replayErr.Error(), "SAGE is still running") {
+		t.Fatalf("replay failure wrongly reported as a running node: %v", replayErr)
+	}
+	if !strings.Contains(replayErr.Error(), "needs recovery") {
+		t.Fatalf("replay failure did not explain recovery: %v", replayErr)
+	}
+}
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,0 +1,495 @@
+# Upgrading SAGE
+
+This is the procedure for moving an **existing SAGE node** to a newer release,
+including the long jump from v10.x to current v11.
+
+Your chain advances **in place**. SAGE does not reset, rebuild, or re-genesis a
+lived-in node during an upgrade, and no supported procedure asks you to export
+SQLite and initialize a fresh chain. Memories, domains, grants, agent
+identities, governance records, and block history all survive.
+
+**Every command in this document ships in the binary.** If a step tells you to
+run something, it exists.
+
+---
+
+## TL;DR for a personal (single-node) install
+
+```bash
+# 1. Install the new binary FIRST. It does not touch your data directory,
+#    and it is what provides the backup/preflight commands below.
+# 2. Stop SAGE.
+# 3. Take a real backup and check the chain can make the climb:
+sage-gui backup --full
+sage-gui upgrade preflight
+
+# 4. Start the new binary:
+sage-gui serve
+
+# 5. Watch the ladder climb (it is automatic on a personal node):
+sage-gui upgrade status
+```
+
+> **Install the new binary before you back up.** `backup --full` and `upgrade
+> preflight` are recent additions — an older `sage-gui` does not have them, and
+> a v10.x binary certainly does not. Installing a new binary is safe and
+> reversible on its own: it changes no data and activates no fork until the node
+> runs and governance approves each rung. Check what you have with
+> `sage-gui upgrade preflight --help`; if it is not recognized, your binary
+> predates these commands.
+
+On a personal node that is the whole upgrade. The node proposes and activates
+each consensus fork by itself until it reaches the binary's ceiling.
+
+Quorum clusters are manual — see [Quorum clusters](#quorum-clusters).
+
+---
+
+## What actually changes between releases
+
+SAGE has two independent version numbers, and confusing them is the source of
+most upgrade anxiety.
+
+| | What it is | When it changes |
+|---|---|---|
+| **Release version** (`v11.17.15`) | The binary/semver you download | Every release |
+| **App version** (`app-v26`) | The consensus state-machine version, activated by governance | Only when consensus rules change |
+
+There is also a **consensus fork version**, currently `1`, which has never been
+bumped. It is the refusal gate for genuinely incompatible on-disk state. Because
+it is still `1`, **a v10.x data directory is compatible with a current v11
+binary** — no migration tooling, no re-genesis.
+
+Installing a new binary does *not* by itself change the app version. The binary
+gains the *ability* to run newer forks; each fork then activates through
+governance. That activation is the "ladder".
+
+### Release → app version
+
+Use this to work out how far your chain has to climb.
+
+| Release | Introduces |
+|---|---|
+| v10.0 | app-v11 |
+| v10.5.x | app-v12, app-v13 |
+| v10.7.0 | app-v14 |
+| v11.0 | app-v15 |
+| v11.2 | app-v16 |
+| v11.5 | app-v17 |
+| v11.7 | app-v18 |
+| v11.8 | app-v19 |
+| v11.9 | app-v20 |
+| v11.13.4 | app-v21 |
+| v11.14.1 | app-v22 |
+| v11.15.0 | app-v23 |
+| v11.16.0 | app-v24 |
+| v11.16.2 | app-v25 |
+| v11.17.0 | app-v26 |
+
+A v10.x chain therefore sits somewhere around **app-v11 to app-v14**, and
+current v11 binaries support up to **app-v26**. That is roughly a dozen rungs.
+
+Forks activate **strictly one at a time**: every proposal must target the
+chain's current version **+ 1**. Skipping is rejected — a jump from 14 to 26
+would turn on app-v26 alone and permanently strand everything between.
+
+---
+
+## Step 1 — Install the new binary
+
+Do this first. It touches no data, activates no fork, and it is what gives you
+the backup and preflight commands the rest of this procedure uses.
+
+```bash
+# macOS / Windows / Linux download
+# https://github.com/l33tdawg/sage/releases/latest
+
+# From source
+git clone https://github.com/l33tdawg/sage.git && cd sage
+go build -o sage-gui ./cmd/sage-gui/
+
+# Docker
+docker pull ghcr.io/l33tdawg/sage:11.17.15
+```
+
+> Replacing a binary on disk does **not** upgrade a running node. A long-lived
+> `sage-gui serve` process keeps executing the code it started with. Stop and
+> restart it, and confirm with `sage-gui upgrade status`.
+
+### Desktop app (macOS .app / Windows installer)
+
+The desktop builds are the primary release artifacts, and they need two extra
+notes:
+
+- **Quit SAGE fully** before the next step — closing the window is not enough on
+  macOS; the node keeps running. The backup and preflight commands refuse while
+  the node holds its instance lock, which is the check working correctly.
+- **The macOS CLI is inside the bundle**, not on your `PATH`:
+  `/Applications/SAGE.app/Contents/MacOS/sage-gui`. Use that full path for every
+  `sage-gui` command in this guide, or add it to your `PATH`. The DMG is a
+  drag-to-replace install, not a binary swap. On Windows the installer puts
+  `sage-gui.exe` on the `PATH`.
+- CEREBRUM's in-app update banner replaces the binary and restarts the node for
+  you. That is fine for ordinary patch releases; for the v10 → v11 jump, take
+  the backup and run preflight yourself first.
+
+---
+
+## Step 2 — Stop the node and take a real backup
+
+```bash
+sage-gui backup --full
+```
+
+> **`sage-gui backup` (without `--full`) is not sufficient before an upgrade.**
+> It copies only `data/sage.db`, the SQLite *serving projection*. The canonical
+> consensus state — memories, RBAC, governance, agent identities, block history
+> — lives in BadgerDB and CometBFT and is **not** in that file. Restoring a
+> `.db` copy cannot rebuild a chain.
+
+`backup --full` writes a single `sage-full-<timestamp>.tar.gz` containing your
+whole `SAGE_HOME` (config, agent keys, vault key) plus the data directory
+(Badger, CometBFT, SQLite) when it lives elsewhere, with a manifest recording
+the binary version, consensus fork, app version, and block height.
+
+It **refuses to run while SAGE is running**, and that refusal is load-bearing:
+archiving a live Badger LSM tree captures a torn state that will not restore.
+Stop the node first. It also refuses to report success if the finished archive
+contains no consensus database, so a misconfigured `data_dir` cannot hand you an
+empty backup that looks complete.
+
+> **The archive is unencrypted and contains every node secret** — `agent.key`,
+> `vault.key`, TLS private keys, and MCP tokens. Treat the file as a credential:
+> keep it on an encrypted volume, and never upload it as-is. Size it roughly at
+> your current `~/.sage` footprint.
+
+To restore:
+
+```bash
+sage-gui restore --from /path/to/sage-full-2026-08-07T09-12-33.tar.gz --force
+```
+
+`--force` is **required whenever a SAGE home already exists**, which on a real
+node is always. Despite the name it is not destructive: it is what authorizes
+the move-aside. The existing tree is renamed to
+`~/.sage.pre-restore-<timestamp>` and never deleted, and the archive is
+unpacked into a staging directory first, so a failure part-way through cannot
+leave a half-populated tree at the live path.
+
+The default backup location is inside `~/.sage`, which restore is about to
+replace. It handles that for you: the archive is copied to a temporary directory
+first, so the file cannot vanish mid-restore. Nothing extra to do.
+
+### Docker
+
+The data lives in the mounted volume, not the image, so back up the volume with
+the container stopped:
+
+```bash
+docker stop sage
+docker run --rm -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:11.17.15 \
+  backup --full --out /root/.sage/backups/pre-upgrade.tar.gz
+```
+
+The image's `ENTRYPOINT` is already `sage-gui`, so pass the subcommand directly —
+`docker run … sage-gui backup` would try to run `sage-gui sage-gui backup`. The
+archive lands in the mounted volume, so it survives the container.
+
+Then preflight the same way before pulling the new image:
+
+```bash
+docker run --rm -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:11.17.15 upgrade preflight
+```
+
+---
+
+## Step 3 — Preflight
+
+```bash
+sage-gui upgrade preflight
+```
+
+Run this **with the node stopped**, after installing the new binary (Step 1) and
+alongside the backup (Step 2). It is read-only: it inspects the consensus
+database without writing, proposing, or mutating anything.
+
+It answers the one question that is otherwise unanswerable until it is too late:
+**will this chain survive the climb?**
+
+### The predecessor-ladder invariant
+
+app-v22 and app-v23 refuse to be proposed, approved, activated, *or restored*
+unless consensus storage proves the complete predecessor ladder: a canonical
+applied-upgrade record for app-v6, and an individual record for every version
+from app-v7 upward, each with the exact target and a strictly increasing
+activation height. Missing, synthesized, or out-of-order evidence fails closed.
+
+(app-v6's record is the single compatibility proof for the historical cumulative
+app-v2 through app-v5 activation. Everything from app-v7 needs its own record.)
+
+Why this matters on an old chain: a gap does not stop the climb early. The node
+walks happily up to **app-v21** and only then fails closed — mid-ladder, long
+after you committed to the upgrade. Preflight reads the same records with the
+same rules and tells you up front.
+
+A healthy result ends with:
+
+```
+VERDICT: clear to climb from app-v14 to app-v26.
+```
+
+A bad one names the exact rung:
+
+```
+VERDICT: this chain CANNOT reach app-v22.
+  app-v17: missing canonical applied app-v17 record
+```
+
+If you get that: **do not delete the data directory.** The evidence is missing
+from consensus storage and cannot be re-proposed or synthesized. Restore a
+complete backup taken before the gap, or open an issue with the preflight
+output.
+
+### The app-v23 authority preview
+
+Preflight also prints what app-v23 will do to your administrators, because this
+surprises people more than anything else in the upgrade:
+
+```
+app-v23 authority preview (what activation will do to your admins):
+  becomes CEREBRUM Root : ops-primary (3f9a1c…)
+  demoted to Member     : 2 other Admin(s) …
+```
+
+See [What app-v23 does to your admins](#3-what-app-v23-does-to-your-admins).
+
+---
+
+## Step 4 — Climb the ladder
+
+### Personal nodes (single validator)
+
+Automatic. A node with quorum disabled runs an auto-advance worker that
+proposes each next fork, waits for activation, and moves to the next rung until
+it reaches the binary's ceiling. Start the node and watch:
+
+```bash
+sage-gui upgrade status
+```
+
+```
+Chain app version : 26 (app-v26)
+Binary supports   : up to app-v26
+Next fork         : none — chain is at the highest version this binary supports
+```
+
+A dozen rungs takes a while: each activation waits out an upgrade delay of at
+least 200 blocks. **This is normal.** An idle SAGE chain mints no blocks at all,
+so the node submits harmless heartbeat transactions to tick a quiescent chain
+toward each pending plan's activation height.
+
+### Is it stuck, or just slow?
+
+Each rung waits out at least 200 blocks. Personal nodes run
+`timeout_commit = 1s` and the watchdog heartbeats a quiescent chain every 2s, so
+budget **roughly 4–7 minutes per rung**; quorum clusters run `timeout_commit =
+3s`, so **roughly 10 minutes**. A twelve-rung v10 → app-v26 climb is therefore
+about **1 hour on a personal node** and **2 hours on a cluster**. Treat these as
+order-of-magnitude, not a guarantee — a busy chain mints blocks faster.
+
+`upgrade status` shows the app version but not the block height, so it looks
+frozen between activations even when everything is fine. The reliable progress
+signal is **block height rising**:
+
+```bash
+curl -s http://127.0.0.1:26657/status | grep latest_block_height
+```
+
+If the height is climbing, the upgrade is working — leave it alone. If the
+height is static for more than a few minutes *while a plan is pending*, check
+the node log for these two lines, which mean stop waiting and start diagnosing:
+
+- `auto-advance halted:` — terminal. See
+  [the admin-key failure](#1-auto-advance-halted--the-proposer-is-not-a-chain-admin) below.
+- Repeated `propose rejected` — the proposal is not being accepted; the log's
+  code and message say why.
+
+A healthy idle chain minting no blocks is not a fault — see
+[`reference/concepts/block-production-and-idle.md`](reference/concepts/block-production-and-idle.md).
+
+### Quorum clusters
+
+Manual, one rung at a time, from the node holding the admin key:
+
+```bash
+sage-gui upgrade status                    # shows the next target
+sage-gui upgrade propose --target 15 --wait
+sage-gui upgrade propose --target 16 --wait
+# … repeat to the ceiling
+```
+
+`--wait` stays attached and heartbeats a quiescent chain until the fork
+activates. Proposals route through the 2/3 governance quorum; validators
+auto-vote ACCEPT if they support the target. Upgrade every validator's binary
+before climbing — a validator that does not support the target cannot vote for
+it.
+
+---
+
+## The four things that actually go wrong
+
+### 1. "auto-advance halted" — the proposer is not a chain admin
+
+Past app-v8 the proposer must be a chain-admin agent: the signing key's agent ID
+must hold `Role==admin` in the on-chain registry. If it does not, the proposal
+is rejected at block execution (**code 47**) and auto-advance stops with:
+
+```
+auto-advance halted: this node's agent.key is not the on-chain chain-admin …
+```
+
+There is deliberately no automatic reset — rebuilding from SQLite would discard
+canonical memory, RBAC, governance, and block history, and `repair-chain` is
+disabled for the same reason.
+
+Fix it by proposing with the key that *is* the chain admin:
+
+```bash
+sage-gui upgrade propose --target <N> --agent-key /path/to/chain-admin.key
+```
+
+`--agent-key` accepts an `agent.key` seed or a CometBFT
+`priv_validator_key.json`. On many deployments the genesis validator key is the
+admin.
+
+If **no** key you hold is the chain admin, what you can do depends on where the
+chain already is:
+
+- **Below app-v9**, the wire `role=admin` self-grant is still open, so running
+  any admin operation with your key materializes the role, and the climb can
+  continue.
+- **At app-v9 or above**, that door is closed by consensus. A chain whose admin
+  key is lost recovers only from a complete stopped-node backup. There is no
+  reset path: `repair-chain` is disabled precisely because rebuilding from
+  SQLite would discard canonical history.
+
+[`ISSUE_52_RECOVERY.md`](ISSUE_52_RECOVERY.md) is the authority for this failure
+mode; read it before attempting anything else.
+
+### 2. The signing identity changes at app-v23
+
+Below app-v23, upgrade proposals are signed with the operator `agent.key`. From
+app-v23 the default becomes **the current CEREBRUM Root credential**, resolved
+from local key material (including recovery bundles). This is not a setting you
+change; it is a consequence of Root becoming a distinct singleton authority.
+
+Practical consequence: **keep the Root credential on the node host.** If Root
+has been rotated, the stale genesis `agent.key` is no longer the right signer,
+and `--agent-key` is an explicitly reviewed local Admin override rather than the
+normal path.
+
+### 3. What app-v23 does to your admins
+
+app-v23 replaces capability-bit administration with roles, security profiles,
+and Access Groups. The migration is deterministic and it is not gentle with a
+multi-admin chain:
+
+- **The earliest legacy Admin by registration height becomes the singleton
+  CEREBRUM Root** (canonical Agent ID breaks ties). Root cannot be dragged into
+  groups, messaged, demoted, or removed through ordinary agent controls.
+- **Every other legacy Admin is demoted to an active Member** with its exact
+  capability mask, the migration-only `legacy_restricted` profile, and
+  disposition `legacy_admin_review`. Consensus cannot prove any other exportable
+  legacy Admin key is still local to this machine, so none is promoted
+  automatically — restoring one to Admin needs an explicit review attested by
+  the current Root in CEREBRUM.
+- The complete old Admin roster is kept as immutable audit evidence. Nothing is
+  lost; authority is re-derived.
+- Ordinary Members keep their exact app-v22 mask. Masks `0`/`16` map to
+  `standard`, `15`/`31` to `companion`, everything else to `legacy_restricted`
+  pending review.
+- An agent matching the app-v22 bare self-registration fingerprint (mask `30`,
+  no owned domain, no explicit grant) becomes **inactive** with `pending_review`
+  and needs an administrator to assign an intentional profile.
+
+Run `sage-gui upgrade preflight` beforehand to see exactly which agent becomes
+Root and which ones land in review. Plan for it — do not discover it from a
+support ticket.
+
+Two more app-v23 mechanics worth knowing:
+
+- **Activation block H is a quiescence barrier.** Every transaction delivered at
+  H is rejected with **code 96**; normal execution resumes at H+1. This is
+  intentional — it freezes the migration input so nothing races the activation.
+  Brief write failures at exactly that height are expected, not a fault.
+- **After app-v23 state or transaction types are committed, there is no in-band
+  downgrade to app-v22.** Recovery is a forward fix or a trusted
+  pre-activation snapshot. This is the point of no return in the ladder; it is
+  the reason for Step 2.
+- **Legacy MCP bearer tokens are revoked.** Activation durably retires every
+  bearer token that has no key of its own. Any client authenticating over HTTP
+  MCP with such a token — ChatGPT Work connectors, Cursor, Cline, Claude Desktop
+  over `:8443` — stops working until you issue a new one with
+  `sage-gui mcp-token create`. Clients using the stdio bridge (`sage-gui mcp`)
+  are unaffected beyond a session restart. Plan this for the same maintenance
+  window; it is the most common "the upgrade broke my agents" report.
+
+### 4. app-v25 repairs historical memories, and may quarantine some
+
+app-v25 makes new memory envelopes immutable and automatically repairs
+historical rows. A row that cannot be repaired is quarantined record-locally and
+surfaced honestly rather than silently dropped, with Root retry and deprecation
+controls. If the UI shows partially displayed or repairing historical memories
+after this rung, that is the documented behaviour — see
+[`reference/app-v25-upgrade-recovery.md`](reference/app-v25-upgrade-recovery.md).
+
+---
+
+## Verifying you are done
+
+```bash
+sage-gui upgrade status     # app version == binary ceiling
+sage-gui status             # node health
+```
+
+Then check that recall works from an actual agent — an MCP `sage_recall` on a
+domain you know has content is the honest end-to-end test.
+
+If your agents were connected over MCP, restart their sessions. A long-lived
+MCP client keeps talking to the node it connected to, and short-lived `sage-gui
+mcp` subprocesses proxy to the running node, so tool descriptions and behaviour
+can look stale until both ends are restarted.
+
+If you crossed app-v23, also reissue HTTP MCP bearer tokens — activation revoked
+every legacy keyless bearer:
+
+```bash
+sage-gui mcp-token list      # revoked entries show here
+sage-gui mcp-token create    # issue a replacement per client
+```
+
+---
+
+## What never to do
+
+- **Do not delete `~/.sage/data`** to fix an upgrade. That discards consensus
+  history and is not an upgrade or repair procedure.
+- **Do not export SQLite and initialize a new chain** and call it an upgrade.
+  That is a different chain with none of your history.
+- **Do not rely on `sage-gui backup`** (without `--full`) as pre-upgrade
+  insurance. It backs up a rebuildable projection, not the chain.
+- **Do not skip rungs.** Proposals must target current + 1.
+
+---
+
+## Related reference
+
+- [`reference/app-v23-access-control-design.md`](reference/app-v23-access-control-design.md)
+  — Root, roles, security profiles, Access Groups, and the full migration contract
+- [`reference/app-v25-upgrade-recovery.md`](reference/app-v25-upgrade-recovery.md)
+  — historical repair, quarantine, and Root resolution controls
+- [`reference/concepts/app-v26-access-groups.md`](reference/concepts/app-v26-access-groups.md)
+  — the current Access Group authority model
+- [`reference/concepts/block-production-and-idle.md`](reference/concepts/block-production-and-idle.md)
+  — why a healthy idle chain mints no blocks
+- [`GETTING_STARTED.md`](GETTING_STARTED.md) — first-time setup

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -52,7 +52,7 @@ most upgrade anxiety.
 
 | | What it is | When it changes |
 |---|---|---|
-| **Release version** (`v11.17.15`) | The binary/semver you download | Every release |
+| **Release version** (`v11.x.y`) | The binary/semver you download | Every release |
 | **App version** (`app-v26`) | The consensus state-machine version, activated by governance | Only when consensus rules change |
 
 There is also a **consensus fork version**, currently `1`, which has never been
@@ -109,7 +109,7 @@ git clone https://github.com/l33tdawg/sage.git && cd sage
 go build -o sage-gui ./cmd/sage-gui/
 
 # Docker
-docker pull ghcr.io/l33tdawg/sage:11.17.15
+docker pull ghcr.io/l33tdawg/sage:latest
 ```
 
 > Replacing a binary on disk does **not** upgrade a running node. A long-lived
@@ -187,7 +187,7 @@ the container stopped:
 
 ```bash
 docker stop sage
-docker run --rm -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:11.17.15 \
+docker run --rm -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:latest \
   backup --full --out /root/.sage/backups/pre-upgrade.tar.gz
 ```
 
@@ -195,10 +195,23 @@ The image's `ENTRYPOINT` is already `sage-gui`, so pass the subcommand directly 
 `docker run … sage-gui backup` would try to run `sage-gui sage-gui backup`. The
 archive lands in the mounted volume, so it survives the container.
 
-Then preflight the same way before pulling the new image:
+> **Confirm the image actually has these commands before you rely on the
+> backup.** An image older than the release that introduced them does not reject
+> `--full` — it ignores the flag, writes the SQLite-only copy, and prints
+> `Backup saved`. A success message, for the wrong thing, right before an
+> irreversible climb. Check first:
+>
+> ```bash
+> docker run --rm ghcr.io/l33tdawg/sage:latest upgrade preflight --help
+> ```
+>
+> If that errors with an unknown subcommand, the image predates these commands —
+> pull a newer one before going further.
+
+Then preflight the same way, using that same current image:
 
 ```bash
-docker run --rm -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:11.17.15 upgrade preflight
+docker run --rm -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:latest upgrade preflight
 ```
 
 ---

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -42,6 +42,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 
 | You want to… | Go to |
 |--------------|-------|
+| Upgrade an existing node to a newer release (incl. v10.x → v11) | [`../UPGRADING.md`](../UPGRADING.md) — backup, `upgrade preflight`, the app-version ladder, app-v23 admin migration |
 | Boot your memory at conversation start | **Boot sequence** below, then [`mcp-tools.md`](mcp-tools.md) |
 | Submit a memory with a clearance level | [`python-sdk.md`](python-sdk.md) `propose()` / [`rest-api.md`](rest-api.md) `POST /v1/memory/submit` |
 | Understand why another agent can't see your memory | [`concepts/clearance-classification.md`](concepts/clearance-classification.md) + [`concepts/rbac-orgs-federation.md`](concepts/rbac-orgs-federation.md) |


### PR DESCRIPTION
Operators upgrading v10.x → v11 reported that the repo has no upgrade
instructions. It did not. The only "Upgrading from an older version?" section
covered re-running the pre-v5.0 MCP installer, `docs/reference/INDEX.md` had no
upgrade entry at all, and `GETTING_STARTED.md` carried only warnings about what
*not* to do — no positive procedure.

## What this adds

**`docs/UPGRADING.md`** — the missing procedure: the release → app-version map,
the in-place ladder climb (automatic on personal nodes, one rung at a time on
quorum), and the four things that actually go wrong: the app-v8+ chain-admin
gate, the signing-identity switch to the CEREBRUM Root credential at app-v23,
the app-v23 admin migration, and app-v25 historical repair.

**And the commands it tells operators to run**, because a guide whose steps
don't exist is worse than no guide:

| Command | Why |
|---|---|
| `sage-gui backup --full` | The complete stopped-node archive every recovery doc already demanded but nothing produced. Plain `backup` copies only `data/sage.db`, the SQLite projection — it cannot rebuild a chain, so it was never sufficient pre-upgrade insurance. |
| `sage-gui restore --from` | Matching restore: staged extraction, move-aside instead of delete, layout derived from the archive manifest. |
| `sage-gui upgrade preflight` | Read-only pre-upgrade check on a stopped node. |

### Why preflight exists

app-v22/app-v23 refuse to activate without complete, strictly ordered
predecessor evidence, so a chain with a historical gap climbs happily to
app-v21 and *only then* fails closed — mid-ladder, after the operator has
committed. Preflight applies the same rules as
`validatePersistedAppV22PredecessorLadder` / `...AppV23...`, scoped to the
version the chain has actually reached (rungs above that are created *by* the
climb). It also previews which legacy Admin app-v23 will promote to singleton
CEREBRUM Root and which ones land in `legacy_admin_review`.

### Notes for review

- Liveness is gated on SAGE's own instance lock, not a Badger probe: badger
  refuses read-only opens on Windows (`ErrWindowsNotSupported`), which would
  have made these commands brick walls on a shipped platform. Cross-compiled
  against `GOOS=windows` to confirm.
- `docs/*` is gitignored with an allowlist, so `UPGRADING.md` needed an explicit
  `!docs/UPGRADING.md` negation or it would silently never commit.
- The `.claude/settings.json` hunk is MCP self-heal
  (`cmd/sage-gui/mcp.go:840`) dropping the retired `sage_red_pill` alias.

### Verification

`go build ./...` (host + `GOOS=windows`), `go vet`, `gofmt`, and the full
`./cmd/sage-gui` package suite pass. Hand-run end-to-end: backup → the literal
restore command backup prints → preflight, for a nested data dir, a data dir
symlinked to an external volume, and a data dir symlinked in-tree.

Four adversarial review rounds ran over this changeset (19 → 19 → 3 → 0
confirmed findings). Two things they caught that would otherwise have shipped:
preflight told **every** healthy chain below app-v21 that it was unrecoverable,
and preflight could never run on Windows.

### Follow-up (not in this PR)

The three commands are unreleased, so the doc hedges with "recent additions" and
Step 1 pins `ghcr.io/l33tdawg/sage:11.17.15` — an image without them. Both need
pinning to a real version when the next release is cut.