### PR TITLE
security: raise the Go floor to 1.25.12 and scan for it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,30 @@ jobs:
           cd natter
           golangci-lint run ./...
 
+  vulncheck:
+    name: Vulnerability scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          # Deliberately go-version-file, NOT go-version: '1.25'. A floating
+          # '1.25' resolves to the newest patch release, which would scan a
+          # toolchain nobody is required to build with and hide the real
+          # question. Scanning the version go.mod actually mandates is what
+          # makes this job catch the floor drifting behind the stdlib fixes.
+          go-version-file: go.mod
+          cache: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+      - name: govulncheck (root module)
+        run: govulncheck ./...
+      - name: govulncheck (natter)
+        run: |
+          cd natter
+          govulncheck ./...
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/deploy/Dockerfile.node
+++ b/deploy/Dockerfile.node
@@ -7,7 +7,7 @@
 # permissions for that fixed container user.
 
 # -- Builder -------------------------------------------
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git make
 

--- a/deploy/init-testnet.sh
+++ b/deploy/init-testnet.sh
@@ -83,7 +83,7 @@ elif [ "${HOST_COMETBFT_VERSION}" != "${COMETBFT_VERSION#v}" ]; then
     # instead of leaking through as a confusing "cometbft: not found" from the
     # testnet call below. The build's stderr is intentionally NOT suppressed.
     docker run --rm -v "${GENESIS_DIR}:/genesis" \
-        golang:1.22-alpine sh -c '
+        golang:1.25-alpine sh -c '
         set -e
         apk add --no-cache git make >/dev/null 2>&1
         git clone --branch v'"${COMETBFT_VERSION#v}"' --depth 1 https://github.com/cometbft/cometbft.git /tmp/cometbft 2>/dev/null

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/l33tdawg/sage
 
-go 1.25.7
+go 1.25.12
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/natter/go.mod
+++ b/natter/go.mod
@@ -1,6 +1,6 @@
 module github.com/l33tdawg/sage/natter
 
-go 1.25.7
+go 1.25.12
 
 require (
 	github.com/libp2p/go-libp2p v0.48.0


### PR DESCRIPTION
Independent of #167. Off `main`, no overlap with the v11.18.2 release branch.

## Finding

Nothing in CI consults the Go vulnerability database — `golangci-lint` checks code patterns, CodeQL checks code flaws. Running `govulncheck` against the toolchain `go.mod` actually mandates (`go 1.25.7`) reports **16 reachable standard-library vulnerabilities**, including:

- `GO-2026-5856` — Encrypted Client Hello privacy leak in `crypto/tls`
- `GO-2026-5037` — inefficient candidate hostname parsing in `crypto/x509`
- `GO-2026-4601` — incorrect IPv6 host literal parsing in `net/url`
- `GO-2026-4600` / `GO-2026-4599` — panic and email-constraint defects in `crypto/x509`

All are fixed in **go1.25.12**.

## Released binaries were never affected

CI pins `go-version: '1.25'`, which resolves to the newest patch release. The Test job on #167 ran `go version go1.25.12 linux/amd64`, so shipped artifacts already carry the fixes.

The defect is that **the fix was incidental rather than mandatory**. A builder with `GOTOOLCHAIN=local` on 1.25.7 satisfies `go.mod` and produces a binary carrying all 16. Raising the floor makes the patched stdlib a requirement instead of a coincidence.

## Changes

| Change | Why |
|---|---|
| `go.mod`, `natter/go.mod`: `1.25.7` → `1.25.12` | Verified fix: **16 reachable → 0** in root, **0** in natter |
| New `vulncheck` CI job | Nothing was checking the vulnerability database |
| `deploy/Dockerfile.node`, `deploy/init-testnet.sh`: `golang:1.22-alpine` → `1.25-alpine` | Go 1.22 is EOL |

## The one non-obvious decision

The new job resolves its toolchain with `go-version-file: go.mod`, **not** the floating `go-version: '1.25'` the neighbouring jobs use:

```yaml
# Deliberately go-version-file, NOT go-version: '1.25'. A floating
# '1.25' resolves to the newest patch release, which would scan a
# toolchain nobody is required to build with and hide the real
# question.
go-version-file: go.mod
```

A floating `'1.25'` would have scanned 1.25.12 and reported clean while `go.mod` still said 1.25.7 — **the job would have passed against this exact defect and caught nothing.** Scanning the mandated version is what makes it detect floor drift, which is the failure mode that actually occurred here.

`govulncheck` is pinned to `v1.6.0`, matching this repo's practice of pinning CI tooling rather than tracking a moving target. The vulnerability database is fetched live regardless, so pinning the tool costs no freshness.

## Verification

- `govulncheck ./...` at the new floor: **0 reachable**, both modules
- `go build ./...`, `go vet ./...`, `natter` build: clean
- `go test ./...` — **41 packages ok, 0 failures**
- `node --test scripts/version-alignment.test.mjs` — 4/4

## Not included

`automated-security-fixes` is `{"enabled": false}` on this repository — Dependabot alerts fire but no auto-fix PRs are opened. That is a repository setting, not a code change, so it is flagged here rather than altered.