### PR TITLE
Fix federation peer export authorization and mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,26 +51,32 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
-## What's New in v11.17.16
+## What's New in v11.17.17
 
-**Federated domain discovery now reports effective authority, not intent.**
-`sage_federation` no longer labels the intersection of two policy catalogs as
-readable before the destination has checked the exact requesting agent. A new
-bounded, authenticated, non-mutating availability probe applies the same live
-agreement generation, peer policy, linked-reader row, Access Group membership,
-domain ownership, and classification gates used by recall planning. Only that
-verified subset appears in `shared_read_domains`; policy-only intersections are
-reported separately as `read_candidate_domains` with an explicit authorization
-status. Older or temporarily unavailable peers therefore fail honestly instead
-of inviting an agent to issue a recall that can only return 403.
+**Federated Read plans now stay true until disclosure.** The v11.17.16
+exported-agent model correctly made a trusted node pair its own federation
+group, but a source agent's standing or clearance could change between planning
+and the remote query. v11.17.17 binds the source authorization model and exact
+attestation into the signed plan and single-use challenge, then holds the final
+source authorization lease through the destination query. A changed export,
+domain owner, enrollment, clearance, agreement, or capability now fails closed
+before any memory is returned and requires a fresh plan and signature.
 
-This is an off-consensus protocol and projection correction. It changes no
-transaction codec, AppHash input, fork target, key format, memory, domain,
-linked-reader row, or existing agreement. Both SAGEs must run v11.17.16 to use
-the exact availability probe; mixed-version pairs remain connected and mark
-the read candidates unverified.
+CEREBRUM and `sage_federation` also expose the negotiated authenticated-read
+capability explicitly. A reachable peer missing it is described honestly as
+possibly still warming/binding or needing an update; SAGE does not guess which.
+Policy candidates stay separate from domains the destination has verified. The
+Docker federation lane covers pairwise default Read, explicit denial,
+non-transitive exports, Copy backfill, incremental mirroring, bidirectional
+mirroring, and restart recovery.
 
-Container: `ghcr.io/l33tdawg/sage:11.17.16`. SDK 11.17.16.
+This is an off-consensus protocol, authorization, and projection correction. It
+changes no transaction codec, AppHash input, fork target, key format, memory, domain,
+linked-reader row, or existing agreement. Both SAGEs must run v11.17.17 for the
+complete signed authorization tuple; older clients are told to re-plan and
+re-sign instead of silently downgrading it.
+
+Container: `ghcr.io/l33tdawg/sage:11.17.17`. SDK 11.17.17.
 
 ## What's New in v11.17.15
 
@@ -1399,7 +1405,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.17.16`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.17.17`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.17.16
+  version: 11.17.17
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.
@@ -5850,6 +5850,66 @@ paths:
         "403": {$ref: "#/components/responses/Forbidden"}
         "429":
           description: Caller or process outbound discovery budget exhausted; retry after Retry-After.
+          content: {application/problem+json: {schema: {$ref: "#/components/schemas/ProblemDetails"}}}
+
+  /v1/federation/recall-plan:
+    post:
+      operationId: createFederatedRecallPlan
+      summary: Create the destination-bound signing plan for a federated recall.
+      description: >-
+        First half of the app-v23 two-request recall protocol. The caller must
+        copy destinations to the second recall's federate_chains and copy
+        source_chain_id, agreement_bindings, query_challenges,
+        authorization_models, and authorization_attestations verbatim into its
+        signed federation_context. A peer that cannot complete current planning
+        is reported in errors and omitted from destinations. A second request
+        that omits authorization map entries is an old-client error and must be
+        re-planned and re-signed; an empty model plus explicit zero attestation
+        remains a valid legacy-peer tuple.
+      tags: [Federation]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [domain_tag]
+              properties:
+                domain_tag: {type: string, minLength: 1, maxLength: 256}
+                federate_chains:
+                  type: array
+                  maxItems: 8
+                  items: {type: string, minLength: 1}
+      responses:
+        "200":
+          description: Exact finite destination plan and complete signing tuple.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [protocol_version, source_chain_id, destinations, agreement_bindings, query_challenges, authorization_models, authorization_attestations, expires_at]
+                properties:
+                  protocol_version: {type: integer, const: 23}
+                  source_chain_id: {type: string, minLength: 1}
+                  destinations: {type: array, maxItems: 8, items: {type: string}}
+                  agreement_bindings: {type: object, additionalProperties: {type: string}}
+                  query_challenges: {type: object, additionalProperties: {type: string}}
+                  authorization_models: {type: object, additionalProperties: {type: string}}
+                  authorization_attestations:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      required: [eligible, max_classification]
+                      properties:
+                        eligible: {type: boolean}
+                        max_classification: {type: integer, minimum: 0, maximum: 4}
+                  expires_at: {type: object, additionalProperties: {type: integer, format: int64}}
+                  errors: {type: object, additionalProperties: {type: string}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "502":
+          description: Planning failed before a valid per-peer result could be returned.
           content: {application/problem+json: {schema: {$ref: "#/components/schemas/ProblemDetails"}}}
 
   /v1/federation/contacts/authorize:

--- a/api/rest/federated_recall_test.go
+++ b/api/rest/federated_recall_test.go
@@ -466,6 +466,50 @@ func TestFederatedSemanticRecallCarriesTextFallback(t *testing.T) {
 	assert.Equal(t, "benchmark exact words", fed.lastReq.Query)
 }
 
+func TestPostV23FederatedRecallRejectsOldClientAuthorizationTupleOmission(t *testing.T) {
+	srv, _, _ := newTestServer(t, "")
+	fed := &fakeFederation{}
+	srv.SetFederation(fed)
+	body, err := json.Marshal(SearchMemoryRequest{
+		Query: "signed plan", DomainTag: "shared", Federated: true,
+		FederateChains: []string{"chain-a"},
+		FederationContext: &FederatedRecallProofContext{
+			SourceChainID:     fed.LocalChainID(),
+			AgreementBindings: map[string]string{"chain-a": "binding-a"},
+			QueryChallenges:   map[string]string{"chain-a": "challenge-a"},
+			// A pre-authorization-tuple client copied only the historical plan
+			// fields. Empty authorization values are valid for a legacy peer, but
+			// omitted map entries are an old-client signing error.
+		},
+	})
+	require.NoError(t, err)
+	req, callerID := signedRequest(t, http.MethodPost, "/v1/memory/search", body)
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Host = "127.0.0.1:8080"
+	badger, err := store.NewBadgerStore(filepath.Join(t.TempDir(), "badger"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, badger.CloseBadger()) })
+	require.NoError(t, badger.BootstrapAppV23Genesis(store.AppV23GenesisBootstrap{
+		RootID: callerID, Scope: "rest-old-client-plan",
+		AgentID: strings.Repeat("7a", 32), Profile: store.AppV23ProfileStandard,
+		HomeDomain: "companion.home", Clearance: 2, Height: 1,
+		BootstrapDigest: "rest-old-client-plan",
+	}))
+	srv.badgerStore = badger
+	srv.SetPostV23ForNextTxAccessor(func() bool { return true })
+
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var response QueryMemoryResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	require.NotNil(t, response.Federation)
+	assert.Equal(t, 0, fed.calls, "an incomplete signed tuple must fail before peer fan-out")
+	assert.Contains(t, response.Federation.Errors["chain-a"], "signed federation authorization tuple")
+	assert.Contains(t, response.Federation.Errors["chain-a"], "recall-plan")
+	assert.Contains(t, response.Federation.Errors["chain-a"], "re-sign")
+}
+
 func TestFederatedRecallDeduplicatesLocalAndLiveByContentHash(t *testing.T) {
 	srv, memStore, _ := newTestServer(t, "")
 	memStore.memories["local-copy-shape"] = &memory.MemoryRecord{
@@ -553,6 +597,10 @@ func TestCrossFedStatusExposesAuthenticatedRemoteDiscovery(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 	assert.Equal(t, true, response["reachable"])
 	assert.Equal(t, "DKAN-TII", response["network_name"])
+	assert.Equal(t, []any{
+		federation.CapabilitySync,
+		federation.CapabilityFederatedPipeline,
+	}, response["capabilities"])
 	assert.NotNil(t, response["peer_rbac_grant"])
 	assert.NotNil(t, response["pipe_contacts"])
 }

--- a/api/rest/federation_recall_plan.go
+++ b/api/rest/federation_recall_plan.go
@@ -57,12 +57,14 @@ func (s *Server) handleFederationRecallPlan(w http.ResponseWriter, r *http.Reque
 		targets = s.federationRecallTargets(r.Context(), targets, req.DomainTag)
 		if len(targets) == 0 {
 			writeJSON(w, http.StatusOK, &federation.RecallPlan{
-				ProtocolVersion:   federation.FederationProtocolV23,
-				SourceChainID:     s.federation.LocalChainID(),
-				Destinations:      []string{},
-				AgreementBindings: map[string]string{},
-				QueryChallenges:   map[string]string{},
-				ExpiresAt:         map[string]int64{},
+				ProtocolVersion:           federation.FederationProtocolV23,
+				SourceChainID:             s.federation.LocalChainID(),
+				Destinations:              []string{},
+				AgreementBindings:         map[string]string{},
+				QueryChallenges:           map[string]string{},
+				AuthorizationModels:       map[string]string{},
+				AuthorizationAttestations: map[string]federation.SourceAuthorizationAttestation{},
+				ExpiresAt:                 map[string]int64{},
 			})
 			return
 		}

--- a/api/rest/memory_handler.go
+++ b/api/rest/memory_handler.go
@@ -102,16 +102,51 @@ type QueryMemoryRequest struct {
 }
 
 type FederatedRecallProofContext struct {
-	SourceChainID     string            `json:"source_chain_id"`
-	AgreementBindings map[string]string `json:"agreement_bindings"`
-	QueryChallenges   map[string]string `json:"query_challenges"`
+	SourceChainID             string                                               `json:"source_chain_id"`
+	AgreementBindings         map[string]string                                    `json:"agreement_bindings"`
+	QueryChallenges           map[string]string                                    `json:"query_challenges"`
+	AuthorizationModels       map[string]string                                    `json:"authorization_models"`
+	AuthorizationAttestations map[string]federation.SourceAuthorizationAttestation `json:"authorization_attestations"`
 }
 
-func federationPlanFields(ctx *FederatedRecallProofContext) (map[string]string, map[string]string) {
+func federationPlanFields(ctx *FederatedRecallProofContext) (string, map[string]string, map[string]string, map[string]string, map[string]federation.SourceAuthorizationAttestation) {
 	if ctx == nil {
-		return nil, nil
+		return "", nil, nil, nil, nil
 	}
-	return ctx.AgreementBindings, ctx.QueryChallenges
+	return ctx.SourceChainID, ctx.AgreementBindings, ctx.QueryChallenges, ctx.AuthorizationModels, ctx.AuthorizationAttestations
+}
+
+const missingSignedFederationAuthorizationTuple = "signed federation authorization tuple is missing or incomplete; call POST /v1/federation/recall-plan again, copy its exact destinations and authorization tuple, then re-sign the recall request with a current client"
+
+func (s *Server) validateSignedFederationPlan(chains []string, req *federation.QueryRequest) map[string]string {
+	missing := make(map[string]string)
+	if req == nil || req.PlanSourceChainID == "" || req.PlanSourceChainID != s.federation.LocalChainID() {
+		missing["*"] = missingSignedFederationAuthorizationTuple
+		return missing
+	}
+	targets := chains
+	if len(targets) == 0 {
+		targets = []string{"*"}
+	}
+	if len(targets) == 1 && targets[0] == "*" {
+		if len(req.PlanAgreementBindings) == 0 {
+			missing["*"] = missingSignedFederationAuthorizationTuple
+			return missing
+		}
+		targets = make([]string, 0, len(req.PlanAgreementBindings))
+		for chain := range req.PlanAgreementBindings {
+			targets = append(targets, chain)
+		}
+	}
+	for _, chain := range targets {
+		_, modelBound := req.PlanAuthorizationModels[chain]
+		_, attestationBound := req.PlanAuthorizationAttestations[chain]
+		if chain == "" || chain == "*" || req.PlanAgreementBindings[chain] == "" ||
+			req.PlanChallenges[chain] == "" || !modelBound || !attestationBound {
+			missing[chain] = missingSignedFederationAuthorizationTuple
+		}
+	}
+	return missing
 }
 
 func (s *Server) requireFederatedEmbeddingProvider(
@@ -2012,19 +2047,22 @@ func (s *Server) handleQueryMemory(w http.ResponseWriter, r *http.Request) {
 	if req.Query != "" {
 		federatedMode = federation.ModeHybrid
 	}
-	agreementBindings, queryChallenges := federationPlanFields(req.FederationContext)
+	planSourceChainID, agreementBindings, queryChallenges, authorizationModels, authorizationAttestations := federationPlanFields(req.FederationContext)
 	s.mergeFederatedRecall(r, &resp, req.Federated, req.FederateChains, &federation.QueryRequest{
-		Mode:                  federatedMode,
-		Query:                 req.Query,
-		Embedding:             req.Embedding,
-		EmbeddingProvider:     req.EmbeddingProvider,
-		Provider:              req.Provider,
-		DomainTag:             req.DomainTag,
-		MinConfidence:         req.MinConfidence,
-		TopK:                  req.TopK,
-		Tags:                  req.Tags,
-		PlanAgreementBindings: agreementBindings,
-		PlanChallenges:        queryChallenges,
+		Mode:                          federatedMode,
+		Query:                         req.Query,
+		Embedding:                     req.Embedding,
+		EmbeddingProvider:             req.EmbeddingProvider,
+		Provider:                      req.Provider,
+		DomainTag:                     req.DomainTag,
+		MinConfidence:                 req.MinConfidence,
+		TopK:                          req.TopK,
+		Tags:                          req.Tags,
+		PlanSourceChainID:             planSourceChainID,
+		PlanAgreementBindings:         agreementBindings,
+		PlanChallenges:                queryChallenges,
+		PlanAuthorizationModels:       authorizationModels,
+		PlanAuthorizationAttestations: authorizationAttestations,
 	})
 
 	writeJSON(w, http.StatusOK, resp)
@@ -2086,6 +2124,12 @@ func (s *Server) mergeFederatedRecall(r *http.Request, resp *QueryMemoryResponse
 	s.enrichStoredCopyProvenance(r.Context(), resp.Results)
 	if s.federation == nil || (!federated && len(chains) == 0) {
 		return
+	}
+	if s.isPostV23ForNextTx() {
+		if missing := s.validateSignedFederationPlan(chains, fedReq); len(missing) > 0 {
+			resp.Federation = &FederationInfo{Queried: []string{}, Errors: missing}
+			return
+		}
 	}
 	callerID := middleware.ContextAgentID(r.Context())
 	allowed, callerClearance := s.federationCallerCanRead(r.Context(), callerID, fedReq.DomainTag)
@@ -2719,17 +2763,20 @@ func (s *Server) handleSearchMemory(w http.ResponseWriter, r *http.Request) {
 	}
 	setFilterInfo(w, &resp, filterApplied, hiddenByClassification)
 
-	agreementBindings, queryChallenges := federationPlanFields(req.FederationContext)
+	planSourceChainID, agreementBindings, queryChallenges, authorizationModels, authorizationAttestations := federationPlanFields(req.FederationContext)
 	s.mergeFederatedRecall(r, &resp, req.Federated, req.FederateChains, &federation.QueryRequest{
-		Mode:                  federation.ModeText,
-		Query:                 req.Query,
-		Provider:              req.Provider,
-		DomainTag:             req.DomainTag,
-		MinConfidence:         req.MinConfidence,
-		TopK:                  req.TopK,
-		Tags:                  req.Tags,
-		PlanAgreementBindings: agreementBindings,
-		PlanChallenges:        queryChallenges,
+		Mode:                          federation.ModeText,
+		Query:                         req.Query,
+		Provider:                      req.Provider,
+		DomainTag:                     req.DomainTag,
+		MinConfidence:                 req.MinConfidence,
+		TopK:                          req.TopK,
+		Tags:                          req.Tags,
+		PlanSourceChainID:             planSourceChainID,
+		PlanAgreementBindings:         agreementBindings,
+		PlanChallenges:                queryChallenges,
+		PlanAuthorizationModels:       authorizationModels,
+		PlanAuthorizationAttestations: authorizationAttestations,
 	})
 
 	writeJSON(w, http.StatusOK, resp)
@@ -3052,19 +3099,22 @@ func (s *Server) handleHybridSearchMemory(w http.ResponseWriter, r *http.Request
 	}
 	setFilterInfo(w, &resp, filterApplied, hiddenByClassification)
 
-	agreementBindings, queryChallenges := federationPlanFields(req.FederationContext)
+	planSourceChainID, agreementBindings, queryChallenges, authorizationModels, authorizationAttestations := federationPlanFields(req.FederationContext)
 	s.mergeFederatedRecall(r, &resp, req.Federated, req.FederateChains, &federation.QueryRequest{
-		Mode:                  federation.ModeHybrid,
-		Query:                 req.Query,
-		Embedding:             req.Embedding,
-		EmbeddingProvider:     req.EmbeddingProvider,
-		Provider:              req.Provider,
-		DomainTag:             req.DomainTag,
-		MinConfidence:         req.MinConfidence,
-		TopK:                  req.TopK,
-		Tags:                  req.Tags,
-		PlanAgreementBindings: agreementBindings,
-		PlanChallenges:        queryChallenges,
+		Mode:                          federation.ModeHybrid,
+		Query:                         req.Query,
+		Embedding:                     req.Embedding,
+		EmbeddingProvider:             req.EmbeddingProvider,
+		Provider:                      req.Provider,
+		DomainTag:                     req.DomainTag,
+		MinConfidence:                 req.MinConfidence,
+		TopK:                          req.TopK,
+		Tags:                          req.Tags,
+		PlanSourceChainID:             planSourceChainID,
+		PlanAgreementBindings:         agreementBindings,
+		PlanChallenges:                queryChallenges,
+		PlanAuthorizationModels:       authorizationModels,
+		PlanAuthorizationAttestations: authorizationAttestations,
 	})
 
 	writeJSON(w, http.StatusOK, resp)

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.17.16-acceptance
+ARG VERSION=v11.17.17-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.17.16 federation Docker acceptance
+# v11.17.17 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third
@@ -9,7 +9,7 @@ default (`FED_NODE_A_PORT` / `FED_NODE_B_PORT` override them).
 Run the reproducible topology smoke test with:
 
 ```sh
-FED_ACCEPTANCE_STATE=/tmp/sage-v111716-fed \
+FED_ACCEPTANCE_STATE=/tmp/sage-v111717-fed \
   deploy/federation-acceptance/run.sh topology
 ```
 
@@ -57,6 +57,10 @@ with the phase and tool name instead of hanging CI indefinitely.
 | Stale snapshot | set persisted `expires_at` in the past | stale route is rejected, refreshed, and flow recovers |
 | Relay outage | stop then restart natter | explicit offline/no-route while down; automatic recovery after restart |
 | Upgrade | v11.17.4 `p2p_peers` fixture | peer survives load and gains current route snapshot |
+| Pairwise Read | reciprocal exported Mynah agents; no mirrored Access Group or linked-reader fixture | either ordinary companion can read the other's exported owned domain; writes remain ungranted |
+| Copy backfill | each source independently offers Copy; each receiver independently subscribes | receiver-local recall finds memories created before consent in both directions |
+| Copy incremental | create a new source memory after consent | receiver-local recall finds the new copy in both directions |
+| Copy restart | restart both nodes, then stop each source in turn | each receiver still recalls both backfilled and incremental copies locally while its source is offline |
 | Offline inbox | recipient stopped after send | durable inbox delivery, read, reply, and final sender status |
 
 The contract test is fast and does not require Docker:

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -1,8 +1,8 @@
-name: sage-v111716-federation
+name: sage-v111717-federation
 
 services:
   relay:
-    image: sage-v111716-natter:local
+    image: sage-v111717-natter:local
     build:
       context: ../../natter
       dockerfile: ../deploy/federation-acceptance/Dockerfile.natter
@@ -22,12 +22,12 @@ services:
         aliases: [relay]
 
   node-a:
-    image: sage-v111716-node:local
+    image: sage-v111717-node:local
     build:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.17.16-acceptance
+        VERSION: v11.17.17-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage
@@ -44,7 +44,7 @@ services:
       control_a: {}
 
   node-b:
-    image: sage-v111716-node:local
+    image: sage-v111717-node:local
     environment:
       SAGE_HOME: /root/.sage
       SAGE_EMBEDDING_PROVIDER: hash
@@ -61,17 +61,17 @@ services:
 
 networks:
   edge_a:
-    name: sage-v111716-federation-edge-a
+    name: sage-v111717-federation-edge-a
     internal: true
   edge_b:
-    name: sage-v111716-federation-edge-b
+    name: sage-v111717-federation-edge-b
     internal: true
   lan:
-    name: sage-v111716-federation-lan
+    name: sage-v111717-federation-lan
     internal: true
   # Separate host-control bridges keep REST observable without giving the two
   # nodes a shared container network that could bypass the relay assertion.
   control_a:
-    name: sage-v111716-federation-control-a
+    name: sage-v111717-federation-control-a
   control_b:
-    name: sage-v111716-federation-control-b
+    name: sage-v111717-federation-control-b

--- a/deploy/federation-acceptance/run.sh
+++ b/deploy/federation-acceptance/run.sh
@@ -3,7 +3,7 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
 COMPOSE="$ROOT/deploy/federation-acceptance/docker-compose.yml"
-STATE=${FED_ACCEPTANCE_STATE:-/tmp/sage-v111716-federation-state}
+STATE=${FED_ACCEPTANCE_STATE:-/tmp/sage-v111717-federation-state}
 MODE=${1:-full}
 PORT_A=${FED_NODE_A_PORT:-28080}
 PORT_B=${FED_NODE_B_PORT:-28081}
@@ -32,6 +32,22 @@ mcp_call() {
     die "MCP tool $tool on $svc failed or exceeded ${MCP_TIMEOUT_SECONDS}s"
   node -e 'const lines=process.argv[1].trim().split(/\n/); const r=JSON.parse(lines.at(-1)); if(r.error) throw new Error(JSON.stringify(r.error)); const t=r.result.content[0].text; try { process.stdout.write(JSON.stringify(JSON.parse(t))) } catch { process.stdout.write(t) }' "$out"
 }
+remember_committed() {
+  remember_svc=$1 remember_args=$2
+  remember_result=$(mcp_call "$remember_svc" sage_remember "$remember_args")
+  node -e '
+    const result = JSON.parse(process.argv[1]);
+    if (result.skipped || result.status === "skipped" || result.status === "rejected") {
+      console.error(`sage_remember did not create a memory: ${JSON.stringify(result)}`);
+      process.exit(1);
+    }
+    if (!result.memory_id || result.committed !== true) {
+      console.error(`sage_remember did not confirm a committed memory: ${JSON.stringify(result)}`);
+      process.exit(1);
+    }
+  ' "$remember_result" || die "sage_remember on $remember_svc did not commit a new source memory"
+  printf '%s' "$remember_result"
+}
 wait_health() {
   url=$1
   i=0
@@ -45,13 +61,13 @@ container_ip() {
   docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' "$(container_id "$1")"
 }
 lan_ip() {
-  docker inspect -f '{{(index .NetworkSettings.Networks "sage-v111716-federation-lan").IPAddress}}' "$(container_id "$1")"
+  docker inspect -f '{{(index .NetworkSettings.Networks "sage-v111717-federation-lan").IPAddress}}' "$(container_id "$1")"
 }
 
 cleanup() {
   dc down --remove-orphans >/dev/null 2>&1 || true
   for cid in $CHURN_IDS; do docker stop "$cid" >/dev/null 2>&1 || true; done
-  docker network rm sage-v111716-federation-lan >/dev/null 2>&1 || true
+  docker network rm sage-v111717-federation-lan >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
 
@@ -84,10 +100,10 @@ wait_health "http://127.0.0.1:$PORT_A"
 wait_health "http://127.0.0.1:$PORT_B"
 
 phase "same-LAN topology"
-docker network inspect sage-v111716-federation-lan >/dev/null 2>&1 || \
-  docker network create --internal sage-v111716-federation-lan >/dev/null
-docker network connect --alias node-a sage-v111716-federation-lan "$(container_id node-a)"
-docker network connect --alias node-b sage-v111716-federation-lan "$(container_id node-b)"
+docker network inspect sage-v111717-federation-lan >/dev/null 2>&1 || \
+  docker network create --internal sage-v111717-federation-lan >/dev/null
+docker network connect --alias node-a sage-v111717-federation-lan "$(container_id node-a)"
+docker network connect --alias node-b sage-v111717-federation-lan "$(container_id node-b)"
 dc exec -T node-a getent hosts node-b >/dev/null
 dc exec -T node-b getent hosts node-a >/dev/null
 
@@ -163,6 +179,12 @@ if [ "$MODE" = full ]; then
   api node-a PUT "/v1/dashboard/federation/connections/$chain_a/agent-exports" "$export_a" >/dev/null
   api node-b PUT "/v1/dashboard/federation/connections/$chain_b/agent-exports" "$export_b" >/dev/null
 
+	phase "prove peer-export read has no legacy linked-reader fixture"
+	linked_a=$(api node-a GET /v1/dashboard/network/access/linked-readers)
+	linked_b=$(api node-b GET /v1/dashboard/network/access/linked-readers)
+	[ "$(jfield "$linked_a" total)" = 0 ] || die "node A contains legacy linked-reader state; peer-export acceptance is not isolated"
+	[ "$(jfield "$linked_b" total)" = 0 ] || die "node B contains legacy linked-reader state; peer-export acceptance is not isolated"
+
   phase "directional peer export read needs no mirrored group"
   export_probe="federation default read probe $RUN_TOKEN"
   remember_args=$(node -e 'process.stdout.write(JSON.stringify({content:process.argv[1],domain:"mynah-a-home",type:"fact",confidence:0.95}))' "$export_probe")
@@ -170,7 +192,16 @@ if [ "$MODE" = full ]; then
   i=0
   while :; do
     exported=$(mcp_call node-b sage_federation '{}') || true
-    echo "$exported" | grep -q 'mynah-a-home' && break
+		if node -e '
+			const response=JSON.parse(process.argv[1]);
+			const connection=(response.connections||[]).find(v=>v.remote_chain_id===process.argv[2]);
+			if (!connection) process.exit(1);
+			if (!(connection.capabilities||[]).includes("federated-peer-export-read-v1")) process.exit(1);
+			if (connection.read_authorization!=="verified" || connection.read_authorization_complete!==true) process.exit(1);
+			if (!(connection.shared_read_domains||[]).includes(process.argv[3])) process.exit(1);
+		' "$exported" "$chain_b" "mynah-a-home"; then
+			break
+		fi
     i=$((i + 1)); [ "$i" -lt 45 ] || die "node B never discovered node A's directional domain export"
     sleep 2
   done
@@ -182,11 +213,81 @@ if [ "$MODE" = full ]; then
     i=$((i + 1)); [ "$i" -lt 45 ] || die "ordinary node B companion could not read node A's export without a mirrored group"
     sleep 2
   done
+
+  phase "bidirectional Copy: seed pre-consent memories for initial backfill"
+  mirror_a_initial="federation mirror A initial $RUN_TOKEN"
+  mirror_b_initial="federation mirror B initial $RUN_TOKEN"
+  remember_a_initial=$(node -e 'process.stdout.write(JSON.stringify({content:process.argv[1],domain:"mynah-a-home",type:"fact",confidence:0.96}))' "$mirror_a_initial")
+  remember_b_initial=$(node -e 'process.stdout.write(JSON.stringify({content:process.argv[1],domain:"mynah-b-home",type:"fact",confidence:0.96}))' "$mirror_b_initial")
+  remember_committed node-a "$remember_a_initial" >/dev/null
+  remember_committed node-b "$remember_b_initial" >/dev/null
+
+  phase "bidirectional Copy: each owner offers Copy and each receiver independently subscribes"
+  permission_a='{"permissions":[{"domain":"mynah-a-home","read":true,"copy":true}]}'
+  permission_b='{"permissions":[{"domain":"mynah-b-home","read":true,"copy":true}]}'
+  api node-a PUT "/v1/dashboard/federation/connections/$chain_a/permissions" "$permission_a" >/dev/null
+  api node-b PUT "/v1/dashboard/federation/connections/$chain_b/permissions" "$permission_b" >/dev/null
+  subscribe_a='{"subscribe_domains":["mynah-b-home"]}'
+  subscribe_b='{"subscribe_domains":["mynah-a-home"]}'
+  i=0
+  while :; do
+    saved_a=$(api node-a PUT "/v1/dashboard/federation/connections/$chain_a/sync" "$subscribe_a" 2>/dev/null || true)
+    saved_b=$(api node-b PUT "/v1/dashboard/federation/connections/$chain_b/sync" "$subscribe_b" 2>/dev/null || true)
+    has_a=$(jfield "$saved_a" subscribe_domains.0 2>/dev/null || true)
+    has_b=$(jfield "$saved_b" subscribe_domains.0 2>/dev/null || true)
+    [ "$has_a" = mynah-b-home ] && [ "$has_b" = mynah-a-home ] && break
+    i=$((i + 1)); [ "$i" -lt 60 ] || die "bidirectional receiver Copy consent did not become active"
+    sleep 2
+  done
+
+  wait_local_copy() {
+    copy_svc=$1 copy_token=$2 copy_domain=$3
+    copy_args=$(node -e 'process.stdout.write(JSON.stringify({query:process.argv[1],domain:process.argv[2],scope:"local",top_k:10}))' "$copy_token" "$copy_domain")
+    copy_i=0
+    while :; do
+      copy_result=$(mcp_call "$copy_svc" sage_recall "$copy_args") || true
+      echo "$copy_result" | grep -q "$copy_token" && return 0
+      copy_i=$((copy_i + 1)); [ "$copy_i" -lt 90 ] || die "$copy_svc never stored local mirrored copy for $copy_domain"
+      sleep 2
+    done
+  }
+
+  phase "bidirectional Copy: initial anti-entropy backfill"
+  wait_local_copy node-b "$mirror_a_initial" mynah-a-home
+  wait_local_copy node-a "$mirror_b_initial" mynah-b-home
+
+  phase "bidirectional Copy: incremental delivery after consent"
+  # Keep these deliberately unlike the initial-backfill probes. sage_remember
+  # rejects >60%-similar content as a duplicate, and a skipped source write
+  # must never be misreported as a Copy delivery failure.
+  mirror_a_incremental="post-consent orchid telescope quartz from node A $RUN_TOKEN"
+  mirror_b_incremental="live delta copper nebula violin from node B $RUN_TOKEN"
+  remember_a_incremental=$(node -e 'process.stdout.write(JSON.stringify({content:process.argv[1],domain:"mynah-a-home",type:"fact",confidence:0.97}))' "$mirror_a_incremental")
+  remember_b_incremental=$(node -e 'process.stdout.write(JSON.stringify({content:process.argv[1],domain:"mynah-b-home",type:"fact",confidence:0.97}))' "$mirror_b_incremental")
+  remember_committed node-a "$remember_a_incremental" >/dev/null
+  remember_committed node-b "$remember_b_incremental" >/dev/null
+  wait_local_copy node-b "$mirror_a_incremental" mynah-a-home
+  wait_local_copy node-a "$mirror_b_incremental" mynah-b-home
+
+  phase "bidirectional Copy: restart persistence and source-offline local reads"
+  dc restart node-a node-b >/dev/null
+  wait_health "http://127.0.0.1:$PORT_A"
+  wait_health "http://127.0.0.1:$PORT_B"
+  dc stop node-a >/dev/null
+  wait_local_copy node-b "$mirror_a_initial" mynah-a-home
+  wait_local_copy node-b "$mirror_a_incremental" mynah-a-home
+  dc start node-a >/dev/null
+  wait_health "http://127.0.0.1:$PORT_A"
+  dc stop node-b >/dev/null
+  wait_local_copy node-a "$mirror_b_initial" mynah-b-home
+  wait_local_copy node-a "$mirror_b_incremental" mynah-b-home
+  dc start node-b >/dev/null
+  wait_health "http://127.0.0.1:$PORT_B"
 fi
 
 phase "remove LAN; only the relay bridges edge_a and edge_b"
-docker network disconnect sage-v111716-federation-lan "$(container_id node-a)"
-docker network disconnect sage-v111716-federation-lan "$(container_id node-b)"
+docker network disconnect sage-v111717-federation-lan "$(container_id node-a)"
+docker network disconnect sage-v111717-federation-lan "$(container_id node-b)"
 
 phase "restart A, B, then both and require container IP churn"
 for svc in node-a node-b; do
@@ -194,8 +295,8 @@ for svc in node-a node-b; do
   dc stop "$svc" >/dev/null
   dc rm -f "$svc" >/dev/null
   case "$svc" in
-    node-a) edge=sage-v111716-federation-edge-a; control=sage-v111716-federation-control-a ;;
-    node-b) edge=sage-v111716-federation-edge-b; control=sage-v111716-federation-control-b ;;
+    node-a) edge=sage-v111717-federation-edge-a; control=sage-v111717-federation-control-a ;;
+    node-b) edge=sage-v111717-federation-edge-b; control=sage-v111717-federation-control-b ;;
   esac
   # Occupy the just-freed addresses so Docker cannot hand the recreated node
   # the same pair and accidentally skip the stale-address recovery condition.
@@ -264,7 +365,7 @@ elif [ "$MODE" = full ]; then
   target=$(jfield "$found" matches.0.to)
   [ -n "$target" ] || die "sage_find_agent returned no exact remote Mynah target"
   dc stop node-b >/dev/null
-  send_args=$(node -e 'process.stdout.write(JSON.stringify({to:process.argv[1],intent:"acceptance",payload:"v11.17.16 durable offline inbox probe "+process.argv[2],idempotency_key:"v111716-offline-probe-"+process.argv[2]}))' "$target" "$RUN_TOKEN")
+  send_args=$(node -e 'process.stdout.write(JSON.stringify({to:process.argv[1],intent:"acceptance",payload:"v11.17.17 durable offline inbox probe "+process.argv[2],idempotency_key:"v111717-offline-probe-"+process.argv[2]}))' "$target" "$RUN_TOKEN")
   send_started=$(date +%s)
   sent=$(mcp_call node-a sage_message_send "$send_args")
   send_elapsed=$(( $(date +%s) - send_started ))
@@ -284,7 +385,7 @@ elif [ "$MODE" = full ]; then
     i=$((i + 1)); [ "$i" -lt 45 ] || die "offline message did not persist/deliver to restarted inbox"
     sleep 2
   done
-  reply_args=$(node -e 'process.stdout.write(JSON.stringify({message_id:process.argv[1],result:"v11.17.16 acceptance reply"}))' "$received_id")
+  reply_args=$(node -e 'process.stdout.write(JSON.stringify({message_id:process.argv[1],result:"v11.17.17 acceptance reply"}))' "$received_id")
   mcp_call node-b sage_message_reply "$reply_args" >/dev/null
   status_args=$(node -e 'process.stdout.write(JSON.stringify({message_id:process.argv[1]}))' "$message_id")
   i=0

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.17.16"
+version = "11.17.17"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.17.16"
+version = "11.17.17"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.17.16",
+  "version": "11.17.17",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.17.16/app-v26. -->
+<!-- Reconciled through SAGE v11.17.17/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.17.16
+# sage-gui v11.17.17
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.17.16 advertises 31 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.17.17 advertises 31 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.17.16 is the current release.** This corrective release makes caller-facing federation discovery distinguish peer-policy candidates from domains that the destination has live-verified against the exact linked-reader relation. It preserves v11.17.15's writable-agent approval, governed bulk recovery, agent directory, messaging, and packaging corrections. Governed app-v26 and consensus remain unchanged. Existing chains upgrade in place without rewriting memories, historical authors, domains, trust, or prior blocks.
+**Status (2026-08):** **v11.17.17 is the current release.** This corrective release pins the exported-agent authorization model and source-agent attestation into every signed federated Read plan and holds final authorization through disclosure. It also makes authenticated-read capability readiness visible and extends the Docker lane through bidirectional Copy backfill, incremental mirroring, and restart recovery. Governed app-v26 and consensus remain unchanged. Existing chains upgrade in place without rewriting memories, historical authors, domains, trust, or prior blocks.
 
 **Hard constraint driving the whole plan:** no chain reset, no operator-typed commands. Existing chains must upgrade in place across all future releases.
 
@@ -54,12 +54,14 @@ with a deep link to the exact agent setting. It also generates a unique
 name-based home domain when a writable pending-agent approval leaves that field
 blank. v11.17.13 and the superseded v11.17.14 tag were not published.
 
-v11.17.16 closes the discovery-versus-recall authorization gap exposed by the
-physical Mynah pair. The peer Read catalog and local caller policy now form an
-explicit candidate list only. A bounded authenticated destination probe applies
-the live linked-reader, group, ownership, agreement-generation and peer-policy
-gates without issuing recall challenges; only its returned subset is advertised
-as readable. Mixed-version peers stay connected but mark candidates unverified.
+v11.17.17 closes the final plan-versus-disclosure race exposed while validating
+the physical Mynah pair. The source authorization model and exact active-agent
+and clearance attestation are signed, challenge-bound, revalidated under the
+source authorization lease, and held until the destination query completes.
+Capability projection reports missing authenticated-read support without
+guessing whether the peer is still binding or needs an update. The acceptance
+lane now proves pairwise default Read, explicit denial, non-transitive exports,
+and bidirectional Copy backfill/incremental/restart behavior.
 
 The following acceptance and follow-up boundaries remain open after the 11.17.9
 code merge; they are not implied complete by Docker or CI evidence:

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.17.16. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.17.17. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -165,7 +165,7 @@ CometBFT without treating the consensus RPC as proof of application storage.
 
 ---
 
-## Related docs (reconciled through v11.17.16)
+## Related docs (reconciled through v11.17.17)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.17.16.
+Status: implementation contract through SAGE v11.17.17.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.17.16 authorization layer is off-consensus and does not require
+The current v11.17.17 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/app-v25-upgrade-recovery.md
+++ b/docs/reference/app-v25-upgrade-recovery.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.17.16: internal/abci/app.go (app-v25 gate and immutable envelope), web/appv25_memory_legacy_adoption_worker.go, web/appv25_domain_continuity_worker.go, web/appv25_memory_legacy_adoption_control.go, and internal/store/appv25_domain_continuity.go. -->
+<!-- Reconciled through SAGE v11.17.17: internal/abci/app.go (app-v25 gate and immutable envelope), web/appv25_memory_legacy_adoption_worker.go, web/appv25_domain_continuity_worker.go, web/appv25_memory_legacy_adoption_control.go, and internal/store/appv25_domain_continuity.go. -->
 
 # App-v25 Upgrade, Historical Recovery, and Domain Continuity
 

--- a/docs/reference/concepts/app-v26-access-groups.md
+++ b/docs/reference/concepts/app-v26-access-groups.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.17.16/app-v26 code (2026-08-07). Cite file:line when behavior is non-obvious. -->
+<!-- Verified against SAGE v11.17.17/app-v26 code (2026-08-07). Cite file:line when behavior is non-obvious. -->
 
 # App-v26 Access Groups and member authority
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.17.16/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.17.17/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.17.16. Legacy organization/federation sections retain
+Verified against SAGE v11.17.17. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.17.16. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.17.17. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.17.16 code (2026-08-07). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.17.17 code (2026-08-07). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 
@@ -70,9 +70,13 @@ revocation restores the default and re-pairing does not resurrect an old rule
 `internal/store/federated_reader_restrictions.go`).
 
 Each recall still starts with an authenticated destination plan and a durable,
-short-lived, single-use query challenge. The original local requester signs
-the canonical request. The source SAGE attests that requester is an active
-ordinary agent and carries its current classification ceiling. The destination
+short-lived, single-use query challenge. The plan and challenge bind the
+negotiated authorization model plus the source eligibility/classification
+attestation; the original local requester signs that complete tuple in the
+canonical request. A capability or source-attestation change after planning
+fails locally before query delivery, and a mismatched final tuple cannot consume
+the challenge. The source SAGE attests that requester is an active ordinary
+agent and carries its current classification ceiling. The destination
 verifies the nested proof after the outer peer-operator, mTLS CA-pin, active
 agreement, and policy checks, then clamps disclosure to the minimum of the
 source clearance, agreement ceiling, exported-agent ceiling, active peer Read
@@ -715,7 +719,7 @@ Every route 501s when the transport is not wired (`fedReady`,
 | `GET /v1/dashboard/federation/connections/{chain_id}/pipe-contacts` | `handleFedPipeContactsGet` (`web/federation_pipe_contacts.go:20-63`) | Return the current explicit-export contact projection and the peer's authenticated read-only snapshot. Manual domain-only policy never creates a contact. `?live=0` skips the peer probe and reports `remote_known:false`. |
 | `PUT /v1/dashboard/federation/connections/{chain_id}/pipe-contacts` | `handleFedPipeContactsPut` (`web/federation_pipe_contacts.go:66-107`) | Legacy exact-contact acceptance control. Current exported agents accept messaging by membership unless `DenyFederatedPipe`; this route never creates export membership or memory authority. |
 | `POST /v1/dashboard/federation/connections/{chain_id}/revoke` | `handleFedRevoke` (`web/federation_join.go`) | Commit local tx-34, best-effort notify the peer with the retained exact old credentials, purge locally, and return notification status. |
-| `GET /v1/dashboard/federation/connections/{chain_id}/status` | `handleFedPeerStatus` (`web/federation_join.go`) | The panel's single authenticated peer reachability preflight. On success it preserves the peer-scoped `peer_rbac_grant`, legacy `sharing_grant`, and `pipe_contacts` projections from `/fed/v1/status`, while omitting the agreement-binding digest and transport internals. |
+| `GET /v1/dashboard/federation/connections/{chain_id}/status` | `handleFedPeerStatus` (`web/federation_join.go`) | The panel's single authenticated peer reachability preflight. On success it preserves the peer's advertised `capabilities` plus the peer-scoped `peer_rbac_grant`, legacy `sharing_grant`, and `pipe_contacts` projections from `/fed/v1/status`, while omitting the agreement-binding digest and transport internals. CEREBRUM uses missing current capabilities only as a non-blocking mixed-version warning; capability advertisement is not read authorization, presence, or delivery evidence. |
 | `POST /v1/dashboard/federation/groups/refresh` | `handleFedGroupRefresh` (`web/federation_join.go`) | Prompt one bounded group-journal anti-entropy pass and wait for it to finish before CEREBRUM reloads the local group projection. Ordinary group-list polling remains a local SQLite read. |
 | `GET /v1/dashboard/federation/join/routes` | `handleFedJoinRoutes` (`web/federation_join.go`) | Return locally prepared Direct/Secure relay candidates. `ready` means prepared locally, not proven reachable and not currently selected. |
 | `POST /v1/dashboard/federation/join/host/create` | `handleFedHostCreate` (`web/federation_join.go`) | Host H1; current CEREBRUM sends `transport:"auto"`. `lan` and `internet` remain compatibility inputs for older clients. |

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.17.16.
+Reconciled against internal/mcp for SAGE v11.17.17.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.17.16. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.17.17. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.17.16
+**Package:** `sage-agent-sdk` **Version:** 11.17.17
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.17.16. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.17.17. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 
@@ -1999,6 +1999,64 @@ Revocation returns the same empty projection as an absent name, and exact
 `POST /v1/pipe/resolve` repeats live authorization before send
 (`api/rest/federation_handler.go`;
 `internal/federation/v23_linked_directory.go`).
+
+### `POST /v1/federation/recall-plan`
+
+Federated recall is an authenticated two-request protocol. A current client
+must never construct the second request from cached agreement data or sign it
+before obtaining this plan.
+
+1. Sign and send a plan request containing the exact `domain_tag` and requested
+   `federate_chains` (`["*"]` may be used only at this planning step).
+2. The response expands the request to a finite `destinations` list and returns
+   five pieces of signing state: `source_chain_id`, `agreement_bindings`,
+   `query_challenges`, `authorization_models`, and
+   `authorization_attestations`. `expires_at` tells the client when each
+   challenge becomes unusable; `errors` reports peers excluded from
+   `destinations`.
+3. Build one of `POST /v1/memory/query`, `POST /v1/memory/search`, or
+   `POST /v1/memory/hybrid` with `federated:true`, copy `destinations` verbatim
+   to `federate_chains`, and copy all five signing-state fields verbatim into
+   `federation_context`. Then sign that complete second body with a fresh nonce.
+
+Plan request:
+
+```json
+{"domain_tag":"mynah-home","federate_chains":["*"]}
+```
+
+Complete plan response shape:
+
+```json
+{
+  "protocol_version": 23,
+  "source_chain_id": "chain-a",
+  "destinations": ["chain-b"],
+  "agreement_bindings": {"chain-b": "<binding-digest>"},
+  "query_challenges": {"chain-b": "<single-use-challenge>"},
+  "authorization_models": {"chain-b": "peer-export-v1"},
+  "authorization_attestations": {
+    "chain-b": {"eligible": true, "max_classification": 4}
+  },
+  "expires_at": {"chain-b": 1786071600}
+}
+```
+
+The map entry itself is significant. A compatibility-plan entry for a legacy
+peer has an empty authorization-model string and an explicit
+`{"eligible":false,"max_classification":0}` attestation; omitting either map
+entry does not mean legacy. It identifies an old client that failed to copy the
+current signed tuple. Such a second request is stopped before peer fan-out with
+`signed federation authorization tuple is missing or incomplete` and must be
+re-planned and re-signed.
+
+The version boundary is deliberately asymmetric. An old peer that cannot
+complete current v23 planning appears in the plan's `errors` and is absent from
+`destinations`; a current client does not downgrade the signed contract for it.
+An old client talking to a current local node may receive a complete plan but
+omit the newer authorization fields from its second signed body; the local node
+rejects that omission and directs the client to re-plan. Updating the remote
+peer is therefore not inferred from this particular error.
 
 ### `POST /v1/federation/contacts/authorize`
 

--- a/internal/federation/client.go
+++ b/internal/federation/client.go
@@ -49,6 +49,16 @@ func receiptDeliveryTimeout() time.Duration {
 
 const maxFedResponseBytes = 16 << 20
 
+// maxFederatedQueryAuthorizationLease bounds how long a peer can retain the
+// source node's sync-policy and Badger authorization read leases after final
+// attestation. context.WithTimeout preserves any earlier caller deadline; this
+// is only the hard ceiling for direct Manager callers without one.
+const maxFederatedQueryAuthorizationLease = 5 * time.Second
+
+func boundedFederatedQueryContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, maxFederatedQueryAuthorizationLease)
+}
+
 // A v11.13.0 peer ignores the compact-status preference and can legally send
 // its older full v1 contact snapshot. Allow that compatibility retry one at a
 // time so an eight-peer named discovery fan-out never multiplies the legacy
@@ -355,6 +365,14 @@ func (m *Manager) QueryPeer(ctx context.Context, remoteChainID string, qr *Query
 	}
 	expectedDigest := qr.PlanAgreementBindings[remoteChainID]
 	expectedChallenge := qr.PlanChallenges[remoteChainID]
+	expectedAuthorizationModel, modelBound := qr.PlanAuthorizationModels[remoteChainID]
+	expectedAttestation, attestationBound := qr.PlanAuthorizationAttestations[remoteChainID]
+	if !modelBound || !attestationBound {
+		return nil, fmt.Errorf(
+			"v23 federation query signed plan is missing the source authorization tuple for %s; call POST /v1/federation/recall-plan again and re-sign the recall request with a current client",
+			remoteChainID,
+		)
+	}
 	if expectedDigest == "" || expectedChallenge == "" {
 		return nil, fmt.Errorf("v23 federation query has no agent-signed plan for %s", remoteChainID)
 	}
@@ -380,29 +398,61 @@ func (m *Manager) QueryPeer(ctx context.Context, remoteChainID string, qr *Query
 	v23req.DestinationChainID = remoteChainID
 	v23req.AgreementBindingDigest = expectedDigest
 	v23req.QueryChallenge = expectedChallenge
+	currentAuthorizationModel := ""
 	if slices.Contains(peerStatus.Capabilities, CapabilityPeerExportReadV1) {
-		ceiling, eligible, attestErr := m.attestLocalFederatedAgent(v23req.AgentProof.AgentID)
+		currentAuthorizationModel = SourceAuthorizationPeerExportV1
+	}
+	if currentAuthorizationModel != expectedAuthorizationModel {
+		return nil, fmt.Errorf(
+			"peer %s federation authorization model changed after the agent signed its recall plan (planned=%q current=%q)",
+			remoteChainID, authorizationModelDiagnostic(expectedAuthorizationModel),
+			authorizationModelDiagnostic(currentAuthorizationModel),
+		)
+	}
+	v23req.SourceAuthorizationModel = expectedAuthorizationModel
+	ss := m.syncStore()
+	if ss == nil || m.badger == nil {
+		return nil, errors.New("local federation agent policy is unavailable")
+	}
+	queryCtx, cancelQuery := boundedFederatedQueryContext(ctx)
+	defer cancelQuery()
+	// Global authorization lock order is sync-policy then Badger. Hold both from
+	// the final source-agent attestation through the bounded peer request so a
+	// completed enrollment, suspension, clearance, or reader-policy mutation
+	// guarantees that no later disclosure begins from the superseded snapshot.
+	readerUnlock := ss.LockSyncPolicyRead()
+	ownerUnlock := m.badger.LockDomainOwnershipRead()
+	locksHeld := true
+	releaseAuthorization := func() {
+		if !locksHeld {
+			return
+		}
+		ownerUnlock()
+		readerUnlock()
+		locksHeld = false
+	}
+	defer releaseAuthorization()
+	if expectedAuthorizationModel == SourceAuthorizationPeerExportV1 {
+		ceiling, eligible, attestErr := m.attestLocalFederatedAgentLocked(v23req.AgentProof.AgentID)
 		if attestErr != nil || !eligible {
 			return nil, errors.New("federated recall requires an active ordinary source agent")
 		}
-		v23req.SourceAuthorizationModel = SourceAuthorizationPeerExportV1
-		v23req.SourceAgentEligible = true
-		v23req.SourceAgentMaxClassification = ceiling
+		if !expectedAttestation.Eligible || expectedAttestation.MaxClassification != ceiling {
+			return nil, fmt.Errorf("peer %s source authorization attestation changed after the agent signed its recall plan", remoteChainID)
+		}
+	} else if expectedAttestation.Eligible || expectedAttestation.MaxClassification != 0 {
+		return nil, fmt.Errorf("peer %s signed legacy authorization plan has a non-legacy source attestation", remoteChainID)
 	}
-	ss := m.syncStore()
-	if ss == nil {
-		return nil, errors.New("federated reader restrictions require SQLite")
-	}
-	readerUnlock := ss.LockSyncPolicyRead()
+	v23req.SourceAgentEligible = expectedAttestation.Eligible
+	v23req.SourceAgentMaxClassification = expectedAttestation.MaxClassification
 	readerAllowed, readerErr := m.federatedReaderAllowsLocked(
-		ctx, agreement, v23req.AgentProof.AgentID, v23req.DomainTag,
+		queryCtx, agreement, v23req.AgentProof.AgentID, v23req.DomainTag,
 	)
 	if readerErr != nil || !readerAllowed {
-		readerUnlock()
 		return nil, errors.New("local federation access controls deny this peer domain")
 	}
-	body, status, err := m.doPeerRequest(ctx, agreement, http.MethodPost, "/fed/v1/query", v23req)
-	readerUnlock()
+	body, status, err := m.doPeerRequest(queryCtx, agreement, http.MethodPost, "/fed/v1/query", v23req)
+	releaseAuthorization()
 	if err != nil {
 		return nil, err
 	}
@@ -535,12 +585,14 @@ func (m *Manager) PlanRecall(ctx context.Context, targets []string, agentID, dom
 	}
 	sort.Strings(chains)
 	plan := &RecallPlan{
-		ProtocolVersion:   FederationProtocolV23,
-		SourceChainID:     m.localChainID,
-		AgreementBindings: make(map[string]string),
-		QueryChallenges:   make(map[string]string),
-		ExpiresAt:         make(map[string]int64),
-		Errors:            make(map[string]string),
+		ProtocolVersion:           FederationProtocolV23,
+		SourceChainID:             m.localChainID,
+		AgreementBindings:         make(map[string]string),
+		QueryChallenges:           make(map[string]string),
+		AuthorizationModels:       make(map[string]string),
+		AuthorizationAttestations: make(map[string]SourceAuthorizationAttestation),
+		ExpiresAt:                 make(map[string]int64),
+		Errors:                    make(map[string]string),
 	}
 	for _, chain := range chains {
 		agreement, err := m.ActiveAgreement(chain)
@@ -558,6 +610,8 @@ func (m *Manager) PlanRecall(ctx context.Context, targets []string, agentID, dom
 			continue
 		}
 		request := &QueryPlanRequest{AgentID: agentID, DomainTag: domain}
+		authorizationModel := ""
+		authorizationAttestation := SourceAuthorizationAttestation{}
 		if slices.Contains(status.Capabilities, CapabilityPeerExportReadV1) {
 			ceiling, eligible, attestErr := m.attestLocalFederatedAgent(agentID)
 			if attestErr != nil || !eligible {
@@ -565,8 +619,12 @@ func (m *Manager) PlanRecall(ctx context.Context, targets []string, agentID, dom
 				continue
 			}
 			request.SourceAuthorizationModel = SourceAuthorizationPeerExportV1
+			authorizationModel = SourceAuthorizationPeerExportV1
 			request.SourceAgentEligible = true
 			request.SourceAgentMaxClassification = ceiling
+			authorizationAttestation = SourceAuthorizationAttestation{
+				Eligible: true, MaxClassification: ceiling,
+			}
 		}
 		ss := m.syncStore()
 		if ss == nil {
@@ -600,6 +658,9 @@ func (m *Manager) PlanRecall(ctx context.Context, targets []string, agentID, dom
 			destination.SourceChainID != m.localChainID ||
 			destination.DestinationChainID != chain ||
 			destination.AgreementBindingDigest != status.QueryAgreementBindingDigest ||
+			destination.SourceAuthorizationModel != authorizationModel ||
+			destination.SourceAgentEligible != authorizationAttestation.Eligible ||
+			destination.SourceAgentMaxClassification != authorizationAttestation.MaxClassification ||
 			destination.QueryChallenge == "" || destination.ExpiresAt <= time.Now().Unix() {
 			plan.Errors[chain] = "peer returned a stale or mismatched v23 recall plan"
 			continue
@@ -607,12 +668,21 @@ func (m *Manager) PlanRecall(ctx context.Context, targets []string, agentID, dom
 		plan.Destinations = append(plan.Destinations, chain)
 		plan.AgreementBindings[chain] = destination.AgreementBindingDigest
 		plan.QueryChallenges[chain] = destination.QueryChallenge
+		plan.AuthorizationModels[chain] = authorizationModel
+		plan.AuthorizationAttestations[chain] = authorizationAttestation
 		plan.ExpiresAt[chain] = destination.ExpiresAt
 	}
 	if len(plan.Errors) == 0 {
 		plan.Errors = nil
 	}
 	return plan, nil
+}
+
+func authorizationModelDiagnostic(model string) string {
+	if model == "" {
+		return "legacy-linked-reader"
+	}
+	return model
 }
 
 func validatePeerV23Status(status *StatusResponse) error {

--- a/internal/federation/peer_rbac_test.go
+++ b/internal/federation/peer_rbac_test.go
@@ -334,9 +334,11 @@ func peerRBACV23Request(
 		"query": text, "domain_tag": domain, "top_k": 10,
 		"federated": true, "federate_chains": []string{m.localChainID},
 		"federation_context": map[string]any{
-			"source_chain_id":    chainID,
-			"agreement_bindings": map[string]string{m.localChainID: digest},
-			"query_challenges":   map[string]string{m.localChainID: challenge},
+			"source_chain_id":            chainID,
+			"agreement_bindings":         map[string]string{m.localChainID: digest},
+			"query_challenges":           map[string]string{m.localChainID: challenge},
+			"authorization_models":       map[string]string{m.localChainID: ""},
+			"authorization_attestations": map[string]SourceAuthorizationAttestation{m.localChainID: {}},
 		},
 	})
 	if signedBodyErr != nil {

--- a/internal/federation/query_v23.go
+++ b/internal/federation/query_v23.go
@@ -33,9 +33,11 @@ type signedRecallBody struct {
 }
 
 type signedFederationContext struct {
-	SourceChainID     string            `json:"source_chain_id"`
-	AgreementBindings map[string]string `json:"agreement_bindings"`
-	QueryChallenges   map[string]string `json:"query_challenges"`
+	SourceChainID             string                                    `json:"source_chain_id"`
+	AgreementBindings         map[string]string                         `json:"agreement_bindings"`
+	QueryChallenges           map[string]string                         `json:"query_challenges"`
+	AuthorizationModels       map[string]string                         `json:"authorization_models"`
+	AuthorizationAttestations map[string]SourceAuthorizationAttestation `json:"authorization_attestations"`
 }
 
 func splitCanonicalAgentRequest(canonical []byte) (method, path string, body []byte, err error) {
@@ -128,10 +130,24 @@ func (m *Manager) verifyQueryAgentProofV23(now time.Time, req *QueryRequest) (st
 	if !signed.Federated || !containsExactChain(signed.FederateChains, req.DestinationChainID) {
 		return "", errors.New("v23 signed recall body does not authorize this exact destination")
 	}
+	signedAuthorizationModel := ""
+	signedAttestation := SourceAuthorizationAttestation{}
+	modelBound := false
+	attestationBound := false
+	if signed.FederationContext != nil {
+		signedAuthorizationModel, modelBound =
+			signed.FederationContext.AuthorizationModels[req.DestinationChainID]
+		signedAttestation, attestationBound =
+			signed.FederationContext.AuthorizationAttestations[req.DestinationChainID]
+	}
 	if signed.FederationContext == nil ||
 		signed.FederationContext.SourceChainID != req.SourceChainID ||
 		signed.FederationContext.AgreementBindings[req.DestinationChainID] != req.AgreementBindingDigest ||
-		signed.FederationContext.QueryChallenges[req.DestinationChainID] != req.QueryChallenge {
+		signed.FederationContext.QueryChallenges[req.DestinationChainID] != req.QueryChallenge ||
+		!modelBound || signedAuthorizationModel != req.SourceAuthorizationModel ||
+		!attestationBound ||
+		signedAttestation.Eligible != req.SourceAgentEligible ||
+		signedAttestation.MaxClassification != req.SourceAgentMaxClassification {
 		return "", errors.New("v23 signed recall body does not authorize this source, agreement generation, and challenge")
 	}
 	mode, err := queryModeForSignedPath(path, signed)
@@ -181,13 +197,16 @@ func (m *Manager) validateQueryEnvelopeV23(ctx context.Context, peer *peerIdenti
 		return 0, errors.New("v23 durable query challenge store is unavailable")
 	}
 	if err := m.queryChallengeStore.ConsumeFederatedQueryChallenge(ctx, store.FederatedQueryChallenge{
-		ChallengeID:            req.QueryChallenge,
-		RemoteChainID:          peer.ChainID,
-		PeerAgentID:            peer.AgentID,
-		RequestedAgentID:       requestedAgentID,
-		DomainTag:              req.DomainTag,
-		AgreementBindingDigest: req.AgreementBindingDigest,
-		ExpiresAt:              1, // validated from the durable row by the atomic UPDATE.
+		ChallengeID:                  req.QueryChallenge,
+		RemoteChainID:                peer.ChainID,
+		PeerAgentID:                  peer.AgentID,
+		RequestedAgentID:             requestedAgentID,
+		DomainTag:                    req.DomainTag,
+		AgreementBindingDigest:       req.AgreementBindingDigest,
+		SourceAuthorizationModel:     req.SourceAuthorizationModel,
+		SourceAgentEligible:          req.SourceAgentEligible,
+		SourceAgentMaxClassification: req.SourceAgentMaxClassification,
+		ExpiresAt:                    1, // validated from the durable row by the atomic UPDATE.
 	}, time.Now()); err != nil {
 		return 0, err
 	}

--- a/internal/federation/query_v23_test.go
+++ b/internal/federation/query_v23_test.go
@@ -37,6 +37,12 @@ func (f v23GroupResolverFake) FederatedGuestGroupAllowsDomain(_ context.Context,
 }
 
 func makeV23QueryFixture(t *testing.T) (*Manager, *peerIdentity, *store.CrossFedRecord, *QueryRequest) {
+	return makeV23QueryFixtureWithAuthorizationTuple(t, true)
+}
+
+func makeV23QueryFixtureWithAuthorizationTuple(
+	t *testing.T, includeAuthorizationTuple bool,
+) (*Manager, *peerIdentity, *store.CrossFedRecord, *QueryRequest) {
 	t.Helper()
 	localPub, localKey, localKeyErr := ed25519.GenerateKey(rand.Reader)
 	if localKeyErr != nil {
@@ -134,18 +140,24 @@ func makeV23QueryFixture(t *testing.T) (*Manager, *peerIdentity, *store.CrossFed
 	}, time.Now()); err != nil {
 		t.Fatal(err)
 	}
+	federationContext := map[string]any{
+		"source_chain_id":    "chain-a",
+		"agreement_bindings": map[string]string{"chain-b": digest},
+		"query_challenges":   map[string]string{"chain-b": challenge},
+	}
+	if includeAuthorizationTuple {
+		federationContext["authorization_models"] = map[string]string{"chain-b": ""}
+		federationContext["authorization_attestations"] =
+			map[string]SourceAuthorizationAttestation{"chain-b": {}}
+	}
 	signedBody, signedBodyErr := json.Marshal(map[string]any{
-		"query":           "needle",
-		"domain_tag":      "research",
-		"top_k":           7,
-		"tags":            []string{"reviewed"},
-		"federated":       true,
-		"federate_chains": []string{"chain-b"},
-		"federation_context": map[string]any{
-			"source_chain_id":    "chain-a",
-			"agreement_bindings": map[string]string{"chain-b": digest},
-			"query_challenges":   map[string]string{"chain-b": challenge},
-		},
+		"query":              "needle",
+		"domain_tag":         "research",
+		"top_k":              7,
+		"tags":               []string{"reviewed"},
+		"federated":          true,
+		"federate_chains":    []string{"chain-b"},
+		"federation_context": federationContext,
 	})
 	if signedBodyErr != nil {
 		t.Fatal(signedBodyErr)
@@ -232,9 +244,11 @@ func TestVerifyQueryAgentProofV23BindsEmbeddingProvider(t *testing.T) {
 					"federated":       true,
 					"federate_chains": []string{"chain-b"},
 					"federation_context": map[string]any{
-						"source_chain_id":    "chain-a",
-						"agreement_bindings": map[string]string{"chain-b": "binding-v23"},
-						"query_challenges":   map[string]string{"chain-b": "challenge-v23"},
+						"source_chain_id":            "chain-a",
+						"agreement_bindings":         map[string]string{"chain-b": "binding-v23"},
+						"query_challenges":           map[string]string{"chain-b": "challenge-v23"},
+						"authorization_models":       map[string]string{"chain-b": ""},
+						"authorization_attestations": map[string]SourceAuthorizationAttestation{"chain-b": {}},
 					},
 				}
 				embeddingProvider := ""
@@ -598,4 +612,22 @@ func TestFederatedQueryRequiresLivePeerReadAndUnpausedPolicy(t *testing.T) {
 			t.Fatalf("removed Read status=%d body=%s", recorder.Code, recorder.Body.String())
 		}
 	})
+}
+
+func TestFederatedQueryRejectsOmittedLegacyAuthorizationTuple(t *testing.T) {
+	m, peer, _, req := makeV23QueryFixtureWithAuthorizationTuple(t, false)
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpReq := httptest.NewRequest(http.MethodPost, "/fed/v1/query", bytes.NewReader(body))
+	httpReq = httpReq.WithContext(context.WithValue(httpReq.Context(), peerCtxKey{}, peer))
+	recorder := httptest.NewRecorder()
+	m.handleQuery(recorder, httpReq)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("omitted legacy authorization tuple status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "signed recall body does not authorize") {
+		t.Fatalf("omitted legacy authorization tuple returned the wrong error: %s", recorder.Body.String())
+	}
 }

--- a/internal/federation/reader_restrictions_e2e_test.go
+++ b/internal/federation/reader_restrictions_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -210,6 +211,273 @@ func TestFederatedReaderRestrictionMutationLinearizesWithInFlightQuery(t *testin
 	}
 }
 
+func TestFederatedSourceClearanceMutationLinearizesWithInFlightQuery(t *testing.T) {
+	source := newTestChain(t, "source-clearance-lease-source")
+	destination := newTestChain(t, "source-clearance-lease-destination")
+	queryArrived := make(chan struct{})
+	releaseQuery := make(chan struct{})
+	var queryRequests atomic.Int32
+	listener := startBlockingQueryListener(t, destination, queryArrived, releaseQuery, &queryRequests)
+	const domain = "clearance.lease.notes"
+	federate(t, destination, source, "https://unused.invalid", []string{domain}, 4, 0)
+	federate(t, source, destination, listener.URL, []string{domain}, 4, 0)
+	enableV23Pair(t, source, destination, []string{domain})
+
+	readerPub, readerKey, keyErr := ed25519.GenerateKey(rand.Reader)
+	if keyErr != nil {
+		t.Fatal(keyErr)
+	}
+	readerID := hex.EncodeToString(readerPub)
+	enrollV23SourceReadAllAdmin(t, source, "source-clearance-member", readerPub, 10)
+	insertCommitted(t, destination, "clearance-lease-memory", domain, "source clearance lease note")
+	plan := planV23QueryForAgent(t, source, destination, readerID, domain)
+	query := signV23QueryAs(t, readerKey, plan, &QueryRequest{
+		Mode: ModeText, Query: "source clearance lease", DomainTag: domain, TopK: 5,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	queryDone := make(chan error, 1)
+	go func() {
+		_, queryErr := source.mgr.QueryPeer(ctx, destination.chainID, query)
+		queryDone <- queryErr
+	}()
+	select {
+	case <-queryArrived:
+	case <-ctx.Done():
+		t.Fatal("authorized query never reached peer")
+	}
+
+	enrollment, enrollmentErr := source.badger.GetAppV23Enrollment(readerID)
+	if enrollmentErr != nil || enrollment == nil {
+		t.Fatalf("read source enrollment: enrollment=%+v err=%v", enrollment, enrollmentErr)
+	}
+	role, roleErr := source.badger.GetAppV23Role(readerID)
+	if roleErr != nil || role == nil {
+		t.Fatalf("read source role: role=%+v err=%v", role, roleErr)
+	}
+	updated := *enrollment
+	updated.Clearance = 3
+	updated.Profile = store.AppV23ProfileCompanion
+	updated.Capabilities = store.DefaultSelfRegisteredAgentCapabilities |
+		store.AgentCapabilityReadAllDomains
+	updated.UpdatedHeight++
+	mutationStarted := make(chan struct{})
+	mutationDone := make(chan error, 1)
+	go func() {
+		close(mutationStarted)
+		mutationDone <- source.badger.ApproveAppV23LocalAgent(
+			updated, store.AppV23RoleMember, enrollment.Revision, role.Revision,
+		)
+	}()
+	<-mutationStarted
+	var earlyMutationErr error
+	mutationCompletedEarly := false
+	select {
+	case mutationErr := <-mutationDone:
+		earlyMutationErr = mutationErr
+		mutationCompletedEarly = true
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(releaseQuery)
+	if queryErr := <-queryDone; queryErr != nil {
+		t.Fatalf("in-flight authorized query: %v", queryErr)
+	}
+	if mutationCompletedEarly {
+		t.Fatalf("source clearance mutation completed while an authorized request held its source attestation: %v", earlyMutationErr)
+	}
+	if mutationErr := <-mutationDone; mutationErr != nil {
+		t.Fatalf("source clearance mutation after query drained: %v", mutationErr)
+	}
+	if got := queryRequests.Load(); got != 1 {
+		t.Fatalf("peer query requests = %d, want 1", got)
+	}
+	if _, queryErr := source.mgr.QueryPeer(ctx, destination.chainID, query); queryErr == nil ||
+		!strings.Contains(queryErr.Error(), "source authorization attestation changed") {
+		t.Fatalf("stale signed query error = %v, want source-attestation drift", queryErr)
+	}
+	if got := queryRequests.Load(); got != 1 {
+		t.Fatalf("stale query reached peer; query requests = %d", got)
+	}
+}
+
+func TestFederatedQueryLeaseBoundsHangingPeerAndReleasesSourceMutation(t *testing.T) {
+	source := newTestChain(t, "bounded-query-source")
+	destination := newTestChain(t, "bounded-query-destination")
+	queryArrived := make(chan struct{})
+	releaseQuery := make(chan struct{})
+	var queryRequests atomic.Int32
+	listener := startBlockingQueryListener(t, destination, queryArrived, releaseQuery, &queryRequests)
+	const domain = "bounded.query.notes"
+	federate(t, destination, source, "https://unused.invalid", []string{domain}, 4, 0)
+	federate(t, source, destination, listener.URL, []string{domain}, 4, 0)
+	enableV23Pair(t, source, destination, []string{domain})
+
+	readerPub, readerKey, keyErr := ed25519.GenerateKey(rand.Reader)
+	if keyErr != nil {
+		t.Fatal(keyErr)
+	}
+	readerID := hex.EncodeToString(readerPub)
+	enrollV23SourceReadAllAdmin(t, source, "bounded-query-member", readerPub, 10)
+	plan := planV23QueryForAgent(t, source, destination, readerID, domain)
+	query := signV23QueryAs(t, readerKey, plan, &QueryRequest{
+		Mode: ModeText, Query: "bounded query", DomainTag: domain, TopK: 5,
+	})
+
+	queryDone := make(chan error, 1)
+	startedAt := time.Now()
+	go func() {
+		_, queryErr := source.mgr.QueryPeer(context.Background(), destination.chainID, query)
+		queryDone <- queryErr
+	}()
+	select {
+	case <-queryArrived:
+	case <-time.After(3 * time.Second):
+		t.Fatal("bounded query never reached the hanging peer")
+	}
+
+	enrollment, enrollmentErr := source.badger.GetAppV23Enrollment(readerID)
+	if enrollmentErr != nil || enrollment == nil {
+		t.Fatalf("read source enrollment: enrollment=%+v err=%v", enrollment, enrollmentErr)
+	}
+	role, roleErr := source.badger.GetAppV23Role(readerID)
+	if roleErr != nil || role == nil {
+		t.Fatalf("read source role: role=%+v err=%v", role, roleErr)
+	}
+	updated := *enrollment
+	updated.Clearance = 3
+	updated.Profile = store.AppV23ProfileCompanion
+	updated.Capabilities = store.DefaultSelfRegisteredAgentCapabilities |
+		store.AgentCapabilityReadAllDomains
+	updated.UpdatedHeight++
+	mutationDone := make(chan error, 1)
+	go func() {
+		mutationDone <- source.badger.ApproveAppV23LocalAgent(
+			updated, store.AppV23RoleMember, enrollment.Revision, role.Revision,
+		)
+	}()
+	select {
+	case mutationErr := <-mutationDone:
+		close(releaseQuery)
+		t.Fatalf("source mutation bypassed the active query lease: %v", mutationErr)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	select {
+	case queryErr := <-queryDone:
+		if queryErr == nil || !strings.Contains(queryErr.Error(), "context deadline exceeded") {
+			close(releaseQuery)
+			t.Fatalf("hanging peer query error = %v, want hard deadline", queryErr)
+		}
+	case <-time.After(maxFederatedQueryAuthorizationLease + 2*time.Second):
+		close(releaseQuery)
+		t.Fatal("hanging peer retained the source authorization lease past its hard bound")
+	}
+	close(releaseQuery)
+	if elapsed := time.Since(startedAt); elapsed > maxFederatedQueryAuthorizationLease+2*time.Second {
+		t.Fatalf("bounded query took %s", elapsed)
+	}
+	select {
+	case mutationErr := <-mutationDone:
+		if mutationErr != nil {
+			t.Fatalf("source mutation after query lease expiry: %v", mutationErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("source mutation did not complete after query lease expiry")
+	}
+	if _, queryErr := source.mgr.QueryPeer(context.Background(), destination.chainID, query); queryErr == nil ||
+		!strings.Contains(queryErr.Error(), "source authorization attestation changed") {
+		t.Fatalf("stale signed query error = %v, want source-attestation drift", queryErr)
+	}
+	if got := queryRequests.Load(); got != 1 {
+		t.Fatalf("stale query reached peer; query requests = %d", got)
+	}
+}
+
+func TestFederatedQueryLeasePreservesShorterCallerDeadline(t *testing.T) {
+	caller, cancelCaller := context.WithTimeout(context.Background(), time.Second)
+	defer cancelCaller()
+	callerDeadline, ok := caller.Deadline()
+	if !ok {
+		t.Fatal("caller context has no deadline")
+	}
+	bounded, cancelBounded := boundedFederatedQueryContext(caller)
+	defer cancelBounded()
+	boundedDeadline, ok := bounded.Deadline()
+	if !ok || !boundedDeadline.Equal(callerDeadline) {
+		t.Fatalf("bounded deadline = %v, want shorter caller deadline %v", boundedDeadline, callerDeadline)
+	}
+}
+
+func TestFederatedRecallAuthorizationModelDriftFailsBeforeQueryAndPreservesChallenge(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		capabilityByCall map[int32]bool
+		legacyPlan       bool
+		planned          string
+		current          string
+	}{
+		{
+			name: "peer-export-to-legacy", capabilityByCall: map[int32]bool{1: true, 2: false, 3: true},
+			planned: SourceAuthorizationPeerExportV1, current: "legacy-linked-reader",
+		},
+		{
+			name: "legacy-to-peer-export", capabilityByCall: map[int32]bool{1: false, 2: true, 3: false},
+			legacyPlan: true, planned: "legacy-linked-reader", current: SourceAuthorizationPeerExportV1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := newTestChain(t, "model-source-"+tc.name)
+			destination := newTestChain(t, "model-destination-"+tc.name)
+			var statusRequests atomic.Int32
+			var queryRequests atomic.Int32
+			listener := startAuthorizationDriftListener(
+				t, destination, tc.capabilityByCall, tc.legacyPlan,
+				&statusRequests, &queryRequests,
+			)
+			const domain = "model.notes"
+			federate(t, destination, source, "https://unused.invalid", []string{domain}, 4, 0)
+			federate(t, source, destination, listener.URL, []string{domain}, 4, 0)
+			enableV23Pair(t, source, destination, []string{domain})
+
+			readerPub, readerKey, err := ed25519.GenerateKey(rand.Reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+			readerID := hex.EncodeToString(readerPub)
+			enrollV23SourceReadAllAdmin(t, source, "model-reader", readerPub, 10)
+			if tc.legacyPlan {
+				addV23TestGuest(t, destination, source, readerID, domain, 4)
+			}
+			insertCommitted(t, destination, "model-memory", domain, "authorization model note")
+			plan := planV23QueryForAgent(t, source, destination, readerID, domain)
+			query := signV23QueryAs(t, readerKey, plan, &QueryRequest{
+				Mode: ModeText, Query: "authorization model", DomainTag: domain, TopK: 5,
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if _, err := source.mgr.QueryPeer(ctx, destination.chainID, query); err == nil ||
+				!strings.Contains(err.Error(), "authorization model changed after the agent signed") ||
+				!strings.Contains(err.Error(), "planned=\""+tc.planned+"\"") ||
+				!strings.Contains(err.Error(), "current=\""+tc.current+"\"") {
+				t.Fatalf("authorization drift error=%v", err)
+			}
+			if got := queryRequests.Load(); got != 0 {
+				t.Fatalf("model-drift query reached peer %d times", got)
+			}
+			response, err := source.mgr.QueryPeer(ctx, destination.chainID, query)
+			if err != nil || len(response.Results) != 1 || response.Results[0].MemoryID != "model-memory" {
+				t.Fatalf("exact retry after local drift rejection: response=%+v err=%v", response, err)
+			}
+			if got := queryRequests.Load(); got != 1 {
+				t.Fatalf("exact retry query requests=%d, want 1", got)
+			}
+		})
+	}
+}
+
 func startBlockingQueryListener(
 	t *testing.T,
 	chain *testChain,
@@ -235,6 +503,90 @@ func startBlockingQueryListener(
 			}
 		}
 		router.ServeHTTP(w, r)
+	})
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = tlsConfig
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	return server
+}
+
+func startAuthorizationDriftListener(
+	t *testing.T,
+	chain *testChain,
+	capabilityByCall map[int32]bool,
+	omitPlanBinding bool,
+	statusRequests, queryRequests *atomic.Int32,
+) *httptest.Server {
+	t.Helper()
+	tlsConfig, err := chain.mgr.ServerTLSConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := chain.mgr.Router()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fed/v1/query" {
+			queryRequests.Add(1)
+		}
+		if r.URL.Path == "/fed/v1/query/plan" && omitPlanBinding {
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, r)
+			var response map[string]any
+			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+				t.Errorf("decode legacy plan response: %v", err)
+				return
+			}
+			delete(response, "source_authorization_model")
+			delete(response, "source_agent_eligible")
+			delete(response, "source_agent_max_classification")
+			body, err := json.Marshal(response)
+			if err != nil {
+				t.Errorf("encode legacy plan response: %v", err)
+				return
+			}
+			for key, values := range recorder.Header() {
+				for _, value := range values {
+					w.Header().Add(key, value)
+				}
+			}
+			w.WriteHeader(recorder.Code)
+			_, _ = w.Write(body)
+			return
+		}
+		if r.URL.Path != "/fed/v1/status" {
+			router.ServeHTTP(w, r)
+			return
+		}
+		call := statusRequests.Add(1)
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, r)
+		body := recorder.Body.Bytes()
+		if recorder.Code == http.StatusOK && !capabilityByCall[call] {
+			var status StatusResponse
+			if err := json.Unmarshal(body, &status); err != nil {
+				t.Errorf("decode status response: %v", err)
+				return
+			}
+			filtered := status.Capabilities[:0]
+			for _, capability := range status.Capabilities {
+				if capability != CapabilityPeerExportReadV1 {
+					filtered = append(filtered, capability)
+				}
+			}
+			status.Capabilities = filtered
+			body, err = json.Marshal(&status)
+			if err != nil {
+				t.Errorf("encode status response: %v", err)
+				return
+			}
+		}
+		for key, values := range recorder.Header() {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
+		w.WriteHeader(recorder.Code)
+		_, _ = w.Write(body)
 	})
 	server := httptest.NewUnstartedServer(handler)
 	server.TLS = tlsConfig

--- a/internal/federation/reader_restrictions_e2e_test.go
+++ b/internal/federation/reader_restrictions_e2e_test.go
@@ -458,11 +458,11 @@ func TestFederatedRecallAuthorizationModelDriftFailsBeforeQueryAndPreservesChall
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			if _, err := source.mgr.QueryPeer(ctx, destination.chainID, query); err == nil ||
-				!strings.Contains(err.Error(), "authorization model changed after the agent signed") ||
-				!strings.Contains(err.Error(), "planned=\""+tc.planned+"\"") ||
-				!strings.Contains(err.Error(), "current=\""+tc.current+"\"") {
-				t.Fatalf("authorization drift error=%v", err)
+			if _, queryErr := source.mgr.QueryPeer(ctx, destination.chainID, query); queryErr == nil ||
+				!strings.Contains(queryErr.Error(), "authorization model changed after the agent signed") ||
+				!strings.Contains(queryErr.Error(), "planned=\""+tc.planned+"\"") ||
+				!strings.Contains(queryErr.Error(), "current=\""+tc.current+"\"") {
+				t.Fatalf("authorization drift error=%v", queryErr)
 			}
 			if got := queryRequests.Load(); got != 0 {
 				t.Fatalf("model-drift query reached peer %d times", got)
@@ -519,9 +519,9 @@ func startAuthorizationDriftListener(
 	statusRequests, queryRequests *atomic.Int32,
 ) *httptest.Server {
 	t.Helper()
-	tlsConfig, err := chain.mgr.ServerTLSConfig()
-	if err != nil {
-		t.Fatal(err)
+	tlsConfig, tlsErr := chain.mgr.ServerTLSConfig()
+	if tlsErr != nil {
+		t.Fatal(tlsErr)
 	}
 	router := chain.mgr.Router()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -574,11 +574,12 @@ func startAuthorizationDriftListener(
 				}
 			}
 			status.Capabilities = filtered
-			body, err = json.Marshal(&status)
-			if err != nil {
-				t.Errorf("encode status response: %v", err)
+			marshaledBody, marshalErr := json.Marshal(&status)
+			if marshalErr != nil {
+				t.Errorf("encode status response: %v", marshalErr)
 				return
 			}
+			body = marshaledBody
 		}
 		for key, values := range recorder.Header() {
 			for _, value := range values {

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -1016,25 +1016,31 @@ func (m *Manager) handleQueryPlan(w http.ResponseWriter, r *http.Request) {
 	expiresAt := now.Add(queryPlanTTL).Unix()
 	challengeID := hex.EncodeToString(challengeBytes)
 	if err := m.queryChallengeStore.IssueFederatedQueryChallenge(r.Context(), store.FederatedQueryChallenge{
-		ChallengeID:            challengeID,
-		RemoteChainID:          peer.ChainID,
-		PeerAgentID:            peer.AgentID,
-		RequestedAgentID:       req.AgentID,
-		DomainTag:              req.DomainTag,
-		AgreementBindingDigest: digest,
-		ExpiresAt:              expiresAt,
+		ChallengeID:                  challengeID,
+		RemoteChainID:                peer.ChainID,
+		PeerAgentID:                  peer.AgentID,
+		RequestedAgentID:             req.AgentID,
+		DomainTag:                    req.DomainTag,
+		AgreementBindingDigest:       digest,
+		SourceAuthorizationModel:     req.SourceAuthorizationModel,
+		SourceAgentEligible:          req.SourceAgentEligible,
+		SourceAgentMaxClassification: req.SourceAgentMaxClassification,
+		ExpiresAt:                    expiresAt,
 	}, now); err != nil {
 		m.logger.Warn().Err(err).Str("peer", peer.ChainID).Msg("federation v23 query plan denied")
 		httpError(w, http.StatusServiceUnavailable, "could not persist query challenge")
 		return
 	}
 	writeJSON(w, http.StatusOK, &QueryPlanResponse{
-		ProtocolVersion:        FederationProtocolV23,
-		SourceChainID:          peer.ChainID,
-		DestinationChainID:     m.localChainID,
-		AgreementBindingDigest: digest,
-		QueryChallenge:         challengeID,
-		ExpiresAt:              expiresAt,
+		ProtocolVersion:              FederationProtocolV23,
+		SourceChainID:                peer.ChainID,
+		DestinationChainID:           m.localChainID,
+		AgreementBindingDigest:       digest,
+		SourceAuthorizationModel:     req.SourceAuthorizationModel,
+		SourceAgentEligible:          req.SourceAgentEligible,
+		SourceAgentMaxClassification: req.SourceAgentMaxClassification,
+		QueryChallenge:               challengeID,
+		ExpiresAt:                    expiresAt,
 	})
 }
 

--- a/internal/federation/types.go
+++ b/internal/federation/types.go
@@ -91,8 +91,11 @@ type QueryRequest struct {
 	// PlanAgreementBindings and PlanChallenges are local broker state only.
 	// They are populated from the agent-signed REST request and are never sent
 	// as a second, unsigned source of truth.
-	PlanAgreementBindings map[string]string `json:"-"`
-	PlanChallenges        map[string]string `json:"-"`
+	PlanAgreementBindings         map[string]string                         `json:"-"`
+	PlanChallenges                map[string]string                         `json:"-"`
+	PlanSourceChainID             string                                    `json:"-"`
+	PlanAuthorizationModels       map[string]string                         `json:"-"`
+	PlanAuthorizationAttestations map[string]SourceAuthorizationAttestation `json:"-"`
 }
 
 // QueryPlanResponse is returned by the destination after peer authentication
@@ -100,12 +103,15 @@ type QueryRequest struct {
 // gets an independent challenge so one peer cannot replay authorization at
 // another peer.
 type QueryPlanResponse struct {
-	ProtocolVersion        int    `json:"protocol_version"`
-	SourceChainID          string `json:"source_chain_id"`
-	DestinationChainID     string `json:"destination_chain_id"`
-	AgreementBindingDigest string `json:"agreement_binding_digest"`
-	QueryChallenge         string `json:"query_challenge"`
-	ExpiresAt              int64  `json:"expires_at"`
+	ProtocolVersion              int    `json:"protocol_version"`
+	SourceChainID                string `json:"source_chain_id"`
+	DestinationChainID           string `json:"destination_chain_id"`
+	AgreementBindingDigest       string `json:"agreement_binding_digest"`
+	SourceAuthorizationModel     string `json:"source_authorization_model"`
+	SourceAgentEligible          bool   `json:"source_agent_eligible"`
+	SourceAgentMaxClassification uint8  `json:"source_agent_max_classification"`
+	QueryChallenge               string `json:"query_challenge"`
+	ExpiresAt                    int64  `json:"expires_at"`
 }
 
 type QueryPlanRequest struct {
@@ -116,16 +122,23 @@ type QueryPlanRequest struct {
 	SourceAgentMaxClassification uint8  `json:"source_agent_max_classification"`
 }
 
+type SourceAuthorizationAttestation struct {
+	Eligible          bool  `json:"eligible"`
+	MaxClassification uint8 `json:"max_classification"`
+}
+
 // RecallPlan is the agent-facing projection of exact, authenticated
 // destination plans. Wildcards are expanded before the agent signs a recall.
 type RecallPlan struct {
-	ProtocolVersion   int               `json:"protocol_version"`
-	SourceChainID     string            `json:"source_chain_id"`
-	Destinations      []string          `json:"destinations"`
-	AgreementBindings map[string]string `json:"agreement_bindings"`
-	QueryChallenges   map[string]string `json:"query_challenges"`
-	ExpiresAt         map[string]int64  `json:"expires_at"`
-	Errors            map[string]string `json:"errors,omitempty"`
+	ProtocolVersion           int                                       `json:"protocol_version"`
+	SourceChainID             string                                    `json:"source_chain_id"`
+	Destinations              []string                                  `json:"destinations"`
+	AgreementBindings         map[string]string                         `json:"agreement_bindings"`
+	QueryChallenges           map[string]string                         `json:"query_challenges"`
+	AuthorizationModels       map[string]string                         `json:"authorization_models"`
+	AuthorizationAttestations map[string]SourceAuthorizationAttestation `json:"authorization_attestations"`
+	ExpiresAt                 map[string]int64                          `json:"expires_at"`
+	Errors                    map[string]string                         `json:"errors,omitempty"`
 }
 
 // QueryAgentProof is the original local REST authentication proof. The

--- a/internal/federation/v23_e2e_helpers_test.go
+++ b/internal/federation/v23_e2e_helpers_test.go
@@ -149,9 +149,11 @@ func planAndSignV23Query(
 		"tags": request.Tags, "federated": true,
 		"federate_chains": plan.Destinations,
 		"federation_context": map[string]any{
-			"source_chain_id":    plan.SourceChainID,
-			"agreement_bindings": plan.AgreementBindings,
-			"query_challenges":   plan.QueryChallenges,
+			"source_chain_id":            plan.SourceChainID,
+			"agreement_bindings":         plan.AgreementBindings,
+			"query_challenges":           plan.QueryChallenges,
+			"authorization_models":       plan.AuthorizationModels,
+			"authorization_attestations": plan.AuthorizationAttestations,
 		},
 	}
 	if request.EmbeddingProvider != "" {
@@ -173,5 +175,7 @@ func planAndSignV23Query(
 	}
 	request.PlanAgreementBindings = plan.AgreementBindings
 	request.PlanChallenges = plan.QueryChallenges
+	request.PlanAuthorizationModels = plan.AuthorizationModels
+	request.PlanAuthorizationAttestations = plan.AuthorizationAttestations
 	return request
 }

--- a/internal/federation/v23_guest.go
+++ b/internal/federation/v23_guest.go
@@ -131,6 +131,18 @@ func (m *Manager) attestLocalFederatedAgent(agentID string) (uint8, bool, error)
 	defer policyUnlock()
 	ownerUnlock := m.badger.LockDomainOwnershipRead()
 	defer ownerUnlock()
+	return m.attestLocalFederatedAgentLocked(agentID)
+}
+
+// attestLocalFederatedAgentLocked is the non-locking form for bounded
+// federation side effects that already hold the global sync-policy -> Badger
+// authorization read order. Keeping the final attestation and outbound request
+// inside that lease prevents an enrollment, suspension, or clearance mutation
+// from committing after the source fact is checked but before disclosure.
+func (m *Manager) attestLocalFederatedAgentLocked(agentID string) (uint8, bool, error) {
+	if m.badger == nil {
+		return 0, false, errors.New("local federation agent policy is unavailable")
+	}
 	eligible, err := m.localFederatedGuestAgentEligible(agentID)
 	if err != nil || !eligible {
 		return 0, false, err

--- a/internal/federation/v23_identity_oracle_e2e_test.go
+++ b/internal/federation/v23_identity_oracle_e2e_test.go
@@ -99,9 +99,11 @@ func signV23QueryAs(
 		"tags": request.Tags, "federated": true,
 		"federate_chains": plan.Destinations,
 		"federation_context": map[string]any{
-			"source_chain_id":    plan.SourceChainID,
-			"agreement_bindings": plan.AgreementBindings,
-			"query_challenges":   plan.QueryChallenges,
+			"source_chain_id":            plan.SourceChainID,
+			"agreement_bindings":         plan.AgreementBindings,
+			"query_challenges":           plan.QueryChallenges,
+			"authorization_models":       plan.AuthorizationModels,
+			"authorization_attestations": plan.AuthorizationAttestations,
 		},
 	}
 	if request.EmbeddingProvider != "" {
@@ -128,6 +130,8 @@ func signV23QueryAs(
 	}
 	request.PlanAgreementBindings = plan.AgreementBindings
 	request.PlanChallenges = plan.QueryChallenges
+	request.PlanAuthorizationModels = plan.AuthorizationModels
+	request.PlanAuthorizationAttestations = plan.AuthorizationAttestations
 	return request
 }
 

--- a/internal/mcp/federation_plan_v23_test.go
+++ b/internal/mcp/federation_plan_v23_test.go
@@ -33,6 +33,8 @@ func TestMCPFederatedRecallPlanExpandsAndSignsExactDestinationState(t *testing.T
 					"destinations":["chain-x"],
 					"agreement_bindings":{"chain-x":"binding-x"},
 					"query_challenges":{"chain-x":"challenge-x"},
+					"authorization_models":{"chain-x":"peer-export-v1"},
+					"authorization_attestations":{"chain-x":{"eligible":true,"max_classification":3}},
 					"expires_at":{"chain-x":9999999999}
 				}`)),
 			}, nil
@@ -66,6 +68,10 @@ func TestMCPFederatedRecallPlanExpandsAndSignsExactDestinationState(t *testing.T
 	require.Equal(t, "chain-local", contextBody["source_chain_id"])
 	require.Equal(t, "binding-x", contextBody["agreement_bindings"].(map[string]any)["chain-x"])
 	require.Equal(t, "challenge-x", contextBody["query_challenges"].(map[string]any)["chain-x"])
+	require.Equal(t, "peer-export-v1", contextBody["authorization_models"].(map[string]any)["chain-x"])
+	attestation := contextBody["authorization_attestations"].(map[string]any)["chain-x"].(map[string]any)
+	require.Equal(t, true, attestation["eligible"])
+	require.Equal(t, float64(3), attestation["max_classification"])
 }
 
 func TestMCPFederatedVectorRecallSignsDiscoveredEmbeddingProvider(t *testing.T) {
@@ -124,6 +130,8 @@ func TestMCPFederatedVectorRecallSignsDiscoveredEmbeddingProvider(t *testing.T) 
 						"destinations":["chain-x"],
 						"agreement_bindings":{"chain-x":"binding-x"},
 						"query_challenges":{"chain-x":"challenge-x"},
+						"authorization_models":{"chain-x":"peer-export-v1"},
+						"authorization_attestations":{"chain-x":{"eligible":true,"max_classification":4}},
 						"expires_at":{"chain-x":9999999999}
 					}`)
 				case test.path:

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/l33tdawg/sage/internal/federation"
 	"github.com/l33tdawg/sage/internal/idfmt"
 	"github.com/l33tdawg/sage/internal/store"
 	"github.com/l33tdawg/sage/internal/taskidempotency"
@@ -1228,11 +1229,13 @@ func (s *Server) applyRecallFederation(ctx context.Context, r recallRequest, opt
 		return err
 	}
 	var plan struct {
-		SourceChainID     string            `json:"source_chain_id"`
-		Destinations      []string          `json:"destinations"`
-		AgreementBindings map[string]string `json:"agreement_bindings"`
-		QueryChallenges   map[string]string `json:"query_challenges"`
-		Errors            map[string]string `json:"errors"`
+		SourceChainID             string                                               `json:"source_chain_id"`
+		Destinations              []string                                             `json:"destinations"`
+		AgreementBindings         map[string]string                                    `json:"agreement_bindings"`
+		QueryChallenges           map[string]string                                    `json:"query_challenges"`
+		AuthorizationModels       map[string]string                                    `json:"authorization_models"`
+		AuthorizationAttestations map[string]federation.SourceAuthorizationAttestation `json:"authorization_attestations"`
+		Errors                    map[string]string                                    `json:"errors"`
 	}
 	if err := s.doSignedJSON(ctx, "POST", "/v1/federation/recall-plan", planBody, &plan); err != nil {
 		return fmt.Errorf("plan federated recall: %w", err)
@@ -1243,9 +1246,11 @@ func (s *Server) applyRecallFederation(ctx context.Context, r recallRequest, opt
 	r["federated"] = true
 	r["federate_chains"] = plan.Destinations
 	r["federation_context"] = map[string]any{
-		"source_chain_id":    plan.SourceChainID,
-		"agreement_bindings": plan.AgreementBindings,
-		"query_challenges":   plan.QueryChallenges,
+		"source_chain_id":            plan.SourceChainID,
+		"agreement_bindings":         plan.AgreementBindings,
+		"query_challenges":           plan.QueryChallenges,
+		"authorization_models":       plan.AuthorizationModels,
+		"authorization_attestations": plan.AuthorizationAttestations,
 	}
 	return nil
 }

--- a/internal/store/federated_query_challenges.go
+++ b/internal/store/federated_query_challenges.go
@@ -20,13 +20,16 @@ const (
 // FederatedQueryChallenge is a destination-issued, durable, single-use token.
 // The original local agent signs it into the final recall request.
 type FederatedQueryChallenge struct {
-	ChallengeID            string
-	RemoteChainID          string
-	PeerAgentID            string
-	RequestedAgentID       string
-	DomainTag              string
-	AgreementBindingDigest string
-	ExpiresAt              int64
+	ChallengeID                  string
+	RemoteChainID                string
+	PeerAgentID                  string
+	RequestedAgentID             string
+	DomainTag                    string
+	AgreementBindingDigest       string
+	SourceAuthorizationModel     string
+	SourceAgentEligible          bool
+	SourceAgentMaxClassification uint8
+	ExpiresAt                    int64
 }
 
 func validateFederatedQueryChallenge(c FederatedQueryChallenge) error {
@@ -54,6 +57,19 @@ func validateFederatedQueryChallenge(c FederatedQueryChallenge) error {
 		len(c.DomainTag) > 256 || strings.ContainsAny(c.DomainTag, "\x00\r\n") {
 		return errors.New("federated query challenge domain is invalid")
 	}
+	if c.SourceAuthorizationModel != "" && c.SourceAuthorizationModel != "peer-export-v1" {
+		return errors.New("federated query challenge authorization model is invalid")
+	}
+	if c.SourceAuthorizationModel == "" &&
+		(c.SourceAgentEligible || c.SourceAgentMaxClassification != 0) {
+		return errors.New("legacy federated query challenge has a source attestation")
+	}
+	if c.SourceAuthorizationModel == "peer-export-v1" && !c.SourceAgentEligible {
+		return errors.New("peer-export federated query challenge lacks source eligibility")
+	}
+	if c.SourceAgentMaxClassification > 4 {
+		return errors.New("federated query challenge source classification is invalid")
+	}
 	if c.ExpiresAt <= 0 {
 		return errors.New("federated query challenge expiry is invalid")
 	}
@@ -69,11 +85,34 @@ func (s *SQLiteStore) migrateFederatedQueryChallenges(ctx context.Context) error
 		requested_agent_id           TEXT NOT NULL,
 		domain_tag                   TEXT NOT NULL,
 		agreement_binding_digest     TEXT NOT NULL,
+		source_authorization_model  TEXT NOT NULL DEFAULT '__unbound__',
+		source_agent_eligible       INTEGER NOT NULL DEFAULT 0,
+		source_agent_max_classification INTEGER NOT NULL DEFAULT 0,
 		expires_at                   INTEGER NOT NULL,
 		consumed_at                  INTEGER NOT NULL DEFAULT 0,
 		created_at                   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 	)`); err != nil {
 		return fmt.Errorf("create federated query challenge table: %w", err)
+	}
+	for column, statement := range map[string]string{
+		"source_authorization_model": `ALTER TABLE federated_query_challenge
+			ADD COLUMN source_authorization_model TEXT NOT NULL DEFAULT '__unbound__'`,
+		"source_agent_eligible": `ALTER TABLE federated_query_challenge
+			ADD COLUMN source_agent_eligible INTEGER NOT NULL DEFAULT 0`,
+		"source_agent_max_classification": `ALTER TABLE federated_query_challenge
+			ADD COLUMN source_agent_max_classification INTEGER NOT NULL DEFAULT 0`,
+	} {
+		if err := s.addSQLiteColumnIfMissing(ctx, "federated_query_challenge", column, statement); err != nil {
+			return fmt.Errorf("migrate federated query challenge %s: %w", column, err)
+		}
+	}
+	// Pre-binding rows cannot reveal whether they were minted under legacy
+	// linked-reader or peer-export authorization. Invalidate them instead of
+	// silently defaulting a peer-export challenge to legacy after upgrade. Run
+	// this on every startup so a crash between ALTER and cleanup remains safe.
+	if _, err := s.writeExecContext(ctx, `DELETE FROM federated_query_challenge
+		WHERE source_authorization_model='__unbound__'`); err != nil {
+		return fmt.Errorf("invalidate unbound federated query challenges: %w", err)
 	}
 	if _, err := s.writeExecContext(ctx, `
 	CREATE INDEX IF NOT EXISTS idx_federated_query_challenge_peer
@@ -109,7 +148,9 @@ func (s *SQLiteStore) FederationV23SchemaReady(ctx context.Context) error {
 			authorized_by, authority_kind, authority_root_generation,
 			authority_role_revision, authority_enrollment_revision, signature`,
 		"federated_query_challenge": `challenge_id, remote_chain_id, peer_agent_id,
-			requested_agent_id, domain_tag, agreement_binding_digest, expires_at,
+			requested_agent_id, domain_tag, agreement_binding_digest,
+			source_authorization_model, source_agent_eligible,
+			source_agent_max_classification, expires_at,
 			consumed_at`,
 		"federated_admin_elevation_nonce": `scope, root_generation, admin_id,
 			nonce, expires_at, consumed_at`,
@@ -187,11 +228,14 @@ func (s *SQLiteStore) IssueFederatedQueryChallenge(ctx context.Context, challeng
 		_, err := tx.conn.ExecContext(ctx, `
 			INSERT INTO federated_query_challenge (
 				challenge_id, remote_chain_id, peer_agent_id, requested_agent_id, domain_tag,
-				agreement_binding_digest, expires_at, consumed_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, 0)`,
+				agreement_binding_digest, source_authorization_model,
+				source_agent_eligible, source_agent_max_classification, expires_at, consumed_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
 			challenge.ChallengeID, challenge.RemoteChainID, challenge.PeerAgentID,
 			challenge.RequestedAgentID, challenge.DomainTag,
-			challenge.AgreementBindingDigest, challenge.ExpiresAt)
+			challenge.AgreementBindingDigest, challenge.SourceAuthorizationModel,
+			challenge.SourceAgentEligible, challenge.SourceAgentMaxClassification,
+			challenge.ExpiresAt)
 		return err
 	})
 }
@@ -212,10 +256,13 @@ func (s *SQLiteStore) ConsumeFederatedQueryChallenge(ctx context.Context, challe
 		SET consumed_at=?
 		WHERE challenge_id=? AND remote_chain_id=? AND peer_agent_id=?
 			AND requested_agent_id=? AND domain_tag=?
-			AND agreement_binding_digest=? AND consumed_at=0 AND expires_at>=?`,
+			AND agreement_binding_digest=? AND source_authorization_model=?
+			AND source_agent_eligible=? AND source_agent_max_classification=?
+			AND consumed_at=0 AND expires_at>=?`,
 		now.Unix(), challenge.ChallengeID, challenge.RemoteChainID,
 		challenge.PeerAgentID, challenge.RequestedAgentID, challenge.DomainTag,
-		challenge.AgreementBindingDigest, now.Unix())
+		challenge.AgreementBindingDigest, challenge.SourceAuthorizationModel,
+		challenge.SourceAgentEligible, challenge.SourceAgentMaxClassification, now.Unix())
 	if err != nil {
 		return err
 	}

--- a/internal/store/federation_v23_security_test.go
+++ b/internal/store/federation_v23_security_test.go
@@ -81,34 +81,34 @@ func TestFederatedQueryChallengeBindsAuthorizationTupleWithoutConsumptionOnMisma
 func TestFederatedQueryChallengeMigrationInvalidatesUnboundRows(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "pre-binding.db")
-	db, err := sql.Open("sqlite", path)
-	if err != nil {
-		t.Fatal(err)
+	db, openErr := sql.Open("sqlite", path)
+	if openErr != nil {
+		t.Fatal(openErr)
 	}
-	_, err = db.Exec(`CREATE TABLE federated_query_challenge (
+	_, createErr := db.Exec(`CREATE TABLE federated_query_challenge (
 		challenge_id TEXT PRIMARY KEY, remote_chain_id TEXT NOT NULL,
 		peer_agent_id TEXT NOT NULL, requested_agent_id TEXT NOT NULL,
 		domain_tag TEXT NOT NULL, agreement_binding_digest TEXT NOT NULL,
 		expires_at INTEGER NOT NULL, consumed_at INTEGER NOT NULL DEFAULT 0,
 		created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')))`)
-	if err != nil {
-		t.Fatal(err)
+	if createErr != nil {
+		t.Fatal(createErr)
 	}
-	_, err = db.Exec(`INSERT INTO federated_query_challenge
+	_, insertErr := db.Exec(`INSERT INTO federated_query_challenge
 		(challenge_id, remote_chain_id, peer_agent_id, requested_agent_id,
 		 domain_tag, agreement_binding_digest, expires_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?)`, strings.Repeat("e5", 32), "chain-a",
 		strings.Repeat("11", 32), strings.Repeat("22", 32), "research.notes",
 		strings.Repeat("33", 32), time.Now().Add(time.Minute).Unix())
-	if err != nil {
-		t.Fatal(err)
+	if insertErr != nil {
+		t.Fatal(insertErr)
 	}
-	if err := db.Close(); err != nil {
-		t.Fatal(err)
+	if closeErr := db.Close(); closeErr != nil {
+		t.Fatal(closeErr)
 	}
-	s, err := NewSQLiteStore(ctx, path)
-	if err != nil {
-		t.Fatal(err)
+	s, storeErr := NewSQLiteStore(ctx, path)
+	if storeErr != nil {
+		t.Fatal(storeErr)
 	}
 	t.Cleanup(func() { _ = s.Close() })
 	var count int

--- a/internal/store/federation_v23_security_test.go
+++ b/internal/store/federation_v23_security_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"database/sql"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -13,6 +14,111 @@ import (
 	"testing"
 	"time"
 )
+
+func TestFederatedQueryChallengeBindsAuthorizationTupleWithoutConsumptionOnMismatch(t *testing.T) {
+	ctx := context.Background()
+	s, err := NewSQLiteStore(ctx, filepath.Join(t.TempDir(), "tuple.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	peer, _, _ := ed25519.GenerateKey(rand.Reader)
+	agent, _, _ := ed25519.GenerateKey(rand.Reader)
+	now := time.Now()
+	challenge := FederatedQueryChallenge{
+		ChallengeID: strings.Repeat("a1", 32), RemoteChainID: "chain-a",
+		PeerAgentID: stringHex(peer), RequestedAgentID: stringHex(agent),
+		DomainTag: "research.notes", AgreementBindingDigest: strings.Repeat("b2", 32),
+		SourceAuthorizationModel: "peer-export-v1", SourceAgentEligible: true,
+		SourceAgentMaxClassification: 4, ExpiresAt: now.Add(time.Minute).Unix(),
+	}
+	if err := s.IssueFederatedQueryChallenge(ctx, challenge, now); err != nil {
+		t.Fatal(err)
+	}
+	wrongModel := challenge
+	wrongModel.SourceAuthorizationModel = ""
+	wrongModel.SourceAgentEligible = false
+	wrongModel.SourceAgentMaxClassification = 0
+	if err := s.ConsumeFederatedQueryChallenge(ctx, wrongModel, now.Add(time.Second)); err == nil {
+		t.Fatal("peer-export challenge consumed as legacy")
+	}
+	wrongCeiling := challenge
+	wrongCeiling.SourceAgentMaxClassification = 3
+	if err := s.ConsumeFederatedQueryChallenge(ctx, wrongCeiling, now.Add(2*time.Second)); err == nil {
+		t.Fatal("peer-export challenge consumed with changed source ceiling")
+	}
+	if err := s.ConsumeFederatedQueryChallenge(ctx, challenge, now.Add(3*time.Second)); err != nil {
+		t.Fatalf("tuple mismatch consumed the challenge; exact retry failed: %v", err)
+	}
+
+	legacy := challenge
+	legacy.ChallengeID = strings.Repeat("c3", 32)
+	legacy.SourceAuthorizationModel = ""
+	legacy.SourceAgentEligible = false
+	legacy.SourceAgentMaxClassification = 0
+	if err := s.IssueFederatedQueryChallenge(ctx, legacy, now); err != nil {
+		t.Fatal(err)
+	}
+	legacyAsExport := legacy
+	legacyAsExport.SourceAuthorizationModel = "peer-export-v1"
+	legacyAsExport.SourceAgentEligible = true
+	legacyAsExport.SourceAgentMaxClassification = 4
+	if err := s.ConsumeFederatedQueryChallenge(ctx, legacyAsExport, now.Add(time.Second)); err == nil {
+		t.Fatal("legacy challenge consumed as peer-export")
+	}
+	if err := s.ConsumeFederatedQueryChallenge(ctx, legacy, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("legacy mismatch consumed challenge; exact retry failed: %v", err)
+	}
+
+	invalid := challenge
+	invalid.ChallengeID = strings.Repeat("d4", 32)
+	invalid.SourceAgentMaxClassification = 5
+	if err := s.IssueFederatedQueryChallenge(ctx, invalid, now); err == nil {
+		t.Fatal("source classification above Top Secret was accepted")
+	}
+}
+
+func TestFederatedQueryChallengeMigrationInvalidatesUnboundRows(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "pre-binding.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`CREATE TABLE federated_query_challenge (
+		challenge_id TEXT PRIMARY KEY, remote_chain_id TEXT NOT NULL,
+		peer_agent_id TEXT NOT NULL, requested_agent_id TEXT NOT NULL,
+		domain_tag TEXT NOT NULL, agreement_binding_digest TEXT NOT NULL,
+		expires_at INTEGER NOT NULL, consumed_at INTEGER NOT NULL DEFAULT 0,
+		created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`INSERT INTO federated_query_challenge
+		(challenge_id, remote_chain_id, peer_agent_id, requested_agent_id,
+		 domain_tag, agreement_binding_digest, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`, strings.Repeat("e5", 32), "chain-a",
+		strings.Repeat("11", 32), strings.Repeat("22", 32), "research.notes",
+		strings.Repeat("33", 32), time.Now().Add(time.Minute).Unix())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewSQLiteStore(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	var count int
+	if err := s.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM federated_query_challenge`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("migration retained %d authorization-unbound challenges", count)
+	}
+}
 
 func TestFederatedQueryChallengeDurableSingleUseAcrossRestart(t *testing.T) {
 	ctx := context.Background()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "check:js": "node scripts/check-static-js.mjs",
-    "test": "npm run check:js && node --test scripts/appv23-linked-message-ui.test.mjs scripts/appv23-policy.test.mjs scripts/cerebrum-shell.test.mjs scripts/chrome-extension-contract.test.mjs scripts/domain-inventory.test.mjs scripts/federation-flow.test.mjs scripts/federation-route-state.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/governance-retry.test.mjs scripts/release-recovery-workflow.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/task-reorder.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
+    "test": "npm run check:js && node --test scripts/appv23-linked-message-ui.test.mjs scripts/appv23-policy.test.mjs scripts/cerebrum-shell.test.mjs scripts/chrome-extension-contract.test.mjs scripts/domain-inventory.test.mjs scripts/federation-acceptance-contract.test.mjs scripts/federation-flow.test.mjs scripts/federation-peer-capabilities.test.mjs scripts/federation-route-state.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/governance-retry.test.mjs scripts/release-recovery-workflow.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/task-reorder.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/cerebrum-shell.test.mjs
+++ b/scripts/cerebrum-shell.test.mjs
@@ -11,6 +11,7 @@ const indexSource = await readFile(new URL('../web/static/index.html', import.me
 const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
 const mriPageSource = await readFile(new URL('../web/static/mri.html', import.meta.url), 'utf8');
 const federationRouteSource = await readFile(new URL('../web/static/js/federation-route-state.js', import.meta.url), 'utf8');
+const federationPeerCapabilitiesSource = await readFile(new URL('../web/static/js/federation-peer-capabilities.js', import.meta.url), 'utf8');
 const traySource = await readFile(new URL('../cmd/sage-tray/main.swift', import.meta.url), 'utf8');
 const { MRI_LAYOUT, mriBrainstemBias, mriDepthForAge, mriVerticalPosition } = await import('../web/static/js/mri-layout.js');
 
@@ -83,6 +84,25 @@ test('inline script inspection follows case-insensitive HTML end-tag parsing', (
         inlineScriptBodies('<SCRIPT>one()</script ><script type="module">two()</SCRIPT data-x>'),
         ['one()', 'two()'],
     );
+});
+
+test('federated-agent compatibility warning is live, informational, and capability-derived', () => {
+    assert.match(appSource, /federationPeerAgentCompatibility\(connectionStatus\)/);
+    assert.match(appSource, /Some federated-agent capabilities are not ready/);
+    assert.match(appSource, /may still be starting or binding this connection, or may need an update/);
+    assert.match(appSource, /Your local agent choices remain saved; retry after both SAGEs show the connection as ready/);
+    assert.doesNotMatch(appSource, /can take effect after the peer updates/,
+        'missing live capabilities must not claim that an update is the proven cause or remedy');
+    assert.match(federationPeerCapabilitiesSource, /federated-peer-export-read-v1/);
+    assert.match(federationPeerCapabilitiesSource, /federated-query-availability-v1/);
+    assert.match(federationPeerCapabilitiesSource, /federated-pipeline-v1/);
+    assert.match(federationPeerCapabilitiesSource, /linked-message-directory-enumeration-v1/);
+
+    const pickerStart = appSource.indexOf('id=${`fed-agent-picker-${chain}`}');
+    const pickerEnd = appSource.indexOf('aria-busy=${pipeContactLookupBusy}', pickerStart);
+    assert.ok(pickerStart >= 0 && pickerEnd > pickerStart, 'federated-agent picker must remain present');
+    assert.doesNotMatch(appSource.slice(pickerStart, pickerEnd), /peerAgentCompatibility/,
+        'mixed-version diagnostics must not disable durable local export controls');
 });
 
 test('task status mutations reject HTTP failures before optimistic board state can settle', () => {

--- a/scripts/federation-acceptance-contract.test.mjs
+++ b/scripts/federation-acceptance-contract.test.mjs
@@ -9,7 +9,7 @@ const runner = fs.readFileSync(path.join(base, 'run.sh'), 'utf8');
 const legacy = fs.readFileSync(path.join(base, 'v11.17.4-config.template.yaml'), 'utf8');
 
 for (const service of ['relay:', 'node-a:', 'node-b:']) assert.match(compose, new RegExp(`\\n  ${service}`));
-assert.equal((compose.match(/image: sage-v111716-node:local/g) || []).length, 2,
+assert.equal((compose.match(/image: sage-v111717-node:local/g) || []).length, 2,
   'both nodes must run the exact same built image');
 for (const network of ['edge_a:', 'edge_b:', 'lan:']) assert.match(compose, new RegExp(`\\n  ${network}`));
 assert.match(compose, /SAGE_VENDORED_AGENT_HOME_DOMAIN: mynah-a-home/);
@@ -24,6 +24,11 @@ for (const gate of [
   'v11.17.4 persisted p2p_peers compatibility shape',
   'canonical MCP flow: find -> send -> offline inbox -> read -> reply/status',
   'directional peer export read needs no mirrored group',
+  'bidirectional Copy: seed pre-consent memories for initial backfill',
+  'bidirectional Copy: each owner offers Copy and each receiver independently subscribes',
+  'bidirectional Copy: initial anti-entropy backfill',
+  'bidirectional Copy: incremental delivery after consent',
+  'bidirectional Copy: restart persistence and source-offline local reads',
 ]) assert.ok(runner.includes(gate), `missing matrix gate: ${gate}`);
 
 assert.match(runner, /automatic real JOIN ceremony over LAN/);
@@ -38,12 +43,76 @@ assert.match(runner, /sage_inbox/);
 assert.match(runner, /sage_message_reply/);
 assert.match(runner, /sage_message_status/);
 assert.match(runner, /mcp_call node-a sage_remember/);
+assert.match(runner, /remember_committed\(\)/);
+assert.match(runner, /result\.skipped \|\| result\.status === "skipped" \|\| result\.status === "rejected"/);
+assert.match(runner, /!result\.memory_id \|\| result\.committed !== true/);
+for (const call of [
+  'remember_committed node-a "$remember_a_initial"',
+  'remember_committed node-b "$remember_b_initial"',
+  'remember_committed node-a "$remember_a_incremental"',
+  'remember_committed node-b "$remember_b_incremental"',
+]) assert.ok(runner.includes(call), `missing fail-closed source admission: ${call}`);
+assert.equal((runner.match(/remember_committed node-[ab] /g) || []).length, 4,
+  'every initial and incremental source seed must use the fail-closed admission helper');
+const marker = name => runner.match(new RegExp(`${name}="([^"]+)"`))?.[1];
+const significant = value => {
+  const seen = new Set();
+  for (const raw of value.toLowerCase().trim().split(/\s+/)) {
+    const word = raw.replace(/^[.,;:!?"'()[\]{}—-]+|[.,;:!?"'()[\]{}—-]+$/g, '');
+    if (word.length >= 4) seen.add(word);
+  }
+  return [...seen];
+};
+for (const side of ['a', 'b']) {
+  const initial = significant(marker(`mirror_${side}_initial`));
+  const incremental = significant(marker(`mirror_${side}_incremental`));
+  const existing = initial.join(' ').toLowerCase();
+  const overlap = incremental.filter(word => existing.includes(word)).length / incremental.length;
+  assert.ok(overlap <= 0.60,
+    `node ${side.toUpperCase()} incremental fixture would trip the >60% duplicate guard (${overlap})`);
+}
 assert.match(runner, /connections\/\$chain_a\/agent-exports/);
 assert.match(runner, /connections\/\$chain_b\/agent-exports/);
 assert.doesNotMatch(runner, /grant reciprocal Mynah home-domain read and exact inbox consent/);
 assert.match(runner, /mcp_call node-b sage_federation/);
 assert.match(runner, /mcp_call node-b sage_recall/);
+assert.match(runner, /network\/access\/linked-readers/);
+assert.match(runner, /contains legacy linked-reader state/);
+assert.match(runner, /federated-peer-export-read-v1/);
+assert.match(runner, /read_authorization!=="verified"/);
+assert.match(runner, /read_authorization_complete!==true/);
+assert.match(runner, /shared_read_domains/);
+assert.doesNotMatch(runner, /echo "\$exported" \| grep -q 'mynah-a-home'/,
+  'a candidate-only domain string must not satisfy peer-export acceptance');
 assert.match(runner, /ordinary node B companion could not read node A's export without a mirrored group/);
+assert.match(runner, /node-a PUT "\/v1\/dashboard\/federation\/connections\/\$chain_a\/permissions" "\$permission_a"/);
+assert.match(runner, /node-b PUT "\/v1\/dashboard\/federation\/connections\/\$chain_b\/permissions" "\$permission_b"/);
+assert.equal((runner.match(/"copy":true/g) || []).length, 2,
+  'both source nodes must explicitly offer Copy for their own domain');
+assert.match(runner, /subscribe_a='\{"subscribe_domains":\["mynah-b-home"\]\}'/);
+assert.match(runner, /subscribe_b='\{"subscribe_domains":\["mynah-a-home"\]\}'/);
+assert.match(runner, /scope:\"local\"/,
+  'mirroring must be verified from receiver-local storage, not live federation recall');
+for (const call of [
+  'wait_local_copy node-b "$mirror_a_initial" mynah-a-home',
+  'wait_local_copy node-a "$mirror_b_initial" mynah-b-home',
+  'wait_local_copy node-b "$mirror_a_incremental" mynah-a-home',
+  'wait_local_copy node-a "$mirror_b_incremental" mynah-b-home',
+]) assert.ok(runner.includes(call), `missing receiver-local mirror assertion: ${call}`);
+const initialPhase = runner.slice(
+  runner.indexOf('phase "bidirectional Copy: initial anti-entropy backfill"'),
+  runner.indexOf('phase "bidirectional Copy: incremental delivery after consent"'),
+);
+assert.ok(initialPhase.includes('wait_local_copy node-b "$mirror_a_initial" mynah-a-home'));
+assert.ok(initialPhase.includes('wait_local_copy node-a "$mirror_b_initial" mynah-b-home'));
+const incrementalPhase = runner.slice(
+  runner.indexOf('phase "bidirectional Copy: incremental delivery after consent"'),
+  runner.indexOf('phase "bidirectional Copy: restart persistence and source-offline local reads"'),
+);
+assert.ok(incrementalPhase.includes('wait_local_copy node-b "$mirror_a_incremental" mynah-a-home'));
+assert.ok(incrementalPhase.includes('wait_local_copy node-a "$mirror_b_incremental" mynah-b-home'));
+assert.match(runner, /dc stop node-a[\s\S]*wait_local_copy node-b "\$mirror_a_initial"/);
+assert.match(runner, /dc stop node-b[\s\S]*wait_local_copy node-a "\$mirror_b_initial"/);
 assert.match(runner, /timeout "\$MCP_TIMEOUT_SECONDS" sage-gui mcp/);
 assert.match(runner, /\[ "\$app_a" -ge 26 \]/);
 assert.match(runner, /\[ "\$app_b" -ge 26 \]/);

--- a/scripts/federation-peer-capabilities.test.mjs
+++ b/scripts/federation-peer-capabilities.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { federationPeerAgentCompatibility } from '../web/static/js/federation-peer-capabilities.js';
+
+const currentCapabilities = [
+  'federated-peer-export-read-v1',
+  'federated-query-availability-v1',
+  'federated-pipeline-v1',
+  'linked-message-directory-enumeration-v1',
+];
+
+test('current peer advertises complete federated-agent compatibility', () => {
+  const compatibility = federationPeerAgentCompatibility({
+    reachable: true,
+    capabilities: [...currentCapabilities, 'future-additive-capability-v1'],
+  });
+
+  assert.equal(compatibility.observed, true);
+  assert.equal(compatibility.exportedRead, true);
+  assert.equal(compatibility.agentMessaging, true);
+  assert.equal(compatibility.linkedDirectory, true);
+  assert.equal(compatibility.fullySupported, true);
+  assert.deepEqual(compatibility.missing, []);
+});
+
+for (const missingReadCapability of [
+  'federated-peer-export-read-v1',
+  'federated-query-availability-v1',
+]) {
+  test(`exported reading requires ${missingReadCapability}`, () => {
+    const compatibility = federationPeerAgentCompatibility({
+      reachable: true,
+      capabilities: currentCapabilities.filter(capability => capability !== missingReadCapability),
+    });
+
+    assert.equal(compatibility.exportedRead, false);
+    assert.equal(compatibility.agentMessaging, true);
+    assert.deepEqual(compatibility.missing, ['default cross-SAGE reading']);
+  });
+}
+
+test('read and messaging compatibility remain independent', () => {
+  const compatibility = federationPeerAgentCompatibility({
+    reachable: true,
+    capabilities: currentCapabilities.filter(capability => capability !== 'federated-pipeline-v1'),
+  });
+
+  assert.equal(compatibility.exportedRead, true);
+  assert.equal(compatibility.agentMessaging, false);
+  assert.equal(compatibility.linkedDirectory, true);
+  assert.deepEqual(compatibility.missing, ['agent messaging']);
+});
+
+test('linked directory compatibility is reported independently', () => {
+  const compatibility = federationPeerAgentCompatibility({
+    reachable: true,
+    capabilities: currentCapabilities.filter(capability => capability !== 'linked-message-directory-enumeration-v1'),
+  });
+
+  assert.equal(compatibility.exportedRead, true);
+  assert.equal(compatibility.agentMessaging, true);
+  assert.equal(compatibility.linkedDirectory, false);
+  assert.deepEqual(compatibility.missing, ['federated recipient discovery']);
+});
+
+test('reachable legacy and malformed responses fail closed as unsupported', () => {
+  for (const capabilities of [undefined, null, {}, [1, null, {}]]) {
+    const compatibility = federationPeerAgentCompatibility({ reachable: true, capabilities });
+    assert.equal(compatibility.observed, true);
+    assert.equal(compatibility.fullySupported, false);
+    assert.deepEqual(compatibility.missing, [
+      'default cross-SAGE reading',
+      'agent messaging',
+      'federated recipient discovery',
+    ]);
+  }
+});
+
+test('offline or unchecked peers do not produce a mixed-version diagnosis', () => {
+  for (const status of [undefined, null, {}, { reachable: false, capabilities: currentCapabilities }]) {
+    const compatibility = federationPeerAgentCompatibility(status);
+    assert.equal(compatibility.observed, false);
+    assert.equal(compatibility.fullySupported, false);
+    assert.deepEqual(compatibility.missing, []);
+  }
+});

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -62,7 +62,7 @@ test('release-facing version metadata stays aligned', () => {
   }
 });
 
-test('v11.17.16 user and SDK guides keep canonical Messages contracts aligned', () => {
+test('v11.17.17 user and SDK guides keep canonical Messages contracts aligned', () => {
   const architecture = read('docs/ARCHITECTURE.md');
   const roadmap = read('docs/ROADMAP.md');
   const gettingStarted = read('docs/GETTING_STARTED.md');

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.17.16 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.17.17 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.17.16"
+version = "11.17.17"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.17.16"
+__version__ = "11.17.17"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.17.16",
+  "version": "11.17.17",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.17.16",
+      "identifier": "ghcr.io/l33tdawg/sage:11.17.17",
       "transport": {
         "type": "stdio"
       }

--- a/web/federation_group_auth_test.go
+++ b/web/federation_group_auth_test.go
@@ -50,6 +50,11 @@ func (d *groupRefreshTestDriver) NudgeJournalReconcileAndWait(context.Context) e
 func (peerStatusTestDriver) PeerStatus(context.Context, string) (*federation.StatusResponse, error) {
 	return &federation.StatusResponse{
 		NetworkName: "DKAN-TII", Time: 123,
+		Capabilities: []string{
+			federation.CapabilityFederationV23,
+			federation.CapabilityPeerExportReadV1,
+			"future-additive-capability-v1",
+		},
 		PeerRBACGrant: &federation.PeerRBACGrant{
 			PolicyVersion: federation.SyncPolicyVersionPeerRBAC,
 			Domains:       []federation.PeerRBACDomainGrant{{Domain: "shared.research", Read: true}},
@@ -86,6 +91,7 @@ func TestFederationPeerStatusReturnsFriendlyNetworkName(t *testing.T) {
 		PeerRBACGrant *federation.PeerRBACGrant    `json:"peer_rbac_grant"`
 		SharingGrant  *federation.SharingGrant     `json:"sharing_grant"`
 		PipeContacts  *federation.PipeContactGrant `json:"pipe_contacts"`
+		Capabilities  []string                     `json:"capabilities"`
 		BindingDigest string                       `json:"query_agreement_binding_digest"`
 	}
 	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
@@ -99,6 +105,11 @@ func TestFederationPeerStatusReturnsFriendlyNetworkName(t *testing.T) {
 	require.NotNil(t, got.SharingGrant)
 	require.NotNil(t, got.PipeContacts)
 	require.True(t, got.PipeContacts.Contacts[0].Accepting)
+	require.Equal(t, []string{
+		federation.CapabilityFederationV23,
+		federation.CapabilityPeerExportReadV1,
+		"future-additive-capability-v1",
+	}, got.Capabilities, "dashboard projection must preserve authenticated additive peer capabilities")
 	require.Empty(t, got.BindingDigest, "dashboard projection must not expose transport binding internals")
 }
 
@@ -118,11 +129,13 @@ func TestFederationPeerStatusTypesFailureAheadOfHistoricalRoute(t *testing.T) {
 		FailureState string                      `json:"failure_state"`
 		Error        string                      `json:"error"`
 		Route        federation.RouteDiagnostics `json:"route"`
+		Capabilities []string                    `json:"capabilities"`
 	}
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
 	assert.False(t, got.Reachable)
 	assert.Equal(t, "trust_failure", got.FailureState)
 	assert.Contains(t, got.Error, "revoked")
+	assert.Empty(t, got.Capabilities, "an unreachable result must not fabricate peer capabilities")
 	assert.Equal(t, federation.RouteKindDirect, got.Route.ActiveKind,
 		"historical diagnostics remain available but must not override the typed failure")
 }

--- a/web/federation_join.go
+++ b/web/federation_join.go
@@ -976,9 +976,15 @@ func (h *DashboardHandler) handleFedPeerStatus(w http.ResponseWriter, r *http.Re
 	}
 	out := map[string]any{"remote_chain_id": chain, "reachable": true, "peer_time": st.Time, "network_name": st.NetworkName}
 	// The peer status call is the panel's one authenticated live probe. Preserve
-	// its already peer-scoped authorization projections so the UI does not show a
-	// reachable connection while claiming the peer reported no domains/agents.
-	// Do not expose the agreement binding digest or other transport internals.
+	// its advertised capabilities and already peer-scoped authorization
+	// projections so the UI does not show a reachable connection while claiming
+	// the peer reported no domains/agents. Capabilities are authenticated,
+	// read-only compatibility metadata already exposed by the operator REST
+	// status route; they grant no authority. Do not expose the agreement binding
+	// digest or other transport internals.
+	if len(st.Capabilities) > 0 {
+		out["capabilities"] = append([]string(nil), st.Capabilities...)
+	}
 	if st.PeerRBACGrant != nil {
 		out["peer_rbac_grant"] = st.PeerRBACGrant
 	}

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -45,6 +45,7 @@ import {
     federationRoutePresentation,
     normalizeFederationRoutePlan,
 } from './federation-route-state.js';
+import { federationPeerAgentCompatibility } from './federation-peer-capabilities.js';
 
 const { h, render, createContext, Fragment } = preact;
 const { useState, useEffect, useRef, useLayoutEffect, useCallback, useContext } = preactHooks;
@@ -56,7 +57,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.17.16';
+const SAGE_VERSION = 'v11.17.17';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace
@@ -16637,6 +16638,7 @@ function FedPermissionsPanel({ conn, connectionStatus, onRevoke, revokeBusy }) {
     const hiddenRemoteRowCount = Math.max(0, orderedRemoteRows.length - renderedRemoteRows.length);
     const dirty = !fedPermissionMapsEqual(saved, draft);
     const subscribeDirty = JSON.stringify(subscribeSaved) !== JSON.stringify(subscribeDraft);
+	const peerAgentCompatibility = federationPeerAgentCompatibility(connectionStatus);
 
     const togglePermission = (row, field) => {
         if (field === 'write') return;
@@ -17170,6 +17172,13 @@ function FedPermissionsPanel({ conn, connectionStatus, onRevoke, revokeBusy }) {
 					<p>Adding a local agent explicitly joins it to this federation. ${peerName}'s ordinary agents can read its owned domains by default and message it; Write remains blocked unless you configure a separate receiving rule.</p>
 				</div>
 			</div>
+			${peerAgentCompatibility.observed && !peerAgentCompatibility.fullySupported && html`
+				<div class="fed-warn" role="status">
+					<strong>Some federated-agent capabilities are not ready.</strong>
+					This SAGE's latest reachable status did not advertise ${peerAgentCompatibility.missing.join(', ')}.
+					The peer may still be starting or binding this connection, or may need an update. Your local agent choices remain saved; retry after both SAGEs show the connection as ready.
+				</div>
+			`}
 			<div class="fed-agent-columns">
 				<div class="fed-agent-column">
 					<h5>Agents on this SAGE</h5>

--- a/web/static/js/federation-peer-capabilities.js
+++ b/web/static/js/federation-peer-capabilities.js
@@ -1,0 +1,45 @@
+const FEDERATED_AGENT_CAPABILITIES = Object.freeze({
+    peerExportRead: 'federated-peer-export-read-v1',
+    queryAvailability: 'federated-query-availability-v1',
+    pipeline: 'federated-pipeline-v1',
+    linkedDirectory: 'linked-message-directory-enumeration-v1',
+});
+
+// Interpret only the authenticated live peer-status projection. Capability
+// advertisement is compatibility metadata, not proof of authorization,
+// presence, or delivery. An offline/unchecked peer therefore has no observed
+// compatibility state and must not be mislabeled as an old peer.
+export function federationPeerAgentCompatibility(status) {
+    if (!status || status.reachable !== true) {
+        return {
+            observed: false,
+            exportedRead: false,
+            agentMessaging: false,
+            linkedDirectory: false,
+            fullySupported: false,
+            missing: [],
+        };
+    }
+
+    const capabilities = new Set(
+        (Array.isArray(status.capabilities) ? status.capabilities : [])
+            .filter(capability => typeof capability === 'string'),
+    );
+    const exportedRead = capabilities.has(FEDERATED_AGENT_CAPABILITIES.peerExportRead)
+        && capabilities.has(FEDERATED_AGENT_CAPABILITIES.queryAvailability);
+    const agentMessaging = capabilities.has(FEDERATED_AGENT_CAPABILITIES.pipeline);
+    const linkedDirectory = capabilities.has(FEDERATED_AGENT_CAPABILITIES.linkedDirectory);
+    const missing = [];
+    if (!exportedRead) missing.push('default cross-SAGE reading');
+    if (!agentMessaging) missing.push('agent messaging');
+    if (!linkedDirectory) missing.push('federated recipient discovery');
+
+    return {
+        observed: true,
+        exportedRead,
+        agentMessaging,
+        linkedDirectory,
+        fullySupported: missing.length === 0,
+        missing,
+    };
+}


### PR DESCRIPTION
## Summary\n- make reciprocal explicit agent exports the federation read boundary: ordinary active peer agents can read exported domains by default, while writes remain RBAC-gated\n- cryptographically bind and revalidate the complete signed recall authorization tuple to close plan/query TOCTOU gaps\n- separate advertised candidate domains from verified readable capabilities in CEREBRUM\n- bump the release contract to v11.17.17 (app-v26)\n\n## Validation\n- full Go suite: go test ./... -count=1\n- focused federation race suite\n- npm test: 222/222\n- fresh Docker acceptance: PASS (full)\n  - real JOIN and sequential app-v23 -> v24 -> v25 -> v26\n  - reciprocal Mynah export and default read without mirrored Access Groups or linked-reader fixtures\n  - bidirectional Copy initial backfill and incremental sync\n  - restart persistence and receiver-local reads with either source offline\n  - LAN removal, relay-only IP churn, relay outage/recovery, expired-route restart, v11.17.4 compatibility\n  - canonical offline message/inbox/read/reply/status\n- git diff --check