### PR TITLE
release: SAGE v11.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,32 +51,62 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
-## What's New in v11.17.17
+## What's New in v11.18.0
 
-**Federated Read plans now stay true until disclosure.** The v11.17.16
-exported-agent model correctly made a trusted node pair its own federation
-group, but a source agent's standing or clearance could change between planning
-and the remote query. v11.17.17 binds the source authorization model and exact
-attestation into the signed plan and single-use challenge, then holds the final
-source authorization lease through the destination query. A changed export,
-domain owner, enrollment, clearance, agreement, or capability now fails closed
-before any memory is returned and requires a fresh plan and signature.
+**A connected pair is now the federation group users expect it to be.** Each
+side explicitly exports the ordinary local agents it places in that pair. Every
+active ordinary agent on the other SAGE may then live-read those exported
+agents' owned domain trees by default—no matching local group, receiving
+domain, or linked-reader grant is required. A receiving operator can narrow
+that default with exact agent/domain denials. Local-only group membership is
+never exported transitively, and adding another federated agent is an explicit
+new export. Read remains borrowed; Copy still requires a source offer plus the
+receiver's **Save here** subscription, while remote memory Write remains
+reserved and fails closed.
 
-CEREBRUM and `sage_federation` also expose the negotiated authenticated-read
-capability explicitly. A reachable peer missing it is described honestly as
-possibly still warming/binding or needing an update; SAGE does not guess which.
-Policy candidates stay separate from domains the destination has verified. The
-Docker federation lane covers pairwise default Read, explicit denial,
-non-transitive exports, Copy backfill, incremental mirroring, bidirectional
-mirroring, and restart recovery.
+**Federated authorization now stays true through disclosure.** The signed Read
+plan and single-use challenge bind the exact source-agent standing, clearance,
+export, agreement, policy generation, and negotiated authorization model. The
+source authorization lease is revalidated and held until the destination query
+finishes, so a concurrent rename-safe identity change, restriction, ownership
+change, pause, or revoke cannot leak a result. CEREBRUM and `sage_federation`
+also report authenticated-read readiness honestly, and the Docker acceptance
+lane proves default Read, explicit denial, non-transitive exports, bidirectional
+Copy backfill/incremental sync, and restart recovery.
 
-This is an off-consensus protocol, authorization, and projection correction. It
-changes no transaction codec, AppHash input, fork target, key format, memory, domain,
-linked-reader row, or existing agreement. Both SAGEs must run v11.17.17 for the
-complete signed authorization tuple; older clients are told to re-plan and
-re-sign instead of silently downgrading it.
+**People can address agents without giving up canonical identity.** Local and
+federated message targets accept a unique display or immutable registered name;
+the resolved request and wire proof still carry only the canonical agent ID and
+chain. Ambiguous local/remote collisions fail with bounded immutable choices
+instead of selecting the first label. Federated replies now return an immutable
+`reply_event_id`, and the replier can query that exact event's delivery status
+without pretending it is a new inbox message.
 
-Container: `ghcr.io/l33tdawg/sage:11.17.17`. SDK 11.17.17.
+**Access Controls is now one usable control surface.** Dedicated **Agents**,
+**Groups**, and **Federation** tabs use compact searchable/sortable lists and
+focused detail drawers instead of mounting every permission matrix at once.
+Modern and legacy URL deep links preserve the selected tab and exact local or
+federated identity. Dialog/drawer focus ownership, Escape/Tab handling, ARIA
+labels, and narrow-screen behavior are covered by browser-contract tests.
+
+**JOIN and upgrade recovery are bounded and explicit.** A JOIN session still
+expires after 15 minutes, while each pasted/scanned code gets up to five minutes
+of Direct/relay discovery as long as its pairing screen remains open. v11.18.0
+is also the first concrete release containing stopped-node `backup --full`,
+recoverable `restore --from`, `upgrade preflight`, and the app-v21 → app-v22
+`upgrade lineage status|doctor|verify` workflow. A legacy-lineage repair is
+create-only, chain/current-state bound, embedded in the exact immutable upgrade
+proposal, never auto-voted, and requires every validator to verify and vote
+explicitly; an unverified anchor requires a deliberate acknowledgement.
+
+The federation/UI work is off-consensus. The narrow lineage ceremony repairs
+only an eligible chain still at app-v21 before its governed app-v22 transition.
+Existing app-v22 through app-v26 chains are not rewritten, **app-v26 remains the
+binary ceiling, and v11.18.0 introduces no app-v27**. Both SAGEs should run
+v11.18.0 for the complete signed federation tuple; older peers fail closed
+rather than silently downgrade it.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.0`. SDK 11.18.0.
 
 ## What's New in v11.17.15
 
@@ -1405,7 +1435,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.17.17`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.0`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.17.17
+  version: 11.18.0
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/api/rest/messages_handler.go
+++ b/api/rest/messages_handler.go
@@ -366,3 +366,40 @@ func (s *Server) handleMessageStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, status)
 }
+
+// handleMessageReplyStatus exposes only the replying agent's own immutable
+// federated result event. It is deliberately separate from sender-owned message
+// status: no request/result content or original-message workflow state crosses
+// this boundary, and the reply is never represented as another inbox request.
+func (s *Server) handleMessageReplyStatus(w http.ResponseWriter, r *http.Request) {
+	if !requireExactSignedMessageAction(w, r) {
+		return
+	}
+	replyEventID := chi.URLParam(r, "reply_event_id")
+	transportStore, ok := s.store.(store.FederatedPipelineStore)
+	if !ok {
+		writeCanonicalMessageNotFound(w, replyEventID)
+		return
+	}
+	event, err := transportStore.GetPipelineTransport(r.Context(), replyEventID)
+	if err != nil || event == nil || event.EventKind != "result" ||
+		event.SourceAgentID != middleware.ContextAgentID(r.Context()) {
+		writeCanonicalMessageNotFound(w, replyEventID)
+		return
+	}
+	transportStatus := event.State
+	if transportStatus == "pending" {
+		transportStatus = "queued"
+	}
+	response := map[string]any{
+		"reply_event_id":   replyEventID,
+		"scope":            "federated",
+		"reply_status":     transportStatus,
+		"transport_status": transportStatus,
+		"created_at":       event.CreatedAt,
+	}
+	if event.DeliveredAt != nil {
+		response["delivered_at"] = event.DeliveredAt
+	}
+	writeJSON(w, http.StatusOK, response)
+}

--- a/api/rest/messages_handler_test.go
+++ b/api/rest/messages_handler_test.go
@@ -37,6 +37,7 @@ func messageRouterAs(s *Server, callerID string, exactProof bool) http.Handler {
 	r.Put("/v1/messages/{message_id}/read", s.handleMessageRead)
 	r.Put("/v1/messages/read-batch", s.handleMessageReadBatch)
 	r.Get("/v1/messages/{message_id}/status", s.handleMessageStatus)
+	r.Get("/v1/messages/replies/{reply_event_id}/status", s.handleMessageReplyStatus)
 	return r
 }
 

--- a/api/rest/pipe_handler.go
+++ b/api/rest/pipe_handler.go
@@ -288,6 +288,7 @@ func (s *Server) handlePipeResolve(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	var localMatches []*store.AgentEntry
 	if s.agentStore != nil {
 		if pub, err := auth.AgentIDToPublicKey(target); err == nil && auth.PublicKeyToAgentID(pub) == target {
 			isRoot, rootErr := s.appV23IsRootIdentity(target)
@@ -333,6 +334,7 @@ func (s *Server) handlePipeResolve(w http.ResponseWriter, r *http.Request) {
 					"The local agent directory could not be searched.")
 				return
 			}
+			seenLocal := make(map[string]struct{})
 			for _, agent := range agents {
 				if agent == nil {
 					continue
@@ -356,8 +358,10 @@ func (s *Server) handlePipeResolve(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 					if active {
-						writeJSON(w, http.StatusOK, map[string]any{"to_agent": agent.AgentID, "to_provider": "", "destination_chain_id": ""})
-						return
+						if _, seen := seenLocal[agent.AgentID]; !seen {
+							seenLocal[agent.AgentID] = struct{}{}
+							localMatches = append(localMatches, agent)
+						}
 					}
 				}
 			}
@@ -366,12 +370,40 @@ func (s *Server) handlePipeResolve(w http.ResponseWriter, r *http.Request) {
 					"The bounded local candidate scan was exhausted; use the exact agent ID from sage_find_agent.")
 				return
 			}
+			if len(localMatches) > 1 {
+				choices := make([]string, 0, min(len(localMatches), 20))
+				for _, agent := range localMatches[:min(len(localMatches), 20)] {
+					choices = append(choices, agent.AgentID)
+				}
+				writeProblem(w, http.StatusConflict, "Ambiguous local agent",
+					fmt.Sprintf("Multiple active local agents match %q; choose one immutable agent ID: %s", target, strings.Join(choices, ", ")))
+				return
+			}
 		}
 	}
 	if remote, handled := resolveRemote(); remote != nil {
+		if !s.callerCanReachFederatedPipeTarget(r.Context(), middleware.ContextAgentID(r.Context()), remote) {
+			// An unauthorized remote route is not a collision candidate and remains
+			// indistinguishable from an absent contact.
+			if len(localMatches) == 1 {
+				writeJSON(w, http.StatusOK, map[string]any{"to_agent": localMatches[0].AgentID, "to_provider": "", "destination_chain_id": ""})
+				return
+			}
+			writeProblem(w, http.StatusNotFound, "Unknown target", fmt.Sprintf("no registered local or visible federated agent matches %q", target))
+			return
+		}
+		if len(localMatches) == 1 {
+			writeProblem(w, http.StatusConflict, "Ambiguous agent",
+				fmt.Sprintf("A local and federated agent both match %q; choose %s or %s", target, localMatches[0].AgentID, remote.Address))
+			return
+		}
 		writeRemote(remote)
 		return
 	} else if handled {
+		return
+	}
+	if len(localMatches) == 1 {
+		writeJSON(w, http.StatusOK, map[string]any{"to_agent": localMatches[0].AgentID, "to_provider": "", "destination_chain_id": ""})
 		return
 	}
 	writeProblem(w, http.StatusNotFound, "Unknown target", fmt.Sprintf("no registered local or visible federated agent matches %q", target))
@@ -1308,6 +1340,7 @@ func (s *Server) handlePipeResult(w http.ResponseWriter, r *http.Request) {
 	// durable return event, so a crash cannot acknowledge locally and lose the
 	// requesting agent's answer.
 	var completeErr error
+	var replyEventID string
 	if msg.SourceChainID != "" {
 		transportStore, ok := pipeStore.(store.FederatedPipelineStore)
 		if !ok {
@@ -1339,6 +1372,7 @@ func (s *Server) handlePipeResult(w http.ResponseWriter, r *http.Request) {
 			TargetAgentID:     msg.FromAgent, Proof: transportProof, CreatedAt: created,
 			ExpiresAt: created.Add(24 * time.Hour),
 		}
+		replyEventID = event.EventID
 		authorizer := s.federation.(federatedPipeAdmissionAuthorizer)
 		completeErr = authorizer.WithAuthorizedImportedPipe(r.Context(), msg, func() error {
 			return transportStore.CompleteFederatedPipelineWithTransport(r.Context(), pipeID, agentID, req.Result, event)
@@ -1364,11 +1398,16 @@ func (s *Server) handlePipeResult(w http.ResponseWriter, r *http.Request) {
 		s.OnEvent("pipeline_complete", pipeID, "agent-pipeline", summary, nil)
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	response := map[string]any{
 		"status":     "completed",
 		"journal_id": journalID,
 		"journaled":  journaled,
-	})
+	}
+	if replyEventID != "" {
+		response["reply_event_id"] = replyEventID
+		response["reply_status"] = "queued"
+	}
+	writeJSON(w, http.StatusOK, response)
 }
 
 // callerCanViewPipe reports whether callerID is a party to msg (sender,

--- a/api/rest/pipe_handler_test.go
+++ b/api/rest/pipe_handler_test.go
@@ -614,6 +614,61 @@ func TestHandlePipeResolveReturnsExactFederatedBindingWithoutQueueing(t *testing
 	require.Empty(t, pipes)
 }
 
+func TestHandlePipeResolveRejectsLocalFederatedFriendlyNameCollision(t *testing.T) {
+	s, memStore := newPipeServer(t)
+	localAgentID := strings.Repeat("31", 32)
+	remoteAgentID := strings.Repeat("42", 32)
+	callerID := strings.Repeat("53", 32)
+	require.NoError(t, memStore.CreateAgent(context.Background(), &store.AgentEntry{
+		AgentID: localAgentID, Name: "Mynah", RegisteredName: "mynah/local",
+		Role: "member", Status: "active",
+	}))
+	require.NoError(t, memStore.CreateAgent(context.Background(), &store.AgentEntry{
+		AgentID: callerID, Name: "caller", Role: "member", Status: "active",
+		DomainAccess: `[{"domain":"research","read":true}]`,
+	}))
+	s.SetFederation(&remotePipeResolver{
+		fakeFederation: &fakeFederation{},
+		target: &federation.RemotePipeTarget{
+			ChainID: "chain-mini", AgentID: remoteAgentID,
+			Address: remoteAgentID + "@chain-mini", DisplayName: "Mynah",
+			Domains: []federation.PipeContactDomain{{Domain: "research"}},
+		},
+	})
+
+	body, err := json.Marshal(map[string]any{"to": "Mynah"})
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	pipeRouterAs(s, callerID).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodPost, "/v1/pipe/resolve", bytes.NewReader(body)))
+	require.Equal(t, http.StatusConflict, rr.Code, rr.Body.String())
+	problem := decodeProblem(t, rr)
+	assert.Contains(t, problem["detail"], localAgentID)
+	assert.Contains(t, problem["detail"], remoteAgentID+"@chain-mini")
+
+	pipes, err := memStore.ListPipelines(context.Background(), "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, pipes, "ambiguous friendly resolution must not queue work")
+}
+
+func TestHandlePipeResolveRejectsMultipleLocalFriendlyNameMatches(t *testing.T) {
+	s, memStore := newPipeServer(t)
+	for _, agentID := range []string{strings.Repeat("61", 32), strings.Repeat("62", 32)} {
+		require.NoError(t, memStore.CreateAgent(context.Background(), &store.AgentEntry{
+			AgentID: agentID, Name: "Shared Helper", Role: "member", Status: "active",
+		}))
+	}
+	body, err := json.Marshal(map[string]any{"to": "Shared Helper"})
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	pipeRouterAs(s, strings.Repeat("63", 32)).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodPost, "/v1/pipe/resolve", bytes.NewReader(body)))
+	require.Equal(t, http.StatusConflict, rr.Code, rr.Body.String())
+	problem := decodeProblem(t, rr)
+	assert.Contains(t, problem["detail"], strings.Repeat("61", 32))
+	assert.Contains(t, problem["detail"], strings.Repeat("62", 32))
+}
+
 func TestFederatedPipeTargetRequiresCurrentCallerDomainAccess(t *testing.T) {
 	s, memStore := newPipeServer(t)
 	remoteAgentID := strings.Repeat("ab", 32)
@@ -726,12 +781,34 @@ func TestHandlePipeResult_ForeignWorkNeverAutoJournals(t *testing.T) {
 	pipeRouterAs(s, recipient).ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 	var response struct {
-		JournalID string `json:"journal_id"`
-		Journaled bool   `json:"journaled"`
+		JournalID    string `json:"journal_id"`
+		Journaled    bool   `json:"journaled"`
+		ReplyEventID string `json:"reply_event_id"`
+		ReplyStatus  string `json:"reply_status"`
 	}
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&response))
 	assert.Empty(t, response.JournalID)
 	assert.False(t, response.Journaled)
+	assert.NotEmpty(t, response.ReplyEventID)
+	assert.Equal(t, "queued", response.ReplyStatus)
+
+	replyStatusRequest := func(caller, eventID string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/v1/messages/replies/"+eventID+"/status", nil)
+		rr := httptest.NewRecorder()
+		messageRouterAs(s, caller, true).ServeHTTP(rr, req)
+		return rr
+	}
+	ownedStatus := replyStatusRequest(recipient, response.ReplyEventID)
+	require.Equal(t, http.StatusOK, ownedStatus.Code, ownedStatus.Body.String())
+	assert.Contains(t, ownedStatus.Body.String(), `"reply_status":"queued"`)
+	assert.NotContains(t, ownedStatus.Body.String(), "foreign result must stay transient")
+	assert.NotContains(t, ownedStatus.Body.String(), `"workflow_status"`)
+
+	absentStatus := replyStatusRequest(foreignAgent, "missing-reply-event")
+	foreignStatus := replyStatusRequest(foreignAgent, response.ReplyEventID)
+	require.Equal(t, http.StatusNotFound, foreignStatus.Code)
+	assert.Equal(t, absentStatus.Body.String(), foreignStatus.Body.String(),
+		"unrelated callers must not learn whether a reply event exists")
 
 	stats, err := memStore.GetStats(ctx)
 	require.NoError(t, err)

--- a/api/rest/server.go
+++ b/api/rest/server.go
@@ -836,6 +836,7 @@ func (s *Server) setupRouter() chi.Router {
 			r.Put("/v1/messages/{message_id}/read", s.handleMessageRead)
 			r.Put("/v1/messages/read-batch", s.handleMessageReadBatch)
 			r.Get("/v1/messages/{message_id}/status", s.handleMessageStatus)
+			r.Get("/v1/messages/replies/{reply_event_id}/status", s.handleMessageReplyStatus)
 			r.Post("/v1/pipe/resolve", s.handlePipeResolve)
 			r.Post("/v1/pipe/send", s.handlePipeSend)
 			r.Get("/v1/pipe/inbox", s.handlePipeInbox)

--- a/cmd/sage-gui/upgrade.go
+++ b/cmd/sage-gui/upgrade.go
@@ -66,6 +66,8 @@ func runUpgrade(args []string) error {
 		return runUpgradeStatus(args[1:])
 	case "preflight":
 		return runUpgradePreflight(args[1:])
+	case "lineage":
+		return runUpgradeLineage(args[1:])
 	case "help", "--help", "-h":
 		printUpgradeUsage()
 		return nil
@@ -93,6 +95,10 @@ Subcommands:
   preflight                    Read-only pre-upgrade check on a STOPPED node: verifies the
                                app-v22/app-v23 predecessor-ladder invariant and previews the
                                app-v23 Root election. Run this before adopting a new binary.
+  lineage status --json        Live, read-only persisted lineage inventory
+  lineage doctor --json        At app-v21, diagnose MISSING canonical records and optionally
+                               emit a repair manifest; take a stopped-node backup first
+  lineage verify --manifest F  Independently verify exact claims on each validator before voting
   propose --target <N>         Propose activation of app-v<N> (must be current+1)
 
 propose flags:
@@ -113,11 +119,17 @@ propose flags:
                     blocks, so on a quiescent node the plan's activation height
                     never arrives by itself (issue #41); a v10.5.2+ node pumps a
                     pending plan forward on its own, --wait does it interactively.
+  --lineage-repair <file>
+                    App-v22 only. Bind the exact doctor-emitted repair manifest
+                    into the ordinary quorum-approved upgrade proposal.
 
 The proposal is signed with the configured operator key before app-v23, and with the
 current CEREBRUM Root credential at app-v23+ (or the explicit --agent-key file). It is
 routed through the 2/3 governance quorum; validators auto-vote ACCEPT if they support
-the target. Run this on the node host where the key lives.
+the target. Lineage-repair proposals are the exception: automatic voting is disabled
+and every validator must independently review and explicitly vote. Run this on the
+node host where the key lives. A present-but-invalid canonical lineage record is
+never overwritten by repair; restore a complete backup from before that record.
 
 Past app-v8 the proposer must be a chain-admin agent: the signing key's agent ID must
 hold Role==admin in the on-chain registry. On a standard node that is usually your
@@ -184,6 +196,7 @@ func runUpgradePropose(args []string) error {
 	rpc := fs.String("rpc", defaultCometRPC(), "CometBFT RPC endpoint")
 	yes := fs.Bool("yes", false, "skip the confirmation prompt")
 	wait := fs.Bool("wait", false, "after the propose lands, heartbeat a quiescent chain until the fork activates (at app-v12+ an idle chain mints no blocks, so the activation height never arrives by itself)")
+	lineageRepairPath := fs.String("lineage-repair", "", "app-v22-only repair manifest emitted by upgrade lineage doctor")
 	agentKeyPath := fs.String("agent-key", "", "explicit signing-key override (an agent.key seed or a CometBFT priv_validator_key.json); app-v23+ otherwise resolves the current local CEREBRUM Root credential")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -211,6 +224,20 @@ func runUpgradePropose(args []string) error {
 	if err != nil {
 		return err
 	}
+	lineageRepair := ""
+	if *lineageRepairPath != "" {
+		if current != 21 || *target != 22 {
+			return fmt.Errorf("--lineage-repair is admitted only for the app-v21 to app-v22 proposal")
+		}
+		raw, readErr := os.ReadFile(*lineageRepairPath) //nolint:gosec // explicit operator path
+		if readErr != nil {
+			return fmt.Errorf("read --lineage-repair: %w", readErr)
+		}
+		lineageRepair, err = sageabci.CanonicalizeLegacyLineageRepair(raw)
+		if err != nil {
+			return fmt.Errorf("validate --lineage-repair: %w", err)
+		}
+	}
 
 	canonical, err := validateUpgradeTarget(current, *target, sageabci.MaxSupportedAppVersion(), *name)
 	if err != nil {
@@ -229,7 +256,12 @@ func runUpgradePropose(args []string) error {
 	// Confirm — this is a consensus action routed through the 2/3 quorum.
 	if !*yes {
 		fmt.Printf("Propose activation of %s (app version %d) on the chain at app-v%d?\n", canonical, *target, current)
-		fmt.Println("  • Routed through the 2/3 governance quorum; validators auto-vote ACCEPT if they support the target.")
+		if lineageRepair != "" {
+			fmt.Println("  • Routed through the 2/3 governance quorum; automatic voting is DISABLED for lineage repair.")
+			fmt.Println("  • Every validator must independently compare the manifest and cast an explicit vote.")
+		} else {
+			fmt.Println("  • Routed through the 2/3 governance quorum; validators auto-vote ACCEPT if they support the target.")
+		}
 		if current >= 8 {
 			fmt.Println("  • Post-app-v8: the proposer must be a chain-admin agent, else rejected at block execution (code 47).")
 		}
@@ -253,6 +285,12 @@ func runUpgradePropose(args []string) error {
 	ptx, err := buildUpgradeProposeTx(cfg, *target)
 	if err != nil {
 		return fmt.Errorf("build upgrade propose tx: %w", err)
+	}
+	if lineageRepair != "" {
+		ptx.UpgradePropose.LineageRepair = lineageRepair
+		if signErr := tx.SignTx(ptx, key); signErr != nil {
+			return fmt.Errorf("sign lineage-bound upgrade proposal: %w", signErr)
+		}
 	}
 	encoded, err := tx.EncodeTx(ptx)
 	if err != nil {
@@ -291,7 +329,7 @@ func runUpgradePropose(args []string) error {
 		// there's no fresh height/hash to print — go straight to the standard
 		// accepted guidance.
 		fmt.Printf("✓ Proposed %s (target app version %d) — the plan is pending (the first broadcast landed despite the RPC error).\n", canonical, *target)
-		printProposeAcceptedGuidance(*target)
+		printProposeAcceptedGuidance(*target, lineageRepair != "")
 		return finishProposeActivation(cfg, current, *wait)
 	}
 	if res.CheckTxCode != 0 {
@@ -324,7 +362,7 @@ func runUpgradePropose(args []string) error {
 
 	fmt.Printf("✓ Proposed %s (target app version %d) — accepted at height %d.\n", canonical, *target, res.Height)
 	fmt.Printf("  tx hash: %s\n", res.Hash)
-	printProposeAcceptedGuidance(*target)
+	printProposeAcceptedGuidance(*target, lineageRepair != "")
 	return finishProposeActivation(cfg, current, *wait)
 }
 
@@ -365,8 +403,15 @@ func finishProposeActivation(cfg upgradeWatchdogConfig, current uint64, wait boo
 // printProposeAcceptedGuidance prints the post-acceptance operator guidance
 // shared by the clean-commit path and the landed-despite-broadcast-error path:
 // how to track activation, and the next rung of the fork ladder.
-func printProposeAcceptedGuidance(target uint64) {
-	fmt.Println("  Routed to the governance quorum — validators will auto-vote ACCEPT. Track activation with:")
+func printProposeAcceptedGuidance(target uint64, lineageRepair bool) {
+	if lineageRepair {
+		fmt.Println("  Routed to the governance quorum — automatic voting is disabled for lineage repair.")
+		fmt.Println("  Every validator must independently review the manifest and explicitly vote ACCEPT or REJECT.")
+		fmt.Println("  Use CEREBRUM Governance, sage_gov_status + sage_gov_vote, or POST /v1/governance/vote.")
+		fmt.Println("  Track activation with:")
+	} else {
+		fmt.Println("  Routed to the governance quorum — validators will auto-vote ACCEPT. Track activation with:")
+	}
 	fmt.Println("    sage-gui upgrade status")
 	if target < sageabci.MaxSupportedAppVersion() {
 		fmt.Printf("  After it activates, propose the next fork: sage-gui upgrade propose --target %d\n", target+1)

--- a/cmd/sage-gui/upgrade_lineage.go
+++ b/cmd/sage-gui/upgrade_lineage.go
@@ -1,0 +1,504 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	sageabci "github.com/l33tdawg/sage/internal/abci"
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+type upgradeLineageRPCStatus struct {
+	Schema             string `json:"schema"`
+	CurrentAppVersion  uint64 `json:"current_app_version"`
+	PersistedHeight    int64  `json:"persisted_height"`
+	GovernanceDomain   string `json:"governance_domain"`
+	ValidLineageDigest string `json:"valid_lineage_digest"`
+	RepairAudit        any    `json:"repair_audit,omitempty"`
+	Rungs              []struct {
+		Version       uint64 `json:"version"`
+		Name          string `json:"name"`
+		Present       bool   `json:"present"`
+		AppliedHeight int64  `json:"applied_height,omitempty"`
+		Valid         bool   `json:"valid"`
+		Problem       string `json:"problem,omitempty"`
+	} `json:"rungs"`
+}
+
+type lineageDoctorOutput struct {
+	Status             upgradeLineageRPCStatus `json:"status"`
+	Repairable         bool                    `json:"repairable"`
+	ManualVoteRequired bool                    `json:"manual_vote_required"`
+	ManifestDigest     string                  `json:"manifest_digest,omitempty"`
+	Diagnostics        []string                `json:"diagnostics"`
+	ReviewSteps        []string                `json:"review_steps,omitempty"`
+	Manifest           json.RawMessage         `json:"manifest,omitempty"`
+}
+
+type lineageVerifyOutput struct {
+	Valid           bool                             `json:"valid"`
+	HistoryVerified bool                             `json:"history_verified"`
+	EligibleForVote bool                             `json:"eligible_for_manual_vote"`
+	ManifestDigest  string                           `json:"manifest_digest"`
+	EvidenceSource  string                           `json:"evidence_source,omitempty"`
+	Claims          []sageabci.LegacyLineageEvidence `json:"claims"`
+	Diagnostics     []string                         `json:"diagnostics"`
+}
+
+func runUpgradeLineage(args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: sage-gui upgrade lineage status|doctor --json")
+	}
+	switch args[0] {
+	case "status":
+		return runUpgradeLineageStatus(args[1:])
+	case "doctor":
+		return runUpgradeLineageDoctor(args[1:])
+	case "verify":
+		return runUpgradeLineageVerify(args[1:])
+	default:
+		return fmt.Errorf("unknown upgrade lineage subcommand %q", args[0])
+	}
+}
+
+func runUpgradeLineageVerify(args []string) error {
+	fs := flag.NewFlagSet("upgrade lineage verify", flag.ContinueOnError)
+	rpc := fs.String("rpc", defaultCometRPC(), "CometBFT RPC endpoint")
+	manifestPath := fs.String("manifest", "", "canonical lineage repair manifest to verify")
+	jsonOut := fs.Bool("json", false, "emit machine-readable JSON")
+	ackAnchor := fs.Bool("acknowledge-unverified-anchor", false, "explicitly accept that anchor claims cannot be checked against retained history")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *manifestPath == "" {
+		return errors.New("--manifest is required")
+	}
+	raw, err := os.ReadFile(*manifestPath) //nolint:gosec // explicit operator path
+	if err != nil {
+		return err
+	}
+	canonical, err := sageabci.CanonicalizeLegacyLineageRepair(raw)
+	if err != nil {
+		return err
+	}
+	var manifest sageabci.LegacyLineageRepairManifest
+	if err := json.Unmarshal([]byte(canonical), &manifest); err != nil {
+		return err
+	}
+	digest := sha256.Sum256([]byte(canonical))
+	out := lineageVerifyOutput{ManifestDigest: hex.EncodeToString(digest[:]), Claims: manifest.Evidence}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	status, statusErr := readUpgradeLineageStatus(ctx, *rpc)
+	chainID, chainErr := readCometChainID(ctx, *rpc)
+	if statusErr != nil {
+		out.Diagnostics = append(out.Diagnostics, "read local lineage status: "+statusErr.Error())
+	}
+	if chainErr != nil {
+		out.Diagnostics = append(out.Diagnostics, "read local chain ID: "+chainErr.Error())
+	}
+	if statusErr == nil && chainErr == nil {
+		if manifest.Schema != status.Schema || manifest.ChainID != chainID ||
+			manifest.GovernanceDomain != status.GovernanceDomain || manifest.CurrentAppVersion != 21 ||
+			status.CurrentAppVersion != 21 || manifest.PriorLineageDigest != status.ValidLineageDigest {
+			out.Diagnostics = append(out.Diagnostics, "manifest chain, app version, governance domain, or prior-lineage digest does not match this validator")
+		} else {
+			missing := make(map[uint64]bool)
+			for _, rung := range status.Rungs {
+				if rung.Present && !rung.Valid {
+					out.Diagnostics = append(out.Diagnostics, rung.Name+" is present but invalid; create-only repair is forbidden")
+				}
+				if !rung.Present {
+					missing[rung.Version] = true
+				}
+			}
+			if len(manifest.Evidence) != len(missing) {
+				out.Diagnostics = append(out.Diagnostics, "manifest evidence does not equal the exact current missing-rung set")
+			} else if len(manifest.Evidence) == 0 {
+				out.Diagnostics = append(out.Diagnostics, "manifest contains no missing-rung claims")
+			} else {
+				source := manifest.Evidence[0].Source
+				out.EvidenceSource = source
+				claimsOK := true
+				seen := make(map[uint64]bool, len(manifest.Evidence))
+				for _, claim := range manifest.Evidence {
+					if !missing[claim.Version] || claim.Name != tx.CanonicalUpgradeName(claim.Version) ||
+						claim.AppliedHeight <= 0 || claim.AppliedHeight > status.PersistedHeight || claim.Source != source || seen[claim.Version] {
+						claimsOK = false
+						break
+					}
+					seen[claim.Version] = true
+				}
+				if !claimsOK {
+					out.Diagnostics = append(out.Diagnostics, "manifest contains mixed, future-height, duplicate, or non-missing claims")
+				} else if source == "comet-block-results" {
+					out.HistoryVerified = true
+					for _, claim := range manifest.Evidence {
+						version, versionErr := readBlockResultAppVersion(ctx, *rpc, claim.AppliedHeight)
+						hash, hashErr := readBlockHash(ctx, *rpc, claim.AppliedHeight)
+						if versionErr != nil || hashErr != nil || version != claim.Version || hash != claim.BlockHash {
+							out.HistoryVerified = false
+							out.Diagnostics = append(out.Diagnostics, fmt.Sprintf("app-v%d claim does not match this validator's retained block_results and block hash at height %d", claim.Version, claim.AppliedHeight))
+						}
+					}
+					out.Valid = out.HistoryVerified
+					out.EligibleForVote = out.Valid
+				} else if source == "legacy-anchor" {
+					anchorBytes, anchorErr := hex.DecodeString(manifest.AnchorDigest)
+					canonicalAnchor := anchorErr == nil && len(anchorBytes) == sha256.Size && hex.EncodeToString(anchorBytes) == manifest.AnchorDigest
+					if !canonicalAnchor {
+						out.Diagnostics = append(out.Diagnostics, "legacy-anchor manifest has no canonical anchor_digest")
+					} else if manifest.AnchorAttestation != "operator-quorum-attested-unverified-history" || !*ackAnchor {
+						out.Diagnostics = append(out.Diagnostics, "legacy-anchor claims are unverified history and require --acknowledge-unverified-anchor before an operator vote")
+					} else {
+						out.Valid, out.EligibleForVote = true, true
+						out.Diagnostics = append(out.Diagnostics, "anchor heights are operator claims, not locally history-verified facts; the explicit vote attests these exact claims")
+					}
+				} else {
+					out.Diagnostics = append(out.Diagnostics, "unsupported or mixed evidence source")
+				}
+			}
+		}
+	}
+	if *jsonOut {
+		if err := writeJSONStdout(out); err != nil {
+			return err
+		}
+	} else {
+		for _, diagnostic := range out.Diagnostics {
+			fmt.Println(diagnostic)
+		}
+	}
+	if !out.EligibleForVote {
+		return errors.New("lineage manifest is not eligible for this validator's manual vote")
+	}
+	return nil
+}
+
+func runUpgradeLineageStatus(args []string) error {
+	fs := flag.NewFlagSet("upgrade lineage status", flag.ContinueOnError)
+	rpc := fs.String("rpc", defaultCometRPC(), "CometBFT RPC endpoint")
+	jsonOut := fs.Bool("json", false, "emit machine-readable JSON")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	status, err := readUpgradeLineageStatus(ctx, *rpc)
+	if err != nil {
+		return err
+	}
+	if *jsonOut {
+		return writeJSONStdout(status)
+	}
+	fmt.Printf("Upgrade lineage: app-v%d at height %d\n", status.CurrentAppVersion, status.PersistedHeight)
+	for _, rung := range status.Rungs {
+		state := "missing"
+		if rung.Valid {
+			state = fmt.Sprintf("height %d", rung.AppliedHeight)
+		} else if rung.Present {
+			state = "INVALID: " + rung.Problem
+		}
+		fmt.Printf("  app-v%-2d %s\n", rung.Version, state)
+	}
+	return nil
+}
+
+func runUpgradeLineageDoctor(args []string) error {
+	fs := flag.NewFlagSet("upgrade lineage doctor", flag.ContinueOnError)
+	rpc := fs.String("rpc", defaultCometRPC(), "CometBFT RPC endpoint")
+	jsonOut := fs.Bool("json", false, "emit machine-readable JSON")
+	manifestOut := fs.String("manifest-out", "", "write only the canonical repair manifest to this file")
+	legacyAnchor := fs.String("legacy-anchor", "", "audited JSON fallback containing {\"heights\":{\"7\":123,...}}")
+	ackAnchor := fs.Bool("acknowledge-unverified-anchor", false, "explicitly attest that legacy-anchor heights are not locally history-verified and require quorum review")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	status, err := readUpgradeLineageStatus(ctx, *rpc)
+	if err != nil {
+		return err
+	}
+	out := lineageDoctorOutput{Status: *status}
+	missing := make(map[uint64]struct{})
+	invalidPresent := false
+	for _, rung := range status.Rungs {
+		if rung.Present && !rung.Valid {
+			invalidPresent = true
+			out.Diagnostics = append(out.Diagnostics, fmt.Sprintf("%s exists but is invalid; repair is forbidden from overwriting it", rung.Name))
+		}
+		if !rung.Present && rung.Version <= status.CurrentAppVersion {
+			missing[rung.Version] = struct{}{}
+		}
+	}
+	if invalidPresent {
+		out.Diagnostics = append(out.Diagnostics, "lineage is not repairable while any persisted rung is present but invalid")
+		return emitLineageDoctor(out, *jsonOut, "")
+	}
+	if len(missing) == 0 {
+		out.Repairable = true
+		out.Diagnostics = append(out.Diagnostics, "no missing activated lineage records")
+		return emitLineageDoctor(out, *jsonOut, "")
+	}
+	if status.CurrentAppVersion != 21 {
+		out.Diagnostics = append(out.Diagnostics, "repair manifests are admitted only while the chain is exactly app-v21")
+		return emitLineageDoctor(out, *jsonOut, "")
+	}
+	chainID, err := readCometChainID(ctx, *rpc)
+	if err != nil {
+		return err
+	}
+	evidence, diagnostics := discoverCometLineageEvidence(ctx, *rpc, status.PersistedHeight, missing)
+	out.Diagnostics = append(out.Diagnostics, diagnostics...)
+	if len(evidence) > 0 {
+		out.Diagnostics = append(out.Diagnostics,
+			"comet-block-results entries and block hashes are evidence from this validator's retained local archive; consensus does not independently verify those hashes")
+	}
+
+	anchorDigest := ""
+	if len(evidence) < len(missing) && *legacyAnchor != "" {
+		if !*ackAnchor {
+			out.Diagnostics = append(out.Diagnostics, "legacy-anchor fallback requires --acknowledge-unverified-anchor because its heights cannot be verified from retained local history")
+			return emitLineageDoctor(out, *jsonOut, "")
+		}
+		raw, readErr := os.ReadFile(*legacyAnchor) //nolint:gosec // explicit operator audit file
+		if readErr != nil {
+			return readErr
+		}
+		var anchor struct {
+			Heights map[string]int64 `json:"heights"`
+		}
+		decoder := json.NewDecoder(strings.NewReader(string(raw)))
+		decoder.DisallowUnknownFields()
+		if decodeErr := decoder.Decode(&anchor); decodeErr != nil {
+			return fmt.Errorf("decode legacy anchor: %w", decodeErr)
+		}
+		canonical, _ := json.Marshal(anchor)
+		digest := sha256.Sum256(canonical)
+		anchorDigest = hex.EncodeToString(digest[:])
+		// Never blend two trust models in one manifest. When retained Comet
+		// history is incomplete, the explicit legacy anchor must attest every
+		// missing rung and replaces the partial local-history set wholesale.
+		evidence = evidence[:0]
+		for version := range missing {
+			height := anchor.Heights[strconv.FormatUint(version, 10)]
+			if height > 0 {
+				evidence = append(evidence, sageabci.LegacyLineageEvidence{Version: version, Name: tx.CanonicalUpgradeName(version), AppliedHeight: height, Source: "legacy-anchor"})
+			}
+		}
+	}
+	if len(evidence) != len(missing) {
+		out.Diagnostics = append(out.Diagnostics, "retained Comet evidence is incomplete; provide --legacy-anchor only after an independent audit")
+		return emitLineageDoctor(out, *jsonOut, "")
+	}
+	sort.Slice(evidence, func(i, j int) bool { return evidence[i].Version < evidence[j].Version })
+	if evidenceErr := validateDoctorLineageEvidence(status, evidence); evidenceErr != nil {
+		out.Diagnostics = append(out.Diagnostics, evidenceErr.Error())
+		return emitLineageDoctor(out, *jsonOut, "")
+	}
+	manifest := sageabci.LegacyLineageRepairManifest{Schema: status.Schema, ChainID: chainID, GovernanceDomain: status.GovernanceDomain, CurrentAppVersion: 21, PriorLineageDigest: status.ValidLineageDigest, AnchorDigest: anchorDigest, Evidence: evidence}
+	if anchorDigest != "" {
+		manifest.AnchorAttestation = "operator-quorum-attested-unverified-history"
+		out.Diagnostics = append(out.Diagnostics, "legacy-anchor claims are quorum-attested operator assertions and are not verified by retained local history")
+	}
+	manifestBytes, _ := json.Marshal(manifest)
+	canonical, err := sageabci.CanonicalizeLegacyLineageRepair(manifestBytes)
+	if err != nil {
+		return err
+	}
+	out.Repairable = true
+	out.ManualVoteRequired = true
+	out.Manifest = json.RawMessage(canonical)
+	manifestDigest := sha256.Sum256([]byte(canonical))
+	out.ManifestDigest = hex.EncodeToString(manifestDigest[:])
+	out.ReviewSteps = []string{
+		"create the candidate manifest with upgrade lineage doctor on the proposing validator",
+		"run upgrade lineage verify with that exact manifest independently on every validator and compare manifest_digest before proposing",
+		"after proposing, inspect the active proposal with sage_gov_status and cast an explicit sage_gov_vote on every validator; automatic voting is disabled, including on one-validator chains",
+	}
+	if *manifestOut != "" {
+		if err := os.WriteFile(*manifestOut, append([]byte(canonical), '\n'), 0o600); err != nil {
+			return fmt.Errorf("write manifest: %w", err)
+		}
+	}
+	return emitLineageDoctor(out, *jsonOut, canonical)
+}
+
+func validateDoctorLineageEvidence(status *upgradeLineageRPCStatus, evidence []sageabci.LegacyLineageEvidence) error {
+	proposed := make(map[uint64]int64, len(evidence))
+	for _, claim := range evidence {
+		if _, duplicate := proposed[claim.Version]; duplicate {
+			return fmt.Errorf("duplicate app-v%d repair claim", claim.Version)
+		}
+		proposed[claim.Version] = claim.AppliedHeight
+	}
+	var previous int64
+	for _, rung := range status.Rungs {
+		height := rung.AppliedHeight
+		if !rung.Present {
+			height = proposed[rung.Version]
+		}
+		if height <= previous || height > status.PersistedHeight {
+			return fmt.Errorf("app-v%d claimed height %d is not a retained, strictly ordered committed height", rung.Version, height)
+		}
+		previous = height
+	}
+	return nil
+}
+
+func emitLineageDoctor(out lineageDoctorOutput, jsonOut bool, canonical string) error {
+	if jsonOut {
+		return writeJSONStdout(out)
+	}
+	for _, line := range out.Diagnostics {
+		fmt.Println(line)
+	}
+	if canonical != "" {
+		fmt.Printf("Repair manifest digest: %s\n", out.ManifestDigest)
+		fmt.Println("Repair manifest is ready; propose it explicitly with --lineage-repair.")
+		fmt.Println("Automatic voting is disabled. Every validator must independently review and explicitly vote.")
+	}
+	return nil
+}
+
+func writeJSONStdout(value any) error {
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err == nil {
+		fmt.Println(string(encoded))
+	}
+	return err
+}
+
+func readUpgradeLineageStatus(ctx context.Context, rpc string) (*upgradeLineageRPCStatus, error) {
+	raw, err := readABCIQueryValue(ctx, rpc, "/upgrade/lineage")
+	if err != nil {
+		return nil, err
+	}
+	var status upgradeLineageRPCStatus
+	if err := json.Unmarshal(raw, &status); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
+func readABCIQueryValue(ctx context.Context, rpc, path string) ([]byte, error) {
+	queryURL := strings.TrimRight(rpc, "/") + "/abci_query?path=" + url.QueryEscape(strconv.Quote(path))
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, queryURL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Result struct {
+			Response struct {
+				Code  uint32 `json:"code"`
+				Log   string `json:"log"`
+				Value string `json:"value"`
+			} `json:"response"`
+		} `json:"result"`
+		Error any `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	if out.Error != nil || out.Result.Response.Code != 0 {
+		return nil, fmt.Errorf("ABCI lineage query rejected: %s", out.Result.Response.Log)
+	}
+	return base64.StdEncoding.DecodeString(out.Result.Response.Value)
+}
+
+func discoverCometLineageEvidence(ctx context.Context, rpc string, maxHeight int64, missing map[uint64]struct{}) ([]sageabci.LegacyLineageEvidence, []string) {
+	found := make(map[uint64]sageabci.LegacyLineageEvidence)
+	diagnostics := []string{}
+	for height := int64(1); height <= maxHeight && len(found) < len(missing); height++ {
+		version, err := readBlockResultAppVersion(ctx, rpc, height)
+		if err != nil {
+			diagnostics = append(diagnostics, fmt.Sprintf("retained block-results unavailable at height %d: %v", height, err))
+			break
+		}
+		if _, wanted := missing[version]; !wanted {
+			continue
+		}
+		hash, err := readBlockHash(ctx, rpc, height)
+		if err != nil {
+			diagnostics = append(diagnostics, fmt.Sprintf("block hash unavailable at height %d: %v", height, err))
+			continue
+		}
+		found[version] = sageabci.LegacyLineageEvidence{Version: version, Name: tx.CanonicalUpgradeName(version), AppliedHeight: height, Source: "comet-block-results", BlockHash: strings.ToLower(hash)}
+	}
+	result := make([]sageabci.LegacyLineageEvidence, 0, len(found))
+	for _, evidence := range found {
+		result = append(result, evidence)
+	}
+	return result, diagnostics
+}
+
+func readBlockResultAppVersion(ctx context.Context, rpc string, height int64) (uint64, error) {
+	u := fmt.Sprintf("%s/block_results?height=%d", strings.TrimRight(rpc, "/"), height)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Result struct {
+			Updates struct {
+				Version struct {
+					App string `json:"app"`
+				} `json:"version"`
+			} `json:"consensus_param_updates"`
+		} `json:"result"`
+		Error any `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return 0, err
+	}
+	if out.Error != nil {
+		return 0, errors.New("RPC error")
+	}
+	if out.Result.Updates.Version.App == "" {
+		return 0, nil
+	}
+	return strconv.ParseUint(out.Result.Updates.Version.App, 10, 64)
+}
+
+func readBlockHash(ctx context.Context, rpc string, height int64) (string, error) {
+	u := fmt.Sprintf("%s/block?height=%d", strings.TrimRight(rpc, "/"), height)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Result struct {
+			BlockID struct {
+				Hash string `json:"hash"`
+			} `json:"block_id"`
+		} `json:"result"`
+	}
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&out); decodeErr != nil {
+		return "", decodeErr
+	}
+	decoded, err := hex.DecodeString(strings.ToLower(out.Result.BlockID.Hash))
+	if err != nil || len(decoded) != sha256.Size {
+		return "", errors.New("invalid block hash")
+	}
+	return strings.ToLower(out.Result.BlockID.Hash), nil
+}

--- a/cmd/sage-gui/upgrade_lineage_test.go
+++ b/cmd/sage-gui/upgrade_lineage_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sageabci "github.com/l33tdawg/sage/internal/abci"
+)
+
+func captureLineageStdout(t *testing.T, run func() error) string {
+	t.Helper()
+	read, write, err := os.Pipe()
+	require.NoError(t, err)
+	original := os.Stdout
+	os.Stdout = write
+	err = run()
+	os.Stdout = original
+	require.NoError(t, write.Close())
+	require.NoError(t, err)
+	out, err := io.ReadAll(read)
+	require.NoError(t, err)
+	require.NoError(t, read.Close())
+	return string(out)
+}
+
+func TestUpgradeLineageDoctorEmitsBoundManifestAndManualVoteContract(t *testing.T) {
+	status := upgradeLineageRPCStatus{
+		Schema: "sage-upgrade-lineage-repair/v1", CurrentAppVersion: 21,
+		PersistedHeight: 20, GovernanceDomain: strings.Repeat("a", 64),
+		ValidLineageDigest: strings.Repeat("b", 64),
+	}
+	for version := uint64(6); version <= 21; version++ {
+		rung := struct {
+			Version       uint64 `json:"version"`
+			Name          string `json:"name"`
+			Present       bool   `json:"present"`
+			AppliedHeight int64  `json:"applied_height,omitempty"`
+			Valid         bool   `json:"valid"`
+			Problem       string `json:"problem,omitempty"`
+		}{Version: version, Name: "app-v" + strconv.FormatUint(version, 10)}
+		if version != 9 {
+			rung.Present, rung.Valid = true, true
+			if version < 9 {
+				rung.AppliedHeight = int64(version - 5)
+			} else {
+				rung.AppliedHeight = int64(version - 4)
+			}
+		} else {
+			rung.Problem = "missing"
+		}
+		status.Rungs = append(status.Rungs, rung)
+	}
+	statusJSON, err := json.Marshal(status)
+	require.NoError(t, err)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/abci_query", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": map[string]any{"response": map[string]any{
+			"code": 0, "value": base64.StdEncoding.EncodeToString(statusJSON),
+		}}})
+	})
+	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": map[string]any{"node_info": map[string]any{"network": "lineage-chain"}}})
+	})
+	mux.HandleFunc("/block_results", func(w http.ResponseWriter, r *http.Request) {
+		appVersion := ""
+		if r.URL.Query().Get("height") == "4" {
+			appVersion = "9"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": map[string]any{"consensus_param_updates": map[string]any{"version": map[string]any{"app": appVersion}}}})
+	})
+	mux.HandleFunc("/block", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": map[string]any{"block_id": map[string]any{"hash": strings.Repeat("AB", 32)}}})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	manifestPath := filepath.Join(t.TempDir(), "repair.json")
+	output := captureLineageStdout(t, func() error {
+		return runUpgradeLineageDoctor([]string{"--rpc", server.URL, "--json", "--manifest-out", manifestPath})
+	})
+	var doctor lineageDoctorOutput
+	require.NoError(t, json.Unmarshal([]byte(output), &doctor))
+	require.True(t, doctor.Repairable)
+	require.True(t, doctor.ManualVoteRequired)
+	require.Len(t, doctor.ManifestDigest, 64)
+	require.Contains(t, strings.Join(doctor.Diagnostics, "\n"), "consensus does not independently verify")
+	require.Contains(t, strings.Join(doctor.ReviewSteps, "\n"), "explicit sage_gov_vote")
+	require.JSONEq(t, string(doctor.Manifest), string(requireReadFile(t, manifestPath)))
+	verifyOutput := captureLineageStdout(t, func() error {
+		return runUpgradeLineageVerify([]string{"--rpc", server.URL, "--json", "--manifest", manifestPath})
+	})
+	var verified lineageVerifyOutput
+	require.NoError(t, json.Unmarshal([]byte(verifyOutput), &verified))
+	require.True(t, verified.Valid)
+	require.True(t, verified.HistoryVerified)
+	require.True(t, verified.EligibleForVote)
+	require.Equal(t, doctor.ManifestDigest, verified.ManifestDigest)
+}
+
+func TestUpgradeLineageDoctorRefusesPresentInvalidRung(t *testing.T) {
+	status := upgradeLineageRPCStatus{
+		Schema: "sage-upgrade-lineage-repair/v1", CurrentAppVersion: 21, PersistedHeight: 20,
+		Rungs: []struct {
+			Version       uint64 `json:"version"`
+			Name          string `json:"name"`
+			Present       bool   `json:"present"`
+			AppliedHeight int64  `json:"applied_height,omitempty"`
+			Valid         bool   `json:"valid"`
+			Problem       string `json:"problem,omitempty"`
+		}{
+			{Version: 8, Name: "app-v8", Present: true, AppliedHeight: 99, Valid: false, Problem: "invalid order"},
+			{Version: 9, Name: "app-v9", Present: false, Problem: "missing"},
+		},
+	}
+	raw, err := json.Marshal(status)
+	require.NoError(t, err)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": map[string]any{"response": map[string]any{
+			"code": 0, "value": base64.StdEncoding.EncodeToString(raw),
+		}}})
+	}))
+	defer server.Close()
+	output := captureLineageStdout(t, func() error {
+		return runUpgradeLineageDoctor([]string{"--rpc", server.URL, "--json"})
+	})
+	var doctor lineageDoctorOutput
+	require.NoError(t, json.Unmarshal([]byte(output), &doctor))
+	require.False(t, doctor.Repairable)
+	require.Empty(t, doctor.Manifest)
+	require.Contains(t, strings.Join(doctor.Diagnostics, "\n"), "not repairable")
+}
+
+func TestUpgradeLineageDoctorAnchorFallbackIsAllOrNothingAndAcknowledged(t *testing.T) {
+	status := upgradeLineageRPCStatus{
+		Schema: "sage-upgrade-lineage-repair/v1", CurrentAppVersion: 21, PersistedHeight: 10,
+		GovernanceDomain: strings.Repeat("a", 64), ValidLineageDigest: strings.Repeat("b", 64),
+		Rungs: []struct {
+			Version       uint64 `json:"version"`
+			Name          string `json:"name"`
+			Present       bool   `json:"present"`
+			AppliedHeight int64  `json:"applied_height,omitempty"`
+			Valid         bool   `json:"valid"`
+			Problem       string `json:"problem,omitempty"`
+		}{
+			{Version: 8, Name: "app-v8", Present: true, AppliedHeight: 1, Valid: true},
+			{Version: 9, Name: "app-v9", Problem: "missing"},
+			{Version: 10, Name: "app-v10", Problem: "missing"},
+			{Version: 11, Name: "app-v11", Present: true, AppliedHeight: 4, Valid: true},
+		},
+	}
+	statusJSON, err := json.Marshal(status)
+	require.NoError(t, err)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/abci_query", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": map[string]any{"response": map[string]any{"code": 0, "value": base64.StdEncoding.EncodeToString(statusJSON)}}})
+	})
+	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": map[string]any{"node_info": map[string]any{"network": "lineage-chain"}}})
+	})
+	mux.HandleFunc("/block_results", func(w http.ResponseWriter, r *http.Request) {
+		version := ""
+		if r.URL.Query().Get("height") == "2" {
+			version = "9"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": map[string]any{"consensus_param_updates": map[string]any{"version": map[string]any{"app": version}}}})
+	})
+	mux.HandleFunc("/block", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": map[string]any{"block_id": map[string]any{"hash": strings.Repeat("CD", 32)}}})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	anchorPath := filepath.Join(t.TempDir(), "anchor.json")
+	require.NoError(t, os.WriteFile(anchorPath, []byte(`{"heights":{"9":2,"10":3}}`), 0o600))
+
+	withoutAck := captureLineageStdout(t, func() error {
+		return runUpgradeLineageDoctor([]string{"--rpc", server.URL, "--json", "--legacy-anchor", anchorPath})
+	})
+	var refused lineageDoctorOutput
+	require.NoError(t, json.Unmarshal([]byte(withoutAck), &refused))
+	require.False(t, refused.Repairable)
+	require.Contains(t, strings.Join(refused.Diagnostics, "\n"), "requires --acknowledge-unverified-anchor")
+
+	withAck := captureLineageStdout(t, func() error {
+		return runUpgradeLineageDoctor([]string{"--rpc", server.URL, "--json", "--legacy-anchor", anchorPath, "--acknowledge-unverified-anchor"})
+	})
+	var accepted lineageDoctorOutput
+	require.NoError(t, json.Unmarshal([]byte(withAck), &accepted))
+	require.True(t, accepted.Repairable)
+	var manifest struct {
+		AnchorAttestation string                           `json:"anchor_attestation"`
+		Evidence          []sageabci.LegacyLineageEvidence `json:"evidence"`
+	}
+	require.NoError(t, json.Unmarshal(accepted.Manifest, &manifest))
+	require.Equal(t, "operator-quorum-attested-unverified-history", manifest.AnchorAttestation)
+	require.Len(t, manifest.Evidence, 2)
+	for _, claim := range manifest.Evidence {
+		require.Equal(t, "legacy-anchor", claim.Source, "partial Comet history must never be blended into an anchor manifest")
+		require.Empty(t, claim.BlockHash)
+	}
+}
+
+func TestValidateDoctorLineageEvidenceRejectsFutureAnchorHeight(t *testing.T) {
+	status := &upgradeLineageRPCStatus{PersistedHeight: 10}
+	status.Rungs = append(status.Rungs, struct {
+		Version       uint64 `json:"version"`
+		Name          string `json:"name"`
+		Present       bool   `json:"present"`
+		AppliedHeight int64  `json:"applied_height,omitempty"`
+		Valid         bool   `json:"valid"`
+		Problem       string `json:"problem,omitempty"`
+	}{Version: 9, Name: "app-v9"})
+	err := validateDoctorLineageEvidence(status, []sageabci.LegacyLineageEvidence{{Version: 9, AppliedHeight: 11}})
+	require.ErrorContains(t, err, "not a retained")
+}
+
+func requireReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return raw
+}

--- a/cmd/sage-gui/upgrade_preflight.go
+++ b/cmd/sage-gui/upgrade_preflight.go
@@ -138,12 +138,8 @@ func runUpgradePreflight(args []string) error {
 		fmt.Printf("  %s\n", firstProblem)
 		fmt.Println("  app-v22 and app-v23 refuse to be proposed, approved, activated, or restored")
 		fmt.Println("  without complete, strictly ordered predecessor evidence. The climb will stop")
-		fmt.Println("  at app-v21 and fail closed there.")
-		fmt.Println()
-		fmt.Println("  This is not repairable by proposing again: the evidence is missing from")
-		fmt.Println("  consensus storage, and synthesized records are rejected. Restore a complete")
-		fmt.Println("  stopped-node backup taken before the gap, or open an issue with this output —")
-		fmt.Println("  do NOT delete the data directory, that discards all canonical history.")
+		fmt.Println("  safely at app-v21 and fail closed there.")
+		printLadderFailureRecovery(rungs)
 	case adminErr == nil && reached < 23 && len(admins) == 0:
 		// app-v23 elects its singleton Root from the legacy Admin roster. With
 		// an empty roster there is nobody to promote, so the activation cannot
@@ -176,6 +172,47 @@ func runUpgradePreflight(args []string) error {
 	fmt.Println()
 	fmt.Println("Full procedure: docs/UPGRADING.md")
 	return nil
+}
+
+// printLadderFailureRecovery keeps preflight's operator guidance aligned with
+// the app-v22 lineage-repair contract. Missing canonical records can be
+// reconstructed only through the bounded app-v21 doctor/verify/quorum path.
+// A record that is already present but invalid is deliberately outside that
+// path: repair may never overwrite persisted consensus evidence.
+func printLadderFailureRecovery(rungs []ladderRung) {
+	presentInvalid := false
+	missingCanonical := false
+	for _, rung := range rungs {
+		if rung.NotYet || rung.Problem == "" {
+			continue
+		}
+		if rung.Present {
+			presentInvalid = true
+		}
+		if !rung.Present && strings.HasPrefix(rung.Problem, "missing canonical applied ") {
+			missingCanonical = true
+		}
+	}
+
+	fmt.Println()
+	switch {
+	case presentInvalid:
+		fmt.Println("  At least one canonical record is present but invalid. Lineage repair is")
+		fmt.Println("  forbidden from overwriting present consensus evidence. Restore a complete")
+		fmt.Println("  stopped-node backup from before the invalid record; this is restore-only.")
+	case missingCanonical:
+		fmt.Println("  Missing canonical records are recoverable only through the explicit app-v21")
+		fmt.Println("  lineage workflow. First take and retain a complete stopped-node backup. Then,")
+		fmt.Println("  with the chain exactly at app-v21, run `sage-gui upgrade lineage doctor`, have")
+		fmt.Println("  every validator run `sage-gui upgrade lineage verify` on the exact manifest")
+		fmt.Println("  and compare manifest_digest, then use the explicit quorum proposal/vote flow.")
+		fmt.Println("  Automatic voting is disabled for lineage repair, including single-validator")
+		fmt.Println("  chains. Do not synthesize records or delete the data directory.")
+	default:
+		fmt.Println("  This evidence could not be read or validated. Do not continue the climb or")
+		fmt.Println("  mutate the data directory; retain a stopped-node backup and investigate the")
+		fmt.Println("  reported storage error before choosing any recovery path.")
+	}
 }
 
 // openConsensusStoreForInspection opens the chain database for reading.

--- a/cmd/sage-gui/upgrade_preflight_test.go
+++ b/cmd/sage-gui/upgrade_preflight_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -9,6 +11,29 @@ import (
 	"github.com/l33tdawg/sage/internal/store"
 	"github.com/l33tdawg/sage/internal/tx"
 )
+
+func capturePreflightStdout(t *testing.T, run func()) string {
+	t.Helper()
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	original := os.Stdout
+	os.Stdout = write
+	run()
+	os.Stdout = original
+	if closeErr := write.Close(); closeErr != nil {
+		t.Fatalf("close writer: %v", closeErr)
+	}
+	out, err := io.ReadAll(read)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if err := read.Close(); err != nil {
+		t.Fatalf("close reader: %v", err)
+	}
+	return string(out)
+}
 
 // newPreflightStore builds a writable Badger store for ladder fixtures.
 func newPreflightStore(t *testing.T) (*store.BadgerStore, string) {
@@ -196,6 +221,51 @@ func TestLadderVerdictSkipsNotYetRungs(t *testing.T) {
 	}
 	if ok, problem := ladderVerdict(rungs); !ok {
 		t.Fatalf("not-yet-reached rung produced a failure: %s", problem)
+	}
+}
+
+func TestPreflightMissingLineagePrintsBoundedRecoveryWorkflow(t *testing.T) {
+	out := capturePreflightStdout(t, func() {
+		printLadderFailureRecovery([]ladderRung{{
+			Version: 17,
+			Name:    "app-v17",
+			Problem: "missing canonical applied app-v17 record",
+		}})
+	})
+
+	for _, required := range []string{
+		"stopped-node backup",
+		"exactly at app-v21",
+		"upgrade lineage doctor",
+		"upgrade lineage verify",
+		"manifest_digest",
+		"explicit quorum proposal/vote",
+		"Automatic voting is disabled",
+	} {
+		if !strings.Contains(out, required) {
+			t.Fatalf("missing-lineage guidance does not contain %q:\n%s", required, out)
+		}
+	}
+	if strings.Contains(out, "restore-only") {
+		t.Fatalf("missing lineage was incorrectly described as restore-only:\n%s", out)
+	}
+}
+
+func TestPreflightPresentInvalidLineageIsRestoreOnly(t *testing.T) {
+	out := capturePreflightStdout(t, func() {
+		printLadderFailureRecovery([]ladderRung{
+			{Version: 16, Name: "app-v16", Present: true, Problem: "height 2 is not after the previous rung's height 3"},
+			{Version: 17, Name: "app-v17", Problem: "missing canonical applied app-v17 record"},
+		})
+	})
+
+	for _, required := range []string{"present but invalid", "forbidden from overwriting", "restore-only"} {
+		if !strings.Contains(out, required) {
+			t.Fatalf("invalid-lineage guidance does not contain %q:\n%s", required, out)
+		}
+	}
+	if strings.Contains(out, "upgrade lineage doctor") {
+		t.Fatalf("present-invalid lineage was incorrectly sent to doctor repair:\n%s", out)
 	}
 }
 

--- a/cmd/sage-gui/upgrade_test.go
+++ b/cmd/sage-gui/upgrade_test.go
@@ -460,6 +460,11 @@ func TestPrintUpgradeUsage_CurrentLadder(t *testing.T) {
 	if !strings.Contains(out, "ONE AT A TIME") {
 		t.Errorf("usage should state the one-at-a-time sequential rule; output:\n%s", out)
 	}
+	for _, required := range []string{"MISSING canonical records", "stopped-node backup", "present-but-invalid", "never overwritten"} {
+		if !strings.Contains(out, required) {
+			t.Errorf("usage should contain lineage recovery contract %q; output:\n%s", required, out)
+		}
+	}
 }
 
 // shrinkProposeRetryDelay makes the landed-anyway probe immediate for tests.

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.17.17-acceptance
+ARG VERSION=v11.18.0-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.17.17 federation Docker acceptance
+# v11.18.0 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third
@@ -9,7 +9,7 @@ default (`FED_NODE_A_PORT` / `FED_NODE_B_PORT` override them).
 Run the reproducible topology smoke test with:
 
 ```sh
-FED_ACCEPTANCE_STATE=/tmp/sage-v111717-fed \
+FED_ACCEPTANCE_STATE=/tmp/sage-v111800-fed \
   deploy/federation-acceptance/run.sh topology
 ```
 
@@ -30,7 +30,9 @@ diagnostic overrides:
   `p2p_peers` fixture for a paired node, restart it, and assert the peer is
   retained and upgraded to a current non-expired generation-bound route.
 - `FED_ACCEPTANCE_FLOW_COMMAND`: replace the built-in actual MCP stdio flow and
-  prove `sage_find_agent` -> `sage_message_send`; stop the recipient before
+  prove `sage_find_agent` -> direct unique registered-name `sage_message_send`,
+  canonical remote delivery, and the replier-owned immutable reply-event status;
+  then stop the recipient before
   delivery; restart it; prove `sage_inbox` persistence, read/claim,
   `sage_message_reply`, and `sage_message_status` on the sender. The send must
   omit `ttl_minutes`, wait longer than the old 60-minute default in a nightly

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -1,8 +1,8 @@
-name: sage-v111717-federation
+name: sage-v111800-federation
 
 services:
   relay:
-    image: sage-v111717-natter:local
+    image: sage-v111800-natter:local
     build:
       context: ../../natter
       dockerfile: ../deploy/federation-acceptance/Dockerfile.natter
@@ -22,12 +22,12 @@ services:
         aliases: [relay]
 
   node-a:
-    image: sage-v111717-node:local
+    image: sage-v111800-node:local
     build:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.17.17-acceptance
+        VERSION: v11.18.0-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage
@@ -44,7 +44,7 @@ services:
       control_a: {}
 
   node-b:
-    image: sage-v111717-node:local
+    image: sage-v111800-node:local
     environment:
       SAGE_HOME: /root/.sage
       SAGE_EMBEDDING_PROVIDER: hash
@@ -61,17 +61,17 @@ services:
 
 networks:
   edge_a:
-    name: sage-v111717-federation-edge-a
+    name: sage-v111800-federation-edge-a
     internal: true
   edge_b:
-    name: sage-v111717-federation-edge-b
+    name: sage-v111800-federation-edge-b
     internal: true
   lan:
-    name: sage-v111717-federation-lan
+    name: sage-v111800-federation-lan
     internal: true
   # Separate host-control bridges keep REST observable without giving the two
   # nodes a shared container network that could bypass the relay assertion.
   control_a:
-    name: sage-v111717-federation-control-a
+    name: sage-v111800-federation-control-a
   control_b:
-    name: sage-v111717-federation-control-b
+    name: sage-v111800-federation-control-b

--- a/deploy/federation-acceptance/run.sh
+++ b/deploy/federation-acceptance/run.sh
@@ -3,7 +3,7 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
 COMPOSE="$ROOT/deploy/federation-acceptance/docker-compose.yml"
-STATE=${FED_ACCEPTANCE_STATE:-/tmp/sage-v111717-federation-state}
+STATE=${FED_ACCEPTANCE_STATE:-/tmp/sage-v111800-federation-state}
 MODE=${1:-full}
 PORT_A=${FED_NODE_A_PORT:-28080}
 PORT_B=${FED_NODE_B_PORT:-28081}
@@ -22,11 +22,16 @@ jfield() {
 }
 mcp_call() {
   svc=$1 tool=$2 args=$3
+  case "$svc" in
+    node-a) project=voice-bridge-a ;;
+    node-b) project=voice-bridge-b ;;
+    *) die "unknown MCP acceptance service $svc" ;;
+  esac
   init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"fed-acceptance","version":"1"}}}'
   inception='{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"sage_inception","arguments":{}}}'
   call=$(node -e 'process.stdout.write(JSON.stringify({jsonrpc:"2.0",id:3,method:"tools/call",params:{name:process.argv[1],arguments:JSON.parse(process.argv[2])}}))' "$tool" "$args")
   out=$(printf '%s\n%s\n%s\n' "$init" "$inception" "$call" | dc exec -T \
-    -e SAGE_PROVIDER=mynah -e SAGE_PROJECT=voice-bridge \
+    -e SAGE_PROVIDER=mynah -e SAGE_PROJECT="$project" \
     -e SAGE_IDENTITY_PATH=/root/.sage/agents/mynah/agent.key "$svc" \
     timeout "$MCP_TIMEOUT_SECONDS" sage-gui mcp) ||
     die "MCP tool $tool on $svc failed or exceeded ${MCP_TIMEOUT_SECONDS}s"
@@ -61,13 +66,13 @@ container_ip() {
   docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' "$(container_id "$1")"
 }
 lan_ip() {
-  docker inspect -f '{{(index .NetworkSettings.Networks "sage-v111717-federation-lan").IPAddress}}' "$(container_id "$1")"
+  docker inspect -f '{{(index .NetworkSettings.Networks "sage-v111800-federation-lan").IPAddress}}' "$(container_id "$1")"
 }
 
 cleanup() {
   dc down --remove-orphans >/dev/null 2>&1 || true
   for cid in $CHURN_IDS; do docker stop "$cid" >/dev/null 2>&1 || true; done
-  docker network rm sage-v111717-federation-lan >/dev/null 2>&1 || true
+  docker network rm sage-v111800-federation-lan >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
 
@@ -100,10 +105,10 @@ wait_health "http://127.0.0.1:$PORT_A"
 wait_health "http://127.0.0.1:$PORT_B"
 
 phase "same-LAN topology"
-docker network inspect sage-v111717-federation-lan >/dev/null 2>&1 || \
-  docker network create --internal sage-v111717-federation-lan >/dev/null
-docker network connect --alias node-a sage-v111717-federation-lan "$(container_id node-a)"
-docker network connect --alias node-b sage-v111717-federation-lan "$(container_id node-b)"
+docker network inspect sage-v111800-federation-lan >/dev/null 2>&1 || \
+  docker network create --internal sage-v111800-federation-lan >/dev/null
+docker network connect --alias node-a sage-v111800-federation-lan "$(container_id node-a)"
+docker network connect --alias node-b sage-v111800-federation-lan "$(container_id node-b)"
 dc exec -T node-a getent hosts node-b >/dev/null
 dc exec -T node-b getent hosts node-a >/dev/null
 
@@ -286,8 +291,8 @@ if [ "$MODE" = full ]; then
 fi
 
 phase "remove LAN; only the relay bridges edge_a and edge_b"
-docker network disconnect sage-v111717-federation-lan "$(container_id node-a)"
-docker network disconnect sage-v111717-federation-lan "$(container_id node-b)"
+docker network disconnect sage-v111800-federation-lan "$(container_id node-a)"
+docker network disconnect sage-v111800-federation-lan "$(container_id node-b)"
 
 phase "restart A, B, then both and require container IP churn"
 for svc in node-a node-b; do
@@ -295,8 +300,8 @@ for svc in node-a node-b; do
   dc stop "$svc" >/dev/null
   dc rm -f "$svc" >/dev/null
   case "$svc" in
-    node-a) edge=sage-v111717-federation-edge-a; control=sage-v111717-federation-control-a ;;
-    node-b) edge=sage-v111717-federation-edge-b; control=sage-v111717-federation-control-b ;;
+    node-a) edge=sage-v111800-federation-edge-a; control=sage-v111800-federation-control-a ;;
+    node-b) edge=sage-v111800-federation-edge-b; control=sage-v111800-federation-control-b ;;
   esac
   # Occupy the just-freed addresses so Docker cannot hand the recreated node
   # the same pair and accidentally skip the stale-address recovery condition.
@@ -356,16 +361,52 @@ elif [ "$MODE" = full ]; then
 fi
 
 if [ -n "${FED_ACCEPTANCE_FLOW_COMMAND:-}" ]; then
-  phase "canonical MCP flow: find -> send -> offline inbox -> read -> reply/status"
+	phase "canonical MCP flow: friendly registered-name send -> reply receipt -> offline inbox -> read -> reply/status"
   sh -c "$FED_ACCEPTANCE_FLOW_COMMAND"
 elif [ "$MODE" = full ]; then
-  phase "canonical MCP flow: find -> send -> offline inbox -> read -> reply/status"
+  phase "canonical MCP flow: friendly registered-name send -> reply receipt -> offline inbox -> read -> reply/status"
   find_args=$(node -e 'process.stdout.write(JSON.stringify({name:"mynah",peer_chain:process.argv[1]}))' "$chain_a")
   found=$(mcp_call node-a sage_find_agent "$find_args")
   target=$(jfield "$found" matches.0.to)
   [ -n "$target" ] || die "sage_find_agent returned no exact remote Mynah target"
+  friendly_target=$(jfield "$found" matches.0.registered_name)
+  [ -n "$friendly_target" ] || die "sage_find_agent returned no immutable registered name"
+  friendly_payload="v11.18 friendly registered-name probe $RUN_TOKEN"
+  friendly_args=$(node -e 'process.stdout.write(JSON.stringify({to:process.argv[1],intent:"acceptance",payload:process.argv[2],idempotency_key:"v1118-friendly-probe-"+process.argv[3]}))' "$friendly_target" "$friendly_payload" "$RUN_TOKEN")
+  friendly_sent=$(mcp_call node-a sage_message_send "$friendly_args")
+  friendly_message_id=$(jfield "$friendly_sent" message_id)
+  [ -n "$friendly_message_id" ] || die "friendly registered-name send returned no canonical message_id"
+  [ "$(jfield "$friendly_sent" destination_chain_id)" = "$chain_a" ] || die "friendly registered-name send did not resolve the expected immutable peer chain"
+  i=0
+  while :; do
+    friendly_inbox=$(mcp_call node-b sage_inbox '{"limit":5}') || true
+    friendly_received_id=$(node "$ROOT/scripts/federation-acceptance-find-inbox-message.mjs" \
+      "$friendly_inbox" acceptance "$friendly_payload" "$agent_a" "$chain_b" 2>/dev/null || true)
+    [ -n "$friendly_received_id" ] && break
+    i=$((i + 1)); [ "$i" -lt 45 ] || die "friendly registered-name message did not reach the exact remote inbox"
+    sleep 2
+  done
+  friendly_reply_args=$(node -e 'process.stdout.write(JSON.stringify({message_id:process.argv[1],result:"v11.18 friendly acceptance reply"}))' "$friendly_received_id")
+  friendly_reply=$(mcp_call node-b sage_message_reply "$friendly_reply_args")
+  reply_event_id=$(jfield "$friendly_reply" reply_event_id)
+  [ -n "$reply_event_id" ] || die "federated reply returned no immutable reply_event_id"
+  reply_status_args=$(node -e 'process.stdout.write(JSON.stringify({message_id:process.argv[1]}))' "$reply_event_id")
+  reply_status=$(mcp_call node-b sage_message_status "$reply_status_args")
+  [ "$(jfield "$reply_status" reply_event_id)" = "$reply_event_id" ] || die "replying agent cannot inspect its own immutable reply event"
+  [ -z "$(jfield "$reply_status" workflow_status 2>/dev/null || true)" ] || die "reply event status leaked original message workflow"
+  friendly_sender_status_args=$(node -e 'process.stdout.write(JSON.stringify({message_id:process.argv[1]}))' "$friendly_message_id")
+  i=0
+  while :; do
+    friendly_sender_status=$(mcp_call node-a sage_message_status "$friendly_sender_status_args") || true
+    friendly_read_status=$(jfield "$friendly_sender_status" read_status 2>/dev/null || true)
+    friendly_workflow_status=$(jfield "$friendly_sender_status" workflow_status 2>/dev/null || true)
+    [ "$friendly_read_status" = confirmed ] && [ "$friendly_workflow_status" = completed ] && break
+    i=$((i + 1)); [ "$i" -lt 45 ] || die "friendly sender status lacks confirmed read and completed reply after retry window (read=$friendly_read_status workflow=$friendly_workflow_status)"
+    sleep 2
+  done
   dc stop node-b >/dev/null
-  send_args=$(node -e 'process.stdout.write(JSON.stringify({to:process.argv[1],intent:"acceptance",payload:"v11.17.17 durable offline inbox probe "+process.argv[2],idempotency_key:"v111717-offline-probe-"+process.argv[2]}))' "$target" "$RUN_TOKEN")
+  offline_payload="v11.18.0 durable offline inbox probe $RUN_TOKEN"
+  send_args=$(node -e 'process.stdout.write(JSON.stringify({to:process.argv[1],intent:"acceptance",payload:process.argv[2],idempotency_key:"v111800-offline-probe-"+process.argv[3]}))' "$target" "$offline_payload" "$RUN_TOKEN")
   send_started=$(date +%s)
   sent=$(mcp_call node-a sage_message_send "$send_args")
   send_elapsed=$(( $(date +%s) - send_started ))
@@ -380,12 +421,13 @@ elif [ "$MODE" = full ]; then
   i=0
   while :; do
     inbox=$(mcp_call node-b sage_inbox '{"limit":5}') || true
-    received_id=$(jfield "$inbox" items.0.message_id 2>/dev/null || true)
+    received_id=$(node "$ROOT/scripts/federation-acceptance-find-inbox-message.mjs" \
+      "$inbox" acceptance "$offline_payload" "$agent_a" "$chain_b" 2>/dev/null || true)
     [ -n "$received_id" ] && break
     i=$((i + 1)); [ "$i" -lt 45 ] || die "offline message did not persist/deliver to restarted inbox"
     sleep 2
   done
-  reply_args=$(node -e 'process.stdout.write(JSON.stringify({message_id:process.argv[1],result:"v11.17.17 acceptance reply"}))' "$received_id")
+  reply_args=$(node -e 'process.stdout.write(JSON.stringify({message_id:process.argv[1],result:"v11.18.0 acceptance reply"}))' "$received_id")
   mcp_call node-b sage_message_reply "$reply_args" >/dev/null
   status_args=$(node -e 'process.stdout.write(JSON.stringify({message_id:process.argv[1]}))' "$message_id")
   i=0

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.17.17"
+version = "11.18.0"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.17.17"
+version = "11.18.0"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/src/control.rs
+++ b/desktop/sage-shell/src/control.rs
@@ -189,7 +189,7 @@ fn supported_daemon_version(value: &str) -> bool {
     }
     let major = parts[0].parse::<u64>().ok();
     let minor = parts[1].parse::<u64>().ok();
-    major == Some(11) && matches!(minor, Some(10..=17))
+    major == Some(11) && matches!(minor, Some(10..=18))
 }
 
 fn valid_semver_number(value: &str) -> bool {
@@ -657,7 +657,8 @@ mod tests {
         assert!(supported_daemon_version("v11.15.1-rc.1+build.7"));
         assert!(supported_daemon_version("11.16.0"));
         assert!(supported_daemon_version("11.17.0"));
-        assert!(!supported_daemon_version("11.18.0"));
+        assert!(supported_daemon_version("11.18.0"));
+        assert!(!supported_daemon_version("11.19.0"));
         assert!(!supported_daemon_version("eleven"));
         assert!(valid_generation(&"A".repeat(43)));
         assert!(!valid_generation(&"B".repeat(43)));

--- a/desktop/sage-shell/src/main.rs
+++ b/desktop/sage-shell/src/main.rs
@@ -128,17 +128,6 @@ fn main() {
             },
         ))
         .plugin(tauri_plugin_deep_link::init())
-        .on_window_event(|window, event| {
-            if matches!(event, tauri::WindowEvent::CloseRequested { .. })
-                && should_exit_on_main_window_close(window.label())
-            {
-                // The native shell is only a view onto the independently
-                // supervised SAGE daemon. Make the main-window lifecycle
-                // explicit: a normal close exits this shell process while the
-                // daemon keeps serving CEREBRUM and MCP clients.
-                window.app_handle().exit(0);
-            }
-        })
         .setup({
             let session = Arc::clone(&session);
             move |app| {
@@ -202,12 +191,14 @@ fn main() {
                 Ok(())
             }
         })
+        // Leave a normal main-window close to Tauri/Wry's native lifecycle.
+        // CloseRequested first permits Windows to destroy WebView2; the
+        // resulting last-window Destroyed event then exits the event loop.
+        // Calling AppHandle::exit from CloseRequested races that teardown and
+        // can leave the installed Windows shell resident indefinitely. The
+        // bundled daemon is a separate process and therefore keeps serving.
         .run(tauri::generate_context!())
         .expect("SAGE native shell runtime failed");
-}
-
-fn should_exit_on_main_window_close(label: &str) -> bool {
-    label == "main"
 }
 
 fn supervise<R: tauri::Runtime>(
@@ -897,13 +888,6 @@ mod tests {
         let state = session.lock().unwrap();
         assert_eq!(state.pending_routes.len(), 1);
         assert_eq!(state.pending_routes.front().unwrap(), "/search/agent-123");
-    }
-
-    #[test]
-    fn normal_main_window_close_exits_only_the_shell() {
-        assert!(should_exit_on_main_window_close("main"));
-        assert!(!should_exit_on_main_window_close("settings"));
-        assert!(!should_exit_on_main_window_close(""));
     }
 
     #[test]

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.17.17",
+  "version": "11.18.0",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.17.17/app-v26. -->
+<!-- Reconciled through SAGE v11.18.0/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -8,16 +8,32 @@ It is written for the person clicking the buttons. You do not need to understand
 
 ## What a federation connection is
 
-A federation connection is a trusted link between **two whole SAGE networks**. JOIN proves which SAGE is on the other end; it does not grant access to any domain. After the link is active, each person separately chooses what their own SAGE may share.
+A federation connection is a trusted link between **two whole SAGE networks**.
+JOIN proves which SAGE is on the other end; it does not indiscriminately expose
+that node's domains. During/after pairing, each operator explicitly chooses the
+ordinary local agent or agents participating in this pairwise federation group.
+That export carries each selected agent's owned domain tree into the default
+Read contract described below.
 
-Four things make it what it is:
+Five things make it what it is:
 
 - **Whole-SAGE to whole-SAGE.** You are linking one entire brain to another entire brain. This is not the same as adding an agent to your own SAGE (that is the **Agents** section), and it is not the same as joining more computers on your own LAN into one shared brain (that is the node-join flow under **Connect an AI tool**, which makes another computer a peer node on your own network).
+- **Exported-agent Read is the pairwise default.** Once you explicitly export a
+  local ordinary agent into this connection, any active ordinary agent on the
+  other SAGE may live-read that exported agent's owned domain tree. The receiver
+  needs no same-named group or receiving domain. Its operator may narrow this
+  default with exact local-agent/domain restrictions. Agents in an unrelated
+  local Access Group are not exported, and adding another federated agent is a
+  separate explicit action.
 - **Read borrows; Copy is a separate two-sided choice.** Read results come back tagged with their source and are shown in the moment; they are not stored merely because Read is enabled. Copy is offered by the source per domain, but nothing is retained unless the receiving SAGE independently selects **Save here**. An accepted copy enters the receiver's ordinary local consensus pipeline and then follows that brain's own lifecycle.
-- **Connection-bound Write is not available in v11.9.** The versioned field and route are reserved for compatibility, but the route returns authenticated `501`. An ordinary domain grant is not enough because it is not bound to one trusted connection and one exact submission.
-- **It deletes nothing.** Connecting adds a small treaty record and an empty permission policy. It does not touch, move, or erase a single memory on either side. Turning the connection off stops future access and synchronization; copies already accepted by either sovereign brain remain governed there.
+- **Connection-bound Write is not available.** The versioned field and route are reserved for compatibility, but the route returns authenticated `501`. An ordinary domain grant is not enough because it is not bound to one trusted connection and one exact submission.
+- **It deletes nothing.** Connecting adds a treaty and pairwise export/policy records. It does not touch, move, or erase a single memory on either side. Turning the connection off stops future access and synchronization; copies already accepted by either sovereign brain remain governed there.
 
-You grant what **they** may Read or Copy from **you**; they grant what **you** may Read or Copy from **them**. The two permission snapshots are independent, start empty, and can change at any time without running JOIN again. Neither side can quietly widen the other's access, and a Copy offer still cannot force the receiver to retain anything.
+You choose which of **your agents** the peer may see and Read; they make the
+same independent choice for their agents. Receiver-side restrictions can only
+narrow that default. Separately, manual domain-only peer permissions and Copy
+offers start empty and can change without running JOIN again. Neither side can
+quietly export a local-only group member or force the receiver to retain a Copy.
 
 ---
 
@@ -26,7 +42,11 @@ You grant what **they** may Read or Copy from **you**; they grant what **you** m
 - Both people need federation switched on. There is no LAN-versus-internet choice: SAGE prepares every usable direct and secure-relay candidate, then selects a working route during the encrypted exchange. The wizard reads the actual federation listener address and port (usually **8444**) for the Direct candidate. An explicit listener host is honored exactly; a wildcard bind lets the wizard offer detected addresses. Port `0` is invalid because an ephemeral port cannot be truthfully advertised.
 - Internet reachability depends on at least one configured relay being ready when no direct route works. SAGE ships with the project relay route and operators may add or replace relay multiaddrs. A relay outage can delay a relay-only connection, but does not weaken authentication or expose memory content.
 - You will each need a camera, or a shared screen, or at least a phone call you placed to a number you trust. The connection is safest when you are in the same room or on a video call you started.
-- You do not choose domains during JOIN. After both codes match, open the connection and choose from domains that already exist on your own SAGE. Leaving every box clear is a healthy connected state that shares nothing.
+- JOIN itself remains trust-only. Choose the local ordinary agent(s) that belong
+  to this pairwise federation explicitly. Leaving all agent exports and manual
+  domain permissions empty is a healthy connected state that shares nothing;
+  exporting an agent enables the default borrowed Read of that agent's owned
+  tree, not Copy or Write.
 
 Open **Federation** in the sidebar. You will see two big choices:
 
@@ -196,16 +216,25 @@ Under the covers each code is a short **time-based one-time code (TOTP, RFC-6238
 
 ---
 
-## Permissions after JOIN - what actually crosses the link
+## Permissions after JOIN - manual domain Read/Copy
 
-Open a connection from **Federation**. Each side controls a complete per-peer snapshot on its own SAGE; saving replaces that side's previous snapshot. The source enforces it again when serving or sending, so a peer cannot talk its way past a withdrawn permission (`web/federation_permissions.go`, `internal/federation/server.go`, `internal/federation/sync_outbox.go`).
+Open a connection from **Federation**. In addition to the exported-agent default
+Read above, each side controls a complete manual domain-only snapshot on its own
+SAGE; saving replaces that side's previous snapshot. The source enforces it
+again when serving or sending, so a peer cannot talk its way past a withdrawn
+permission (`web/federation_permissions.go`, `internal/federation/server.go`,
+`internal/federation/sync_outbox.go`).
 
 - **Existing domains only.** The picker is built from domains already registered or observed on the source node. A trailing `*` such as `tii*` filters the list for safe bulk selection; it does not create a wildcard grant or a new domain.
 - **Read.** Allows live recall inside that exact domain subtree. Every returned record is checked again, and the receiver borrows the result without storing it.
 - **Copy offer.** Implies Read and permits the source to synchronize the domain, but delivery is effective only where the receiver has separately checked **Save here**. Removing either the offer or the subscription closes future delivery.
-- **Write (not yet).** Always off in v11.9. Attempts fail closed because SAGE does not yet have a consensus authorization bound to the active connection generation, peer, domain, and exact submission.
+- **Write (not yet).** Always off in the current protocol. Attempts fail closed because SAGE does not yet have a consensus authorization bound to the active connection generation, peer, domain, and exact submission.
 
-A present empty snapshot is explicit deny-all, including immediately after a fresh JOIN. Each side can change its own snapshot independently and at any time without pairing again.
+A present empty snapshot is explicit deny-all for this **manual domain-only
+lane**, including immediately after a fresh JOIN. It does not synthesize or
+revoke exported-agent membership; narrow that separate default with the
+receiver's agent/domain restrictions. Each side can change its own snapshot
+independently and at any time without pairing again.
 
 ---
 
@@ -236,9 +265,11 @@ So: only ever connect when you are confident, by your own eyes or your own ears 
 
 **What the link can and cannot do once connected:**
 
-- It can serve live borrowed recall only for domains where you enabled Read.
+- It can serve live borrowed recall only for an explicitly exported agent's
+  owned tree or a domain where you enabled manual Read, always subject to the
+  receiver's current restrictions and classification ceiling.
 - It can offer copies only for domains where you enabled Copy, and the other person must independently choose **Save here** before their SAGE retains them.
-- It cannot perform connection-bound remote Write in v11.9. The authenticated endpoint returns `501` and never dispatches the submitted body into the memory API.
+- It cannot perform connection-bound remote Write in the current protocol. The authenticated endpoint returns `501` and never dispatches the submitted body into the memory API.
 - It cannot delete anything, on either side.
 - It cannot use the JOIN itself, a stale agreement generation, a different operator/CA, or unrelated group membership to widen domain access.
 
@@ -265,7 +296,11 @@ Generate fresh codes after correcting `federation.listen_addr`; never edit a QR
 payload or reuse the old return card.
 
 **The session expired / "join session not found or expired."**
-A join has to finish within about 15 minutes. If you left it sitting, the session times out for safety. Start over from the Federation page - nothing was created.
+A join has to finish within about 15 minutes. Within that session, each pasted
+or scanned code is allowed up to five minutes to discover and dial its Direct
+and secure-relay targets while the pairing screen remains open. Closing the
+screen cancels that attempt; expiry burns the session. Start over from the
+Federation page—nothing was created.
 
 **"Refusing self-federation."**
 You tried to connect a SAGE to itself (same network id). Federation is between two different networks.
@@ -277,7 +312,12 @@ The listener rate-limits repeated attempts from the same connection. Wait a minu
 Some treaties carry an expiry. An expired row no longer serves or queries. Turn it off and re-run the join to refresh it.
 
 **The connection is green but no memories are shared.**
-That is the safe default. JOIN establishes trust with an empty permission snapshot. Expand the connection, enable Read or Copy on existing domains you control, and save your snapshot. For copies, the other person must also enable **Save here** on their computer.
+JOIN alone is trust-only. Expand the connection and explicitly export the local
+ordinary agent that should participate; its owned tree then becomes readable to
+active ordinary agents on the peer unless that peer's operator has narrowed the
+default. Manual domain-only Read/Copy remains available for advanced sharing.
+For copies, you must offer Copy and the other person must also enable **Save
+here** on their computer.
 
 **Read works but copies do not arrive.**
 Check both halves of the Copy decision: the source must offer Copy for the domain and the receiver must subscribe with **Save here**. Either side can withdraw its half without reconnecting.
@@ -286,6 +326,6 @@ Check both halves of the Copy decision: the source must offer Copy for the domai
 
 ### Under the hood (optional)
 
-The ceremony runs over a dedicated mutually authenticated federation listener. Each operator's compatibility treaty set/revoke reaches its own chain, while mutable peer Read/Copy snapshots and transport subscriptions remain off-consensus. Fresh JOIN accepts only the fixed empty-domain compatibility envelope and installs an explicit deny-all policy. Peer admission binds the exact active agreement, chain, operator key, CA pin, and policy epoch; synchronization-group traffic additionally needs the exact active group/member/domain projection. Agreement changes, JOIN activation, narrowing, and revocation use the same mutation boundary across signed REST and dashboard paths, so a completed change cannot leave a superseded broader response in flight.
+The ceremony runs over a dedicated mutually authenticated federation listener. Each operator's compatibility treaty set/revoke reaches its own chain, while mutable peer Read/Copy snapshots, exported-agent membership, receiver restrictions, and transport subscriptions remain off-consensus. Fresh JOIN accepts only the fixed empty-domain compatibility envelope and installs an explicit deny-all **manual peer-RBAC** policy; it does not negate the separate default Read that begins only when an operator explicitly exports an ordinary agent into the pair. Peer admission binds the exact active agreement, chain, operator key, CA pin, and policy epoch; synchronization-group traffic additionally needs the exact active group/member/domain projection. Agreement changes, JOIN activation, narrowing, and revocation use the same mutation boundary across signed REST and dashboard paths, so a completed change cannot leave a superseded broader response in flight.
 
 The operator wizard routes live at `/v1/dashboard/federation/join/*` (`web/federation_join.go`), dashboard permissions at `/v1/dashboard/federation/connections/{chain_id}/permissions` (`web/federation_permissions.go`), the peer-facing ceremony and data plane at `/fed/v1/*` (`internal/federation/join_routes.go`, `internal/federation/server.go`), and Copy authorization in `internal/federation/sync_outbox.go`. Borrowed Read results are never persisted (`internal/federation/proxy.go`); accepted copies are locally signed ordinary memory submissions. The reserved Write route fails before parsing or dialing (`api/rest/federation_write_handler.go`, `internal/federation/remote_write.go`).

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.17.17
+# sage-gui v11.18.0
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.17.17 advertises 31 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.0 advertises 31 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,21 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.17.17 is the current release.** This corrective release pins the exported-agent authorization model and source-agent attestation into every signed federated Read plan and holds final authorization through disclosure. It also makes authenticated-read capability readiness visible and extends the Docker lane through bidirectional Copy backfill, incremental mirroring, and restart recovery. Governed app-v26 and consensus remain unchanged. Existing chains upgrade in place without rewriting memories, historical authors, domains, trust, or prior blocks.
+**Status (2026-08):** **v11.18.0 is the current release.** It completes the
+pairwise exported-agent federation model, safe registered-name addressing and
+reply-event visibility, the three-tab Access Controls redesign, five-minute
+JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
+and a governed app-v21 → app-v22 legacy-lineage recovery ceremony. Existing
+app-v22 through app-v26 chains are not rewritten. The supported consensus
+ceiling remains app-v26; **v11.18.0 does not introduce app-v27**.
 
-**Hard constraint driving the whole plan:** no chain reset, no operator-typed commands. Existing chains must upgrade in place across all future releases.
+**Hard constraint driving the whole plan:** no chain reset. Existing chains must
+upgrade in place across all future releases. Routine personal-node upgrades
+remain automatic; the exceptional legacy-lineage repair is deliberately an
+explicit, reviewed operator ceremony rather than a silent mutation.
 
-## v11.17.x completion ledger
+## v11.18.0 completion ledger
 
-The 11.17 line has shipped the app-v23 through app-v26 governed upgrade path,
+v11.18.0 carries forward the 11.17 line's app-v23 through app-v26 governed upgrade path,
 historical-memory recovery controls, responsive Access Controls, authenticated
 Consensus loading, mutable agent display names, canonical Messages, deprecated
 hidden `sage_pipe*` compatibility aliases, durable-until-handled message retention, signed
@@ -54,14 +63,43 @@ with a deep link to the exact agent setting. It also generates a unique
 name-based home domain when a writable pending-agent approval leaves that field
 blank. v11.17.13 and the superseded v11.17.14 tag were not published.
 
-v11.17.17 closes the final plan-versus-disclosure race exposed while validating
-the physical Mynah pair. The source authorization model and exact active-agent
-and clearance attestation are signed, challenge-bound, revalidated under the
-source authorization lease, and held until the destination query completes.
-Capability projection reports missing authenticated-read support without
-guessing whether the peer is still binding or needs an update. The acceptance
-lane now proves pairwise default Read, explicit denial, non-transitive exports,
-and bidirectional Copy backfill/incremental/restart behavior.
+v11.18.0 makes every trusted two-SAGE connection its own pairwise federation
+group. An operator explicitly exports the local ordinary agent(s) participating
+in that pair; every active ordinary agent on the peer may then Read those
+agents' owned domain trees by default. Receiver-side exact agent/domain denies
+narrow that default. Local Access Groups are not exported transitively, and a
+new remote-visible agent exists only after an explicit federation export. Read
+is borrowed, Copy remains the two-sided source-offer plus receiver-subscription
+workflow, and remote memory Write remains reserved/denied.
+
+The signed Read plan now commits to the source authorization model, exact
+active-agent/clearance attestation, agreement and policy generations, and the
+single-use challenge. Final authorization is revalidated and leased through
+disclosure. Capability projection reports missing authenticated-read support
+without guessing whether a peer is binding or outdated. The Docker lane proves
+default Read, explicit denial, non-transitive exports, bidirectional Copy
+backfill and incremental sync, and restart recovery.
+
+Agent messaging resolves unique local or federated display/registered names to
+canonical IDs before signing; collisions return bounded immutable choices.
+Federated reply calls return `reply_event_id`, which the exact replier can use
+for payload-free delivery status. Access Controls now has dedicated Agents,
+Groups, and Federation tabs with compact search/sort lists, focused drawers,
+stable URL/deep-link selection, and keyboard/ARIA boundaries. JOIN retains its
+15-minute ceremony lifetime while a pasted/scanned code may spend up to five
+minutes discovering Direct/relay targets as long as the pairing screen stays
+open.
+
+The release also integrates the complete stopped-node recovery tooling from
+PR #161: `backup --full`, recoverable `restore --from`, and read-only `upgrade
+preflight`. For the narrow historical case where a chain is still at app-v21
+with absent but independently recoverable predecessor records, `upgrade lineage
+status|doctor|verify` builds and verifies a chain/current-lineage-bound,
+create-only app-v22 repair manifest. It is part of the exact immutable upgrade
+proposal, automatic voting is disabled even on one validator, and every
+validator explicitly verifies and votes. Unverified anchors require an explicit
+acknowledgement. Already-upgraded app-v22–app-v26 chains are untouched; there is
+no app-v27 fork in this release.
 
 The following acceptance and follow-up boundaries remain open after the 11.17.9
 code merge; they are not implied complete by Docker or CI evidence:

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -8,8 +8,12 @@ lived-in node during an upgrade, and no supported procedure asks you to export
 SQLite and initialize a fresh chain. Memories, domains, grants, agent
 identities, governance records, and block history all survive.
 
-**Every command in this document ships in the binary.** If a step tells you to
-run something, it exists.
+**The recovery commands in this guide require SAGE v11.18.0 or later.** That is
+the first concrete release containing `backup --full`, `restore --from`,
+`upgrade preflight`, and `upgrade lineage status|doctor|verify`. Install the
+v11.18.0 binary before relying on any of them; an older binary may not recognize
+the command, and an old `backup` implementation may interpret `--full`
+differently.
 
 ---
 
@@ -30,13 +34,14 @@ sage-gui serve
 sage-gui upgrade status
 ```
 
-> **Install the new binary before you back up.** `backup --full` and `upgrade
-> preflight` are recent additions — an older `sage-gui` does not have them, and
-> a v10.x binary certainly does not. Installing a new binary is safe and
+> **Install SAGE v11.18.0 or later before you back up.** That is the concrete
+> minimum for `backup --full`, `restore --from`, `upgrade preflight`, and the
+> `upgrade lineage` commands; v10.x and older v11 binaries do not provide this
+> complete contract. Installing a new binary is safe and
 > reversible on its own: it changes no data and activates no fork until the node
 > runs and governance approves each rung. Check what you have with
-> `sage-gui upgrade preflight --help`; if it is not recognized, your binary
-> predates these commands.
+> `sage-gui upgrade lineage verify --help`; if it is not recognized, your
+> binary predates the complete v11.18.0 recovery toolset.
 
 On a personal node that is the whole upgrade. The node proposes and activates
 each consensus fork by itself until it reaches the binary's ceiling.
@@ -85,9 +90,12 @@ Use this to work out how far your chain has to climb.
 | v11.16.0 | app-v24 |
 | v11.16.2 | app-v25 |
 | v11.17.0 | app-v26 |
+| v11.18.0 | no new app version; app-v26 remains the ceiling |
 
 A v10.x chain therefore sits somewhere around **app-v11 to app-v14**, and
 current v11 binaries support up to **app-v26**. That is roughly a dozen rungs.
+v11.18.0 does **not** introduce app-v27 and does not rewrite an existing
+app-v22, app-v23, app-v24, app-v25, or app-v26 chain.
 
 Forks activate **strictly one at a time**: every proposal must target the
 chain's current version **+ 1**. Skipping is rejected — a jump from 14 to 26
@@ -187,7 +195,7 @@ the container stopped:
 
 ```bash
 docker stop sage
-docker run --rm -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:latest \
+docker run --rm -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:11.18.0 \
   backup --full --out /root/.sage/backups/pre-upgrade.tar.gz
 ```
 
@@ -195,23 +203,23 @@ The image's `ENTRYPOINT` is already `sage-gui`, so pass the subcommand directly 
 `docker run … sage-gui backup` would try to run `sage-gui sage-gui backup`. The
 archive lands in the mounted volume, so it survives the container.
 
-> **Confirm the image actually has these commands before you rely on the
-> backup.** An image older than the release that introduced them does not reject
+> **Confirm the image is v11.18.0 or later before you rely on the backup.** An
+> older image does not necessarily reject
 > `--full` — it ignores the flag, writes the SQLite-only copy, and prints
 > `Backup saved`. A success message, for the wrong thing, right before an
 > irreversible climb. Check first:
 >
 > ```bash
-> docker run --rm ghcr.io/l33tdawg/sage:latest upgrade preflight --help
+> docker run --rm ghcr.io/l33tdawg/sage:11.18.0 upgrade lineage verify --help
 > ```
 >
-> If that errors with an unknown subcommand, the image predates these commands —
-> pull a newer one before going further.
+> If that errors with an unknown subcommand, the image predates the complete
+> recovery commands—pull v11.18.0 or later before going further.
 
 Then preflight the same way, using that same current image:
 
 ```bash
-docker run --rm -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:latest upgrade preflight
+docker run --rm -v ~/.sage:/root/.sage ghcr.io/l33tdawg/sage:11.18.0 upgrade preflight
 ```
 
 ---
@@ -258,10 +266,82 @@ VERDICT: this chain CANNOT reach app-v22.
   app-v17: missing canonical applied app-v17 record
 ```
 
-If you get that: **do not delete the data directory.** The evidence is missing
-from consensus storage and cannot be re-proposed or synthesized. Restore a
-complete backup taken before the gap, or open an issue with the preflight
-output.
+If you get that: **do not delete the data directory and do not edit Badger.** A
+present-but-invalid record cannot be overwritten; restore a complete stopped-
+node backup taken before the damage or open an issue with the preflight output.
+If the named rungs are absent, v11.18.0 has one narrow recovery path: let the
+chain stop safely at app-v21, then use the governed lineage ceremony below.
+Never invent activation heights merely to make the ladder pass.
+
+### Governed legacy-lineage recovery at app-v21
+
+This workflow exists only for an upgraded chain that is **exactly app-v21** and
+is missing one or more canonical app-v6 through app-v21 activation records. It
+does not modify an already-upgraded app-v22–app-v26 chain, repair an invalid
+present record, or introduce app-v27.
+
+1. Keep the stopped-node `backup --full` from Step 2. Start every validator on
+   v11.18.0, allow lower healthy rungs to climb, and stop normal upgrade
+   proposals once `upgrade status` reports app-v21.
+2. On the proposing validator, inventory the live committed state and create a
+   candidate from retained Comet history:
+
+   ```bash
+   sage-gui upgrade lineage status --json
+   sage-gui upgrade lineage doctor --json --manifest-out repair.json
+   ```
+
+   `doctor` is read-only. It emits a manifest only when the chain, governance
+   domain, current valid-lineage digest, exact missing set, strictly ordered
+   committed heights, and one evidence mode agree.
+3. Copy only `repair.json` to every validator operator. Each operator verifies
+   the exact manifest independently against that validator's own chain and
+   retained block results, then compares `manifest_digest` values:
+
+   ```bash
+   sage-gui upgrade lineage verify --json --manifest repair.json
+   ```
+
+   A block hash in the proposal is not self-proving; `verify` must reproduce
+   the app-version update and hash from each validator's retained history.
+4. If retained history is pruned, use an independently audited anchor containing
+   **every** missing version. Do not mix it with retained-Comet claims. Both
+   creation and verification require the explicit unverified-history warning:
+
+   ```bash
+   sage-gui upgrade lineage doctor --json \
+     --legacy-anchor audited-heights.json \
+     --acknowledge-unverified-anchor \
+     --manifest-out repair.json
+
+   sage-gui upgrade lineage verify --json \
+     --manifest repair.json \
+     --acknowledge-unverified-anchor
+   ```
+
+   An anchor is an operator assertion, not recovered cryptographic history. An
+   ACCEPT vote attests those exact claims.
+5. After every validator reports the same eligible manifest digest, submit the
+   exact app-v22 proposal:
+
+   ```bash
+   sage-gui upgrade propose --target 22 --lineage-repair repair.json
+   ```
+
+6. Automatic voting is disabled for every lineage-repair proposal, including
+   on a one-validator chain. Each validator operator reopens the immutable
+   payload in CEREBRUM Governance (or `sage_gov_status`) and explicitly votes
+   ACCEPT, REJECT, or ABSTAIN. Do not accept merely because the proposer or
+   another validator did.
+7. After quorum and app-v22 activation, run `upgrade lineage status --json` on
+   every validator and confirm the immutable repair audit and complete ladder
+   before proposing app-v23.
+
+The manifest is chain/current-lineage bound and execution is create-only. A
+changed digest, extra/missing claim, mixed evidence source, future height,
+existing record, payload change, or insufficient explicit quorum fails closed.
+See [`reference/upgrade-lineage-repair.md`](reference/upgrade-lineage-repair.md)
+for the evidence and persistence contract.
 
 ### The app-v23 authority preview
 
@@ -345,7 +425,9 @@ sage-gui upgrade propose --target 16 --wait
 activates. Proposals route through the 2/3 governance quorum; validators
 auto-vote ACCEPT if they support the target. Upgrade every validator's binary
 before climbing — a validator that does not support the target cannot vote for
-it.
+it. The only exception is an app-v22 proposal carrying `--lineage-repair`:
+automatic voting is disabled and every validator must verify and vote
+explicitly, as described above.
 
 ---
 
@@ -497,6 +579,8 @@ sage-gui mcp-token create    # issue a replacement per client
 
 ## Related reference
 
+- [`reference/upgrade-lineage-repair.md`](reference/upgrade-lineage-repair.md)
+  — app-v21 → app-v22 evidence verification, explicit quorum, and immutable audit
 - [`reference/app-v23-access-control-design.md`](reference/app-v23-access-control-design.md)
   — Root, roles, security profiles, Access Groups, and the full migration contract
 - [`reference/app-v25-upgrade-recovery.md`](reference/app-v25-upgrade-recovery.md)

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.17.17. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.0. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -33,7 +33,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
-| [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal, independent per-peer Read/Copy grants over existing domains, receiver-controlled Copy subscriptions, authenticated domain-owner agent contacts, and the existing pipeline extended across federation through `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
+| [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
 
 ---
@@ -42,7 +42,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 
 | You want to… | Go to |
 |--------------|-------|
-| Upgrade an existing node to a newer release (incl. v10.x → v11) | [`../UPGRADING.md`](../UPGRADING.md) — backup, `upgrade preflight`, the app-version ladder, app-v23 admin migration |
+| Upgrade an existing node to a newer release (incl. v10.x → v11) | [`../UPGRADING.md`](../UPGRADING.md) — v11.18.0 minimum, full backup/restore, preflight, the app-version ladder, governed legacy-lineage recovery, and app-v23 admin migration |
 | Boot your memory at conversation start | **Boot sequence** below, then [`mcp-tools.md`](mcp-tools.md) |
 | Submit a memory with a clearance level | [`python-sdk.md`](python-sdk.md) `propose()` / [`rest-api.md`](rest-api.md) `POST /v1/memory/submit` |
 | Understand why another agent can't see your memory | [`concepts/clearance-classification.md`](concepts/clearance-classification.md) + [`concepts/rbac-orgs-federation.md`](concepts/rbac-orgs-federation.md) |
@@ -51,7 +51,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | Know if a memory will decay | [`concepts/memory-lifecycle.md`](concepts/memory-lifecycle.md) |
 | Understand why your chain's block height isn't moving | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) |
 | Make sure submitted memories actually get committed (not stuck at `proposed`) | [`concepts/voter-operations.md`](concepts/voter-operations.md) |
-| Pair two SAGE nodes, then change which existing domains they share without re-pairing | [`federation-and-brain-api.md`](federation-and-brain-api.md) — “Trust and directional peer RBAC” |
+| Pair two SAGE nodes, export participating agents for default borrowed Read, or change manual Read/Copy without re-pairing | [`federation-and-brain-api.md`](federation-and-brain-api.md) — “Trust and directional peer RBAC” |
 | Send agent work to a visible shared-domain recipient on another federated SAGE | [`mcp-tools.md`](mcp-tools.md) — `sage_find_agent`, then `sage_message_send`; [`federation-and-brain-api.md`](federation-and-brain-api.md) — internal compatibility transport `POST /fed/v1/pipe/event` |
 | Discover connected SAGEs and live-read a domain they share | [`mcp-tools.md`](mcp-tools.md) — `sage_federation`, then `sage_recall` with `federated=true` |
 | Distinguish internet federation, app-v20 quorum replication, and local-vs-network snapshot recovery | [`concepts/rbac-orgs-federation.md`](concepts/rbac-orgs-federation.md) — “v11.9 quorum scopes are not cross-chain federation” |
@@ -166,9 +166,11 @@ CometBFT without treating the consensus RPC as proof of application storage.
 
 ---
 
-## Related docs (reconciled through v11.17.17)
+## Related docs (reconciled through v11.18.0)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
+
+- **[`upgrade-lineage-repair.md`](upgrade-lineage-repair.md)** — app-v21 → app-v22 create-only legacy-lineage inventory, independent validator verification, explicit-vote ceremony, and unverified-history anchor fallback.
 
 - **`api/openapi.yaml`** — the machine-readable **network/agent REST** spec, reconciled to the core remotely callable surface (including the v11.5 `reinstateMemory` operation; `classification` on `MemorySubmitRequest`; `task` in `MemoryType`; `tx_hash` on vote responses; clearance-0 labeled PUBLIC; `/v1/agent/register` documents 201-new / 200-idempotent). It intentionally excludes the same-machine, loopback-only human CEREBRUM control plane under `/v1/dashboard/**`; those operator routes are documented in [`rest-api.md`](rest-api.md), the app-v23 design, and the app-v26 Access Group reference. This exclusion is a trust boundary, not missing SDK coverage. *(A few org/federation/dept GET responses are typed as generic objects — their store models live outside the REST package; fill in later if needed.)*
 - **`docs/ARCHITECTURE.md`** — accurate: it documents *both* the operational and data-classification meanings of the 0–4 integer, and treats BadgerDB as authoritative with SQLite as legacy fallback. Documents PoE-weighted quorum (Phase 2, live since v8.2/`app-v3` and complete through v8.4/`app-v5`): post-fork blocks weight each vote by the validator's demonstrated PoE track record; the equal-weight (1.0) branch is retained only for pre-fork byte-identical replay. For precise per-record gate logic with file:line, prefer [`concepts/`](concepts/).

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.17.17.
+Status: implementation contract through SAGE v11.18.0.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.17.17 authorization layer is off-consensus and does not require
+The current v11.18.0 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/app-v25-upgrade-recovery.md
+++ b/docs/reference/app-v25-upgrade-recovery.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.17.17: internal/abci/app.go (app-v25 gate and immutable envelope), web/appv25_memory_legacy_adoption_worker.go, web/appv25_domain_continuity_worker.go, web/appv25_memory_legacy_adoption_control.go, and internal/store/appv25_domain_continuity.go. -->
+<!-- Reconciled through SAGE v11.18.0: internal/abci/app.go (app-v25 gate and immutable envelope), web/appv25_memory_legacy_adoption_worker.go, web/appv25_domain_continuity_worker.go, web/appv25_memory_legacy_adoption_control.go, and internal/store/appv25_domain_continuity.go. -->
 
 # App-v25 Upgrade, Historical Recovery, and Domain Continuity
 

--- a/docs/reference/concepts/app-v26-access-groups.md
+++ b/docs/reference/concepts/app-v26-access-groups.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.17.17/app-v26 code (2026-08-07). Cite file:line when behavior is non-obvious. -->
+<!-- Verified against SAGE v11.18.0/app-v26 code (2026-08-07). Cite file:line when behavior is non-obvious. -->
 
 # App-v26 Access Groups and member authority
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.17.17/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.0/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.17.17. Legacy organization/federation sections retain
+Verified against SAGE v11.18.0. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.17.17. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.0. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.17.17 code (2026-08-07). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.0 code (2026-08-07). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 
@@ -456,6 +456,14 @@ and a limited mutation receives `Retry-After: 60`. This keeps an authenticated
 ACTIVE confirmation replay reachable without increasing the total mutation
 cap (`internal/federation/joinsession.go`; `internal/federation/join_routes.go`).
 
+The cryptographic JOIN session and guest draft each expire after **15 minutes**
+(`joinSessionTTL`, `guestDraftTTL`). CEREBRUM gives each scan/paste route-
+discovery attempt up to **five minutes** (`fedJoinDiscoveryTimeout`) while the
+pairing screen remains open. That discovery allowance never extends the
+15-minute session; session expiry still wins, and leaving the screen cancels
+the browser request (`internal/federation/joinsession.go`;
+`internal/federation/join_routes.go`; `web/federation_join.go`).
+
 Final confirmation may contain two sequential consensus waits: the guest
 commits its local tx-33 and the host then commits its tx-33. The guest-to-host
 peer deadline covers one configured broadcast timeout plus headroom, while the
@@ -735,7 +743,9 @@ Every route 501s when the transport is not wired (`fedReady`,
 
 (JOIN handlers live in `web/federation_join.go`.) The dashboard owns automatic
 route intent and the fixed trust-only compatibility scope; the remaining join
-request/response bodies mirror the operator REST bodies of §2.
+request/response bodies mirror the operator REST bodies of §2. Scan/paste calls
+use the bounded five-minute discovery context above; the underlying session
+remains bounded to 15 minutes.
 
 The dashboard connection-status response is HTTP `200` for both successful and
 failed probes so a row does not disappear during recovery. A failure includes

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.17.17.
+Reconciled against internal/mcp for SAGE v11.18.0.
 
 # SAGE MCP Tools Reference
 
@@ -878,7 +878,7 @@ read.
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| `to` | string | yes | Exact local agent ID/name, federated `#node/agent` handle, or `agent_id@chain` address. |
+| `to` | string | yes | Exact local agent ID, unique local/federated display or registered name, federated `#node/agent` handle, or `agent_id@chain` address. |
 | `payload` | string | yes | Untrusted agent request content. |
 | `intent` | string | no | Short purpose. |
 | `ttl_minutes` | integer | no | 0–1440; omitted/0 is durable until handled. |
@@ -893,6 +893,13 @@ HTTP MCP SSE sessions authenticated as the exact recipient. The notification
 contains only `message_id`, `from_agent`, and `sent_at`; it is best-effort,
 ignorable, and is never delivery, read, presence, attention, or workflow
 evidence. Stdio and Streamable HTTP remain poll-on-turn.
+
+Friendly labels are accepted only when one exact caller-authorized target wins
+across local and federated scope. Any local/local, remote/remote, or local/remote
+collision fails with bounded immutable candidates. A label is never signed or
+persisted: MCP signs and queues only the resolved agent ID and chain. Mutable
+display-name renames therefore do not alter an agent's registered-name or exact
+`agent_id@chain` address.
 
 **REST:** `POST /v1/messages`.
 
@@ -934,6 +941,12 @@ federated replies retain the negotiated secure transport and event
 deduplication. Only the exact recipient that fetched and claimed the message
 can reply.
 
+A federated reply result includes an immutable `reply_event_id` and its initial
+`reply_status:queued`. This is the signed result outbox event already created by
+the reply transaction, not a new ordinary message. Pass that event ID to
+`sage_message_status` to inspect only the replying agent's outbound transport
+state; no original request workflow/read state or result content is exposed.
+
 | Name | Type | Required | Description |
 |---|---|---|---|
 | `message_id` | string | yes | Exact receiver-local ID. |
@@ -946,7 +959,8 @@ can reply.
 ### sage_message_status
 
 **Purpose:** Query the payload-free state of one exact local or federated
-message sent by this caller. It returns independent `transport_status`, `read_status`, and
+message sent by this caller, or one immutable federated `reply_event_id` returned
+to this caller by `sage_message_reply`. Message status returns independent `transport_status`, `read_status`, and
 `workflow_status` facts plus their bounded timestamps. Recipient, unrelated
 agent, Manager, Admin, Root, node operator, and nonexistent IDs receive the
 same non-enumerating 404 behavior. The projection never decrypts payload or
@@ -954,7 +968,7 @@ result, so it remains usable while the content vault is locked.
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| `message_id` | string | yes | Exact sender-local ID returned by `sage_message_send`. |
+| `message_id` | string | yes | Exact sender-local ID returned by `sage_message_send`, or exact outbound `reply_event_id` returned by `sage_message_reply`. |
 
 `read_status:confirmed` means the exact addressed credential fetched the
 message and signed an acknowledgement naming that exact ID. It does not prove
@@ -964,6 +978,8 @@ workflow row with transport state and receipt-v2 evidence; none of those
 independent facts is inferred from another.
 
 **REST:** `GET /v1/messages/{message_id}/status`.
+Federated reply-event lookup uses
+`GET /v1/messages/replies/{reply_event_id}/status`.
 
 ---
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.17.17. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.0. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.17.17
+**Package:** `sage-agent-sdk` **Version:** 11.18.0
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.17.17. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.0. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 
@@ -1000,6 +1000,19 @@ Pre-app-v23 nodes retain their legacy projection behavior.
 | `POST /v1/dashboard/memory/adoption-retry` | Current-Root-only request for a fresh scan of the exact unresolved App-v25 snapshot. Requires the `projection_revision` field (zero is valid for a first upgraded snapshot) and a positive `expected_count`; it never deletes rows or clears earlier dispositions. |
 | `POST /v1/dashboard/memory/adoption-deprecate` | Current-Root-only retirement of the exact unresolved snapshot. Requires the `projection_revision` field (including valid zero), positive `expected_count`, and typed `DEPRECATE <count>` confirmation. Records remain preserved for audit and are skipped by future automatic repair. |
 
+In v11.18.0 CEREBRUM presents this control plane as three explicit tabs:
+**Agents**, **Groups**, and **Federation**. Each tab uses a bounded compact list
+with local search/sort and opens one selected record in a detail drawer; it does
+not mount every policy editor simultaneously. The hash route
+`#/access?tab=<agents|groups|federation>&item=<exact-key>` preserves the selected
+tab and canonical item, while the older `agent`/`inbox` and
+`remote_chain`/`remote_agent` query forms map into the matching modern tab.
+Dialog and drawer focus is trapped and restored, Escape/Tab handling belongs to
+the active overlay, and controls expose stable ARIA labels. These are browser
+presentation contracts over the same authenticated endpoints, not new
+authorization paths (`web/static/js/access-controls-ui.js`;
+`web/static/js/app.js`; `scripts/access-controls-ui.test.mjs`).
+
 Once app-v26 is active, the legacy
 `PATCH /v1/dashboard/network/agents/{id}` metadata route rejects `name` and
 `boot_bio` with `governed_agent_metadata_required`. Display-label changes use
@@ -1924,7 +1937,7 @@ pipeline row. The MCP client calls this immediately before `send`, then signs
 the exact returned destination (`api/rest/pipe_handler.go:47-126`,
 `internal/mcp/tools.go:2108-2167`).
 
-**Request:** `{"to":"provider, agent name, #node/agent-prefix, or agent@chain"}`
+**Request:** `{"to":"provider, display/registered name, #node/agent-prefix, or agent@chain"}`
 
 **Response** (HTTP 200):
 
@@ -1940,7 +1953,16 @@ the exact returned destination (`api/rest/pipe_handler.go:47-126`,
 }
 ```
 
-Local targets retain their existing provider/name/ID behavior. Federated
+Canonical agent IDs remain exact and never invoke friendly-name discovery.
+Friendly labels match local display/registered/provider fields and federated
+display or registered names exactly (case-insensitive); substring matches are
+discovery-only. A friendly label must identify one caller-authorized target
+across local and federated scope. Local/local, federated/federated, and
+local/federated collisions return HTTP 409 with a bounded set of immutable
+choices instead of selecting the first match. Consequently a display-name
+rename changes that alias immediately while the immutable registered name and
+`agent@chain` address continue to resolve to the same transport identity.
+Federated
 resolution is limited to the finite authenticated contact projection disclosed
 by active peers. A qualified handle never falls through to a similarly named
 local target. Unknown, stale, paused, unavailable, non-accepting, ambiguous, or
@@ -2075,7 +2097,7 @@ malformed or oversize input receives 400.
 
 ### Canonical local Messages service (v11.17)
 
-The six `/v1/messages` operations are one same-node service over the existing
+The `/v1/messages` operations are one service over the existing
 encrypted `pipeline_messages` rows. They do not create a second inbox. Every
 route is inside the active-ordinary-agent boundary; Root is not a messaging
 principal.
@@ -2088,6 +2110,7 @@ principal.
 | `PUT /v1/messages/{message_id}/read` | Fresh nonce-bound exact-recipient signature. The message must already have been returned to that caller by canonical receive. Same acknowledgement is idempotent. |
 | `PUT /v1/messages/read-batch` | One fresh exact-recipient request acknowledges 1–20 already-fetched exact message IDs. Every item is authorized independently and returns `confirmed` or a generic per-item failure; one failure never rolls back independent successes. Exact replay is idempotent. |
 | `GET /v1/messages/{message_id}/status` | Exact sender only, payload-free metadata projection. Returns independent transport/read/workflow state and never decrypts content/proofs. |
+| `GET /v1/messages/replies/{reply_event_id}/status` | Exact federated replier only. Returns payload-free outbound result-event transport state. It is not another inbox request and exposes no original-message workflow/read status or result content. |
 
 Every operation requires a fresh nonce-bound request signed by the exact active
 ordinary agent, including send and sender status. Unauthorized and nonexistent
@@ -2104,6 +2127,11 @@ additive JSON-RPC method is `notifications/sage_message` and its params contain
 only `message_id`, `from_agent`, and `sent_at`. A missing/full stream never
 fails the send, does not alter any message state, and is not evidence that a
 recipient is online. Stdio and Streamable HTTP have no server-push contract.
+
+A successful federated reply returns its immutable `reply_event_id` and
+`reply_status:queued`. That ID names the already-existing signed result outbox
+event; it does not create a duplicate message. Only its signing replier can use
+the reply-status route, and unrelated/missing IDs share the same generic 404.
 
 The canonical same-node Messages routes remain separate from the
 capability-gated federated receipt-v2 surface. A negotiated imported pipe adds

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,0 +1,95 @@
+<!-- Verified against SAGE v11.18.0 lineage implementation (2026-08-07). -->
+
+# Legacy upgrade-lineage repair (app-v21 → app-v22)
+
+App-v22 requires canonical persisted `app-v6` through `app-v21` activation
+records in strictly increasing committed heights. Some old production chains
+activated those versions before every rung was persisted. The repair lane is a
+narrow compatibility ceremony for that case; it is not a general state editor.
+
+## Safety contract
+
+- `sage-gui upgrade lineage status --json` and `doctor --json` are read-only.
+- A repair is accepted only while the chain is exactly app-v21 and only inside
+  an ordinary `app-v22` upgrade proposal.
+- The manifest binds the chain ID-derived governance domain, the exact current
+  valid-lineage digest, and the exact sorted missing-record set.
+- Execution creates absent records only. It never overwrites a present record,
+  including a malformed one. Exact replay is idempotent.
+- Claimed activation heights must be positive, strictly ordered with every
+  existing rung, and no later than the last committed application height.
+- A manifest uses exactly one evidence mode. Mixing retained-Comet and legacy
+  anchor claims is rejected.
+- Lineage-repair proposals never auto-vote. Proposal creation records no
+  implicit proposer vote, the validator background voter abstains, and this is
+  also true on a one-validator chain. Every validator operator must explicitly
+  review and vote.
+
+## Retained-Comet workflow
+
+First take and verify the normal operator backup of consensus and projection
+state. Do not edit Badger keys, copy another validator's database, or use a
+repair manifest as a substitute for a backup.
+
+On the proposing validator, create the candidate manifest:
+
+```text
+sage-gui upgrade lineage doctor --json --manifest-out repair.json
+```
+
+Copy only that manifest to each validator operator. On every validator,
+independently run:
+
+```text
+sage-gui upgrade lineage verify --json --manifest repair.json
+```
+
+`doctor` reads that node's retained `block_results` and block hash at the
+claimed height. A block hash in a manifest is not consensus-verified proof by
+itself; it is a claim about one validator's local archive. `verify` re-reads the
+local chain ID, current lineage digest, exact missing set, consensus-parameter
+app-version update, and block hash. Operators compare the emitted
+`manifest_digest` across validators before proposing:
+
+```text
+sage-gui upgrade propose --target 22 --lineage-repair repair.json
+```
+
+After proposal creation, each validator inspects the immutable payload using
+`sage_gov_status` (or CEREBRUM Governance) and explicitly calls
+`sage_gov_vote` with `accept`, `reject`, or `abstain`. The REST equivalent is
+the validator-local authenticated `POST /v1/governance/vote`. An operator must
+not accept merely because another validator accepted.
+
+After quorum, monitor `sage-gui upgrade status` until app-v22 activates, then
+run `sage-gui upgrade lineage status --json` and confirm the immutable repair
+audit and completed ladder on every validator before proceeding to app-v23.
+
+## Pruned-history anchor fallback
+
+If any required retained block result is unavailable, `doctor` will not blend
+the surviving Comet claims with an anchor. The anchor file must state every
+missing version and height:
+
+```json
+{"heights":{"9":123,"10":140}}
+```
+
+Generating an anchor manifest requires both `--legacy-anchor FILE` and the
+deliberate `--acknowledge-unverified-anchor` flag. The manifest records
+`operator-quorum-attested-unverified-history`; `verify` also requires the same
+acknowledgement. These heights are audited operator assertions, not facts
+recovered from retained history. An ACCEPT vote explicitly attests the exact
+claims shown by `verify --json`.
+
+## Persistence and recovery
+
+Quorum execution stores the canonical manifest, its SHA-256 digest, proposal
+ID, approval height, and exact created records in an immutable AppHash-covered
+audit receipt. Boot and state-sync inspection verify that the duplicated audit
+fields and record order/content still match the manifest and live applied
+records. A mismatch fails closed.
+
+Implementation: `internal/abci/appv22_lineage_repair.go`,
+`internal/store/upgrade_lineage.go`, `cmd/sage-gui/upgrade_lineage.go`, and the
+app-v22 upgrade proposal path in `internal/abci/app.go`.

--- a/internal/abci/app.go
+++ b/internal/abci/app.go
@@ -2472,6 +2472,9 @@ func NewSageAppWithStores(bs *store.BadgerStore, offchain store.OffchainStore, l
 	if invariantErr := app.refreshAppV21Fork(); invariantErr != nil {
 		return nil, invariantErr
 	}
+	if invariantErr := bs.ValidateLegacyUpgradeLineageRepairAudit(); invariantErr != nil {
+		return nil, fmt.Errorf("validate legacy upgrade lineage repair audit: %w", invariantErr)
+	}
 	if invariantErr := app.validateAppV21Prerequisite(); invariantErr != nil {
 		return nil, invariantErr
 	}
@@ -2872,6 +2875,22 @@ func (app *SageApp) ActiveUpgradeVote() (proposalID string, targetVersion uint64
 				Uint64("current_app_version", app.currentAppVersion()).
 				Msg("app-v22 upgrade requires app-v21 as its immediate predecessor; skipping auto-vote")
 			supported = false
+		} else if payload.LineageRepair != "" {
+			// A repair manifest carries historical evidence which cannot be
+			// established from current consensus state alone. In particular, a
+			// retained Comet block hash proves only what this validator's local
+			// archive reports. Never turn local validation into an automatic vote:
+			// every validator operator must independently inspect the exact
+			// chain-bound manifest and cast an explicit governance vote. This is
+			// intentionally true even for a one-validator chain.
+			supported = false
+			if _, _, repairErr := app.validateLegacyLineageRepair(payload.LineageRepair); repairErr != nil {
+				app.logger.Warn().Err(repairErr).Str("proposal_id", prop.ProposalID).
+					Msg("app-v22 lineage repair is invalid; automatic voting is disabled")
+			} else {
+				app.logger.Warn().Str("proposal_id", prop.ProposalID).
+					Msg("app-v22 lineage repair requires manual validator review and vote; automatic voting is disabled")
+			}
 		} else if _, ladderErr := app.validatePersistedAppV22PredecessorLadder(); ladderErr != nil {
 			app.logger.Warn().Err(ladderErr).Str("proposal_id", prop.ProposalID).
 				Msg("app-v22 predecessor ladder is invalid; skipping auto-vote")
@@ -10602,6 +10621,16 @@ func (app *SageApp) Query(_ context.Context, req *abcitypes.RequestQuery) (*abci
 			return &abcitypes.ResponseQuery{Code: 1, Log: "encode current CEREBRUM Root state"}, nil
 		}
 		return &abcitypes.ResponseQuery{Code: 0, Value: value}, nil
+	case "/upgrade/lineage":
+		status, err := app.legacyUpgradeLineageStatus()
+		if err != nil {
+			return &abcitypes.ResponseQuery{Code: 1, Log: "upgrade lineage unavailable: " + err.Error()}, nil
+		}
+		value, err := json.Marshal(status)
+		if err != nil {
+			return &abcitypes.ResponseQuery{Code: 1, Log: "encode upgrade lineage status"}, nil
+		}
+		return &abcitypes.ResponseQuery{Code: 0, Value: value}, nil
 	default:
 		return &abcitypes.ResponseQuery{Code: 1, Log: "unknown query path"}, nil
 	}
@@ -11162,6 +11191,7 @@ type UpgradeProposalPayload struct {
 	BinarySHA256       string `json:"binary_sha256,omitempty"`
 	UpgradeDelayBlocks int64  `json:"upgrade_delay_blocks,omitempty"`
 	GovernanceDomain   string `json:"governance_domain,omitempty"`
+	LineageRepair      string `json:"lineage_repair,omitempty"`
 }
 
 // applyUpgradeProposal persists the pending UpgradePlanRecord for an executed
@@ -11250,7 +11280,11 @@ func (app *SageApp) applyUpgradeProposal(proposal *governance.ProposalState, hei
 		if current := app.currentAppVersion(); current != 21 {
 			return fmt.Errorf("app-v22 upgrade requires current app version 21, got %d", current)
 		}
-		if _, ladderErr := app.validatePersistedAppV22PredecessorLadder(); ladderErr != nil {
+		if p.LineageRepair != "" {
+			if _, _, repairErr := app.validateLegacyLineageRepair(p.LineageRepair); repairErr != nil {
+				return fmt.Errorf("app-v22 lineage repair is invalid: %w", repairErr)
+			}
+		} else if _, ladderErr := app.validatePersistedAppV22PredecessorLadder(); ladderErr != nil {
 			return fmt.Errorf("app-v22 upgrade has invalid predecessor ladder: %w", ladderErr)
 		}
 	}
@@ -11338,6 +11372,14 @@ func (app *SageApp) applyUpgradeProposal(proposal *governance.ProposalState, hei
 		}
 		return nil
 	}
+	if p.Name == appV22UpgradeName && p.LineageRepair != "" {
+		if repairErr := app.applyLegacyLineageRepair(p.LineageRepair, proposal.ProposalID, height); repairErr != nil {
+			return fmt.Errorf("app-v22 lineage repair failed: %w", repairErr)
+		}
+		if _, ladderErr := app.validatePersistedAppV22PredecessorLadder(); ladderErr != nil {
+			return fmt.Errorf("app-v22 predecessor ladder remains invalid after repair: %w", ladderErr)
+		}
+	}
 
 	delay := p.UpgradeDelayBlocks
 	if floor := effectiveUpgradeDelayFloorBlocks(); delay < floor {
@@ -11349,6 +11391,7 @@ func (app *SageApp) applyUpgradeProposal(proposal *governance.ProposalState, hei
 		ActivationHeight: height + delay,
 		BinarySHA256:     p.BinarySHA256,
 		GovernanceDomain: p.GovernanceDomain,
+		LineageRepair:    p.LineageRepair,
 		ProposedAt:       height,
 		ProposerID:       proposal.ProposerID,
 	}
@@ -11423,10 +11466,19 @@ func (app *SageApp) processUpgradePropose(parsedTx *tx.ParsedTx, height int64, b
 			return &abcitypes.ExecTxResult{Code: 47, Log: fmt.Sprintf(
 				"upgrade propose: app-v22 requires current committed app version 21 (got %d)", current)}
 		}
-		if _, ladderErr := app.validatePersistedAppV22PredecessorLadder(); ladderErr != nil {
+		if prop.GovernanceDomain != "" {
+			return &abcitypes.ExecTxResult{Code: 47, Log: "upgrade propose: app-v22 must not carry an app-v20 governance_domain tail"}
+		}
+		if prop.LineageRepair != "" {
+			if _, _, repairErr := app.validateLegacyLineageRepair(prop.LineageRepair); repairErr != nil {
+				return &abcitypes.ExecTxResult{Code: 47, Log: "upgrade propose: app-v22 lineage repair is invalid: " + repairErr.Error()}
+			}
+		} else if _, ladderErr := app.validatePersistedAppV22PredecessorLadder(); ladderErr != nil {
 			return &abcitypes.ExecTxResult{Code: 47, Log: fmt.Sprintf(
 				"upgrade propose: app-v22 predecessor ladder is invalid: %v", ladderErr)}
 		}
+	} else if prop.LineageRepair != "" {
+		return &abcitypes.ExecTxResult{Code: 47, Log: "upgrade propose: lineage repair is admitted only for app-v22"}
 	}
 	if prop.Name == appV23UpgradeName {
 		if prop.TargetAppVersion != 23 {
@@ -11626,16 +11678,30 @@ func (app *SageApp) processUpgradePropose(parsedTx *tx.ParsedTx, height int64, b
 			BinarySHA256:       prop.BinarySHA256,
 			UpgradeDelayBlocks: prop.UpgradeDelayBlocks,
 			GovernanceDomain:   prop.GovernanceDomain,
+			LineageRepair:      prop.LineageRepair,
 		})
 		if mErr != nil {
 			return &abcitypes.ExecTxResult{Code: 47, Log: fmt.Sprintf("upgrade propose: encode payload: %v", mErr)}
 		}
 
 		reason := "app-version upgrade to " + prop.Name
-		proposalID, propErr := app.govEngine.Propose(
-			govProposerID, governance.OpUpgrade, prop.Name, nil, 0,
-			0 /* default expiry */, reason, height, payload,
-		)
+		var proposalID string
+		var propErr error
+		if prop.LineageRepair != "" {
+			// Historical upgrade proposals mirror the proposer's ACCEPT vote.
+			// A lineage repair is intentionally different: its historical
+			// evidence requires an explicit, independent operator decision from
+			// every validator, including the proposer on a single-node chain.
+			proposalID, propErr = app.govEngine.ProposeWithoutAutoVote(
+				govProposerID, governance.OpUpgrade, prop.Name, nil, 0,
+				0 /* default expiry */, reason, height, payload,
+			)
+		} else {
+			proposalID, propErr = app.govEngine.Propose(
+				govProposerID, governance.OpUpgrade, prop.Name, nil, 0,
+				0 /* default expiry */, reason, height, payload,
+			)
+		}
 		if propErr != nil {
 			return &abcitypes.ExecTxResult{Code: 47, Log: "upgrade propose: governance propose failed: " + propErr.Error()}
 		}
@@ -11648,8 +11714,9 @@ func (app *SageApp) processUpgradePropose(parsedTx *tx.ParsedTx, height int64, b
 			}
 		}
 
-		// Mirror processGovPropose's offchain buffering so the proposal and the
-		// proposer's auto-accept vote surface in the SQL mirror / dashboard.
+		// Mirror processGovPropose's offchain buffering. Ordinary historical
+		// proposals include the proposer's auto-accept vote; repair proposals do
+		// not, so the dashboard must not invent a vote absent from consensus.
 		app.pendingWrites = append(app.pendingWrites, pendingWrite{
 			writeType: "gov_proposal",
 			data: govProposalData{
@@ -11663,15 +11730,17 @@ func (app *SageApp) processUpgradePropose(parsedTx *tx.ParsedTx, height int64, b
 				Reason:        reason,
 			},
 		})
-		app.pendingWrites = append(app.pendingWrites, pendingWrite{
-			writeType: "gov_vote",
-			data: govVoteData{
-				ProposalID:  proposalID,
-				ValidatorID: govProposerID,
-				Decision:    "accept",
-				Height:      height,
-			},
-		})
+		if prop.LineageRepair == "" {
+			app.pendingWrites = append(app.pendingWrites, pendingWrite{
+				writeType: "gov_vote",
+				data: govVoteData{
+					ProposalID:  proposalID,
+					ValidatorID: govProposerID,
+					Decision:    "accept",
+					Height:      height,
+				},
+			})
+		}
 
 		app.logger.Info().
 			Str("name", prop.Name).
@@ -11708,6 +11777,7 @@ func (app *SageApp) processUpgradePropose(parsedTx *tx.ParsedTx, height int64, b
 		ActivationHeight: height + delay,
 		BinarySHA256:     prop.BinarySHA256,
 		GovernanceDomain: prop.GovernanceDomain,
+		LineageRepair:    prop.LineageRepair,
 		ProposedAt:       height,
 		ProposerID:       proposerID,
 	}

--- a/internal/abci/appv22_lineage_repair.go
+++ b/internal/abci/appv22_lineage_repair.go
@@ -1,0 +1,284 @@
+package abci
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/l33tdawg/sage/internal/governance"
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+const legacyLineageRepairSchema = "sage-upgrade-lineage-repair/v1"
+
+type LegacyLineageEvidence struct {
+	Version       uint64 `json:"version"`
+	Name          string `json:"name"`
+	AppliedHeight int64  `json:"applied_height"`
+	Source        string `json:"source"` // comet-block-results or legacy-anchor
+	BlockHash     string `json:"block_hash,omitempty"`
+}
+
+type LegacyLineageRepairManifest struct {
+	Schema             string                  `json:"schema"`
+	ChainID            string                  `json:"chain_id"`
+	GovernanceDomain   string                  `json:"governance_domain"`
+	CurrentAppVersion  uint64                  `json:"current_app_version"`
+	PriorLineageDigest string                  `json:"prior_lineage_digest"`
+	AnchorDigest       string                  `json:"anchor_digest,omitempty"`
+	AnchorAttestation  string                  `json:"anchor_attestation,omitempty"`
+	Evidence           []LegacyLineageEvidence `json:"evidence"`
+}
+
+type legacyLineageRungStatus struct {
+	Version       uint64 `json:"version"`
+	Name          string `json:"name"`
+	Present       bool   `json:"present"`
+	AppliedHeight int64  `json:"applied_height,omitempty"`
+	Valid         bool   `json:"valid"`
+	Problem       string `json:"problem,omitempty"`
+}
+
+type legacyLineageStatus struct {
+	Schema             string                                 `json:"schema"`
+	CurrentAppVersion  uint64                                 `json:"current_app_version"`
+	PersistedHeight    int64                                  `json:"persisted_height"`
+	GovernanceDomain   string                                 `json:"governance_domain"`
+	ValidLineageDigest string                                 `json:"valid_lineage_digest"`
+	RepairAudit        *store.LegacyUpgradeLineageRepairAudit `json:"repair_audit,omitempty"`
+	Rungs              []legacyLineageRungStatus              `json:"rungs"`
+}
+
+func (app *SageApp) legacyUpgradeLineageStatus() (*legacyLineageStatus, error) {
+	digest, err := validLegacyLineageDigest(app.badgerStore)
+	if err != nil {
+		return nil, err
+	}
+	audit, err := app.badgerStore.GetLegacyUpgradeLineageRepairAudit()
+	if err != nil {
+		return nil, err
+	}
+	status := &legacyLineageStatus{
+		Schema: legacyLineageRepairSchema, CurrentAppVersion: app.currentAppVersion(),
+		GovernanceDomain: app.GovernanceDelegationDomain(), ValidLineageDigest: digest,
+		RepairAudit: audit,
+	}
+	if app.state != nil {
+		status.PersistedHeight = app.state.Height
+	}
+	var previous int64
+	for version := uint64(6); version <= 21; version++ {
+		name := tx.CanonicalUpgradeName(version)
+		rung := legacyLineageRungStatus{Version: version, Name: name}
+		rec, getErr := app.badgerStore.GetAppliedUpgrade(name)
+		switch {
+		case getErr != nil:
+			rung.Problem = getErr.Error()
+		case rec == nil:
+			rung.Problem = "missing"
+		default:
+			rung.Present = true
+			rung.AppliedHeight = rec.AppliedHeight
+			rung.Valid = rec.Name == name && rec.TargetAppVersion == version && rec.AppliedHeight > previous && rec.AppliedHeight <= status.PersistedHeight
+			if !rung.Valid {
+				rung.Problem = "invalid canonical name, target, height, or order"
+			} else {
+				previous = rec.AppliedHeight
+			}
+		}
+		status.Rungs = append(status.Rungs, rung)
+	}
+	return status, nil
+}
+
+func canonicalLegacyLineageRepair(raw string) (*LegacyLineageRepairManifest, string, error) {
+	if raw == "" {
+		return nil, "", nil
+	}
+	var manifest LegacyLineageRepairManifest
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		return nil, "", fmt.Errorf("decode lineage repair manifest: %w", err)
+	}
+	canonical, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, "", err
+	}
+	if string(canonical) != raw {
+		return nil, "", errors.New("lineage repair manifest must use canonical compact JSON")
+	}
+	digest := sha256.Sum256(canonical)
+	return &manifest, hex.EncodeToString(digest[:]), nil
+}
+
+// CanonicalizeLegacyLineageRepair converts an operator-authored manifest into
+// the exact compact JSON bytes committed by UpgradePropose.
+func CanonicalizeLegacyLineageRepair(raw []byte) (string, error) {
+	var manifest LegacyLineageRepairManifest
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		return "", err
+	}
+	canonical, err := json.Marshal(manifest)
+	return string(canonical), err
+}
+
+func validLegacyLineageDigest(bs *store.BadgerStore) (string, error) {
+	type digestRecord struct {
+		Version uint64 `json:"version"`
+		Name    string `json:"name"`
+		Height  int64  `json:"height"`
+	}
+	records := make([]digestRecord, 0, 16)
+	for version := uint64(6); version <= 21; version++ {
+		name := tx.CanonicalUpgradeName(version)
+		rec, err := bs.GetAppliedUpgrade(name)
+		if err != nil {
+			return "", err
+		}
+		if rec == nil {
+			continue
+		}
+		if rec.Name != name || rec.TargetAppVersion != version || rec.AppliedHeight <= 0 {
+			continue
+		}
+		records = append(records, digestRecord{Version: version, Name: name, Height: rec.AppliedHeight})
+	}
+	encoded, err := json.Marshal(records)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func (app *SageApp) validateLegacyLineageRepair(raw string) (*LegacyLineageRepairManifest, string, error) {
+	manifest, digest, err := canonicalLegacyLineageRepair(raw)
+	if err != nil || manifest == nil {
+		return manifest, digest, err
+	}
+	if manifest.Schema != legacyLineageRepairSchema || manifest.CurrentAppVersion != 21 {
+		return nil, "", errors.New("lineage repair is admitted only for the app-v21 to app-v22 transition")
+	}
+	if len(manifest.Evidence) == 0 || len(manifest.Evidence) > 16 {
+		return nil, "", errors.New("lineage repair must contain one to sixteen missing records")
+	}
+	domain, err := governance.DelegationDomainForChainID(manifest.ChainID)
+	if err != nil || domain != manifest.GovernanceDomain ||
+		manifest.GovernanceDomain != app.expectedGovernanceDelegationDomain() ||
+		manifest.GovernanceDomain != app.GovernanceDelegationDomain() {
+		return nil, "", errors.New("lineage repair is not bound to this chain governance domain")
+	}
+	priorDigest, err := validLegacyLineageDigest(app.badgerStore)
+	if err != nil {
+		return nil, "", err
+	}
+	if manifest.PriorLineageDigest != priorDigest {
+		return nil, "", errors.New("lineage repair prior_lineage_digest does not match current consensus state")
+	}
+
+	entries := append([]LegacyLineageEvidence(nil), manifest.Evidence...)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Version < entries[j].Version })
+	source := entries[0].Source
+	if source != "comet-block-results" && source != "legacy-anchor" {
+		return nil, "", fmt.Errorf("unsupported lineage evidence source %q", source)
+	}
+	for i := range entries {
+		if entries[i] != manifest.Evidence[i] {
+			return nil, "", errors.New("lineage repair evidence must be sorted by version")
+		}
+		e := entries[i]
+		if e.Source != source {
+			return nil, "", errors.New("lineage repair evidence must use exactly one source; mixed Comet and legacy-anchor claims are forbidden")
+		}
+		if e.Version < 6 || e.Version > 21 || e.Name != tx.CanonicalUpgradeName(e.Version) || e.AppliedHeight <= 0 {
+			return nil, "", fmt.Errorf("invalid lineage evidence for app-v%d", e.Version)
+		}
+		if i > 0 && entries[i-1].Version == e.Version {
+			return nil, "", errors.New("lineage repair contains a duplicate version")
+		}
+		if existing, getErr := app.badgerStore.GetAppliedUpgrade(e.Name); getErr != nil {
+			return nil, "", getErr
+		} else if existing != nil {
+			return nil, "", fmt.Errorf("lineage repair may create only missing records; %s already exists", e.Name)
+		}
+		switch e.Source {
+		case "comet-block-results":
+			decoded, decodeErr := hex.DecodeString(e.BlockHash)
+			if decodeErr != nil || len(decoded) != sha256.Size || hex.EncodeToString(decoded) != e.BlockHash {
+				return nil, "", fmt.Errorf("app-v%d Comet evidence has no canonical block hash", e.Version)
+			}
+		case "legacy-anchor":
+			if e.BlockHash != "" {
+				return nil, "", fmt.Errorf("app-v%d legacy anchor must not claim a Comet block hash", e.Version)
+			}
+			decoded, decodeErr := hex.DecodeString(manifest.AnchorDigest)
+			if decodeErr != nil || len(decoded) != sha256.Size || hex.EncodeToString(decoded) != manifest.AnchorDigest {
+				return nil, "", errors.New("legacy-anchor evidence requires a canonical audited anchor_digest")
+			}
+			if manifest.AnchorAttestation != "operator-quorum-attested-unverified-history" {
+				return nil, "", errors.New("legacy-anchor evidence requires explicit unverified-history quorum attestation")
+			}
+		default:
+			return nil, "", fmt.Errorf("app-v%d has unsupported lineage evidence source %q", e.Version, e.Source)
+		}
+	}
+
+	// Validate the complete prospective ladder, using existing records wherever
+	// present and proposed evidence only for an exact absent rung.
+	byVersion := make(map[uint64]LegacyLineageEvidence, len(entries))
+	for _, entry := range entries {
+		byVersion[entry.Version] = entry
+	}
+	var previous int64
+	for version := uint64(6); version <= 21; version++ {
+		name := tx.CanonicalUpgradeName(version)
+		rec, getErr := app.badgerStore.GetAppliedUpgrade(name)
+		if getErr != nil {
+			return nil, "", getErr
+		}
+		height := int64(0)
+		if rec != nil {
+			if rec.Name != name || rec.TargetAppVersion != version || rec.AppliedHeight <= 0 {
+				return nil, "", fmt.Errorf("existing applied %s record is invalid and cannot be repaired", name)
+			}
+			height = rec.AppliedHeight
+		} else if evidence, ok := byVersion[version]; ok {
+			height = evidence.AppliedHeight
+		}
+		if height <= 0 {
+			return nil, "", fmt.Errorf("lineage repair does not cover missing canonical applied %s predecessor", name)
+		}
+		if height <= previous || app.state == nil || height > app.state.Height {
+			return nil, "", fmt.Errorf("prospective app-v%d height %d is outside the strict lineage order", version, height)
+		}
+		previous = height
+	}
+	return manifest, digest, nil
+}
+
+func (app *SageApp) applyLegacyLineageRepair(raw, proposalID string, height int64) error {
+	manifest, manifestDigest, err := app.validateLegacyLineageRepair(raw)
+	if err != nil {
+		return err
+	}
+	if manifest == nil {
+		return nil
+	}
+	records := make([]store.AppliedUpgradeRecord, 0, len(manifest.Evidence))
+	for _, evidence := range manifest.Evidence {
+		records = append(records, store.AppliedUpgradeRecord{Name: evidence.Name, TargetAppVersion: evidence.Version, AppliedHeight: evidence.AppliedHeight})
+	}
+	return app.badgerStore.ApplyLegacyUpgradeLineageRepair(store.LegacyUpgradeLineageRepairAudit{
+		Schema: manifest.Schema, GovernanceDomain: manifest.GovernanceDomain,
+		PriorLineageDigest: manifest.PriorLineageDigest, ManifestDigest: manifestDigest, Manifest: raw,
+		ApprovedHeight: height, ProposalID: proposalID, Records: records,
+	})
+}

--- a/internal/abci/appv22_lineage_repair_test.go
+++ b/internal/abci/appv22_lineage_repair_test.go
@@ -1,0 +1,234 @@
+package abci
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/governance"
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/l33tdawg/sage/internal/tx"
+	"github.com/l33tdawg/sage/internal/validator"
+)
+
+func lineageRepairFixture(t *testing.T, missing uint64) (*SageApp, string) {
+	t.Helper()
+	app := setupTestApp(t)
+	app.state.Height = 100
+	app.appV21AppliedHeight = 90
+	chainID := "lineage-test-chain"
+	domain, err := governance.DelegationDomainForChainID(chainID)
+	require.NoError(t, err)
+	require.NoError(t, app.SetExpectedGovernanceDelegationDomain(chainID))
+	require.NoError(t, app.ensureGovernanceDelegationDomain(domain))
+	seedAppV22PredecessorLadder(t, app.badgerStore, 10, missing, nil)
+	digest, err := validLegacyLineageDigest(app.badgerStore)
+	require.NoError(t, err)
+	proof := sha256.Sum256([]byte("retained-comet-block"))
+	manifest := LegacyLineageRepairManifest{
+		Schema: legacyLineageRepairSchema, ChainID: chainID, GovernanceDomain: domain,
+		CurrentAppVersion: 21, PriorLineageDigest: digest,
+		Evidence: []LegacyLineageEvidence{{Version: missing, Name: tx.CanonicalUpgradeName(missing), AppliedHeight: 10 + int64(missing-6), Source: "comet-block-results", BlockHash: hex.EncodeToString(proof[:])}},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	return app, string(raw)
+}
+
+func TestLegacyLineageRepairCreatesOnlyExactMissingEvidence(t *testing.T) {
+	app, raw := lineageRepairFixture(t, 9)
+	_, _, err := app.validateLegacyLineageRepair(raw)
+	require.NoError(t, err)
+	require.NoError(t, app.applyLegacyLineageRepair(raw, "proposal-1", 101))
+	rec, err := app.badgerStore.GetAppliedUpgrade("app-v9")
+	require.NoError(t, err)
+	require.Equal(t, &store.AppliedUpgradeRecord{Name: "app-v9", TargetAppVersion: 9, AppliedHeight: 13}, rec)
+	_, err = app.validatePersistedAppV22PredecessorLadder()
+	require.NoError(t, err)
+	audit, err := app.badgerStore.GetLegacyUpgradeLineageRepairAudit()
+	require.NoError(t, err)
+	require.Equal(t, "proposal-1", audit.ProposalID)
+}
+
+func TestLegacyLineageRepairDeterministicAcrossIndependentStores(t *testing.T) {
+	left, rawLeft := lineageRepairFixture(t, 12)
+	right, rawRight := lineageRepairFixture(t, 12)
+	require.Equal(t, rawLeft, rawRight)
+	require.NoError(t, left.applyLegacyLineageRepair(rawLeft, "proposal-shared", 101))
+	require.NoError(t, right.applyLegacyLineageRepair(rawRight, "proposal-shared", 101))
+	leftHash, err := left.badgerStore.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	rightHash, err := right.badgerStore.ComputeAppHashExcludingBookkeeping()
+	require.NoError(t, err)
+	require.Equal(t, leftHash, rightHash)
+	status, err := left.legacyUpgradeLineageStatus()
+	require.NoError(t, err)
+	require.NotNil(t, status.RepairAudit)
+}
+
+func TestLegacyLineageRepairDenials(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*LegacyLineageRepairManifest)
+	}{
+		{"cross-chain", func(m *LegacyLineageRepairManifest) { m.ChainID = "other-chain" }},
+		{"wrong-prior-digest", func(m *LegacyLineageRepairManifest) { m.PriorLineageDigest = string(make([]byte, 64)) }},
+		{"wrong-order-height", func(m *LegacyLineageRepairManifest) { m.Evidence[0].AppliedHeight = 99 }},
+		{"proposal-height", func(m *LegacyLineageRepairManifest) { m.Evidence[0].AppliedHeight = 101 }},
+		{"future-height", func(m *LegacyLineageRepairManifest) { m.Evidence[0].AppliedHeight = 102 }},
+		{"unsupported-source", func(m *LegacyLineageRepairManifest) { m.Evidence[0].Source = "operator-says-so" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app, raw := lineageRepairFixture(t, 9)
+			var manifest LegacyLineageRepairManifest
+			require.NoError(t, json.Unmarshal([]byte(raw), &manifest))
+			tc.mutate(&manifest)
+			changed, _ := json.Marshal(manifest)
+			_, _, err := app.validateLegacyLineageRepair(string(changed))
+			require.Error(t, err)
+			rec, getErr := app.badgerStore.GetAppliedUpgrade("app-v9")
+			require.NoError(t, getErr)
+			require.Nil(t, rec)
+		})
+	}
+}
+
+func TestLegacyLineageRepairRejectsMixedEvidenceSources(t *testing.T) {
+	app, _ := lineageRepairFixture(t, 9)
+	require.NoError(t, app.badgerStore.DB().Update(func(txn *badger.Txn) error {
+		return txn.Delete([]byte("upgrade:applied:app-v10"))
+	}))
+	digest, err := validLegacyLineageDigest(app.badgerStore)
+	require.NoError(t, err)
+	domain := app.GovernanceDelegationDomain()
+	proof := sha256.Sum256([]byte("retained-comet-block"))
+	manifest := LegacyLineageRepairManifest{
+		Schema: legacyLineageRepairSchema, ChainID: "lineage-test-chain", GovernanceDomain: domain,
+		CurrentAppVersion: 21, PriorLineageDigest: digest,
+		AnchorDigest: strings.Repeat("a", 64), AnchorAttestation: "operator-quorum-attested-unverified-history",
+		Evidence: []LegacyLineageEvidence{
+			{Version: 9, Name: "app-v9", AppliedHeight: 13, Source: "comet-block-results", BlockHash: hex.EncodeToString(proof[:])},
+			{Version: 10, Name: "app-v10", AppliedHeight: 14, Source: "legacy-anchor"},
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	_, _, err = app.validateLegacyLineageRepair(string(raw))
+	require.ErrorContains(t, err, "mixed Comet and legacy-anchor")
+}
+
+func TestLegacyLineageRepairRefusesExistingRecord(t *testing.T) {
+	app, raw := lineageRepairFixture(t, 9)
+	require.NoError(t, app.badgerStore.MarkUpgradeApplied("app-v9", 9, 13))
+	_, _, err := app.validateLegacyLineageRepair(raw)
+	require.Error(t, err)
+}
+
+func TestLegacyLineageRepairProposalNeverAutoVotesEvenWithOneValidator(t *testing.T) {
+	app, raw := lineageRepairFixture(t, 9)
+	validatorKey := newAgentKey(t)
+	registerAgent(t, app, validatorKey, "lineage-operator", "admin")
+	require.NoError(t, app.validators.AddValidator(&validator.ValidatorInfo{
+		ID: validatorKey.id, PublicKey: validatorKey.pub, Power: 10,
+	}))
+	require.NoError(t, app.badgerStore.SaveValidators(map[string]int64{validatorKey.id: 10}))
+	propose := makeUpgradeProposeTx(t, validatorKey, appV22UpgradeName, 22, "", 200)
+	propose.UpgradePropose.LineageRepair = raw
+	require.NoError(t, tx.SignTx(propose, validatorKey.priv))
+	result := app.processUpgradePropose(propose, 101, time.Now())
+	require.Zero(t, result.Code, result.Log)
+	active, err := app.govEngine.GetActiveProposal()
+	require.NoError(t, err)
+	require.NotNil(t, active)
+	proposalID := active.ProposalID
+	votes, err := app.badgerStore.GetGovVotes(proposalID)
+	require.NoError(t, err)
+	require.Empty(t, votes, "creating a repair proposal must not mirror the proposer's ACCEPT vote")
+	for _, write := range app.pendingWrites {
+		require.NotEqual(t, "gov_vote", write.writeType,
+			"the off-chain projection must not invent a proposer vote absent from consensus")
+	}
+	requireNoPendingPlan(t, app)
+
+	gotID, target, supported, ok := app.ActiveUpgradeVote()
+	require.True(t, ok)
+	require.Equal(t, proposalID, gotID)
+	require.Equal(t, uint64(22), target)
+	require.False(t, supported, "lineage evidence always requires an explicit operator vote")
+}
+
+func TestLegacyLineageRepairProposalRejectsAppV20DomainTail(t *testing.T) {
+	app, raw := lineageRepairFixture(t, 9)
+	operator := newAgentKey(t)
+	registerAgent(t, app, operator, "lineage-operator", "admin")
+	require.NoError(t, app.validators.AddValidator(&validator.ValidatorInfo{ID: operator.id, PublicKey: operator.pub, Power: 10}))
+	require.NoError(t, app.badgerStore.SaveValidators(map[string]int64{operator.id: 10}))
+	propose := makeUpgradeProposeTx(t, operator, appV22UpgradeName, 22, "", 200)
+	propose.UpgradePropose.LineageRepair = raw
+	propose.UpgradePropose.GovernanceDomain = strings.Repeat("a", 64)
+	require.NoError(t, tx.SignTx(propose, operator.priv))
+	result := app.processUpgradePropose(propose, 101, time.Now())
+	require.Equal(t, uint32(47), result.Code)
+	require.Contains(t, result.Log, "must not carry")
+}
+
+func TestLegacyLineageRepairRequiresExplicitFourValidatorQuorum(t *testing.T) {
+	app, raw := lineageRepairFixture(t, 9)
+	validators := []agentKey{newAgentKey(t), newAgentKey(t), newAgentKey(t), newAgentKey(t)}
+	powers := make(map[string]int64, len(validators))
+	for i, key := range validators {
+		role := "member"
+		if i == 0 {
+			role = "admin"
+		}
+		registerAgent(t, app, key, fmt.Sprintf("validator-%d", i+1), role)
+		require.NoError(t, app.validators.AddValidator(&validator.ValidatorInfo{ID: key.id, PublicKey: key.pub, Power: 10}))
+		powers[key.id] = 10
+	}
+	require.NoError(t, app.badgerStore.SaveValidators(powers))
+	propose := makeUpgradeProposeTx(t, validators[0], appV22UpgradeName, 22, "", 200)
+	propose.Nonce = 1
+	propose.UpgradePropose.LineageRepair = raw
+	require.NoError(t, tx.SignTx(propose, validators[0].priv))
+	encodedPropose, err := tx.EncodeTx(propose)
+	require.NoError(t, err)
+	proposed := finalizeBlock(t, app, 101, encodedPropose)
+	require.Zero(t, proposed.TxResults[0].Code, proposed.TxResults[0].Log)
+	active, err := app.govEngine.GetActiveProposal()
+	require.NoError(t, err)
+	require.NotNil(t, active)
+
+	for i := 0; i < 3; i++ {
+		nonce := uint64(1)
+		if i == 0 {
+			nonce = 2
+		}
+		vote := &tx.ParsedTx{
+			Type: tx.TxTypeGovVote, Nonce: nonce, Timestamp: time.Now(),
+			GovVote: &tx.GovVote{ProposalID: active.ProposalID, Decision: tx.VoteDecisionAccept},
+		}
+		require.NoError(t, tx.SignTx(vote, validators[i].priv))
+		encodedVote, encodeErr := tx.EncodeTx(vote)
+		require.NoError(t, encodeErr)
+		response := finalizeBlock(t, app, int64(102+i), encodedVote)
+		require.Zero(t, response.TxResults[0].Code, response.TxResults[0].Log)
+		plan, planErr := app.badgerStore.GetUpgradePlan()
+		require.ErrorIs(t, planErr, store.ErrNoUpgradePlan, "repair must not execute before quorum and the minimum voting window")
+		require.Nil(t, plan)
+	}
+	_ = finalizeBlock(t, app, 101+governance.MinVotingBlocks)
+	plan, err := app.badgerStore.GetUpgradePlan()
+	require.NoError(t, err)
+	require.Equal(t, raw, plan.LineageRepair)
+	repaired, err := app.badgerStore.GetAppliedUpgrade("app-v9")
+	require.NoError(t, err)
+	require.Equal(t, int64(13), repaired.AppliedHeight)
+}

--- a/internal/abci/scoped_state_sync.go
+++ b/internal/abci/scoped_state_sync.go
@@ -294,6 +294,9 @@ func inspectAppV20StateSyncStore(ctx context.Context, badgerStore *store.BadgerS
 	if state.EpochNum != poe.EpochNumber(state.Height) {
 		return 0, nil, fmt.Errorf("%s persisted epoch does not match height", label)
 	}
+	if auditErr := badgerStore.ValidateLegacyUpgradeLineageRepairAudit(); auditErr != nil {
+		return 0, nil, fmt.Errorf("verify %s legacy upgrade lineage repair audit: %w", label, auditErr)
+	}
 	applied, appliedErr := badgerStore.GetAppliedUpgrade(appV20UpgradeName)
 	if appliedErr != nil {
 		return 0, nil, appliedErr

--- a/internal/abci/scoped_state_sync_test.go
+++ b/internal/abci/scoped_state_sync_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"sort"
@@ -22,6 +23,43 @@ import (
 	"github.com/l33tdawg/sage/internal/tx"
 	"github.com/l33tdawg/sage/internal/validator"
 )
+
+func TestAppV20StateSyncPreservesAndValidatesLegacyLineageRepairAudit(t *testing.T) {
+	root := t.TempDir()
+	source, err := store.NewBadgerStore(filepath.Join(root, "source"))
+	require.NoError(t, err)
+	require.NoError(t, source.MarkUpgradeApplied(appV20UpgradeName, 20, 1))
+	seedTestGovernanceDelegationDomain(t, source)
+	manifest := `{"schema":"v1","governance_domain":"scope","prior_lineage_digest":"prior","evidence":[{"version":9,"name":"app-v9","applied_height":2}]}`
+	digest := sha256.Sum256([]byte(manifest))
+	require.NoError(t, source.ApplyLegacyUpgradeLineageRepair(store.LegacyUpgradeLineageRepairAudit{
+		Schema: "v1", GovernanceDomain: "scope", PriorLineageDigest: "prior",
+		ManifestDigest: hex.EncodeToString(digest[:]), Manifest: manifest,
+		ApprovedHeight: 3, ProposalID: "proposal-a",
+		Records: []store.AppliedUpgradeRecord{{Name: "app-v9", TargetAppVersion: 9, AppliedHeight: 2}},
+	}))
+	state := &AppState{Height: 3, EpochNum: poe.EpochNumber(3)}
+	for range 2 {
+		hash, hashErr := source.ComputeAppHashExcludingBookkeeping()
+		require.NoError(t, hashErr)
+		state.AppHash = append([]byte(nil), hash...)
+		require.NoError(t, SaveState(source, state))
+	}
+	trustedHash := append([]byte(nil), state.AppHash...)
+	backupPath := filepath.Join(root, "lineage.backup")
+	backup, err := os.OpenFile(backupPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	require.NoError(t, statesync.WriteCanonicalState(context.Background(), source.DB(), backup))
+	require.NoError(t, backup.Close())
+	require.NoError(t, source.CloseBadger())
+
+	target := filepath.Join(root, "target")
+	require.NoError(t, PrepareAppV20StateSyncBackup(context.Background(), backupPath, target, 3, trustedHash))
+	restored, err := store.OpenBadgerStoreReadOnly(target)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = restored.CloseBadger() })
+	require.NoError(t, restored.ValidateLegacyUpgradeLineageRepairAudit())
+}
 
 func TestPrepareAppV20StateSyncBackupValidatesWithoutActivating(t *testing.T) {
 	root := t.TempDir()

--- a/internal/federation/join_ceremony_test.go
+++ b/internal/federation/join_ceremony_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -339,6 +340,189 @@ func TestAutoHostJoinWindowAcceptsDirectCAFetchFromLegacyGuest(t *testing.T) {
 
 	_, err = guest.mgr.GuestScan(context.Background(), legacyURL.String(), "https://127.0.0.1:19444")
 	require.NoError(t, err)
+}
+
+func TestGuestScanDirectCAFetchHonorsFiveMinuteDiscoveryBudget(t *testing.T) {
+	host := newCeremonyNode(t, "host-slow-ca")
+	guest := newCeremonyNode(t, "guest-slow-ca")
+
+	hostTLS, err := host.mgr.ServerTLSConfig()
+	require.NoError(t, err)
+	baseHandler := host.mgr.Router()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fed/v1/join/ca" {
+			// This deliberately crosses the v11.17 15-second fetch cutoff. The
+			// production GuestScan driver must keep the operator's bounded
+			// discovery request alive instead of replacing it with that cutoff.
+			timer := time.NewTimer(15*time.Second + 250*time.Millisecond)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+			case <-r.Context().Done():
+				return
+			}
+		}
+		baseHandler.ServeHTTP(w, r)
+	}))
+	srv.TLS = hostTLS
+	srv.StartTLS()
+	defer srv.Close()
+
+	create, err := host.mgr.HostCreate(srv.URL)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	_, err = guest.mgr.GuestScan(ctx, create.OTPAuthURI, "https://127.0.0.1:19444")
+	require.NoError(t, err)
+}
+
+func TestGuestScanP2PAllowsDelayedTargetBeyondLegacyAttemptTimeout(t *testing.T) {
+	host := newCeremonyNode(t, "host-delayed-route")
+	guest := newCeremonyNode(t, "guest-delayed-route")
+	hostBundle := testDirectRouteBundle(t, "192.168.50.192")
+	guestBundle := testDirectRouteBundle(t, "192.168.50.193")
+	host.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LocalBundle: func() (JoinP2PBundle, error) { return hostBundle, nil },
+	})
+
+	hostTLS, err := host.mgr.ServerTLSConfig()
+	require.NoError(t, err)
+	srv := httptest.NewUnstartedServer(host.mgr.Router())
+	srv.TLS = hostTLS
+	srv.StartTLS()
+	defer srv.Close()
+
+	guest.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LocalBundle: func() (JoinP2PBundle, error) { return guestBundle, nil },
+		DialTarget: func(ctx context.Context, _ string) (net.Conn, error) {
+			// Relay negotiation can legitimately exceed the old hard-coded two
+			// second candidate timeout.
+			timer := time.NewTimer(2*time.Second + 250*time.Millisecond)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return (&net.Dialer{}).DialContext(ctx, "tcp", srv.Listener.Addr().String())
+		},
+	})
+	create, err := host.mgr.HostCreateAuto(srv.URL)
+	require.NoError(t, err)
+	require.Equal(t, "p2p", create.Transport)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	_, err = guest.mgr.GuestScan(ctx, create.OTPAuthURI, "")
+	require.NoError(t, err)
+}
+
+func TestGuestScanP2PRetriesUntilExactTargetBecomesAvailable(t *testing.T) {
+	host := newCeremonyNode(t, "host-retry-route")
+	guest := newCeremonyNode(t, "guest-retry-route")
+	hostBundle := testDirectRouteBundle(t, "192.168.50.192")
+	guestBundle := testDirectRouteBundle(t, "192.168.50.193")
+	host.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LocalBundle: func() (JoinP2PBundle, error) { return hostBundle, nil },
+	})
+	hostTLS, err := host.mgr.ServerTLSConfig()
+	require.NoError(t, err)
+	srv := httptest.NewUnstartedServer(host.mgr.Router())
+	srv.TLS = hostTLS
+	srv.StartTLS()
+	defer srv.Close()
+
+	var dialMu sync.Mutex
+	dialCount := 0
+	guest.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LocalBundle: func() (JoinP2PBundle, error) { return guestBundle, nil },
+		DialTarget: func(ctx context.Context, _ string) (net.Conn, error) {
+			dialMu.Lock()
+			dialCount++
+			attempt := dialCount
+			dialMu.Unlock()
+			if attempt == 1 {
+				return nil, errors.New("relay reservation is still warming")
+			}
+			return (&net.Dialer{}).DialContext(ctx, "tcp", srv.Listener.Addr().String())
+		},
+	})
+	create, err := host.mgr.HostCreateAuto(srv.URL)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = guest.mgr.GuestScan(ctx, create.OTPAuthURI, "")
+	require.NoError(t, err)
+	dialMu.Lock()
+	defer dialMu.Unlock()
+	assert.Equal(t, 2, dialCount)
+}
+
+func TestGuestScanP2PStopsImmediatelyOnClientCancellation(t *testing.T) {
+	host := newCeremonyNode(t, "host-cancel-route")
+	guest := newCeremonyNode(t, "guest-cancel-route")
+	hostBundle := testDirectRouteBundle(t, "192.168.50.192")
+	guestBundle := testDirectRouteBundle(t, "192.168.50.193")
+	host.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LocalBundle: func() (JoinP2PBundle, error) { return hostBundle, nil },
+	})
+	started := make(chan struct{}, 1)
+	guest.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LocalBundle: func() (JoinP2PBundle, error) { return guestBundle, nil },
+		DialTarget: func(ctx context.Context, _ string) (net.Conn, error) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+	create, err := host.mgr.HostCreateAuto("https://127.0.0.1:65535")
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, scanErr := guest.mgr.GuestScan(ctx, create.OTPAuthURI, "")
+		done <- scanErr
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("P2P discovery did not start")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("GuestScan did not stop after client cancellation")
+	}
+}
+
+func TestGuestScanP2PStopsAtCallerSessionDeadline(t *testing.T) {
+	host := newCeremonyNode(t, "host-expired-route")
+	guest := newCeremonyNode(t, "guest-expired-route")
+	hostBundle := testDirectRouteBundle(t, "192.168.50.192")
+	guestBundle := testDirectRouteBundle(t, "192.168.50.193")
+	host.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LocalBundle: func() (JoinP2PBundle, error) { return hostBundle, nil },
+	})
+	guest.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LocalBundle: func() (JoinP2PBundle, error) { return guestBundle, nil },
+		DialTarget: func(ctx context.Context, _ string) (net.Conn, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+	create, err := host.mgr.HostCreateAuto("https://127.0.0.1:65535")
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 125*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err = guest.mgr.GuestScan(ctx, create.OTPAuthURI, "")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(started), time.Second, "session deadline must preempt route attempts and retry backoff")
 }
 
 func TestHostCreateAutoUsesPreparedDirectBundle(t *testing.T) {

--- a/internal/federation/join_routes.go
+++ b/internal/federation/join_routes.go
@@ -51,10 +51,20 @@ const (
 	// guestDraftTTL bounds how long a guest keeps the scanned seed in memory
 	// between the QR scan and its tx-33.
 	guestDraftTTL = 15 * time.Minute
-	// joinCAFetchTimeout / joinCallTimeout bound the guest's outbound ceremony
-	// calls to the host.
-	joinCAFetchTimeout = 15 * time.Second
-	joinCallTimeout    = 20 * time.Second
+	// joinCADiscoveryTimeout is the hard safety ceiling for the operator-driven
+	// CA discovery step. The dashboard supplies the same five-minute budget;
+	// deriving from the caller here means client cancellation and any earlier
+	// session deadline still win. Later ceremony calls deliberately retain their
+	// much smaller request budget.
+	joinCADiscoveryTimeout = 5 * time.Minute
+	joinCallTimeout        = 20 * time.Second
+
+	// Internet JOIN discovery retries only the exact, QR-attested route bundle.
+	// A candidate gets enough time for libp2p relay setup, while exponential
+	// backoff bounds repeated offline-peer attempts over the discovery window.
+	joinRouteAttemptTimeout = 10 * time.Second
+	joinRouteRetryInitial   = 1 * time.Second
+	joinRouteRetryMax       = 15 * time.Second
 )
 
 // joinP2POnlyEndpoint is transcript material for an Internet ceremony that has
@@ -1936,7 +1946,7 @@ func (m *Manager) fetchHostCA(ctx context.Context, hostEndpoint, sessionID strin
 		return nil, "", err
 	}
 	u += "?session_id=" + url.QueryEscape(sessionID)
-	reqCtx, cancel := context.WithTimeout(ctx, joinCAFetchTimeout)
+	reqCtx, cancel := context.WithTimeout(ctx, joinCADiscoveryTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, u, nil)
 	if err != nil {
@@ -2104,33 +2114,64 @@ func joinP2PHTTPTransport(tlsCfg *tls.Config, dial func(context.Context, string)
 	return &http.Transport{
 		TLSClientConfig: tlsCfg,
 		DialTLSContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			attempts := make([]routeDialAttempt, 0, len(exact))
-			for _, target := range exact {
-				target := target
-				delay := time.Duration(0)
-				if routeKindForTarget(target) == RouteKindRelay {
-					delay = routeCandidateDelay
+			retryDelay := joinRouteRetryInitial
+			var lastErr error
+			for {
+				attempts := make([]routeDialAttempt, 0, len(exact))
+				for _, target := range exact {
+					target := target
+					delay := time.Duration(0)
+					if routeKindForTarget(target) == RouteKindRelay {
+						delay = routeCandidateDelay
+					}
+					attempts = append(attempts, routeDialAttempt{
+						delay: delay,
+						dial: func(attemptCtx context.Context) (PeerRouteDialResult, error) {
+							candidateCtx, cancel := context.WithTimeout(attemptCtx, joinRouteAttemptTimeout)
+							defer cancel()
+							start := time.Now()
+							conn, err := dial(candidateCtx, target)
+							return authenticate(candidateCtx, PeerRouteDialResult{
+								Conn: conn, Kind: routeKindForTarget(target),
+								Target: target, Latency: time.Since(start),
+							}, err)
+						},
+					})
 				}
-				attempts = append(attempts, routeDialAttempt{
-					delay: delay,
-					dial: func(attemptCtx context.Context) (PeerRouteDialResult, error) {
-						candidateCtx, cancel := context.WithTimeout(attemptCtx, 2*time.Second)
-						defer cancel()
-						start := time.Now()
-						conn, err := dial(candidateCtx, target)
-						return authenticate(candidateCtx, PeerRouteDialResult{
-							Conn: conn, Kind: routeKindForTarget(target),
-							Target: target, Latency: time.Since(start),
-						}, err)
-					},
-				})
+				winner, err := raceRouteDials(ctx, attempts)
+				if err == nil {
+					return winner.Conn, nil
+				}
+				lastErr = err
+				if ctx.Err() != nil {
+					return nil, fmt.Errorf("join p2p discovery stopped: %w (last route error: %v)", ctx.Err(), lastErr)
+				}
+				// A pin, certificate, or TLS identity failure is not an availability
+				// event. Retrying it would weaken fail-closed behavior and could hide
+				// a route substitution attempt behind a later candidate.
+				if isSecurityTransportError(err) {
+					return nil, fmt.Errorf("join p2p target authentication failed: %w", err)
+				}
+				if err := waitJoinRouteRetry(ctx, retryDelay); err != nil {
+					return nil, fmt.Errorf("join p2p discovery stopped: %w (last route error: %v)", err, lastErr)
+				}
+				retryDelay *= 2
+				if retryDelay > joinRouteRetryMax {
+					retryDelay = joinRouteRetryMax
+				}
 			}
-			winner, err := raceRouteDials(ctx, attempts)
-			if err != nil {
-				return nil, fmt.Errorf("join p2p targets unreachable: %w", err)
-			}
-			return winner.Conn, nil
 		},
+	}
+}
+
+func waitJoinRouteRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/internal/federation/pipe_contacts.go
+++ b/internal/federation/pipe_contacts.go
@@ -472,7 +472,8 @@ func (m *Manager) buildPipeContactLookupGrant(ctx context.Context, peer *peerIde
 		if err == nil {
 			filtered := agents[:0]
 			for _, agent := range agents {
-				if agent != nil && strings.EqualFold(pipeContactAgentDisplayName(agent), req.Target) {
+				if agent != nil && (strings.EqualFold(pipeContactAgentDisplayName(agent), req.Target) ||
+					strings.EqualFold(agent.RegisteredName, req.Target)) {
 					filtered = append(filtered, agent)
 				}
 			}

--- a/internal/federation/pipe_targets.go
+++ b/internal/federation/pipe_targets.go
@@ -661,12 +661,19 @@ func (m *Manager) resolveRemotePipeTarget(ctx context.Context, target string, al
 		return nil, errors.Join(ErrRemotePipeResolutionIncomplete, errors.Join(lookupErrors...))
 	}
 	if len(matches) != 1 {
-		choices := make([]string, 0, len(matches))
+		const maxAmbiguousChoices = 20
+		choices := make([]string, 0, min(len(matches), maxAmbiguousChoices))
 		for _, match := range matches {
-			choices = append(choices, match.contact.Address)
+			if len(choices) < maxAmbiguousChoices {
+				choices = append(choices, match.contact.Address)
+			}
 		}
 		sort.Strings(choices)
-		return nil, fmt.Errorf("%w: choose one of %s", ErrRemotePipeTargetAmbiguous, strings.Join(choices, ", "))
+		detail := strings.Join(choices, ", ")
+		if len(matches) > len(choices) {
+			detail += fmt.Sprintf(" (and %d more; use sage_find_agent)", len(matches)-len(choices))
+		}
+		return nil, fmt.Errorf("%w: choose one of %s", ErrRemotePipeTargetAmbiguous, detail)
 	}
 	match := matches[0]
 	if match.grant.Paused {
@@ -704,7 +711,12 @@ func matchRemotePipeCandidates(target string, candidates []remotePipeCandidate) 
 		case strings.HasPrefix(target, "#"):
 			matched = strings.EqualFold(contact.Handle, target)
 		default:
-			matched = strings.EqualFold(contact.AgentID, target) || strings.EqualFold(contact.DisplayName, target)
+			// Friendly labels are advisory inputs only. Resolution may match either
+			// exposed name, but the returned route and every signed transport event
+			// remain bound to the immutable AgentID/Address.
+			matched = strings.EqualFold(contact.AgentID, target) ||
+				strings.EqualFold(contact.DisplayName, target) ||
+				strings.EqualFold(contact.RegisteredName, target)
 		}
 		if matched {
 			out = append(out, candidate)

--- a/internal/federation/pipe_targets_test.go
+++ b/internal/federation/pipe_targets_test.go
@@ -78,6 +78,43 @@ func TestMatchRemotePipeCandidatesRequiresExactQualifiedIdentity(t *testing.T) {
 		"short agent prefixes are accepted only inside a peer-qualified handle")
 }
 
+func TestMatchRemotePipeCandidatesAcceptsRegisteredNameButReturnsCanonicalRoute(t *testing.T) {
+	agentID := strings.Repeat("c", 64)
+	candidate := remotePipeCandidate{
+		chainID: "chain-mini",
+		contact: PipeContact{
+			AgentID: agentID, Address: agentID + "@chain-mini",
+			DisplayName: "Mynah on the mini", RegisteredName: "mynah/voice-bridge",
+		},
+	}
+
+	matches := matchRemotePipeCandidates("mynah/voice-bridge", []remotePipeCandidate{candidate})
+	require.Len(t, matches, 1)
+	require.Equal(t, agentID+"@chain-mini", matches[0].contact.Address)
+	require.True(t, pipeContactMatchesTarget(candidate.contact, "mynah/voice-bridge"),
+		"the serving peer's targeted lookup must expose the same exact registered-name match")
+	require.Empty(t, matchRemotePipeCandidates("mynah", []remotePipeCandidate{candidate}),
+		"friendly send resolution must never use substring matching")
+}
+
+func TestMatchRemotePipeCandidatesRenameKeepsRegisteredAndCanonicalIdentityStable(t *testing.T) {
+	agentID := strings.Repeat("d", 64)
+	before := remotePipeCandidate{chainID: "chain-mini", contact: PipeContact{
+		AgentID: agentID, Address: agentID + "@chain-mini",
+		DisplayName: "Old Mynah", RegisteredName: "mynah/voice-bridge",
+	}}
+	after := before
+	after.contact.DisplayName = "Mac Mini Mynah"
+
+	require.Len(t, matchRemotePipeCandidates("Old Mynah", []remotePipeCandidate{before}), 1)
+	require.Empty(t, matchRemotePipeCandidates("Old Mynah", []remotePipeCandidate{after}))
+	for _, label := range []string{"Mac Mini Mynah", "mynah/voice-bridge"} {
+		matches := matchRemotePipeCandidates(label, []remotePipeCandidate{after})
+		require.Len(t, matches, 1)
+		require.Equal(t, agentID+"@chain-mini", matches[0].contact.Address)
+	}
+}
+
 func TestSplitPipeAddressRejectsMalformedQualifiedTargets(t *testing.T) {
 	agentID := strings.Repeat("a", 64)
 	agent, chain := splitPipeAddress(agentID + "@chain-amy")

--- a/internal/federation/routes_test.go
+++ b/internal/federation/routes_test.go
@@ -174,6 +174,21 @@ func TestJoinTransportBlackholedFirstTargetUsesRelay(t *testing.T) {
 	assert.Less(t, time.Since(start), 500*time.Millisecond)
 }
 
+func TestJoinTransportDoesNotRetrySecurityFailure(t *testing.T) {
+	var calls atomic.Int32
+	transport := joinP2PHTTPTransport(nil, func(context.Context, string) (net.Conn, error) {
+		calls.Add(1)
+		return nil, errors.New("tls: bad certificate")
+	}, []string{"/ip4/192.0.2.1/tcp/1/p2p/direct"})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	start := time.Now()
+	_, err := transport.DialTLSContext(ctx, "tcp", "unused")
+	require.ErrorContains(t, err, "authentication failed")
+	assert.Equal(t, int32(1), calls.Load())
+	assert.Less(t, time.Since(start), 250*time.Millisecond, "security failures must not enter availability retry backoff")
+}
+
 func TestMountedRouterRejectsPeerAndJoinTrafficAfterRuntimeDisable(t *testing.T) {
 	m := &Manager{routeStatus: make(map[string]RouteDiagnostics)}
 	router := m.Router()

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -918,7 +918,9 @@ func pipeContactMatchesTarget(contact PipeContact, target string) bool {
 	if strings.HasPrefix(target, "#") {
 		return strings.EqualFold(contact.Handle, target)
 	}
-	return strings.EqualFold(contact.AgentID, target) || strings.EqualFold(contact.DisplayName, target)
+	return strings.EqualFold(contact.AgentID, target) ||
+		strings.EqualFold(contact.DisplayName, target) ||
+		strings.EqualFold(contact.RegisteredName, target)
 }
 
 func pipeContactMatchesName(query string, contact PipeContact) (exact bool, partial bool) {

--- a/internal/mcp/messages_tools_test.go
+++ b/internal/mcp/messages_tools_test.go
@@ -132,7 +132,15 @@ func TestCanonicalMessageToolsHideFederatedPipelineTransport(t *testing.T) {
 		})
 	})
 	mux.HandleFunc("/v1/pipe/remote-local/result", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"status": "completed"})
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "completed", "reply_event_id": "reply-event-1", "reply_status": "queued",
+		})
+	})
+	mux.HandleFunc("/v1/messages/replies/reply-event-1/status", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"reply_event_id": "reply-event-1", "scope": "federated",
+			"reply_status": "delivered", "transport_status": "delivered",
+		})
 	})
 	mux.HandleFunc("/v1/messages/transport-1/status", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -169,6 +177,12 @@ func TestCanonicalMessageToolsHideFederatedPipelineTransport(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "remote-local", reply.(map[string]any)["message_id"])
 	require.Equal(t, "federated", reply.(map[string]any)["scope"])
+	require.Equal(t, "reply-event-1", reply.(map[string]any)["reply_event_id"])
+	require.Contains(t, reply.(map[string]any)["message"], "immutable outbound reply receipt")
+	replyStatus, err := s.toolMessageStatus(context.Background(), map[string]any{"message_id": "reply-event-1"})
+	require.NoError(t, err)
+	require.Equal(t, "delivered", replyStatus.(map[string]any)["reply_status"])
+	require.NotContains(t, replyStatus.(map[string]any), "workflow_status")
 
 	status, err := s.toolMessageStatus(context.Background(), map[string]any{"message_id": "transport-1"})
 	require.NoError(t, err)
@@ -178,6 +192,43 @@ func TestCanonicalMessageToolsHideFederatedPipelineTransport(t *testing.T) {
 	require.Equal(t, "confirmed", status.(map[string]any)["read_status"])
 	require.Equal(t, "completed", status.(map[string]any)["workflow_status"])
 	require.False(t, statusFallbackCalled, "canonical federated status must not lose workflow via the legacy receipt fallback")
+}
+
+func TestMessageSendFriendlyFederatedNameQueuesOnlyCanonicalDestination(t *testing.T) {
+	remoteAgent := strings.Repeat("e", 64)
+	var sendBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/pipe/resolve", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "Mac Mini Mynah", body["to"])
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"to_agent": remoteAgent, "source_chain_id": "chain-local",
+			"destination_chain_id": "chain-mini", "address": remoteAgent + "@chain-mini",
+		})
+	})
+	mux.HandleFunc("/v1/pipe/send", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&sendBody))
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"pipe_id": "canonical-message", "status": "pending", "destination_chain_id": "chain-mini",
+		})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	result, err := NewServer(ts.URL, privateKey).toolMessageSend(context.Background(), map[string]any{
+		"to": "Mac Mini Mynah", "payload": "hello", "idempotency_key": "friendly-send",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "canonical-message", result.(map[string]any)["message_id"])
+	require.Equal(t, remoteAgent, sendBody["to_agent"])
+	require.Equal(t, "chain-mini", sendBody["destination_chain_id"])
+	require.Equal(t, "chain-local", sendBody["source_chain_id"])
+	require.NotContains(t, sendBody, "to")
+	require.NotContains(t, fmt.Sprint(sendBody), "Mac Mini Mynah")
 }
 
 func TestPipeReceiptStatusUsesExactSignedSenderProjection(t *testing.T) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -4665,7 +4665,7 @@ func (s *Server) toolMessageReply(ctx context.Context, params map[string]any) (a
 		response = legacy.(map[string]any)
 		response["message_id"] = messageID
 		response["scope"] = "federated"
-		response["message"] = "Reply queued over the trusted connection. Repeating the same federated event is deduplicated by the receiving SAGE."
+		response["message"] = "Reply queued over the trusted connection. reply_event_id is the immutable outbound reply receipt; pass it to sage_message_status to inspect delivery without creating another inbox request. Repeating the same federated event is deduplicated by the receiving SAGE."
 		return response, nil
 	}
 	response["message"] = "Reply recorded. Repeating this exact reply is safe; a different second reply is rejected."
@@ -4684,6 +4684,12 @@ func (s *Server) toolMessageStatus(ctx context.Context, params map[string]any) (
 	if err := s.doSignedJSON(ctx, http.MethodGet, "/v1/messages/"+url.PathEscape(messageID)+"/status", nil, &response); err != nil {
 		if !isAPIStatus(err, http.StatusNotFound) {
 			return nil, fmt.Errorf("message status: %w", err)
+		}
+		if replyErr := s.doSignedJSON(ctx, http.MethodGet, "/v1/messages/replies/"+url.PathEscape(messageID)+"/status", nil, &response); replyErr == nil {
+			response["message"] = "This is your outbound federated reply event status. It is not a new request and exposes no original-message status or result content."
+			return response, nil
+		} else if !isAPIStatus(replyErr, http.StatusNotFound) {
+			return nil, fmt.Errorf("federated reply status: %w", replyErr)
 		}
 		if receiptErr := s.doSignedJSON(ctx, http.MethodGet, "/v1/pipe/"+url.PathEscape(messageID)+"/receipt", nil, &response); receiptErr != nil {
 			return nil, fmt.Errorf("federated message status: %w", receiptErr)
@@ -5515,9 +5521,11 @@ func (s *Server) toolPipeResult(ctx context.Context, params map[string]any) (any
 	}
 
 	var resp struct {
-		Status    string `json:"status"`
-		JournalID string `json:"journal_id"`
-		Journaled bool   `json:"journaled"`
+		Status       string `json:"status"`
+		JournalID    string `json:"journal_id"`
+		Journaled    bool   `json:"journaled"`
+		ReplyEventID string `json:"reply_event_id"`
+		ReplyStatus  string `json:"reply_status"`
 	}
 	if err := s.doSignedJSON(ctx, "PUT", "/v1/pipe/"+escapedPipeID+"/result", body, &resp); err != nil {
 		return nil, fmt.Errorf("pipeline result: %w", err)
@@ -5529,12 +5537,17 @@ func (s *Server) toolPipeResult(ctx context.Context, params map[string]any) (any
 	} else if resp.Journaled {
 		message += " A local journal entry was created summarizing the exchange."
 	}
-	return map[string]any{
+	response := map[string]any{
 		"status":     resp.Status,
 		"journal_id": resp.JournalID,
 		"journaled":  resp.Journaled,
 		"message":    message,
-	}, nil
+	}
+	if resp.ReplyEventID != "" {
+		response["reply_event_id"] = resp.ReplyEventID
+		response["reply_status"] = resp.ReplyStatus
+	}
+	return response, nil
 }
 
 // checkPipelineInbox keeps sage_turn payload-free. It reports only whether

--- a/internal/store/upgrade_lineage.go
+++ b/internal/store/upgrade_lineage.go
@@ -1,0 +1,170 @@
+package store
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	badger "github.com/dgraph-io/badger/v4"
+)
+
+const legacyUpgradeLineageAuditKey = "upgrade:lineage-repair:app-v22"
+
+// LegacyUpgradeLineageRepairAudit is immutable consensus evidence that a
+// validator quorum approved creation of an exact set of missing legacy applied
+// records. Existing records are never replaced.
+type LegacyUpgradeLineageRepairAudit struct {
+	Schema             string                 `json:"schema"`
+	GovernanceDomain   string                 `json:"governance_domain"`
+	PriorLineageDigest string                 `json:"prior_lineage_digest"`
+	ManifestDigest     string                 `json:"manifest_digest"`
+	Manifest           string                 `json:"manifest"`
+	ApprovedHeight     int64                  `json:"approved_height"`
+	ProposalID         string                 `json:"proposal_id"`
+	Records            []AppliedUpgradeRecord `json:"records"`
+}
+
+// ApplyLegacyUpgradeLineageRepair creates only absent applied-upgrade records
+// and one immutable audit record in the caller's consensus transaction. Exact
+// replay is idempotent; any pre-existing conflicting record fails closed.
+func (s *BadgerStore) ApplyLegacyUpgradeLineageRepair(audit LegacyUpgradeLineageRepairAudit) error {
+	if audit.Schema == "" || audit.GovernanceDomain == "" || audit.ManifestDigest == "" || audit.Manifest == "" ||
+		audit.PriorLineageDigest == "" || audit.ApprovedHeight <= 0 || audit.ProposalID == "" ||
+		len(audit.Records) == 0 {
+		return errors.New("legacy upgrade lineage repair audit is incomplete")
+	}
+	payload, err := json.Marshal(audit)
+	if err != nil {
+		return fmt.Errorf("marshal legacy upgrade lineage audit: %w", err)
+	}
+	return s.update(func(txn *badger.Txn) error {
+		if item, getErr := txn.Get([]byte(legacyUpgradeLineageAuditKey)); getErr == nil {
+			var existing []byte
+			if valueErr := item.Value(func(value []byte) error {
+				existing = append(existing, value...)
+				return nil
+			}); valueErr != nil {
+				return valueErr
+			}
+			if string(existing) == string(payload) {
+				return nil
+			}
+			return errors.New("legacy upgrade lineage repair audit already exists with different content")
+		} else if !errors.Is(getErr, badger.ErrKeyNotFound) {
+			return getErr
+		}
+
+		for _, rec := range audit.Records {
+			key := upgradeAppliedKey(rec.Name)
+			if item, getErr := txn.Get(key); getErr == nil {
+				var existing AppliedUpgradeRecord
+				if valueErr := item.Value(func(value []byte) error { return json.Unmarshal(value, &existing) }); valueErr != nil {
+					return fmt.Errorf("decode existing applied %s: %w", rec.Name, valueErr)
+				}
+				if existing == rec {
+					continue
+				}
+				return fmt.Errorf("refuse to overwrite existing applied %s record", rec.Name)
+			} else if !errors.Is(getErr, badger.ErrKeyNotFound) {
+				return getErr
+			}
+			encoded, marshalErr := json.Marshal(rec)
+			if marshalErr != nil {
+				return marshalErr
+			}
+			if setErr := s.txnSet(txn, key, encoded); setErr != nil {
+				return setErr
+			}
+		}
+		return s.txnSet(txn, []byte(legacyUpgradeLineageAuditKey), payload)
+	})
+}
+
+// ValidateLegacyUpgradeLineageRepairAudit verifies that the immutable repair
+// receipt still binds the exact canonical manifest and every record it
+// created. It is safe on states without a repair receipt.
+func (s *BadgerStore) ValidateLegacyUpgradeLineageRepairAudit() error {
+	audit, err := s.GetLegacyUpgradeLineageRepairAudit()
+	if err != nil || audit == nil {
+		return err
+	}
+	digest := sha256.Sum256([]byte(audit.Manifest))
+	if hex.EncodeToString(digest[:]) != audit.ManifestDigest {
+		return errors.New("legacy upgrade lineage repair manifest digest mismatch")
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(audit.Manifest)); err != nil {
+		return fmt.Errorf("decode legacy upgrade lineage repair manifest: %w", err)
+	}
+	if compact.String() != audit.Manifest {
+		return errors.New("legacy upgrade lineage repair manifest is not canonical JSON")
+	}
+	var manifest struct {
+		Schema             string `json:"schema"`
+		GovernanceDomain   string `json:"governance_domain"`
+		PriorLineageDigest string `json:"prior_lineage_digest"`
+		Evidence           []struct {
+			Version       uint64 `json:"version"`
+			Name          string `json:"name"`
+			AppliedHeight int64  `json:"applied_height"`
+		} `json:"evidence"`
+	}
+	if err := json.Unmarshal([]byte(audit.Manifest), &manifest); err != nil {
+		return fmt.Errorf("decode legacy upgrade lineage repair manifest fields: %w", err)
+	}
+	if audit.Schema != manifest.Schema || audit.GovernanceDomain != manifest.GovernanceDomain ||
+		audit.PriorLineageDigest != manifest.PriorLineageDigest {
+		return errors.New("legacy upgrade lineage repair audit fields do not match its manifest")
+	}
+	if len(audit.Records) != len(manifest.Evidence) {
+		return errors.New("legacy upgrade lineage repair audit record set does not match its manifest")
+	}
+	seen := make(map[string]struct{}, len(audit.Records))
+	for i, expected := range audit.Records {
+		if expected.Name == "" || expected.TargetAppVersion == 0 || expected.AppliedHeight <= 0 {
+			return errors.New("legacy upgrade lineage repair audit contains an invalid record")
+		}
+		evidence := manifest.Evidence[i]
+		if evidence.Name != expected.Name || evidence.Version != expected.TargetAppVersion ||
+			evidence.AppliedHeight != expected.AppliedHeight {
+			return errors.New("legacy upgrade lineage repair audit record order or content does not match its manifest")
+		}
+		if _, duplicate := seen[expected.Name]; duplicate {
+			return fmt.Errorf("legacy upgrade lineage repair audit repeats %s", expected.Name)
+		}
+		seen[expected.Name] = struct{}{}
+		actual, getErr := s.GetAppliedUpgrade(expected.Name)
+		if getErr != nil {
+			return getErr
+		}
+		if actual == nil || *actual != expected {
+			return fmt.Errorf("legacy upgrade lineage repair record %s does not match its audit", expected.Name)
+		}
+	}
+	return nil
+}
+
+func (s *BadgerStore) GetLegacyUpgradeLineageRepairAudit() (*LegacyUpgradeLineageRepairAudit, error) {
+	var audit *LegacyUpgradeLineageRepairAudit
+	err := s.view(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(legacyUpgradeLineageAuditKey))
+		if err != nil {
+			return err
+		}
+		return item.Value(func(value []byte) error {
+			var decoded LegacyUpgradeLineageRepairAudit
+			if err := json.Unmarshal(value, &decoded); err != nil {
+				return err
+			}
+			audit = &decoded
+			return nil
+		})
+	})
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return nil, nil
+	}
+	return audit, err
+}

--- a/internal/store/upgrade_lineage_test.go
+++ b/internal/store/upgrade_lineage_test.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyLegacyUpgradeLineageRepairCreateOnlyAndReplay(t *testing.T) {
+	s := newTestBadger(t)
+	manifest := `{"schema":"v1","governance_domain":"scope","prior_lineage_digest":"prior","evidence":[{"version":9,"name":"app-v9","applied_height":20}]}`
+	digest := sha256.Sum256([]byte(manifest))
+	audit := LegacyUpgradeLineageRepairAudit{Schema: "v1", GovernanceDomain: "scope", PriorLineageDigest: "prior", ManifestDigest: hex.EncodeToString(digest[:]), Manifest: manifest, ApprovedHeight: 50, ProposalID: "p", Records: []AppliedUpgradeRecord{{Name: "app-v9", TargetAppVersion: 9, AppliedHeight: 20}}}
+	require.NoError(t, s.ApplyLegacyUpgradeLineageRepair(audit))
+	require.NoError(t, s.ValidateLegacyUpgradeLineageRepairAudit())
+	require.NoError(t, s.ApplyLegacyUpgradeLineageRepair(audit), "exact replay is idempotent")
+	require.NoError(t, s.MarkUpgradeApplied("app-v10", 10, 30))
+	conflict := audit
+	conflict.ProposalID = "different"
+	conflict.Records = []AppliedUpgradeRecord{{Name: "app-v10", TargetAppVersion: 10, AppliedHeight: 31}}
+	require.Error(t, s.ApplyLegacyUpgradeLineageRepair(conflict))
+	rec, err := s.GetAppliedUpgrade("app-v10")
+	require.NoError(t, err)
+	require.Equal(t, int64(30), rec.AppliedHeight)
+}
+
+func TestLegacyUpgradeLineageRepairSurvivesRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "badger")
+	s, err := NewBadgerStore(path)
+	require.NoError(t, err)
+	manifest := `{"schema":"v1","chain_id":"chain-a","governance_domain":"scope","prior_lineage_digest":"prior","evidence":[{"version":9,"name":"app-v9","applied_height":20}]}`
+	digest := sha256.Sum256([]byte(manifest))
+	audit := LegacyUpgradeLineageRepairAudit{
+		Schema: "v1", GovernanceDomain: "scope", PriorLineageDigest: "prior",
+		ManifestDigest: hex.EncodeToString(digest[:]), Manifest: manifest,
+		ApprovedHeight: 50, ProposalID: "proposal-a",
+		Records: []AppliedUpgradeRecord{{Name: "app-v9", TargetAppVersion: 9, AppliedHeight: 20}},
+	}
+	require.NoError(t, s.ApplyLegacyUpgradeLineageRepair(audit))
+	require.NoError(t, s.CloseBadger())
+
+	reopened, err := NewBadgerStore(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.CloseBadger() })
+	require.NoError(t, reopened.ValidateLegacyUpgradeLineageRepairAudit())
+	got, err := reopened.GetLegacyUpgradeLineageRepairAudit()
+	require.NoError(t, err)
+	require.Equal(t, &audit, got)
+}
+
+func TestValidateLegacyUpgradeLineageRepairAuditRejectsManifestDrift(t *testing.T) {
+	manifest := `{"schema":"v1","governance_domain":"scope","prior_lineage_digest":"prior","evidence":[{"version":9,"name":"app-v9","applied_height":20}]}`
+	digest := sha256.Sum256([]byte(manifest))
+	base := LegacyUpgradeLineageRepairAudit{
+		Schema: "v1", GovernanceDomain: "scope", PriorLineageDigest: "prior",
+		ManifestDigest: hex.EncodeToString(digest[:]), Manifest: manifest,
+		ApprovedHeight: 50, ProposalID: "proposal-a",
+		Records: []AppliedUpgradeRecord{{Name: "app-v9", TargetAppVersion: 9, AppliedHeight: 20}},
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(*LegacyUpgradeLineageRepairAudit)
+	}{
+		{"domain", func(a *LegacyUpgradeLineageRepairAudit) { a.GovernanceDomain = "other" }},
+		{"prior-digest", func(a *LegacyUpgradeLineageRepairAudit) { a.PriorLineageDigest = "other" }},
+		{"record", func(a *LegacyUpgradeLineageRepairAudit) { a.Records[0].AppliedHeight++ }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := newTestBadger(t)
+			audit := base
+			audit.Records = append([]AppliedUpgradeRecord(nil), base.Records...)
+			test.mutate(&audit)
+			require.NoError(t, s.ApplyLegacyUpgradeLineageRepair(audit))
+			require.Error(t, s.ValidateLegacyUpgradeLineageRepairAudit())
+		})
+	}
+}
+
+func TestValidateLegacyUpgradeLineageRepairAuditRejectsRecordOrderDrift(t *testing.T) {
+	s := newTestBadger(t)
+	manifest := `{"schema":"v1","governance_domain":"scope","prior_lineage_digest":"prior","evidence":[{"version":9,"name":"app-v9","applied_height":20},{"version":10,"name":"app-v10","applied_height":30}]}`
+	digest := sha256.Sum256([]byte(manifest))
+	audit := LegacyUpgradeLineageRepairAudit{
+		Schema: "v1", GovernanceDomain: "scope", PriorLineageDigest: "prior",
+		ManifestDigest: hex.EncodeToString(digest[:]), Manifest: manifest,
+		ApprovedHeight: 50, ProposalID: "proposal-a",
+		Records: []AppliedUpgradeRecord{
+			{Name: "app-v10", TargetAppVersion: 10, AppliedHeight: 30},
+			{Name: "app-v9", TargetAppVersion: 9, AppliedHeight: 20},
+		},
+	}
+	require.NoError(t, s.ApplyLegacyUpgradeLineageRepair(audit))
+	require.ErrorContains(t, s.ValidateLegacyUpgradeLineageRepairAudit(), "order or content")
+}

--- a/internal/store/upgrade_plan.go
+++ b/internal/store/upgrade_plan.go
@@ -24,6 +24,7 @@ type UpgradePlanRecord struct {
 	ActivationHeight int64  `json:"activation_height"`
 	BinarySHA256     string `json:"binary_sha256,omitempty"`
 	GovernanceDomain string `json:"governance_domain,omitempty"`
+	LineageRepair    string `json:"lineage_repair,omitempty"`
 	ProposedAt       int64  `json:"proposed_at"`
 	ProposerID       string `json:"proposer_id"`
 }

--- a/internal/tx/codec.go
+++ b/internal/tx/codec.go
@@ -2537,8 +2537,11 @@ func encodeUpgradePropose(u *UpgradePropose) []byte {
 	buf = appendInt64(buf, u.UpgradeDelayBlocks)
 	// Optional wire tail: omitting the empty field preserves every pre-app-v20
 	// UpgradePropose byte-for-byte while target 20 commits the chain domain.
-	if u.GovernanceDomain != "" {
+	if u.Name == "app-v20" && u.TargetAppVersion == 20 && u.GovernanceDomain != "" {
 		buf = appendBytes(buf, []byte(u.GovernanceDomain))
+	}
+	if u.Name == "app-v22" && u.TargetAppVersion == 22 && u.LineageRepair != "" {
+		buf = appendBytes(buf, []byte(u.LineageRepair))
 	}
 	return buf
 }
@@ -2589,6 +2592,11 @@ func decodeUpgradePropose(data []byte) (*UpgradePropose, error) {
 			if domainErr == nil && len(domain) == sha256.Size && hex.EncodeToString(domain) == encoded {
 				u.GovernanceDomain = encoded
 			}
+		}
+	}
+	if u.Name == "app-v22" && u.TargetAppVersion == 22 && off < len(data) {
+		if decoded, next, tailErr := readBytes(data, off); tailErr == nil && next == len(data) {
+			u.LineageRepair = string(decoded)
 		}
 	}
 

--- a/internal/tx/codec_upgrade_test.go
+++ b/internal/tx/codec_upgrade_test.go
@@ -103,6 +103,27 @@ func TestEncodeDecodeUpgradePropose(t *testing.T) {
 	}
 }
 
+func TestEncodeDecodeUpgradeProposeAppV22LineageRepairTail(t *testing.T) {
+	pub, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	original := &ParsedTx{Type: TxTypeUpgradePropose, UpgradePropose: &UpgradePropose{
+		Name: "app-v22", TargetAppVersion: 22,
+		GovernanceDomain: strings.Repeat("a", 64),
+		LineageRepair:    `{"schema":"sage-upgrade-lineage-repair/v1"}`,
+	}}
+	require.NoError(t, SignTx(original, privateKey))
+	encoded, err := EncodeTx(original)
+	require.NoError(t, err)
+	decoded, err := DecodeTx(encoded)
+	require.NoError(t, err)
+	require.Equal(t, original.UpgradePropose.LineageRepair, decoded.UpgradePropose.LineageRepair)
+	require.Empty(t, decoded.UpgradePropose.GovernanceDomain, "app-v20 domain tails must never make app-v22 encoding ambiguous")
+	require.Equal(t, []byte(pub), decoded.PublicKey)
+	valid, err := VerifyTx(decoded)
+	require.NoError(t, err)
+	require.True(t, valid)
+}
+
 // TestDecodeUpgradeProposeLegacyMalformedAppV20Tail pins replay compatibility
 // with the pre-app-v20 decoder, which ignored every payload byte after
 // UpgradeDelayBlocks. A malformed optional tail must still decode and verify

--- a/internal/tx/types.go
+++ b/internal/tx/types.go
@@ -590,6 +590,11 @@ type UpgradePropose struct {
 	// lowercase-hex domain derived from the CometBFT chain_id and explicitly
 	// approved by the upgrade quorum before delegated governance turns on.
 	GovernanceDomain string
+	// LineageRepair is an optional canonical JSON manifest admitted only by the
+	// app-v21 -> app-v22 transition. It binds the exact missing predecessor
+	// records and their evidence into the ordinary quorum-approved upgrade
+	// proposal. Older transitions must leave it empty.
+	LineageRepair string
 }
 
 // CanonicalUpgradeName is the single source of truth for the name an

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "check:js": "node scripts/check-static-js.mjs",
-    "test": "npm run check:js && node --test scripts/appv23-linked-message-ui.test.mjs scripts/appv23-policy.test.mjs scripts/cerebrum-shell.test.mjs scripts/chrome-extension-contract.test.mjs scripts/domain-inventory.test.mjs scripts/federation-acceptance-contract.test.mjs scripts/federation-flow.test.mjs scripts/federation-peer-capabilities.test.mjs scripts/federation-route-state.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/governance-retry.test.mjs scripts/release-recovery-workflow.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/task-reorder.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
+    "test": "npm run check:js && node --test scripts/access-controls-ui.test.mjs scripts/appv23-linked-message-ui.test.mjs scripts/appv23-policy.test.mjs scripts/cerebrum-shell.test.mjs scripts/chrome-extension-contract.test.mjs scripts/domain-inventory.test.mjs scripts/federation-acceptance-contract.test.mjs scripts/federation-flow.test.mjs scripts/federation-peer-capabilities.test.mjs scripts/federation-route-state.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/governance-retry.test.mjs scripts/release-recovery-workflow.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/task-reorder.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/access-controls-ui.test.mjs
+++ b/scripts/access-controls-ui.test.mjs
@@ -1,0 +1,272 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+
+import {
+    accessControlDisplayNameDirty,
+    accessControlModalInertTargets,
+    accessControlNavigationSnapshot,
+    accessControlHash,
+    accessControlRouteState,
+    confirmAccessControlHashNavigation,
+    createAccessControlHistoryNavigator,
+    discardedAccessControlDraft,
+    filterSortAccessAgents,
+    filterSortAccessGroups,
+    filterSortFederatedAgents,
+    protectAccessControlTransition,
+    registerAccessControlNavigationGuard,
+} from '../web/static/js/access-controls-ui.js';
+
+class HistoryModel {
+    constructor(hash = '#/brain') {
+        this.entries = [{ hash, state: null }];
+        this.index = 0;
+        this.pendingGo = [];
+    }
+
+    get hash() { return this.entries[this.index].hash; }
+    get state() { return this.entries[this.index].state; }
+
+    replace(state, hash) {
+        this.entries[this.index] = { state, hash };
+    }
+
+    push(state, hash) {
+        this.entries.splice(this.index + 1);
+        this.entries.push({ state, hash });
+        this.index += 1;
+    }
+
+    pushHash(hash) {
+        this.push(this.state, hash);
+    }
+
+    go(delta) {
+        this.pendingGo.push(delta);
+    }
+
+    async traverse(delta, navigator) {
+        this.index += delta;
+        assert.ok(this.index >= 0 && this.index < this.entries.length, 'history traversal left the model');
+        await navigator.handlePopState(this.state);
+        await navigator.handleHashChange();
+        await this.flush(navigator);
+    }
+
+    async flush(navigator) {
+        while (this.pendingGo.length) {
+            const delta = this.pendingGo.shift();
+            this.index += delta;
+            assert.ok(this.index >= 0 && this.index < this.entries.length, 'history restoration left the model');
+            await navigator.handlePopState(this.state);
+            await navigator.handleHashChange();
+        }
+    }
+}
+
+test('Access Controls route state preserves tab and exact selected item', () => {
+    assert.deepEqual(accessControlRouteState('#/access?tab=groups&item=team-a'), {
+        tab: 'groups', item: 'team-a', remoteChain: '', remoteAgent: '', inbox: false,
+    });
+    const remoteKey = `chain-b\u0000${'a'.repeat(64)}`;
+    const hash = accessControlHash({ tab: 'federation', item: remoteKey });
+    assert.match(hash, /^\/access\?tab=federation&item=/);
+    assert.equal(accessControlRouteState(`#${hash}`).item, remoteKey);
+    assert.equal(accessControlRouteState(`#${hash}`).remoteChain, 'chain-b');
+    assert.equal(accessControlRouteState(`#${hash}`).remoteAgent, 'a'.repeat(64));
+});
+
+test('legacy Access Controls deep links route to the correct modern tab', () => {
+    assert.equal(accessControlRouteState('#/access?agent=local-a&inbox=1').tab, 'agents');
+    assert.equal(accessControlRouteState('#/access?agent=local-a&inbox=1').inbox, true);
+    assert.equal(accessControlRouteState(`#/access?remote_chain=chain-b&remote_agent=${'b'.repeat(64)}`).tab, 'federation');
+});
+
+test('compact Access Controls lists search and sort without mutating source arrays', () => {
+    const agents = [
+        { name: 'Zulu', agent_id: 'z', role: 'member' },
+        { name: 'Alpha', agent_id: 'a', role: 'admin', needs_reauthorization: true },
+    ];
+    assert.deepEqual(filterSortAccessAgents(agents, '', 'status').map(item => item.agent_id), ['a', 'z']);
+    assert.deepEqual(filterSortAccessAgents(agents, 'member').map(item => item.agent_id), ['z']);
+    assert.deepEqual(agents.map(item => item.agent_id), ['z', 'a']);
+
+    const groups = [
+        { name: 'Small', group_id: 's', members: ['a'], member_authority: 'read' },
+        { name: 'Large', group_id: 'l', members: ['a', 'b'], member_authority: 'write' },
+    ];
+    assert.deepEqual(filterSortAccessGroups(groups, '', 'members').map(item => item.group_id), ['l', 's']);
+
+    const remote = [
+        { label: 'Beta', peer_name: 'Zulu node', remote_agent_id: 'b', remote_chain_id: 'z' },
+        { label: 'Alpha', peer_name: 'Alpha node', remote_agent_id: 'a', remote_chain_id: 'a' },
+    ];
+    assert.deepEqual(filterSortFederatedAgents(remote, 'alpha').map(item => item.remote_agent_id), ['a']);
+});
+
+test('dirty Access Controls hash navigation cancels without losing the exact accepted route', async () => {
+    let confirmations = 0;
+    const unregister = registerAccessControlNavigationGuard({
+        currentHash: () => '#/access?tab=agents&item=agent-a&agent=agent-a',
+        confirmDiscard: async () => {
+            confirmations += 1;
+            return false;
+        },
+    });
+    try {
+        assert.deepEqual(accessControlNavigationSnapshot(), {
+            active: true,
+            currentHash: '#/access?tab=agents&item=agent-a&agent=agent-a',
+        });
+        assert.equal(await confirmAccessControlHashNavigation(), false);
+        assert.equal(confirmations, 1);
+        assert.equal(accessControlNavigationSnapshot().currentHash,
+            '#/access?tab=agents&item=agent-a&agent=agent-a');
+    } finally {
+        unregister();
+    }
+    assert.deepEqual(accessControlNavigationSnapshot(), { active: false, currentHash: '' });
+});
+
+test('confirmed discard restores saved name and policy so reopening cannot resurrect edits', async () => {
+    const savedPolicy = {
+        role: 'member', profile: 'standard', clearance: 1, capabilities: 0, home_domain: 'agent-a-home',
+    };
+    let editor = {
+        draft: { ...savedPolicy, role: 'admin', clearance: 4, capabilities: 1 },
+        displayNameDraft: 'Unsaved renamed agent',
+    };
+    let dirty = true;
+    const unregister = registerAccessControlNavigationGuard({
+        currentHash: () => '#/access?tab=agents&item=agent-a&agent=agent-a',
+        confirmDiscard: async () => {
+            if (!dirty) return true;
+            editor = discardedAccessControlDraft(savedPolicy, 'Saved agent name');
+            dirty = false;
+            return true;
+        },
+    });
+    try {
+        assert.equal(await confirmAccessControlHashNavigation(), true);
+        assert.equal(dirty, false);
+        assert.deepEqual(editor, {
+            draft: savedPolicy,
+            displayNameDraft: 'Saved agent name',
+        });
+        assert.notEqual(editor.draft, savedPolicy, 'discard must create a fresh saved-policy draft');
+
+        // Model returning to the same agent after a tab/sidebar round trip: the
+        // state left behind by confirmation is canonical, not the old edits.
+        assert.equal(editor.draft.role, 'member');
+        assert.equal(editor.draft.clearance, 1);
+        assert.equal(editor.displayNameDraft, 'Saved agent name');
+        assert.equal(await confirmAccessControlHashNavigation(), true);
+    } finally {
+        unregister();
+    }
+});
+
+test('clearing a saved display name remains a protected dirty edit', () => {
+    assert.equal(accessControlDisplayNameDirty('Alice', ''), true);
+    assert.equal(accessControlDisplayNameDirty('Alice', '   '), true);
+    assert.equal(accessControlDisplayNameDirty(' Alice ', 'Alice'), false);
+    assert.equal(accessControlDisplayNameDirty('', ''), false);
+});
+
+test('cancelled sidebar, direct-hash, and Back navigation preserve the real history stack', async () => {
+    const history = new HistoryModel('#/brain');
+    let allow = true;
+    const applied = [];
+    const navigator = createAccessControlHistoryNavigator({
+        getHash: () => history.hash,
+        getState: () => history.state,
+        replaceState: (state, hash) => history.replace(state, hash),
+        pushState: (state, hash) => history.push(state, hash),
+        go: delta => history.go(delta),
+        confirmNavigation: async () => allow,
+        applyHash: hash => applied.push(hash),
+    });
+
+    assert.equal(await navigator.navigate('#/access?tab=agents&item=alice'), true);
+    const acceptedEntries = history.entries.map(entry => entry.hash);
+    allow = false;
+
+    assert.equal(await navigator.navigate('#/settings'), false, 'sidebar navigation should be stopped before push');
+    assert.deepEqual(history.entries.map(entry => entry.hash), acceptedEntries);
+    assert.equal(history.hash, '#/access?tab=agents&item=alice');
+
+    await history.traverse(-1, navigator);
+    assert.equal(history.hash, '#/access?tab=agents&item=alice', 'cancelled Back must return to the exact entry');
+    assert.deepEqual(history.entries.map(entry => entry.hash), acceptedEntries,
+        'cancelled Back must not overwrite the prior URL or create a duplicate Access entry');
+
+    history.pushHash('#/settings');
+    assert.equal(await navigator.handleHashChange(), false);
+    await history.flush(navigator);
+    assert.equal(history.hash, '#/access?tab=agents&item=alice');
+    assert.deepEqual(history.entries.map(entry => entry.hash), [
+        '#/brain', '#/access?tab=agents&item=alice', '#/settings',
+    ], 'a cancelled direct hash push remains a forward entry instead of becoming duplicate Access history');
+
+    allow = true;
+    await history.traverse(-1, navigator);
+    assert.equal(history.hash, '#/brain');
+    assert.deepEqual(applied, ['#/access?tab=agents&item=alice', '#/brain']);
+});
+
+test('Access drawer inerting includes exposed rails, tabs, and application siblings', () => {
+    const makeNode = name => ({ name, children: [], parentElement: null, inert: false });
+    const append = (parent, ...children) => {
+        for (const child of children) {
+            child.parentElement = parent;
+            parent.children.push(child);
+        }
+    };
+    const app = makeNode('app');
+    const sidebar = makeNode('sidebar');
+    const main = makeNode('main');
+    const tabs = makeNode('tabs');
+    const grid = makeNode('grid');
+    const rail = makeNode('agent-rail');
+    const drawer = makeNode('drawer');
+    append(app, sidebar, main);
+    append(main, tabs, grid);
+    append(grid, rail, drawer);
+
+    assert.deepEqual(
+        accessControlModalInertTargets(drawer, app).map(node => node.name).sort(),
+        ['agent-rail', 'sidebar', 'tabs'],
+    );
+});
+
+test('dirty editor denial blocks the drag-to-group transition before mutation', async () => {
+    let mutations = 0;
+    if (await protectAccessControlTransition(async () => false)) mutations += 1;
+    assert.equal(mutations, 0);
+    if (await protectAccessControlTransition(async () => true)) mutations += 1;
+    assert.equal(mutations, 1);
+
+    const app = await readFile(new URL('../web/static/js/app.js', import.meta.url), 'utf8');
+    const directGroup = app.slice(
+        app.indexOf('const createDirectLocalGroup = async'),
+        app.indexOf('const removeDraggedMemberFromSourceGroup = async'),
+    );
+    assert.match(directGroup, /await protectAccessControlTransition\(confirmAccessNavigation\)/,
+        'the actual drag/drop mutation must pass through the shared dirty guard');
+});
+
+test('stale guard cleanup cannot unregister the currently mounted editor', async () => {
+    const unregisterOld = registerAccessControlNavigationGuard({
+        currentHash: () => '#/access?tab=agents&item=old',
+        confirmDiscard: async () => false,
+    });
+    const unregisterCurrent = registerAccessControlNavigationGuard({
+        currentHash: () => '#/access?tab=groups&item=current',
+        confirmDiscard: async () => true,
+    });
+    unregisterOld();
+    assert.equal(accessControlNavigationSnapshot().currentHash, '#/access?tab=groups&item=current');
+    assert.equal(await confirmAccessControlHashNavigation(), true);
+    unregisterCurrent();
+});

--- a/scripts/cerebrum-shell.test.mjs
+++ b/scripts/cerebrum-shell.test.mjs
@@ -276,7 +276,7 @@ test('Search page renders projection failures as errors, never empty search resu
 });
 
 test('Access Controls is a first-class sidebar route', () => {
-    assert.match(appSource, /hash === '\/access'\) setPage\('access'\)/);
+    assert.match(appSource, /hash === '\/access'\) \{[\s\S]*setPage\('access'\);[\s\S]*setHashRouteRevision\(current => current \+ 1\);/);
     assert.match(appSource, /navigate\('access'\)/);
     assert.match(appSource, /page === 'access'.*NetworkPage/s);
     assert.match(appSource, /accessMode \? 'access' : 'overview'/);
@@ -290,6 +290,41 @@ test('Access Controls is a first-class sidebar route', () => {
             access.indexOf('setState(next)'),
         'nullable historical collections must be normalized before the first full render',
     );
+});
+
+test('Access Controls uses routable tabs, compact lists, protected drawers, and responsive focus ownership', () => {
+    const access = appSource.slice(
+        appSource.indexOf('function AppV23AccessControl()'),
+        appSource.indexOf('function NetworkPage('),
+    );
+    assert.match(access, /class="access-control-tabs" role="tablist"/);
+    assert.match(access, /ACCESS_CONTROL_TABS\.map\(\(tab, index\)/);
+    assert.match(access, /role="tab"[\s\S]*aria-selected=\$\{activeAccessTab === tab\}[\s\S]*tabIndex=\$\{activeAccessTab === tab \? 0 : -1\}/,
+        'the three tabs must expose roving keyboard focus and selected state');
+    assert.match(access, /event\.key === 'ArrowRight'[\s\S]*event\.key === 'ArrowLeft'[\s\S]*event\.key === 'Home'[\s\S]*event\.key === 'End'/,
+        'tab navigation must support the standard arrow, Home, and End keys');
+    assert.match(access, /accessControlHash\(\{[\s\S]*window\.history\.replaceState\(window\.history\.state, '', `#\$\{next\}`\)/,
+        'the selected tab and exact item must survive reload without erasing the history position marker');
+    assert.match(access, /class="access-control-toolbar" role="search"/);
+    assert.match(access, /filterSortAccessAgents[\s\S]*filterSortAccessGroups[\s\S]*filterSortFederatedAgents/);
+    assert.match(access, /class="access-control-list-row/);
+    assert.match(access, /class="access-control-drawer/);
+    assert.match(access, /const accessDrawerRef = useModalDialog\([\s\S]*!reviewQueueOnly && activeAccessDrawerOpen/,
+        'an open editor must trap focus, own Escape, inert the obscured page branch, and restore the opener');
+    assert.match(access, /const accessDrawerRef = useModalDialog\([\s\S]*!reviewQueueOnly && activeAccessDrawerOpen,[\s\S]*true,/,
+        'the fixed Access drawer must identify itself as the modal surface so its exposed rail is inert');
+    assert.match(access, /const accessEditorDirty = policyDirty \|\| displayNameDirty/);
+    assert.match(access, /showConfirmation\([\s\S]*Discard the unsaved agent changes/);
+    assert.match(access, /window\.addEventListener\('beforeunload', guard\)/,
+        'unsaved agent edits must be protected on both in-app and browser navigation');
+    assert.match(access, /Active ordinary agents may live-read peer-exported domains by default unless explicitly denied/);
+    assert.match(access, /Remote Write is reserved and denied; Linked readers and messaging never enable it/,
+        'default-read federation and explicit write denial must remain understandable and separate');
+    assert.match(cssSource, /\.access-control-list-row\s*\{[\s\S]*grid-template-columns:/);
+    assert.match(cssSource, /@media \(max-width:\s*720px\)[\s\S]*\.access-control-drawer\s*\{[\s\S]*position:\s*fixed/,
+        'the focused editor must become a usable full-screen surface on narrow windows');
+    assert.match(cssSource, /\.access-control-tabs button:focus-visible/,
+        'tab and row focus must remain visually obvious');
 });
 
 test('pending agent activation is surfaced on Agents and excluded from Access Controls', () => {
@@ -332,8 +367,8 @@ test('Agents has a separate exact-identity directory for federated agents', () =
     assert.doesNotMatch(federated, /peer_agent_id/,
         'a federation transport or ceremony principal must never be cast as an ordinary remote agent');
     assert.match(federated, /Permissions not set/);
-    assert.match(federated, /remote_chain: agent\.remote_chain_id[\s\S]*remote_agent: agent\.remote_agent_id/,
-        'permission setup must preserve the exact remote chain and agent identity');
+    assert.match(federated, /accessControlHash\(\{[\s\S]*tab: 'federation',[\s\S]*item: `\$\{agent\.remote_chain_id\}\\u0000\$\{agent\.remote_agent_id\}`/,
+        'permission setup must preserve the exact remote chain and agent identity in the selected-item route');
     assert.ok(
         agentsPage.indexOf('<${FederatedAgentDirectory} />') < agentsPage.indexOf('agent-directory-toolbar'),
         'federated identities must be categorized before the active local directory',
@@ -1251,8 +1286,8 @@ test('Access Controls exposes the independent federated inbox kill switch', () =
         'the explicit switch must preserve the named profile bits while toggling only the independent restriction');
     assert.match(panel, /updateAppV23AgentPolicy\(selected\.agent_id, draft\)/,
         'the switch must use the ordinary consensus policy save instead of a browser-only mutation');
-    assert.match(panel, /const requestedLocalAgentID = routeQuery\.get\('agent'\) \|\| '';/,
-        'an agent deep link must select the requested active principal without an unrelated recovery flag');
+    assert.match(panel, /const initialRoute = accessControlRouteState\(window\.location\.hash\);[\s\S]*const requestedLocalAgentID = initialRoute\.tab === 'agents' \? initialRoute\.item : '';/,
+        'an agent deep link must select the requested active principal through normalized route state');
     assert.match(panel, /v23-federated-inbox-label[\s\S]*scrollIntoView/,
         'an inbox deep link must bring the exact switch into view');
 });

--- a/scripts/federation-acceptance-contract.test.mjs
+++ b/scripts/federation-acceptance-contract.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import { findInboxMessage } from './federation-acceptance-find-inbox-message.mjs';
 
 const root = path.resolve(import.meta.dirname, '..');
 const base = path.join(root, 'deploy', 'federation-acceptance');
@@ -9,7 +10,7 @@ const runner = fs.readFileSync(path.join(base, 'run.sh'), 'utf8');
 const legacy = fs.readFileSync(path.join(base, 'v11.17.4-config.template.yaml'), 'utf8');
 
 for (const service of ['relay:', 'node-a:', 'node-b:']) assert.match(compose, new RegExp(`\\n  ${service}`));
-assert.equal((compose.match(/image: sage-v111717-node:local/g) || []).length, 2,
+assert.equal((compose.match(/image: sage-v111800-node:local/g) || []).length, 2,
   'both nodes must run the exact same built image');
 for (const network of ['edge_a:', 'edge_b:', 'lan:']) assert.match(compose, new RegExp(`\\n  ${network}`));
 assert.match(compose, /SAGE_VENDORED_AGENT_HOME_DOMAIN: mynah-a-home/);
@@ -22,7 +23,7 @@ for (const gate of [
   'relay outage and recovery',
   'expired route snapshot fixture',
   'v11.17.4 persisted p2p_peers compatibility shape',
-  'canonical MCP flow: find -> send -> offline inbox -> read -> reply/status',
+  'canonical MCP flow: friendly registered-name send -> reply receipt -> offline inbox -> read -> reply/status',
   'directional peer export read needs no mirrored group',
   'bidirectional Copy: seed pre-consent memories for initial backfill',
   'bidirectional Copy: each owner offers Copy and each receiver independently subscribes',
@@ -35,6 +36,41 @@ assert.match(runner, /automatic real JOIN ceremony over LAN/);
 assert.match(runner, /federation\/join\/guest\/confirm/);
 assert.match(runner, /sage_find_agent/);
 assert.match(runner, /sage_message_send/);
+assert.match(runner, /node-a\) project=voice-bridge-a[\s\S]*node-b\) project=voice-bridge-b/,
+  'fresh nodes need distinct immutable registered names so the friendly-name gate is not an intentional local/federated collision');
+assert.match(runner, /friendly_target=.*registered_name/);
+assert.equal((runner.match(/federation-acceptance-find-inbox-message\.mjs/g) || []).length, 2,
+  'friendly and offline inbox gates must use the exact correlation helper');
+assert.doesNotMatch(runner, /items\.0\.message_id/,
+  'inbox order is not a delivery guarantee');
+assert.doesNotMatch(runner, /friendly_received_id.*friendly_message_id/,
+  'federated delivery intentionally translates the sender-local message ID');
+
+const correlation = {
+  intent: 'acceptance',
+  payload: 'unique run payload',
+  senderAgent: 'agent-a',
+  sourceChain: 'chain-a',
+};
+const translated = findInboxMessage({ items: [
+  { message_id: 'stale-local', ...correlation, sender_agent: 'agent-a', source_chain: 'wrong-chain' },
+  { message_id: 'msg-fed-receiver-local', intent: correlation.intent, payload: correlation.payload,
+    sender_agent: correlation.senderAgent, source_chain: correlation.sourceChain },
+  { message_id: 'sender-local-id', intent: correlation.intent, payload: 'other run',
+    sender_agent: correlation.senderAgent, source_chain: correlation.sourceChain },
+] }, correlation);
+assert.equal(translated?.message_id, 'msg-fed-receiver-local',
+  'correlation must select the translated receiver-local ID regardless of inbox order');
+assert.equal(findInboxMessage({ items: [
+  { message_id: 'near-match', intent: correlation.intent, payload: correlation.payload,
+    sender_agent: correlation.senderAgent, source_chain: 'wrong-chain' },
+] }, correlation), undefined, 'correlation must reject a near-match from the wrong source chain');
+assert.match(runner, /reply_event_id/);
+assert.match(runner, /reply event status leaked original message workflow/);
+assert.match(runner, /friendly_sender_status=.*sage_message_status/);
+assert.match(runner, /friendly_read_status.*confirmed/);
+assert.match(runner, /friendly_workflow_status.*completed/);
+assert.match(runner, /friendly sender status lacks confirmed read and completed reply after retry window/);
 assert.match(runner, /transport_status.*queued/);
 assert.match(runner, /peer_status.*unconfirmed/);
 assert.match(runner, /send_elapsed.*-le 5/);

--- a/scripts/federation-acceptance-find-inbox-message.mjs
+++ b/scripts/federation-acceptance-find-inbox-message.mjs
@@ -1,0 +1,23 @@
+import { pathToFileURL } from 'node:url';
+
+export function findInboxMessage(inbox, { intent, payload, senderAgent, sourceChain }) {
+  const items = Array.isArray(inbox?.items) ? inbox.items : [];
+  return items.find(item =>
+    typeof item?.message_id === 'string' && item.message_id !== '' &&
+    item.intent === intent &&
+    item.payload === payload &&
+    item.sender_agent === senderAgent &&
+    item.source_chain === sourceChain
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [inboxJSON, intent, payload, senderAgent, sourceChain] = process.argv.slice(2);
+  const item = findInboxMessage(JSON.parse(inboxJSON), {
+    intent,
+    payload,
+    senderAgent,
+    sourceChain,
+  });
+  if (item) process.stdout.write(item.message_id);
+}

--- a/scripts/federation-flow.test.mjs
+++ b/scripts/federation-flow.test.mjs
@@ -2,13 +2,41 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { readFile } from 'node:fs/promises';
 
-import { normalizeFederationJoinState } from '../web/static/js/federation-flow.js';
+import {
+    createFederationJoinScanLifecycle,
+    normalizeFederationJoinState,
+} from '../web/static/js/federation-flow.js';
 
 test('join terminal states are handled independently of protocol casing', () => {
     assert.equal(normalizeFederationJoinState('ABORTED'), 'aborted');
     assert.equal(normalizeFederationJoinState('EXPIRED'), 'expired');
     assert.equal(normalizeFederationJoinState(' active '), 'active');
     assert.equal(normalizeFederationJoinState(null), '');
+});
+
+test('closing or replacing the JOIN screen aborts its live scan request', async () => {
+    const signals = [];
+    const request = (_name, signal) => new Promise((resolve, reject) => {
+        signals.push(signal);
+        signal.addEventListener('abort', () => {
+            const error = new Error('scan cancelled');
+            error.name = 'AbortError';
+            reject(error);
+        }, { once: true });
+    });
+    const lifecycle = createFederationJoinScanLifecycle(request);
+
+    const first = lifecycle.run('first');
+    assert.equal(signals[0].aborted, false);
+    const second = lifecycle.run('second');
+    await assert.rejects(first, { name: 'AbortError' });
+    assert.equal(signals[0].aborted, true, 'a replacement scan must cancel the old dial');
+    assert.equal(signals[1].aborted, false);
+
+    assert.equal(lifecycle.abort(), true, 'component unmount should cancel the active scan');
+    await assert.rejects(second, { name: 'AbortError' });
+    assert.equal(signals[1].aborted, true);
+    assert.equal(lifecycle.abort(), false, 'unmount cleanup must be idempotent');
 });
 
 test('revoked connections are paired again and past rows can be hidden locally', async () => {

--- a/scripts/native-shell-windows-runtime-smoke.test.sh
+++ b/scripts/native-shell-windows-runtime-smoke.test.sh
@@ -48,6 +48,15 @@ grep -Fq "\$sig.PSObject.Properties['Status']" "${HARNESS}"
 grep -Fq '$first.WaitForExit(30000)' "${HARNESS}"
 grep -Fq '$reinstalled.WaitForExit(30000)' "${HARNESS}"
 
+# A normal close must run through Wry's native close -> destroy -> last-window
+# exit sequence. Forcing AppHandle::exit from CloseRequested can race WebView2
+# teardown on Windows and leave the installed shell resident indefinitely.
+if grep -Fq 'WindowEvent::CloseRequested' "${SHELL_SOURCE}"; then
+  echo 'native shell intercepts normal window close instead of using native teardown' >&2
+  exit 1
+fi
+grep -Fq 'Leave a normal main-window close to Tauri/Wry' "${SHELL_SOURCE}"
+
 if grep -Eq 'taskkill\.exe[[:space:]]+/IM|Get-Process[[:space:]]+sage-gui|Stop-Process[[:space:]]+-Name' "${HARNESS}"; then
   echo 'Windows runtime harness contains broad process-name cleanup' >&2
   exit 1

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -234,8 +234,8 @@ test('native shell evidence is version-locked, private, and cannot promote an un
   assert.match(evidence, /SAGE_DAEMON_VERSION/);
   assert.match(
     daemonStager,
-    /SEMVER_PATTERN='\^11\\\.\(10\|11\|12\|13\|14\|15\|16\|17\)\\\./,
-    'the tagged daemon stager must accept the current v11.17 release series',
+    /SEMVER_PATTERN='\^11\\\.\(10\|11\|12\|13\|14\|15\|16\|17\|18\)\\\./,
+    'the tagged daemon stager must accept the current v11.18 release series',
   );
   assert.match(evidence, /Repair v11\.12\.0 native staging helper for immutable-tag recovery/);
   assert.match(evidence, /github\.event_name == 'workflow_dispatch'.*RELEASE_TAG == 'v11\.12\.0'/);

--- a/scripts/stage-native-shell-daemon.sh
+++ b/scripts/stage-native-shell-daemon.sh
@@ -40,9 +40,9 @@ BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 OUTPUT_DIR=${REPO_ROOT}/desktop/sage-shell/binaries
 
 VERSION_CORE=${VERSION#v}
-SEMVER_PATTERN='^11\.(10|11|12|13|14|15|16|17)\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+SEMVER_PATTERN='^11\.(10|11|12|13|14|15|16|17|18)\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
 if [[ ! "${VERSION_CORE}" =~ ${SEMVER_PATTERN} ]]; then
-  echo "SAGE_DAEMON_VERSION must be an SSCP-compatible v11.10.x through v11.17.x semver, got: ${VERSION}" >&2
+  echo "SAGE_DAEMON_VERSION must be an SSCP-compatible v11.10.x through v11.18.x semver, got: ${VERSION}" >&2
   exit 2
 fi
 if [ "${OUTPUT_DIR}" != "${REPO_ROOT}/desktop/sage-shell/binaries" ]; then

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -28,6 +28,8 @@ test('release-facing version metadata stays aligned', () => {
     ['desktop/sage-shell/Cargo.toml', `version = "${version}"`],
     ['desktop/sage-shell/Cargo.lock', `name = "sage-shell"\nversion = "${version}"`],
     ['desktop/sage-shell/tauri.conf.json', `"version": "${version}"`],
+    ['desktop/sage-shell/src/control.rs', 'matches!(minor, Some(10..=18))'],
+    ['scripts/stage-native-shell-daemon.sh', 'through v11.18.x semver'],
     ['web/static/js/app.js', `const SAGE_VERSION = 'v${version}';`],
     ['README.md', `## What's New in v${version}`],
     ['README.md', 'App-v23 replaced capability-bit administration'],
@@ -45,7 +47,13 @@ test('release-facing version metadata stays aligned', () => {
     ['docs/reference/rest-api.md', `Reconciled through SAGE v${version}`],
     ['docs/reference/concepts/rbac-orgs-federation.md', `reconciled through SAGE v${version}`],
     ['docs/reference/app-v23-access-control-design.md', `SAGE v${version}`],
+    ['docs/reference/upgrade-lineage-repair.md', `SAGE v${version}`],
     ['docs/ADMIN_BOOTSTRAP.md', `Reconciled through SAGE v${version}/app-v26`],
+    ['docs/UPGRADING.md', `The recovery commands in this guide require SAGE v${version} or later.`],
+    ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],
+    ['docs/UPGRADING.md', '`upgrade lineage status|doctor|verify`'],
+    ['deploy/federation-acceptance/Dockerfile.node', `ARG VERSION=v${version}-acceptance`],
+    ['deploy/federation-acceptance/docker-compose.yml', 'name: sage-v111800-federation'],
     ['docs/reference/app-v23-access-control-design.md', '## App-v24 readiness and memory-write barrier'],
     ['docs/reference/mcp-tools.md', 'A level-2 grant is never a remedy for a hard'],
     ['docs/reference/mcp-tools.md', 'never be substituted for this caller-scoped projection'],
@@ -62,7 +70,7 @@ test('release-facing version metadata stays aligned', () => {
   }
 });
 
-test('v11.17.17 user and SDK guides keep canonical Messages contracts aligned', () => {
+test('v11.18.0 user, recovery, federation, and SDK guides stay aligned', () => {
   const architecture = read('docs/ARCHITECTURE.md');
   const roadmap = read('docs/ROADMAP.md');
   const gettingStarted = read('docs/GETTING_STARTED.md');
@@ -75,7 +83,13 @@ test('v11.17.17 user and SDK guides keep canonical Messages contracts aligned', 
   assert.match(read('docs/reference/mcp-tools.md'), /call `sage_messages_receive`/);
   assert.match(read('internal/mcp/tools.go'), /Canonical Messages remain durable and queryable/);
   assert.doesNotMatch(read('internal/mcp/tools.go'), /History is retained only for the normal transient message window/);
-  assert.match(roadmap, /v11\.17\.x completion ledger/);
+  assert.match(roadmap, /v11\.18\.0 completion ledger/);
+  assert.match(roadmap, /does not introduce app-v27/);
+  assert.match(read('README.md'), /`reply_event_id`/);
+  assert.match(read('README.md'), /\*\*Agents\*\*,\s+\*\*Groups\*\*, and \*\*Federation\*\* tabs/);
+  assert.match(read('docs/FEDERATION.md'), /up to five minutes/);
+  assert.match(read('docs/FEDERATION.md'), /15 minutes/);
+  assert.match(read('docs/UPGRADING.md'), /sage-gui upgrade lineage verify --json --manifest repair\.json/);
   assert.match(roadmap, /helper outside the replaceable bundle/);
   assert.match(gettingStarted, /advertises 31 MCP tools/);
   assert.match(gettingStarted, /Deprecated `sage_pipe\*`\s+compatibility/);

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.17.17 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.0 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.17.17"
+version = "11.18.0"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.17.17"
+__version__ = "11.18.0"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.17.17",
+  "version": "11.18.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.17.17",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.0",
       "transport": {
         "type": "stdio"
       }

--- a/web/federation_join.go
+++ b/web/federation_join.go
@@ -57,7 +57,31 @@ func (h *DashboardHandler) SetFederation(f FederationJoinDriver) { h.Federation 
 const (
 	fedCallTimeout   = 25 * time.Second
 	fedStatusTimeout = 6 * time.Second
+	// A pasted JOIN enrollment may need several libp2p target attempts before
+	// the host CA can be fetched. Keep that bounded, but give the operator the
+	// promised five-minute window while the pairing screen remains open instead
+	// of inheriting the ordinary dashboard request deadline.
+	fedJoinDiscoveryTimeout = 5 * time.Minute
+	// The handler context and the socket write deadline are independent. The
+	// combined REST server normally uses the shorter two-consensus-operation
+	// budget, so this one route needs enough response headroom to report a final
+	// discovery timeout without relaxing unrelated dashboard/API requests.
+	fedJoinDiscoveryResponseTimeout = fedJoinDiscoveryTimeout + 5*time.Second
 )
+
+func extendFedJoinDiscoveryWriteDeadline(w http.ResponseWriter, r *http.Request) error {
+	err := http.NewResponseController(w).SetWriteDeadline(
+		time.Now().Add(fedJoinDiscoveryResponseTimeout),
+	)
+	// Direct handler tests do not have a live net/http connection whose deadline
+	// can be extended. A production request does: fail closed if middleware hides
+	// that capability, otherwise the UI would promise five minutes while the
+	// outer server still tears down the response at its ordinary deadline.
+	if errors.Is(err, http.ErrNotSupported) && r.Context().Value(http.ServerContextKey) == nil {
+		return nil
+	}
+	return err
+}
 
 func fedWriteJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
@@ -1174,7 +1198,11 @@ func (h *DashboardHandler) handleFedGuestScan(w http.ResponseWriter, r *http.Req
 		fedWriteErr(w, http.StatusBadRequest, "Invalid request.")
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), fedCallTimeout)
+	if err := extendFedJoinDiscoveryWriteDeadline(w, r); err != nil {
+		fedWriteErr(w, http.StatusServiceUnavailable, "Could not reserve the bounded JOIN discovery window.")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), fedJoinDiscoveryTimeout)
 	defer cancel()
 	res, err := h.Federation.GuestScan(ctx, body.URI, body.Endpoint)
 	if err != nil {

--- a/web/federation_join_timeout_test.go
+++ b/web/federation_join_timeout_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,6 +18,89 @@ type joinConfirmDeadlineDriver struct {
 	FederationJoinDriver
 	hasDeadline bool
 	remaining   time.Duration
+}
+
+type joinScanDeadlineDriver struct {
+	FederationJoinDriver
+	hasDeadline bool
+	remaining   time.Duration
+}
+
+type delayedJoinScanDriver struct {
+	FederationJoinDriver
+	delay time.Duration
+}
+
+func (d *delayedJoinScanDriver) GuestScan(ctx context.Context, _, _ string) (*federation.GuestScanResult, error) {
+	select {
+	case <-time.After(d.delay):
+		return &federation.GuestScanResult{SessionID: "slow-scan-completed"}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (d *joinScanDeadlineDriver) GuestScan(ctx context.Context, _, _ string) (*federation.GuestScanResult, error) {
+	deadline, ok := ctx.Deadline()
+	d.hasDeadline = ok
+	if ok {
+		d.remaining = time.Until(deadline)
+	}
+	return &federation.GuestScanResult{}, nil
+}
+
+func TestFedGuestScanAllowsFiveMinuteDiscoveryWindow(t *testing.T) {
+	driver := &joinScanDeadlineDriver{}
+	h := NewDashboardHandler(nil, "test")
+	h.Federation = driver
+	req := httptest.NewRequest(http.MethodPost, "/v1/dashboard/federation/join/guest/scan",
+		bytes.NewBufferString(`{"uri":"otpauth://totp/SAGE:test","endpoint":"https://127.0.0.1:18444"}`))
+	rr := httptest.NewRecorder()
+	h.handleFedGuestScan(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	require.True(t, driver.hasDeadline)
+	require.LessOrEqual(t, driver.remaining, fedJoinDiscoveryTimeout)
+	require.Greater(t, driver.remaining, fedJoinDiscoveryTimeout-time.Second,
+		"JOIN discovery inherited the ordinary dashboard call deadline")
+}
+
+func TestFedGuestScanExtendsOnlyItsOuterServerWriteDeadline(t *testing.T) {
+	driver := &delayedJoinScanDriver{delay: 100 * time.Millisecond}
+	h := NewDashboardHandler(nil, "test")
+	h.Federation = driver
+	mux := http.NewServeMux()
+	mux.HandleFunc("/scan", h.handleFedGuestScan)
+	mux.HandleFunc("/ordinary", func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(driver.delay)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	server := httptest.NewUnstartedServer(mux)
+	server.Config.WriteTimeout = 25 * time.Millisecond
+	server.Start()
+	defer server.Close()
+	client := server.Client()
+	client.Timeout = time.Second
+
+	response, err := client.Post(server.URL+"/scan", "application/json", bytes.NewBufferString(
+		`{"uri":"otpauth://totp/SAGE:test","endpoint":"https://127.0.0.1:18444"}`,
+	))
+	require.NoError(t, err, "the route-local deadline must outlive the outer server's ordinary budget")
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	require.Equal(t, http.StatusOK, response.StatusCode, string(body))
+	require.Contains(t, string(body), "slow-scan-completed")
+
+	// The same server still applies its short default to every other route. A
+	// route-local JOIN exception must not become a server-wide timeout increase.
+	ordinary, ordinaryErr := client.Get(server.URL + "/ordinary")
+	if ordinaryErr == nil {
+		_, ordinaryErr = io.ReadAll(ordinary.Body)
+		_ = ordinary.Body.Close()
+	}
+	require.Error(t, ordinaryErr, "unrelated requests unexpectedly inherited the JOIN deadline")
 }
 
 func (d *joinConfirmDeadlineDriver) GuestConfirm(ctx context.Context, _, _ string, _ federation.ScopeWire) (string, error) {

--- a/web/static/css/sage.css
+++ b/web/static/css/sage.css
@@ -6385,10 +6385,166 @@ input[type="range"]::-moz-range-thumb {
     margin-top: 8px;
     overflow-wrap: anywhere;
 }
+.access-control-tabs {
+    align-items: stretch;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    overflow: hidden;
+}
+.access-control-tabs button {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    border-right: 1px solid var(--border);
+    color: var(--text-muted);
+    cursor: pointer;
+    display: flex;
+    font: inherit;
+    gap: 9px;
+    justify-content: center;
+    min-height: 46px;
+    padding: 10px 16px;
+}
+.access-control-tabs button:last-child { border-right: 0; }
+.access-control-tabs button strong {
+    align-items: center;
+    background: var(--bg-elevated);
+    border-radius: 999px;
+    display: inline-flex;
+    font-size: 10px;
+    justify-content: center;
+    min-width: 24px;
+    padding: 3px 7px;
+}
+.access-control-tabs button.active {
+    background: var(--primary-dim);
+    box-shadow: inset 0 -2px 0 var(--primary);
+    color: var(--text);
+}
+.access-control-tabs button:focus-visible,
+.access-control-list-row:focus-visible,
+.access-control-drawer-close:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: -3px;
+}
+.access-control-summary {
+    align-items: center;
+    background: rgba(6, 182, 212, .035);
+    border: 1px solid rgba(6, 182, 212, .2);
+    border-radius: 10px;
+    color: var(--text-muted);
+    display: flex;
+    flex-wrap: wrap;
+    font-size: 11px;
+    gap: 8px 18px;
+    line-height: 1.45;
+    padding: 10px 13px;
+}
+.access-control-summary strong { color: var(--text); }
+.access-control-toolbar {
+    align-items: center;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: minmax(220px, 1fr) auto auto;
+}
+.access-control-toolbar label { align-items: center; display: flex; gap: 7px; }
+.access-control-toolbar input,
+.access-control-toolbar select {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    color: var(--text);
+    min-height: 36px;
+    padding: 7px 10px;
+}
+.access-control-toolbar input { width: 100%; }
+.access-control-toolbar > span { color: var(--text-muted); font-size: 10px; }
+.access-control-list {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+.access-control-list-row {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+    cursor: pointer;
+    display: grid;
+    font: inherit;
+    gap: 12px;
+    grid-template-columns: minmax(220px, 1fr) minmax(120px, .45fr) auto 18px;
+    min-height: 56px;
+    padding: 9px 13px;
+    text-align: left;
+    width: 100%;
+}
+.access-control-list-row:last-child { border-bottom: 0; }
+.access-control-list-row:hover,
+.access-control-list-row.selected { background: var(--bg-elevated); }
+.access-control-list-row.selected { box-shadow: inset 3px 0 0 var(--primary); }
+.access-control-list-primary { display: grid; gap: 3px; min-width: 0; }
+.access-control-list-primary strong { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.access-control-list-primary small {
+    font-family: var(--font-mono);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.access-control-drawer {
+    background: var(--bg-base);
+    border: 1px solid var(--border-light);
+    border-radius: 16px 0 0 16px;
+    bottom: 12px;
+    box-shadow: -18px 0 48px rgba(0, 0, 0, .34);
+    display: none;
+    max-width: calc(100vw - 32px);
+    overflow: auto;
+    padding: 18px;
+    position: fixed;
+    right: 0;
+    top: 72px;
+    width: min(760px, 68vw);
+    z-index: 1150;
+}
+.access-control-drawer.open { display: block; }
+.access-control-drawer-close {
+    align-items: center;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    color: var(--text-muted);
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 20px;
+    height: 34px;
+    justify-content: center;
+    margin-left: auto;
+    min-width: 34px;
+    padding: 0;
+}
+.access-control-federation-drawer > .access-control-drawer-close {
+    position: sticky;
+    float: right;
+    top: 0;
+    z-index: 2;
+}
+.v23-access-shell:not(.review-queue-only) .v23-policy-panel:not(.open),
+.v23-access-shell:not(.review-queue-only) .v23-group-grid:not(.open),
+.v23-access-shell:not(.review-queue-only) .access-control-federation-drawer:not(.open) {
+    display: none;
+}
 .v23-access-grid {
     display: grid;
     gap: 14px;
-    grid-template-columns: minmax(380px, .42fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr);
 }
 .v23-agent-rail,
 .v23-policy-panel,
@@ -6406,6 +6562,21 @@ input[type="range"]::-moz-range-thumb {
     flex-direction: column;
     gap: 7px;
     padding: 14px;
+}
+.v23-access-shell:not(.review-queue-only) .v23-agent-choice {
+    min-height: 58px;
+}
+.v23-access-shell:not(.review-queue-only) .v23-agent-choice.access-control-list-row {
+    border-bottom: 1px solid var(--border);
+    border-left: 3px solid rgba(16, 185, 129, .55);
+    border-radius: 0;
+    display: grid;
+    grid-template-columns: 38px minmax(0, 1fr) auto;
+    margin: 0;
+    padding: 9px 13px;
+}
+.v23-access-shell:not(.review-queue-only) .v23-agent-choice.access-control-list-row:last-child {
+    border-bottom: 0;
 }
 .v23-agent-rail.remove-drop-ready {
     border-color: var(--primary);
@@ -7339,6 +7510,25 @@ input[type="range"]::-moz-range-thumb {
     .v23-consent-control { align-items: stretch; grid-template-columns: 1fr; }
 }
 @media (max-width: 720px) {
+    .access-control-tabs button { padding: 9px 7px; }
+    .access-control-summary { align-items: flex-start; flex-direction: column; }
+    .access-control-toolbar { grid-template-columns: 1fr; }
+    .access-control-toolbar label { justify-content: space-between; }
+    .access-control-list-row {
+        align-items: start;
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+    .access-control-list-row > :nth-child(2) { grid-column: 1; }
+    .access-control-list-row > :nth-child(3) { grid-column: 2; grid-row: 1; }
+    .access-control-list-row > :last-child { display: none; }
+    .access-control-drawer {
+        border-radius: 0;
+        bottom: 0;
+        max-width: none;
+        padding: 14px;
+        top: 56px;
+        width: 100vw;
+    }
     .v23-root-card { align-items: start; grid-template-columns: auto 1fr; }
     .v23-root-actions { align-items: flex-start; grid-column: 2; }
     .v23-option-grid,
@@ -7365,6 +7555,8 @@ input[type="range"]::-moz-range-thumb {
     .v23-linked-actions { flex-wrap: wrap; }
 }
 @media (max-width: 480px) {
+    .access-control-tabs button { flex-direction: column; gap: 4px; }
+    .v23-access-shell:not(.review-queue-only) .v23-agent-rail { grid-template-columns: 1fr; }
     .v23-root-card { grid-template-columns: 1fr; }
     .v23-root-mark { display: none; }
     .v23-root-actions { grid-column: 1; }

--- a/web/static/js/access-controls-ui.js
+++ b/web/static/js/access-controls-ui.js
@@ -1,0 +1,289 @@
+export const ACCESS_CONTROL_TABS = Object.freeze(['agents', 'groups', 'federation']);
+const ACCESS_HISTORY_INDEX = '__sage_access_history_index';
+
+let activeNavigationGuard = null;
+
+// Access Controls is mounted below the application router, so hash/sidebar
+// navigation must ask the mounted editor before the router unmounts it. Keep
+// the registration module-local rather than exposing mutable state on window.
+export function registerAccessControlNavigationGuard({ confirmDiscard, currentHash }) {
+    if (typeof confirmDiscard !== 'function' || typeof currentHash !== 'function') {
+        throw new TypeError('Access Controls navigation guard requires confirmDiscard and currentHash');
+    }
+    const registration = { confirmDiscard, currentHash };
+    activeNavigationGuard = registration;
+    return () => {
+        if (activeNavigationGuard === registration) activeNavigationGuard = null;
+    };
+}
+
+export function accessControlNavigationSnapshot() {
+    if (!activeNavigationGuard) return { active: false, currentHash: '' };
+    return {
+        active: true,
+        currentHash: String(activeNavigationGuard.currentHash() || ''),
+    };
+}
+
+export async function confirmAccessControlHashNavigation() {
+    if (!activeNavigationGuard) return true;
+    return (await activeNavigationGuard.confirmDiscard()) === true;
+}
+
+export function discardedAccessControlDraft(savedDraft, savedDisplayName = '') {
+    return {
+        draft: savedDraft ? { ...savedDraft } : null,
+        displayNameDraft: String(savedDisplayName || ''),
+    };
+}
+
+export function accessControlDisplayNameDirty(savedDisplayName = '', draftDisplayName = '') {
+    return String(draftDisplayName || '').trim() !== String(savedDisplayName || '').trim();
+}
+
+export async function protectAccessControlTransition(confirmNavigation) {
+    if (typeof confirmNavigation !== 'function') {
+        throw new TypeError('Access Controls transition requires a confirmation function');
+    }
+    return (await confirmNavigation()) === true;
+}
+
+// Access drawers are themselves fixed modal surfaces rather than dialogs
+// nested inside a separate overlay. Return every sibling outside the dialog's
+// ancestor path so the caller can make the complete background inert.
+export function accessControlModalInertTargets(dialog, app) {
+    const targets = [];
+    let branch = dialog;
+    while (branch && branch !== app) {
+        const parent = branch.parentElement;
+        if (!parent) break;
+        for (const child of parent.children || []) {
+            if (child !== branch) targets.push(child);
+        }
+        branch = parent;
+    }
+    return targets;
+}
+
+function historyIndex(state) {
+    const value = state && state[ACCESS_HISTORY_INDEX];
+    return Number.isSafeInteger(value) ? value : null;
+}
+
+function indexedHistoryState(state, index) {
+    const base = state && typeof state === 'object' ? state : {};
+    return { ...base, [ACCESS_HISTORY_INDEX]: index };
+}
+
+// Hash assignment pushes a history entry; Back/Forward traverses one. Blocking
+// either after the URL changed must reverse the traversal, never replace the
+// destination entry (which duplicates or destroys the user's history).
+export function createAccessControlHistoryNavigator({
+    getHash,
+    getState,
+    replaceState,
+    pushState,
+    go,
+    confirmNavigation,
+    applyHash,
+}) {
+    for (const dependency of [getHash, getState, replaceState, pushState, go, confirmNavigation, applyHash]) {
+        if (typeof dependency !== 'function') {
+            throw new TypeError('Access Controls history navigator requires complete history adapters');
+        }
+    }
+
+    const normalizedHash = () => String(getHash() || '#/');
+    let acceptedHash = normalizedHash();
+    let acceptedIndex = historyIndex(getState());
+    if (acceptedIndex === null) {
+        acceptedIndex = 0;
+        replaceState(indexedHistoryState(getState(), acceptedIndex), acceptedHash);
+    }
+    let restoringIndex = null;
+    let skipHashChange = '';
+    let navigationGeneration = 0;
+
+    const mayNavigate = async (requestedHash, generation) => {
+        const allowed = (await confirmNavigation(requestedHash)) === true;
+        return generation === navigationGeneration && allowed;
+    };
+
+    const accept = (requestedHash, requestedIndex) => {
+        acceptedHash = requestedHash;
+        acceptedIndex = requestedIndex;
+        applyHash(requestedHash);
+    };
+
+    return {
+        async navigate(requested) {
+            const requestedHash = String(requested || '#/');
+            if (requestedHash === acceptedHash) return true;
+            const generation = ++navigationGeneration;
+            if (!await mayNavigate(requestedHash, generation)) return false;
+            const requestedIndex = acceptedIndex + 1;
+            pushState(indexedHistoryState(getState(), requestedIndex), requestedHash);
+            accept(requestedHash, requestedIndex);
+            return true;
+        },
+
+        async handleHashChange() {
+            const requestedHash = normalizedHash();
+            if (skipHashChange === requestedHash) {
+                skipHashChange = '';
+                return true;
+            }
+            if (requestedHash === acceptedHash) return true;
+
+            const requestedIndex = acceptedIndex + 1;
+            replaceState(indexedHistoryState(getState(), requestedIndex), requestedHash);
+            const generation = ++navigationGeneration;
+            if (await mayNavigate(requestedHash, generation)) {
+                accept(requestedHash, requestedIndex);
+                return true;
+            }
+            restoringIndex = acceptedIndex;
+            go(acceptedIndex - requestedIndex);
+            return false;
+        },
+
+        async handlePopState(state) {
+            const requestedHash = normalizedHash();
+            skipHashChange = requestedHash;
+            let requestedIndex = historyIndex(state);
+            if (requestedIndex === null) {
+                // Entries older than this SPA session can be reached only by
+                // traversing backwards from the first indexed entry.
+                requestedIndex = acceptedIndex - 1;
+                replaceState(indexedHistoryState(state, requestedIndex), requestedHash);
+            }
+            if (restoringIndex !== null && requestedIndex === restoringIndex) {
+                restoringIndex = null;
+                return true;
+            }
+
+            const generation = ++navigationGeneration;
+            if (await mayNavigate(requestedHash, generation)) {
+                accept(requestedHash, requestedIndex);
+                return true;
+            }
+            restoringIndex = acceptedIndex;
+            const delta = acceptedIndex - requestedIndex;
+            if (delta) go(delta);
+            return false;
+        },
+
+        snapshot() {
+            return { acceptedHash, acceptedIndex, restoringIndex };
+        },
+    };
+}
+
+export function accessControlRouteState(hash = '') {
+    const query = new URLSearchParams(String(hash).split('?')[1] || '');
+    const remoteChain = query.get('remote_chain') || '';
+    const remoteAgent = query.get('remote_agent') || '';
+    const requestedTab = query.get('tab') || '';
+    const tab = ACCESS_CONTROL_TABS.includes(requestedTab)
+        ? requestedTab
+        : (remoteChain && remoteAgent ? 'federation' : 'agents');
+    return {
+        tab,
+        item: query.get('item') || query.get('agent') || query.get('group') ||
+            (remoteChain && remoteAgent ? `${remoteChain}\u0000${remoteAgent}` : ''),
+        remoteChain,
+        remoteAgent,
+        inbox: query.get('inbox') === '1',
+    };
+}
+
+export function accessControlHash({ tab = 'agents', item = '', inbox = false } = {}) {
+    const safeTab = ACCESS_CONTROL_TABS.includes(tab) ? tab : 'agents';
+    const query = new URLSearchParams({ tab: safeTab });
+    if (item) query.set('item', item);
+    if (safeTab === 'agents' && item) query.set('agent', item);
+    if (safeTab === 'groups' && item) query.set('group', item);
+    if (safeTab === 'federation' && item.includes('\u0000')) {
+        const [remoteChain, remoteAgent] = item.split('\u0000');
+        if (remoteChain && remoteAgent) {
+            query.set('remote_chain', remoteChain);
+            query.set('remote_agent', remoteAgent);
+        }
+    }
+    if (inbox) query.set('inbox', '1');
+    return `/access?${query.toString()}`;
+}
+
+function normalized(value) {
+    return String(value || '').trim().toLocaleLowerCase();
+}
+
+export function filterSortAccessAgents(agents = [], query = '', sort = 'name') {
+    const needle = normalized(query);
+    return [...agents]
+        .filter(agent => !needle || [
+            agent?.name,
+            agent?.registered_name,
+            agent?.agent_id,
+            agent?.role,
+            agent?.profile,
+        ].some(value => normalized(value).includes(needle)))
+        .sort((left, right) => {
+            if (sort === 'status') {
+                const rank = agent => agent?.needs_reauthorization ? 0
+                    : (agent?.needs_approval || agent?.profile_needs_review) ? 1 : 2;
+                const delta = rank(left) - rank(right);
+                if (delta) return delta;
+            }
+            if (sort === 'role') {
+                const delta = normalized(left?.role).localeCompare(normalized(right?.role));
+                if (delta) return delta;
+            }
+            return normalized(left?.name || left?.registered_name || left?.agent_id)
+                .localeCompare(normalized(right?.name || right?.registered_name || right?.agent_id));
+        });
+}
+
+export function filterSortAccessGroups(groups = [], query = '', sort = 'name') {
+    const needle = normalized(query);
+    return [...groups]
+        .filter(group => !needle || [group?.name, group?.group_id, group?.member_authority]
+            .some(value => normalized(value).includes(needle)))
+        .sort((left, right) => {
+            if (sort === 'members') {
+                const delta = Number(right?.members?.length || 0) - Number(left?.members?.length || 0);
+                if (delta) return delta;
+            }
+            if (sort === 'authority') {
+                const rank = { read: 0, write: 1, modify: 2 };
+                const delta = (rank[left?.member_authority] ?? 0) - (rank[right?.member_authority] ?? 0);
+                if (delta) return delta;
+            }
+            return normalized(left?.name || left?.group_id).localeCompare(normalized(right?.name || right?.group_id));
+        });
+}
+
+export function filterSortFederatedAgents(agents = [], query = '', sort = 'peer') {
+    const needle = normalized(query);
+    return [...agents]
+        .filter(agent => !needle || [
+            agent?.label,
+            agent?.peer_name,
+            agent?.remote_agent_id,
+            agent?.remote_chain_id,
+            agent?.source,
+        ].some(value => normalized(value).includes(needle)))
+        .sort((left, right) => {
+            if (sort === 'status') {
+                const delta = Number(right?.link_count || 0) - Number(left?.link_count || 0);
+                if (delta) return delta;
+            }
+            const leftKey = sort === 'name'
+                ? `${left?.label || ''}/${left?.peer_name || ''}`
+                : `${left?.peer_name || ''}/${left?.label || ''}`;
+            const rightKey = sort === 'name'
+                ? `${right?.label || ''}/${right?.peer_name || ''}`
+                : `${right?.peer_name || ''}/${right?.label || ''}`;
+            return normalized(leftKey).localeCompare(normalized(rightKey));
+        });
+}

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -1077,8 +1077,9 @@ async function fedFetch(path, opts) {
     }
     return data;
 }
-function fedPost(path, body) {
+function fedPost(path, body, options = {}) {
     return fedFetch(path, {
+        ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body || {}),
@@ -1190,7 +1191,9 @@ export function fedHostApprove(sessionId, grant) { return fedPost(`/v1/dashboard
 export function fedHostAbort(sessionId) { return fedPost(`/v1/dashboard/federation/join/host/${encodeURIComponent(sessionId)}/abort`); }
 
 // Guest wizard.
-export function fedGuestScan(uri, endpoint) { return fedPost('/v1/dashboard/federation/join/guest/scan', { uri, endpoint }); }
+export function fedGuestScan(uri, endpoint, signal) {
+    return fedPost('/v1/dashboard/federation/join/guest/scan', { uri, endpoint }, { signal });
+}
 export function fedGuestRequest(body) { return fedPost('/v1/dashboard/federation/join/guest/request', body); }
 export function fedGuestStatus(sessionId) { return fedFetch(`/v1/dashboard/federation/join/guest/${encodeURIComponent(sessionId)}/status`); }
 export function fedGuestAbort(sessionId) { return fedPost(`/v1/dashboard/federation/join/guest/${encodeURIComponent(sessionId)}/abort`); }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -13,7 +13,7 @@ import { mountMriBrain } from './mri-brain.js';
 import { restartBaselineBootID, requestedRestartIsReady } from './restart-proof.js';
 import { buildUpdateBanner } from './update-banner.js';
 import { computeReorderedColumn, applyColumnOrder } from './task-reorder.js';
-import { normalizeFederationJoinState } from './federation-flow.js';
+import { createFederationJoinScanLifecycle, normalizeFederationJoinState } from './federation-flow.js';
 import { buildBrainDomainInventory } from './domain-inventory.js';
 import { enqueueGovernedTransfer, runWithGovernanceCooldown } from './governance-retry.js';
 import {
@@ -46,6 +46,22 @@ import {
     normalizeFederationRoutePlan,
 } from './federation-route-state.js';
 import { federationPeerAgentCompatibility } from './federation-peer-capabilities.js';
+import {
+    ACCESS_CONTROL_TABS,
+    accessControlHash,
+    accessControlDisplayNameDirty,
+    accessControlModalInertTargets,
+    accessControlNavigationSnapshot,
+    accessControlRouteState,
+    confirmAccessControlHashNavigation,
+    createAccessControlHistoryNavigator,
+    discardedAccessControlDraft,
+    filterSortAccessAgents,
+    filterSortAccessGroups,
+    filterSortFederatedAgents,
+    protectAccessControlTransition,
+    registerAccessControlNavigationGuard,
+} from './access-controls-ui.js';
 
 const { h, render, createContext, Fragment } = preact;
 const { useState, useEffect, useRef, useLayoutEffect, useCallback, useContext } = preactHooks;
@@ -57,7 +73,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.17.17';
+const SAGE_VERSION = 'v11.18.0';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace
@@ -207,7 +223,7 @@ function ConfirmationDialogHost() {
 // Accessible modal behavior shared by the setup flows. `active` lets a parent
 // component temporarily return a child modal without keeping stale listeners or
 // focus ownership. The dialog branch, not the whole app, stays interactive.
-function useModalDialog(onRequestClose, active = true) {
+function useModalDialog(onRequestClose, active = true, dialogOwnsOverlay = false) {
     const dialogRef = useRef(null);
     const closeRef = useRef(onRequestClose);
     closeRef.current = onRequestClose;
@@ -225,7 +241,16 @@ function useModalDialog(onRequestClose, active = true) {
             // portalled directly under #app. Inert every sibling along the full
             // ancestor path so controls in that same page branch are hidden too,
             // while no ancestor containing the modal itself becomes inert.
-            let branch = overlay;
+            const accessTargets = dialogOwnsOverlay
+                ? accessControlModalInertTargets(dialog, app)
+                : null;
+            if (accessTargets) {
+                for (const child of accessTargets) {
+                    inerted.push([child, child.inert]);
+                    child.inert = true;
+                }
+            }
+            let branch = dialogOwnsOverlay ? app : overlay;
             while (branch && branch !== app) {
                 const parent = branch.parentElement;
                 if (!parent) break;
@@ -279,7 +304,7 @@ function useModalDialog(onRequestClose, active = true) {
             inerted.forEach(([child, wasInert]) => { child.inert = wasInert; });
             if (origin && origin.isConnected) origin.focus();
         };
-    }, [active]);
+    }, [active, dialogOwnsOverlay]);
 
     return dialogRef;
 }
@@ -8911,15 +8936,24 @@ function AppV23AccessControl() {
         onDirectoryChanged = null,
         onReviewQueueChanged = null,
     } = arguments[0] || {};
-    const routeQuery = new URLSearchParams((window.location.hash.split('?')[1] || ''));
-    const requestedLocalAgentID = routeQuery.get('agent') || '';
-    const focusFederatedInbox = routeQuery.get('inbox') === '1';
-    const requestedRemoteChainID = routeQuery.get('remote_chain') || '';
-    const requestedRemoteAgentID = routeQuery.get('remote_agent') || '';
+    const initialRoute = accessControlRouteState(window.location.hash);
+    const requestedLocalAgentID = initialRoute.tab === 'agents' ? initialRoute.item : '';
+    const focusFederatedInbox = initialRoute.inbox;
+    const requestedRemoteChainID = initialRoute.remoteChain;
+    const requestedRemoteAgentID = initialRoute.remoteAgent;
     const [state, setState] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
     const [selectedID, setSelectedID] = useState(requestedLocalAgentID);
+    const [activeAccessTab, setActiveAccessTab] = useState(initialRoute.tab);
+    const [selectedGroupID, setSelectedGroupID] = useState(initialRoute.tab === 'groups' ? initialRoute.item : '');
+    const [federationEditorOpen, setFederationEditorOpen] = useState(
+        initialRoute.tab === 'federation' && !!initialRoute.item,
+    );
+    const [accessQuery, setAccessQuery] = useState('');
+    const [accessSort, setAccessSort] = useState('name');
+    const accessTabRefs = useRef([]);
+    const accessReturnFocusRef = useRef(null);
     const [draft, setDraft] = useState(null);
     const [displayNameDraft, setDisplayNameDraft] = useState('');
     const [renameBusy, setRenameBusy] = useState(false);
@@ -8991,10 +9025,9 @@ function AppV23AccessControl() {
             if (reviewQueueOnly && onReviewQueueChanged) {
                 onReviewQueueChanged(candidates.map(agent => agent.agent_id));
             }
-            const editable = candidates[0];
             setSelectedID(current => current && candidates.some(a => a.agent_id === current)
                 ? current
-                : (editable?.agent_id || ''));
+                : (reviewQueueOnly ? (candidates[0]?.agent_id || '') : ''));
         } catch (e) {
             setError(e.message || 'Could not load consensus access controls.');
         } finally {
@@ -9071,7 +9104,7 @@ function AppV23AccessControl() {
                     ? requestedKey
                     : current && next.some(item => item.key === current)
                         ? current
-                        : (next[0]?.key || ''));
+                        : '');
                 setLinkedError('');
             } catch (e) {
                 if (!cancelled) {
@@ -9099,7 +9132,11 @@ function AppV23AccessControl() {
         ? pendingEnrollmentAgents
         : agents.filter(agent => !pendingEnrollmentAgents.some(pending => pending.agent_id === agent.agent_id));
     const selected = localAgents.find(a => a.agent_id === selectedID) || null;
+    const selectedGroup = (state?.groups || []).find(group => group.group_id === selectedGroupID) || null;
     const selectedRemote = remoteCandidates.find(item => item.key === selectedRemoteKey) || null;
+    const visibleAccessAgents = filterSortAccessAgents(localAgents, accessQuery, accessSort);
+    const visibleAccessGroups = filterSortAccessGroups(state?.groups || [], accessQuery, accessSort);
+    const visibleFederatedAgents = filterSortFederatedAgents(remoteCandidates, accessQuery, accessSort);
     const selectedRemoteMaxClearance = Number(selectedRemote?.max_clearance ?? 4);
     const messageLocalCandidates = localAgents.filter(agent =>
         agent.enrollment_active && !agent.needs_reauthorization &&
@@ -9258,6 +9295,109 @@ function AppV23AccessControl() {
         setDisplayNameDraft(selected?.name || '');
     }, [selected?.agent_id, selected?.name]);
 
+    const policyDirty = !!selected && !!draft && appV23PolicyChanged(selected, draft);
+    const displayNameDirty = !!selected &&
+        accessControlDisplayNameDirty(selected.name, displayNameDraft);
+    const accessEditorDirty = policyDirty || displayNameDirty;
+    const activeAccessItem = activeAccessTab === 'agents'
+        ? selectedID
+        : activeAccessTab === 'groups' ? selectedGroupID : selectedRemoteKey;
+    const activeAccessDrawerOpen = activeAccessTab === 'federation'
+        ? federationEditorOpen
+        : !!activeAccessItem;
+    const discardAccessEditorChanges = () => {
+        const reset = discardedAccessControlDraft(
+            selected ? appV23PolicyDraft(selected) : null,
+            selected?.name || '',
+        );
+        setDraft(reset.draft);
+        setDisplayNameDraft(reset.displayNameDraft);
+    };
+    const confirmAccessNavigation = async () => {
+        if (!accessEditorDirty) return true;
+        const confirmed = await showConfirmation(
+            'Discard the unsaved agent changes before leaving this editor?',
+            { title: 'Discard unsaved changes?', confirmLabel: 'Discard changes', tone: 'danger' },
+        );
+        if (confirmed) discardAccessEditorChanges();
+        return confirmed;
+    };
+    const closeAccessDrawer = async () => {
+        if (!await confirmAccessNavigation()) return;
+        if (activeAccessTab === 'agents') setSelectedID('');
+        if (activeAccessTab === 'groups') setSelectedGroupID('');
+        if (activeAccessTab === 'federation') {
+            setSelectedRemoteKey('');
+            setFederationEditorOpen(false);
+        }
+        requestAnimationFrame(() => accessReturnFocusRef.current?.focus?.());
+    };
+    const chooseAccessTab = async tab => {
+        if (tab === activeAccessTab || !ACCESS_CONTROL_TABS.includes(tab)) return false;
+        if (!await confirmAccessNavigation()) return false;
+        setActiveAccessTab(tab);
+        setAccessQuery('');
+        setAccessSort('name');
+        return true;
+    };
+    const onAccessTabKeyDown = event => {
+        const index = ACCESS_CONTROL_TABS.indexOf(activeAccessTab);
+        let next = index;
+        if (event.key === 'ArrowRight') next = (index + 1) % ACCESS_CONTROL_TABS.length;
+        else if (event.key === 'ArrowLeft') next = (index - 1 + ACCESS_CONTROL_TABS.length) % ACCESS_CONTROL_TABS.length;
+        else if (event.key === 'Home') next = 0;
+        else if (event.key === 'End') next = ACCESS_CONTROL_TABS.length - 1;
+        else return;
+        event.preventDefault();
+        chooseAccessTab(ACCESS_CONTROL_TABS[next]).then(changed => {
+            if (changed) accessTabRefs.current[next]?.focus();
+        });
+    };
+    const accessDrawerRef = useModalDialog(
+        closeAccessDrawer,
+        !reviewQueueOnly && activeAccessDrawerOpen,
+        true,
+    );
+
+    useEffect(() => {
+        if (reviewQueueOnly) return;
+        const next = accessControlHash({
+            tab: activeAccessTab,
+            item: activeAccessItem,
+            inbox: activeAccessTab === 'agents' && focusFederatedInbox,
+        });
+        window.history.replaceState(window.history.state, '', `#${next}`);
+    }, [reviewQueueOnly, activeAccessTab, activeAccessItem, focusFederatedInbox]);
+    useEffect(() => {
+        if (!accessEditorDirty) return undefined;
+        const guard = event => {
+            event.preventDefault();
+            event.returnValue = '';
+        };
+        window.addEventListener('beforeunload', guard);
+        return () => window.removeEventListener('beforeunload', guard);
+    }, [accessEditorDirty]);
+    useEffect(() => {
+        if (reviewQueueOnly) return undefined;
+        return registerAccessControlNavigationGuard({
+            confirmDiscard: confirmAccessNavigation,
+            currentHash: () => `#${accessControlHash({
+                tab: activeAccessTab,
+                item: activeAccessItem,
+                inbox: activeAccessTab === 'agents' && focusFederatedInbox,
+            })}`,
+        });
+    }, [
+        reviewQueueOnly,
+        accessEditorDirty,
+        selected?.agent_id,
+        selected?.enrollment_revision,
+        selected?.role_revision,
+        selected?.name,
+        activeAccessTab,
+        activeAccessItem,
+        focusFederatedInbox,
+    ]);
     const mutateDraft = (patch) => setDraft(current => ({ ...(current || {}), ...patch }));
     const beginMutation = (key) => {
         if (mutationLockRef.current) return false;
@@ -9474,6 +9614,7 @@ function AppV23AccessControl() {
             setNewGroupName('');
             showToast(`Access Group “${name}” created on-chain.`, 'success');
             await load();
+            setSelectedGroupID(groupID);
         } catch (e) {
             if (mutationMayHaveCommitted(e)) {
                 await holdPendingConfirmation(e.message);
@@ -9492,6 +9633,7 @@ function AppV23AccessControl() {
         const plan = appV23DirectLocalGroupPlan(state?.groups || [], source, target);
         clearLocalDrag();
         if (!plan || groupBusy || !mutationReady) return;
+        if (!await protectAccessControlTransition(confirmAccessNavigation)) return;
         if (plan.action === 'existing') {
             showToast(`These agents already share Access Group “${plan.name}”.`, 'info');
             return;
@@ -9512,6 +9654,8 @@ function AppV23AccessControl() {
             }
             showToast(`Access Group “${plan.name}” created on-chain at Read. Each owner keeps full control; widen the group only if its members should also write or modify.`, 'success', 8000);
             await load();
+            setActiveAccessTab('groups');
+            setSelectedGroupID(plan.group_id);
         } catch (e) {
             if (mutationMayHaveCommitted(e)) {
                 await holdPendingConfirmation(e.message);
@@ -9550,6 +9694,7 @@ function AppV23AccessControl() {
             }
             showToast(`Access Group “${group.name}” deleted.`, 'success');
             await load();
+            if (selectedGroupID === group.group_id) setSelectedGroupID('');
         } catch (e) {
             if (mutationMayHaveCommitted(e)) {
                 await holdPendingConfirmation(e.message);
@@ -9874,18 +10019,15 @@ function AppV23AccessControl() {
     const legacyHomeReapproval = legacyProfileNeedsReview && homeReapproval;
     const targetConsentReady = (!selected?.needs_approval && !homeReapproval) || selected?.local_key_available;
     const adminLocalReady = draft?.role !== 'admin' || selected?.local_key_available;
-    const policyDirty = !!selected && !!draft && appV23PolicyChanged(selected, draft);
     const policyCommitNeeded = !!selected?.needs_approval || homeReapproval || policyDirty;
     const saveDisabled = saving || !mutationReady || !targetConsentReady ||
         !adminLocalReady || !draft || !draftProfileSelectable || !policyCommitNeeded;
     const capabilityIndicators = appV23CapabilityIndicators(draft || {});
     const federatedInboxEnabled = appV23FederatedInboxEnabled(draft?.capabilities);
-    const selectLocalAgent = async agentID => {
+    const selectLocalAgent = async (agentID, trigger = null) => {
         if (saving || renameBusy || agentID === selectedID) return;
-        if (policyDirty && !await showConfirmation(
-            'Discard the unsaved policy changes for this agent?',
-            { title: 'Discard policy changes?', confirmLabel: 'Discard changes', tone: 'danger' },
-        )) return;
+        if (!await confirmAccessNavigation()) return;
+        accessReturnFocusRef.current = trigger;
         setSelectedID(agentID);
     };
 
@@ -9971,12 +10113,67 @@ function AppV23AccessControl() {
                 </div>
             `}
 
-            <div class="v23-access-legend" aria-label="Identity and access legend">
-                <span class="local"><i aria-hidden="true"></i> Same-node agents</span>
-                <span class="federated"><i aria-hidden="true">↗</i> Federated read-only links</span>
-            </div>
+            ${!reviewQueueOnly && html`
+                <div class="access-control-tabs" role="tablist" aria-label="Access control areas"
+                    onKeyDown=${onAccessTabKeyDown}>
+                    ${ACCESS_CONTROL_TABS.map((tab, index) => html`
+                        <button role="tab" id=${`access-tab-${tab}`}
+                            ref=${element => { accessTabRefs.current[index] = element; }}
+                            aria-selected=${activeAccessTab === tab}
+                            aria-controls=${`access-panel-${tab}`}
+                            tabIndex=${activeAccessTab === tab ? 0 : -1}
+                            class=${activeAccessTab === tab ? 'active' : ''}
+                            onClick=${() => chooseAccessTab(tab)}>
+                            <span>${tab[0].toUpperCase()}${tab.slice(1)}</span>
+                            <strong>${tab === 'agents'
+                                ? localAgents.length
+                                : tab === 'groups' ? (state.groups || []).length : remoteCandidates.length}</strong>
+                        </button>
+                    `)}
+                </div>
+                <div class="access-control-summary" role="status">
+                    ${activeAccessTab === 'agents' && html`
+                        <span><strong>${localAgents.filter(agent => !agent.needs_approval && !agent.needs_reauthorization).length}</strong> active</span>
+                        <span><strong>${localAgents.filter(agent => agent.needs_approval || agent.needs_reauthorization).length}</strong> need review</span>
+                        <span>Roles, profiles, clearance, owned home domains, and inbox restrictions commit atomically.</span>
+                    `}
+                    ${activeAccessTab === 'groups' && html`
+                        <span><strong>${(state.groups || []).length}</strong> local groups</span>
+                        <span>Group Write/Modify applies only among local members. Every owner keeps full control of its own domains.</span>
+                    `}
+                    ${activeAccessTab === 'federation' && html`
+                        <span><strong>${remoteConnections.filter(connection => connection.status !== 'revoked').length}</strong> connected SAGEs</span>
+                        <span>Active ordinary agents may live-read peer-exported domains by default unless explicitly denied. Remote Write is reserved and denied; Linked readers and messaging never enable it.</span>
+                    `}
+                </div>
+                <div class="v23-access-legend" aria-label="Identity type legend">
+                    <span class="local"><i aria-hidden="true"></i>Local agent</span>
+                    <span class="federated"><i aria-hidden="true"></i>Federated agent</span>
+                </div>
+                <div class="access-control-toolbar" role="search" aria-label=${`Find and sort ${activeAccessTab}`}>
+                    <label>
+                        <span class="sr-only">Search ${activeAccessTab}</span>
+                        <input type="search" value=${accessQuery} placeholder=${`Search ${activeAccessTab}`}
+                            onInput=${event => setAccessQuery(event.currentTarget.value)} />
+                    </label>
+                    <label>
+                        <span>Sort</span>
+                        <select value=${accessSort} onChange=${event => setAccessSort(event.currentTarget.value)}>
+                            <option value="name">Name</option>
+                            ${activeAccessTab === 'agents' && html`<option value="role">Role</option><option value="status">Status</option>`}
+                            ${activeAccessTab === 'groups' && html`<option value="members">Member count</option><option value="authority">Authority</option>`}
+                            ${activeAccessTab === 'federation' && html`<option value="peer">Connected SAGE</option><option value="status">Link status</option>`}
+                        </select>
+                    </label>
+                    <span>${activeAccessTab === 'agents'
+                        ? visibleAccessAgents.length
+                        : activeAccessTab === 'groups' ? visibleAccessGroups.length : visibleFederatedAgents.length} shown</span>
+                </div>
+            `}
 
-            <div class="v23-access-grid">
+            ${(reviewQueueOnly || activeAccessTab === 'agents') && html`
+            <div class="v23-access-grid" id="access-panel-agents" role=${reviewQueueOnly ? undefined : 'tabpanel'}
+                aria-labelledby=${reviewQueueOnly ? undefined : 'access-tab-agents'}>
                 <div class="v23-agent-rail ${dragSourceGroupID ? 'remove-drop-ready' : ''}" aria-label="Local agents"
                     onDragOver=${e => {
                         if (readLocalDrag(e).sourceGroupID) e.preventDefault();
@@ -9998,12 +10195,13 @@ function AppV23AccessControl() {
                             Drop here to remove this agent from this Access Group. Its own domains and access from any other groups remain unchanged.
                         </div>
                     `}
-                    ${localAgents.map(agent => html`
-                        <button class="v23-agent-choice local ${selectedID === agent.agent_id ? 'selected' : ''} ${dragAgentID && dragAgentID !== agent.agent_id && agent.enrollment_active ? 'drop-ready' : ''}"
+                    <div class="access-control-list">
+                    ${(reviewQueueOnly ? localAgents : visibleAccessAgents).map(agent => html`
+                        <button class="access-control-list-row v23-agent-choice local ${selectedID === agent.agent_id ? 'selected' : ''} ${dragAgentID && dragAgentID !== agent.agent_id && agent.enrollment_active ? 'drop-ready' : ''}"
                             aria-current=${selectedID === agent.agent_id ? 'true' : undefined}
                             disabled=${saving}
                             draggable=${agent.enrollment_active && mutationReady && !groupBusy && !saving}
-                            onClick=${() => selectLocalAgent(agent.agent_id)}
+                            onClick=${event => selectLocalAgent(agent.agent_id, event.currentTarget)}
                             onDragStart=${event => {
                                 event.stopPropagation();
                                 startLocalDrag(event, agent.agent_id);
@@ -10035,10 +10233,19 @@ function AppV23AccessControl() {
                                 : html`<span class="v23-state-chip active">Active</span>`}
                         </button>
                     `)}
-                    ${localAgents.length === 0 && html`<p class="v23-empty">No activated local agents.</p>`}
+                    ${(reviewQueueOnly ? localAgents : visibleAccessAgents).length === 0 && html`
+                        <p class="v23-empty">${localAgents.length
+                            ? 'No active agents match this search.'
+                            : 'No activated local agents.'}</p>
+                    `}
+                    </div>
                 </div>
 
-                <div class="v23-policy-panel">
+                <div class="v23-policy-panel ${!reviewQueueOnly && selected ? 'access-control-drawer open' : ''}"
+                    ref=${accessDrawerRef} role=${!reviewQueueOnly && selected ? 'dialog' : undefined}
+                    aria-modal=${!reviewQueueOnly && selected ? 'true' : undefined}
+                    aria-label=${!reviewQueueOnly && selected ? `Edit ${agentDisplayName(selected)}` : undefined}
+                    tabIndex=${!reviewQueueOnly && selected ? -1 : undefined}>
                     ${selected && draft ? html`
                         <div class="v23-policy-title">
                             <div>
@@ -10049,6 +10256,10 @@ function AppV23AccessControl() {
                                 ? html`<span class="v23-review-badge">Admin suspended</span>`
                                 : selected.needs_approval && !legacyProfileNeedsReview &&
                                     html`<span class="v23-review-badge">Pending review</span>`}
+                            ${!reviewQueueOnly && html`
+                                <button type="button" class="access-control-drawer-close"
+                                    aria-label="Close agent editor" onClick=${closeAccessDrawer}>×</button>
+                            `}
                         </div>
 
                         <form class="v23-agent-name-editor" onSubmit=${event => { event.preventDefault(); saveDisplayName(); }}>
@@ -10241,8 +10452,10 @@ function AppV23AccessControl() {
                     ` : html`<div class="v23-empty large">Select a local agent to review its policy.</div>`}
                 </div>
             </div>
+            `}
 
-            <div class="v23-groups-section">
+            ${!reviewQueueOnly && activeAccessTab === 'groups' && html`
+            <div class="v23-groups-section" id="access-panel-groups" role="tabpanel" aria-labelledby="access-tab-groups">
                 <div class="v23-section-heading wide">
                     <div>
                         <div class="v23-eyebrow">Consensus Access Groups</div>
@@ -10256,6 +10469,34 @@ function AppV23AccessControl() {
                             placeholder="New group name" />
                         <button type="submit" class="btn" disabled=${!mutationReady || !!groupBusy || !newGroupName.trim()}>Create group</button>
                     </form>
+                </div>
+
+                <div class="access-control-list" aria-label="Local Access Groups">
+                    ${visibleAccessGroups.map(group => html`
+                        <button class="access-control-list-row ${selectedGroupID === group.group_id ? 'selected' : ''}"
+                            aria-current=${selectedGroupID === group.group_id ? 'true' : undefined}
+                            onClick=${event => {
+                                accessReturnFocusRef.current = event.currentTarget;
+                                setSelectedGroupID(group.group_id);
+                            }}
+                            onDragOver=${event => event.preventDefault()}
+                            onDrop=${event => { event.preventDefault(); dropIntoGroup(group, event); }}>
+                            <span class="access-control-list-primary">
+                                <strong>${group.name}</strong>
+                                <small>${group.group_id}</small>
+                            </span>
+                            <span>${group.members.length} member${group.members.length === 1 ? '' : 's'}</span>
+                            <span class="v23-state-chip active">
+                                ${APPV26_GROUP_AUTHORITY_OPTIONS.find(option => option.key === (group.member_authority || 'read'))?.name || 'Read'}
+                            </span>
+                            <span aria-hidden="true">›</span>
+                        </button>
+                    `)}
+                    ${visibleAccessGroups.length === 0 && html`
+                        <div class="v23-empty group">${(state.groups || []).length
+                            ? 'No Access Groups match this search.'
+                            : 'No local groups yet. Create one, then add approved local agents.'}</div>
+                    `}
                 </div>
 
                 <div class="v23-agent-tray" aria-label="Approved local agents available for groups">
@@ -10272,8 +10513,12 @@ function AppV23AccessControl() {
                     `)}
                 </div>
 
-                <div class="v23-group-grid">
-                    ${(state.groups || []).map(group => html`
+                <div class="v23-group-grid access-control-drawer ${selectedGroup ? 'open' : ''}"
+                    ref=${accessDrawerRef} role=${selectedGroup ? 'dialog' : undefined}
+                    aria-modal=${selectedGroup ? 'true' : undefined}
+                    aria-label=${selectedGroup ? `Edit Access Group ${selectedGroup.name}` : undefined}
+                    tabIndex=${selectedGroup ? -1 : undefined}>
+                    ${(selectedGroup ? [selectedGroup] : []).map(group => html`
                         <article key=${`${group.group_id}:${group.revision}`} class="v23-group-card local ${dragAgentID ? 'drop-ready drop-local' : ''} ${dragRemoteKey ? 'drop-ready drop-linked' : ''}"
                             aria-label=${`Local group ${group.name}`}
                             onDragOver=${e => e.preventDefault()}
@@ -10300,6 +10545,8 @@ function AppV23AccessControl() {
                                     aria-label=${`Delete Access Group ${group.name}`}
                                     disabled=${!!groupBusy || !mutationReady}
                                     onClick=${() => deleteGroup(group)}>×</button>
+                                <button class="access-control-drawer-close" type="button"
+                                    aria-label="Close Access Group editor" onClick=${closeAccessDrawer}>×</button>
                             </div>
                             <label class="v23-field v23-group-authority">
                                 <span>Members may</span>
@@ -10369,9 +10616,6 @@ function AppV23AccessControl() {
                             </details>
                         </article>
                     `)}
-                    ${(state.groups || []).length === 0 && html`
-                        <div class="v23-empty group">No local groups yet. Create one, then add approved local agents.</div>
-                    `}
                 </div>
             </div>
 
@@ -10420,7 +10664,46 @@ function AppV23AccessControl() {
                     </div>
                 </div>
             `}
+            `}
 
+            ${!reviewQueueOnly && activeAccessTab === 'federation' && html`
+            <div id="access-panel-federation" role="tabpanel" aria-labelledby="access-tab-federation">
+                <div class="access-control-list" aria-label="Federated agents">
+                    ${visibleFederatedAgents.map(remote => html`
+                        <button class="access-control-list-row ${selectedRemoteKey === remote.key ? 'selected' : ''}"
+                            aria-current=${selectedRemoteKey === remote.key ? 'true' : undefined}
+                            onClick=${event => {
+                                accessReturnFocusRef.current = event.currentTarget;
+                                setSelectedRemoteKey(remote.key);
+                                setFederationEditorOpen(true);
+                            }}>
+                            <span class="access-control-list-primary">
+                                <strong>↗ ${remote.label}</strong>
+                                <small>${remote.remote_agent_id.slice(0, 12)}@${remote.remote_chain_id}</small>
+                            </span>
+                            <span>${remote.peer_name}</span>
+                            <span class="v23-state-chip ${remote.source === 'existing_link' ? 'active' : 'pending'}">
+                                ${remote.source === 'existing_link' ? 'Linked' : 'Available'}
+                            </span>
+                            <span aria-hidden="true">›</span>
+                        </button>
+                    `)}
+                    ${visibleFederatedAgents.length === 0 && html`
+                        <div class="v23-empty">No advertised federated agents match this view.</div>
+                    `}
+                </div>
+                <button class="btn" onClick=${event => {
+                    accessReturnFocusRef.current = event.currentTarget;
+                    setFederationEditorOpen(true);
+                }}>Manage an exact federated identity</button>
+            </div>
+            <div class="access-control-federation-drawer access-control-drawer ${federationEditorOpen ? 'open' : ''}"
+                ref=${accessDrawerRef} role=${federationEditorOpen ? 'dialog' : undefined}
+                aria-modal=${federationEditorOpen ? 'true' : undefined}
+                aria-label=${federationEditorOpen ? 'Federation access editor' : undefined}
+                tabIndex=${federationEditorOpen ? -1 : undefined}>
+                <button class="access-control-drawer-close" type="button"
+                    aria-label="Close federation access editor" onClick=${closeAccessDrawer}>×</button>
             <div class="v23-linked-readers">
                 <div class="v23-linked-intro">
                     <div class="v23-eyebrow">Federation · separate compartment</div>
@@ -10702,6 +10985,8 @@ function AppV23AccessControl() {
                     </div>
                 `}
             </div>
+            </div>
+            `}
         </section>
     `;
 }
@@ -10786,11 +11071,10 @@ function FederatedAgentDirectory() {
     if (loading || remoteAgents.length === 0) return null;
 
     const openPermissions = agent => {
-        const query = new URLSearchParams({
-            remote_chain: agent.remote_chain_id,
-            remote_agent: agent.remote_agent_id,
+        window.location.hash = accessControlHash({
+            tab: 'federation',
+            item: `${agent.remote_chain_id}\u0000${agent.remote_agent_id}`,
         });
-        window.location.hash = `/access?${query.toString()}`;
     };
 
     return html`
@@ -14978,6 +15262,7 @@ function App() {
     const [authState, setAuthState] = useState('loading'); // loading | login | ready
     const [isEncrypted, setIsEncrypted] = useState(false);
     const [page, setPage] = useState('brain');
+    const [hashRouteRevision, setHashRouteRevision] = useState(0);
     const [sseConnected, setSseConnected] = useState(false);
     const [showHelp, setShowHelp] = useState(false);
     const [showOnboarding, setShowOnboarding] = useState(false);
@@ -15015,6 +15300,7 @@ function App() {
         try { return localStorage.getItem('sage-tooltips') !== '0'; } catch (e) { return true; }
     });
     const sseRef = useRef(null);
+    const hashNavigatorRef = useRef(null);
     const [textSize, setTextSize] = useState(() => {
         try { return localStorage.getItem('sage-text-size') || 'medium'; } catch (e) { return 'medium'; }
     });
@@ -15162,26 +15448,50 @@ function App() {
         sseRef.current = sse;
         sse.on('connection', (data) => setSseConnected(data.connected));
 
-        // Hash routing
-        function onHash() {
-            const hash = (window.location.hash.slice(1) || '/').split('?')[0]; // strip ?query (e.g. /search?agent=…) for page matching
+        // Hash routing. Every same-document entry gets a stable position so a
+        // cancelled Back/Forward or direct hash push can be reversed without
+        // replacing (and therefore duplicating or destroying) either entry.
+        function applyHash(requestedHash) {
+            const hash = (requestedHash.slice(1) || '/').split('?')[0]; // strip ?query (e.g. /search?agent=…) for page matching
             if (hash === '/overview') setPage('overview');
             else if (hash === '/search') setPage('search');
             else if (hash === '/tasks') setPage('tasks');
             else if (hash === '/settings') setPage('settings');
             else if (hash === '/import') setPage('import');
             else if (hash === '/network') setPage('network');
-            else if (hash === '/access') setPage('access');
+            else if (hash === '/access') {
+                setPage('access');
+                setHashRouteRevision(current => current + 1);
+            }
             else if (hash === '/pipeline') setPage('tasks'); // legacy deep-link: the message bus lives in Tasks > Messages now
             else if (hash === '/federation') setPage('federation');
             else setPage('brain');
         }
+        const navigator = createAccessControlHistoryNavigator({
+            getHash: () => window.location.hash || '#/',
+            getState: () => window.history.state,
+            replaceState: (state, hash) => window.history.replaceState(state, '', hash),
+            pushState: (state, hash) => window.history.pushState(state, '', hash),
+            go: delta => window.history.go(delta),
+            confirmNavigation: async requestedHash => {
+                const accessNavigation = accessControlNavigationSnapshot();
+                if (!accessNavigation.active || requestedHash === accessNavigation.currentHash) return true;
+                return confirmAccessControlHashNavigation();
+            },
+            applyHash,
+        });
+        hashNavigatorRef.current = navigator;
+        const onHash = () => { navigator.handleHashChange(); };
+        const onPop = event => { navigator.handlePopState(event.state); };
         window.addEventListener('hashchange', onHash);
-        onHash();
+        window.addEventListener('popstate', onPop);
+        applyHash(window.location.hash || '#/');
 
         return () => {
             sse.disconnect();
             window.removeEventListener('hashchange', onHash);
+            window.removeEventListener('popstate', onPop);
+            if (hashNavigatorRef.current === navigator) hashNavigatorRef.current = null;
         };
     }, [authState]);
 
@@ -15220,7 +15530,12 @@ function App() {
     }
 
     function navigate(p) {
-        window.location.hash = p === 'brain' ? '/' : '/' + p;
+        const requestedHash = p === 'brain' ? '#/' : '#/' + p;
+        if (hashNavigatorRef.current) {
+            hashNavigatorRef.current.navigate(requestedHash);
+        } else {
+            window.location.hash = requestedHash;
+        }
     }
 
     function openUpdateSettings() {
@@ -15319,7 +15634,7 @@ function App() {
             ${page === 'tasks' && html`<${TasksPage} sse=${sseRef.current} />`}
             ${page === 'import' && html`<${ImportPage} sse=${sseRef.current} />`}
             ${page === 'network' && html`<${NetworkPage} sse=${sseRef.current} />`}
-            ${page === 'access' && html`<${NetworkPage} sse=${sseRef.current} accessMode=${true} />`}
+            ${page === 'access' && html`<${NetworkPage} key=${`access-route-${hashRouteRevision}`} sse=${sseRef.current} accessMode=${true} />`}
             ${page === 'federation' && html`<${FederationPage} />`}
             ${page === 'settings' && html`<${SettingsPage} onRunSetup=${() => setShowOnboarding(true)} requestedTab=${settingsTabRequest} />`}
         </div>
@@ -15724,6 +16039,13 @@ function GuestJoinWizard({ onExit, recoveryPeer }) {
     const [pollNote, setPollNote] = useState('');
     const [endedReason, setEndedReason] = useState('');
     const confirmInFlight = useRef(false);
+    const scanLifecycle = useRef(null);
+    if (!scanLifecycle.current) {
+        scanLifecycle.current = createFederationJoinScanLifecycle(
+            (uri, currentEndpoint, signal) => fedGuestScan(uri, currentEndpoint, signal),
+        );
+    }
+    useEffect(() => () => scanLifecycle.current?.abort(), []);
 
     useEffect(() => {
         requestAnimationFrame(() => {
@@ -15746,7 +16068,7 @@ function GuestJoinWizard({ onExit, recoveryPeer }) {
         setBusy(true); setErr('');
         try {
             if (source !== 'camera') setTier4(true);
-            const r = await fedGuestScan(uri, endpoint);
+            const r = await scanLifecycle.current.run(uri, endpoint);
             setScan(r);
             const route = normalizeFederationRoutePlan(
                 r && r.route
@@ -15762,7 +16084,9 @@ function GuestJoinWizard({ onExit, recoveryPeer }) {
             if (route.state === 'relay') setTier4(true);
             setStep('return');
         }
-        catch (e) { fail(e, 'route_failure'); }
+        catch (e) {
+            if (e?.name !== 'AbortError') fail(e, 'route_failure');
+        }
         setBusy(false);
     };
     const doRequest = async () => {

--- a/web/static/js/federation-flow.js
+++ b/web/static/js/federation-flow.js
@@ -4,3 +4,34 @@
 export function normalizeFederationJoinState(value) {
     return String(value || '').trim().toLowerCase();
 }
+
+// Own exactly one long JOIN scan request. Starting a replacement aborts the
+// previous fetch, and abort() is safe to call from a component unmount cleanup.
+// The request function receives the AbortSignal as its final argument.
+export function createFederationJoinScanLifecycle(request) {
+    if (typeof request !== 'function') throw new TypeError('JOIN scan request must be a function');
+    let active = null;
+    return {
+        run(...args) {
+            if (active) active.abort();
+            const controller = new AbortController();
+            active = controller;
+            let pending;
+            try {
+                pending = request(...args, controller.signal);
+            } catch (error) {
+                pending = Promise.reject(error);
+            }
+            return Promise.resolve(pending).finally(() => {
+                if (active === controller) active = null;
+            });
+        },
+        abort() {
+            if (!active) return false;
+            const controller = active;
+            active = null;
+            controller.abort();
+            return true;
+        },
+    };
+}


### PR DESCRIPTION
## Summary
- add governed app-v21 to app-v22 lineage inventory, verification, and explicit quorum repair
- make trusted exported agents readable by default, add safe federated friendly-name messaging and reply-event status
- provide real five-minute JOIN discovery with cancellation and bounded P2P retries
- redesign Access Controls into Agents, Groups, and Federation tabs with protected modal editing
- publish backup, restore, preflight, version, SDK, native-shell, and operator documentation for v11.18.0

## Validation
- full uncached Go suite
- race suites for ABCI, store, federation, web, REST, and MCP
- npm test: 234/234
- changed-package golangci-lint: 0 issues
- independent security and UX reviews: no blockers
- fresh two-node Docker federation acceptance is running; merge remains gated on PASS

App version remains 26; this release does not introduce app-v27.