### PR TITLE
fix(updater): verify exact CometBFT H+1 replay snapshots

### DIFF
--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -749,10 +749,20 @@ loose height tolerance. Verification binds the state tuple and AppHash at `H`,
 the `H` block ID and seen commit, then proves the `H+1` block bytes/part set,
 direct-parent ID, state-derived header fields, last commit, seen commit, and
 validator signatures before running CometBFT's own replay-time block validator.
-Any drift greater than one or malformed `H+1` provenance fails before snapshot
-publication or executable mutation (`internal/snapshot/verify.go`
+Because CometBFT v0.38's crash replay uses an empty evidence-pool stub rather
+than rechecking the captured evidence database, the offline updater
+conservatively rejects a non-empty `H+1` evidence list and asks the operator to
+retry after application state catches up; it never labels that block verified.
+Diagnostics mark an unreadable/torn live capture or this evidence limitation as
+`[retryable_capture]`, while tuple, height, block, commit, and AppHash
+mismatches are `[provenance_corruption]`. Any drift greater than one or malformed
+`H+1` provenance fails before snapshot publication or executable mutation
+(`internal/snapshot/verify.go`
 `verifyCommittedCometTip`, `verifyCometReplayBoundary`;
-`internal/abci/snapshot_sched.go` `TakeVerified`).
+`internal/abci/snapshot_sched.go` `TakeVerified`). `TakeVerified` also rechecks
+request cancellation after capture, verification, live-state confirmation,
+immediately before publication, and at updater handoff; a canceled request
+cannot return success and a pre-publication cancellation discards its candidate.
 
 Crash replay is height-bound rather than a nonce bypass. Scoped votes store the
 immutable first decision and its FinalizeBlock height atomically; only an exact

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -742,6 +742,18 @@ content plus classification from Badger
 sync never accepts that rollback format. It is fail-closed by default and can
 be armed only as the separate, explicit consensus-only path described below.
 
+The signed updater's live pre-mutation gate also accepts CometBFT's one exact
+crash-replay boundary: application Badger and persisted consensus state at
+height `H`, with a completely saved blockstore tip at `H+1`. This is not a
+loose height tolerance. Verification binds the state tuple and AppHash at `H`,
+the `H` block ID and seen commit, then proves the `H+1` block bytes/part set,
+direct-parent ID, state-derived header fields, last commit, seen commit, and
+validator signatures before running CometBFT's own replay-time block validator.
+Any drift greater than one or malformed `H+1` provenance fails before snapshot
+publication or executable mutation (`internal/snapshot/verify.go`
+`verifyCommittedCometTip`, `verifyCometReplayBoundary`;
+`internal/abci/snapshot_sched.go` `TakeVerified`).
+
 Crash replay is height-bound rather than a nonce bypass. Scoped votes store the
 immutable first decision and its FinalizeBlock height atomically; only an exact
 submit envelope or exact vote at that same behind height can rebuild projection

--- a/internal/abci/snapshot_sched.go
+++ b/internal/abci/snapshot_sched.go
@@ -312,6 +312,15 @@ func (s *SnapshotScheduler) TakeVerified(
 		return nil, fmt.Errorf("another snapshot is already in progress; retry after it finishes")
 	}
 	defer s.endFlight()
+	checkContext := func(stage string) error {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("pre-upgrade snapshot canceled %s: %w", stage, err)
+		}
+		return nil
+	}
+	if err := checkContext("before capture"); err != nil {
+		return nil, err
+	}
 
 	snapshotDir := filepath.Join(s.cfg.DataDir, "snapshots", fmt.Sprintf("%d", height))
 	var manifest *snapshot.Manifest
@@ -362,7 +371,15 @@ func (s *SnapshotScheduler) TakeVerified(
 			_ = candidate.Discard()
 		}
 	}
+	if err := checkContext("after capture"); err != nil {
+		discardCandidate()
+		return nil, err
+	}
 	if err := s.verifyTransitionSnapshot(snapshotDir, manifest, height, appHash); err != nil {
+		discardCandidate()
+		return nil, err
+	}
+	if err := checkContext("after verification"); err != nil {
 		discardCandidate()
 		return nil, err
 	}
@@ -372,7 +389,15 @@ func (s *SnapshotScheduler) TakeVerified(
 			return nil, err
 		}
 	}
+	if err := checkContext("after live-state confirmation"); err != nil {
+		discardCandidate()
+		return nil, err
+	}
 	if candidate != nil {
+		if err := checkContext("before publication"); err != nil {
+			discardCandidate()
+			return nil, err
+		}
 		published, err := candidate.Publish()
 		if err != nil {
 			discardCandidate()
@@ -380,12 +405,22 @@ func (s *SnapshotScheduler) TakeVerified(
 		}
 		manifest = published
 	}
+	// Publication is safe and recoverable, but an expired updater request must
+	// never proceed to executable mutation. A deadline racing with the atomic
+	// rename therefore returns cancellation even though the verified recovery
+	// point may already be visible.
+	if err := checkContext("before updater handoff"); err != nil {
+		return nil, err
+	}
 
 	s.mu.Lock()
 	s.lastHeight = height
 	s.lastTime = time.Now()
 	s.mu.Unlock()
 	s.pruneRetention()
+	if err := checkContext("at updater handoff"); err != nil {
+		return nil, err
+	}
 	return manifest, nil
 }
 

--- a/internal/abci/snapshot_sched_test.go
+++ b/internal/abci/snapshot_sched_test.go
@@ -81,6 +81,20 @@ func seedTestDataDir(t *testing.T) (dataDir string, live *badger.DB) {
 }
 
 func seedVerifiedCometState(t *testing.T, dataDir string, height int64, appHash []byte) {
+	seedVerifiedCometStateWithAhead(t, dataDir, height, appHash, 0, nil)
+}
+
+func seedVerifiedCometReplayState(t *testing.T, dataDir string, height int64, appHash []byte, ahead int) {
+	t.Helper()
+	seedVerifiedCometStateWithAhead(t, dataDir, height, appHash, ahead, nil)
+}
+
+func seedVerifiedCometReplayStateWithHeaderHash(t *testing.T, dataDir string, height int64, appHash, replayAppHash []byte) {
+	t.Helper()
+	seedVerifiedCometStateWithAhead(t, dataDir, height, appHash, 1, replayAppHash)
+}
+
+func seedVerifiedCometStateWithAhead(t *testing.T, dataDir string, height int64, appHash []byte, ahead int, replayAppHash []byte) {
 	t.Helper()
 	configDir := filepath.Join(dataDir, "cometbft", "config")
 	priv := cmtcrypto.GenPrivKey()
@@ -133,6 +147,13 @@ func seedVerifiedCometState(t *testing.T, dataDir string, height int64, appHash 
 	if validateErr := seenCommit.ValidateBasic(); validateErr != nil {
 		t.Fatal(validateErr)
 	}
+	state.LastBlockHeight = height
+	state.LastBlockID = blockID
+	state.LastBlockTime = block.Time
+	state.LastValidators = state.Validators.Copy()
+	state.AppHash = append([]byte(nil), appHash...)
+	capturedState := state
+
 	cometDataDir := filepath.Join(dataDir, "cometbft", "data")
 	blockDB, err := dbm.NewDB("blockstore", dbm.GoLevelDBBackend, cometDataDir)
 	if err != nil {
@@ -140,20 +161,56 @@ func seedVerifiedCometState(t *testing.T, dataDir string, height int64, appHash 
 	}
 	blockStore := cmtstore.NewBlockStore(blockDB)
 	blockStore.SaveBlock(block, parts, seenCommit)
+	blockState := state
+	if replayAppHash != nil {
+		blockState.AppHash = append([]byte(nil), replayAppHash...)
+	}
+	previousCommit := seenCommit
+	for offset := 1; offset <= ahead; offset++ {
+		nextHeight := height + int64(offset)
+		nextBlock, makeErr := blockState.MakeBlock(nextHeight, nil, previousCommit, nil, pub.Address())
+		if makeErr != nil {
+			t.Fatal(makeErr)
+		}
+		nextParts, partsErr := nextBlock.MakePartSet(cmttypes.BlockPartSizeBytes)
+		if partsErr != nil {
+			t.Fatal(partsErr)
+		}
+		nextBlockID := cmttypes.BlockID{Hash: nextBlock.Hash(), PartSetHeader: nextParts.Header()}
+		nextVote := &cmttypes.Vote{
+			ValidatorAddress: pub.Address(), ValidatorIndex: 0, Height: nextHeight,
+			Round: 0, Type: cmtproto.PrecommitType, BlockID: nextBlockID, Timestamp: time.Unix(2+int64(offset), 0).UTC(),
+		}
+		nextProtoVote := nextVote.ToProto()
+		if signErr := cmttypes.NewMockPVWithParams(priv, false, false).SignVote(blockState.ChainID, nextProtoVote); signErr != nil {
+			t.Fatal(signErr)
+		}
+		nextSeenCommit := &cmttypes.Commit{
+			Height: nextHeight, Round: 0, BlockID: nextBlockID,
+			Signatures: []cmttypes.CommitSig{{
+				BlockIDFlag: cmttypes.BlockIDFlagCommit, ValidatorAddress: pub.Address(),
+				Timestamp: nextVote.Timestamp, Signature: append([]byte(nil), nextProtoVote.Signature...),
+			}},
+		}
+		if validateErr := nextSeenCommit.ValidateBasic(); validateErr != nil {
+			t.Fatal(validateErr)
+		}
+		blockStore.SaveBlock(nextBlock, nextParts, nextSeenCommit)
+		blockState.LastBlockHeight = nextHeight
+		blockState.LastBlockID = nextBlockID
+		blockState.LastBlockTime = nextBlock.Time
+		blockState.LastValidators = blockState.Validators.Copy()
+		previousCommit = nextSeenCommit
+	}
 	if closeErr := blockStore.Close(); closeErr != nil {
 		t.Fatal(closeErr)
 	}
 
-	state.LastBlockHeight = height
-	state.LastBlockID = blockID
-	state.LastBlockTime = block.Time
-	state.LastValidators = state.Validators.Copy()
-	state.AppHash = append([]byte(nil), appHash...)
 	stateDB, err := dbm.NewDB("state", dbm.GoLevelDBBackend, cometDataDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := cmtstate.NewStore(stateDB, cmtstate.StoreOptions{}).Save(state); err != nil {
+	if err := cmtstate.NewStore(stateDB, cmtstate.StoreOptions{}).Save(capturedState); err != nil {
 		t.Fatal(err)
 	}
 	if err := stateDB.Close(); err != nil {
@@ -658,6 +715,144 @@ func TestSnapshotSchedulerTakeVerifiedBindsStateAndRunningBinary(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dataDir, "snapshots", "77", snapshot.OKSentinel)); err != nil {
 		t.Fatalf("wrong requested hash displaced valid anchor: %v", err)
+	}
+}
+
+func TestTakeVerifiedAcceptsExactCometReplayBoundaryRestoresAndReusesAfterRestart(t *testing.T) {
+	dataDir, db := seedTestDataDir(t)
+	defer func() { _ = db.Close() }()
+	appHash := sha256.Sum256([]byte("smoke:1present"))
+	seedVerifiedCometReplayState(t, dataDir, 77, appHash[:], 1)
+
+	sched := newVerifiedSnapshotScheduler(t, dataDir, db)
+	manifest, err := sched.TakeVerified(context.Background(), 77, appHash[:], "h-plus-one", nil)
+	if err != nil {
+		t.Fatalf("TakeVerified rejected exact H/H+1 replay boundary: %v", err)
+	}
+	if manifest.Height != 77 || !bytes.Equal(manifest.AppHash, appHash[:]) {
+		t.Fatalf("unexpected application recovery tuple: %+v", manifest)
+	}
+
+	snapshotDir := filepath.Join(dataDir, "snapshots", "77")
+	restoredDir := t.TempDir()
+	if height, restoreErr := snapshot.Restore(snapshotDir, restoredDir); restoreErr != nil || height != 77 {
+		t.Fatalf("restore exact H/H+1 snapshot: height=%d err=%v", height, restoreErr)
+	}
+	restoredStateDB, err := dbm.NewDB("state", dbm.GoLevelDBBackend, filepath.Join(restoredDir, "cometbft", "data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	restoredState, err := cmtstate.NewStore(restoredStateDB, cmtstate.StoreOptions{}).Load()
+	if closeErr := restoredStateDB.Close(); err != nil || closeErr != nil {
+		t.Fatalf("load restored CometBFT state: stateErr=%v closeErr=%v", err, closeErr)
+	}
+	restoredBlockDB, err := dbm.NewDB("blockstore", dbm.GoLevelDBBackend, filepath.Join(restoredDir, "cometbft", "data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	restoredBlocks := cmtstore.NewBlockStore(restoredBlockDB)
+	if restoredState.LastBlockHeight != 77 || restoredBlocks.Height() != 78 {
+		t.Fatalf("restored tuple = state %d / blockstore %d, want 77/78", restoredState.LastBlockHeight, restoredBlocks.Height())
+	}
+	if closeErr := restoredBlocks.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+
+	// A fresh scheduler (the process-restart shape) must re-verify and reuse
+	// the published snapshot without quarantining or recapturing it.
+	restarted := newVerifiedSnapshotScheduler(t, dataDir, db)
+	if _, err := restarted.TakeVerified(context.Background(), 77, appHash[:], "restart-reuse", nil); err != nil {
+		t.Fatalf("restart could not reuse verified H/H+1 snapshot: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(dataDir, "snapshots"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".invalid-77-") {
+			t.Fatalf("valid H/H+1 snapshot churned into quarantine after restart: %s", entry.Name())
+		}
+	}
+}
+
+func TestTakeVerifiedReplayBoundaryCancelIsReversibleAndRetryable(t *testing.T) {
+	dataDir, db := seedTestDataDir(t)
+	defer func() { _ = db.Close() }()
+	appHash := sha256.Sum256([]byte("smoke:1present"))
+	seedVerifiedCometReplayState(t, dataDir, 77, appHash[:], 1)
+	sched := newVerifiedSnapshotScheduler(t, dataDir, db)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := sched.TakeVerified(canceled, 77, appHash[:], "canceled", nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled capture error = %v, want context cancellation", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "snapshots", "77", snapshot.OKSentinel)); !os.IsNotExist(err) {
+		t.Fatalf("canceled capture published a recovery point: %v", err)
+	}
+	if _, err := sched.TakeVerified(context.Background(), 77, appHash[:], "retry", nil); err != nil {
+		t.Fatalf("retry after canceled H/H+1 capture: %v", err)
+	}
+}
+
+func TestTakeVerifiedRejectsMalformedAndGreaterThanOneReplayBoundaries(t *testing.T) {
+	appHash := sha256.Sum256([]byte("smoke:1present"))
+	for _, tc := range []struct {
+		name string
+		seed func(*testing.T, string)
+		want string
+	}{
+		{
+			name: "greater than one block ahead",
+			seed: func(t *testing.T, dataDir string) {
+				seedVerifiedCometReplayState(t, dataDir, 77, appHash[:], 2)
+			},
+			want: "only the exact restorable H/H+1 replay boundary is allowed",
+		},
+		{
+			name: "replay header AppHash mismatch",
+			seed: func(t *testing.T, dataDir string) {
+				seedVerifiedCometReplayStateWithHeaderHash(t, dataDir, 77, appHash[:], []byte("wrong-replay-app-hash"))
+			},
+			want: "invalid CometBFT H/H+1 replay provenance (not a transient height race)",
+		},
+		{
+			name: "replay seen commit block ID mismatch",
+			seed: func(t *testing.T, dataDir string) {
+				seedVerifiedCometReplayState(t, dataDir, 77, appHash[:], 1)
+				blockDB, err := dbm.NewDB("blockstore", dbm.GoLevelDBBackend, filepath.Join(dataDir, "cometbft", "data"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				blockStore := cmtstore.NewBlockStore(blockDB)
+				commit := blockStore.LoadSeenCommit(78)
+				if commit == nil {
+					t.Fatal("missing replay seen commit")
+				}
+				commit.BlockID.Hash[0] ^= 0xff
+				if err := blockStore.SaveSeenCommit(78, commit); err != nil {
+					t.Fatal(err)
+				}
+				if err := blockStore.Close(); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "invalid CometBFT H/H+1 replay provenance (not a transient height race)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir, db := seedTestDataDir(t)
+			defer func() { _ = db.Close() }()
+			tc.seed(t, dataDir)
+			sched := newVerifiedSnapshotScheduler(t, dataDir, db)
+			_, err := sched.TakeVerified(context.Background(), 77, appHash[:], "invalid-replay-boundary", nil)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want diagnostic containing %q", err, tc.want)
+			}
+			if _, statErr := os.Stat(filepath.Join(dataDir, "snapshots", "77", snapshot.OKSentinel)); !os.IsNotExist(statErr) {
+				t.Fatalf("invalid replay candidate became visible: %v", statErr)
+			}
+		})
 	}
 }
 

--- a/internal/abci/snapshot_sched_test.go
+++ b/internal/abci/snapshot_sched_test.go
@@ -827,12 +827,12 @@ func TestTakeVerifiedAcceptsExactCometReplayBoundaryRestoresAndReusesAfterRestar
 		nextHash:        append([]byte(nil), replayedHash[:]...),
 	}
 	appConns := cmtproxy.NewAppConns(cmtproxy.NewLocalClientCreator(probeApp), cmtproxy.NopMetrics())
-	if err := appConns.Start(); err != nil {
-		t.Fatal(err)
+	if startErr := appConns.Start(); startErr != nil {
+		t.Fatal(startErr)
 	}
 	handshaker := cmtconsensus.NewHandshaker(restoredStateStore, restoredState, restoredBlocks, genesis)
-	if err := handshaker.HandshakeWithContext(context.Background(), appConns); err != nil {
-		t.Fatalf("real CometBFT handshake could not replay restored H+1: %v", err)
+	if handshakeErr := handshaker.HandshakeWithContext(context.Background(), appConns); handshakeErr != nil {
+		t.Fatalf("real CometBFT handshake could not replay restored H+1: %v", handshakeErr)
 	}
 	if handshaker.NBlocks() != 1 {
 		t.Fatalf("handshake replayed %d blocks, want exactly one", handshaker.NBlocks())
@@ -852,8 +852,8 @@ func TestTakeVerifiedAcceptsExactCometReplayBoundaryRestoresAndReusesAfterRestar
 		t.Fatalf("replayed state/app tuple = state(%d,%x) app(%d,%x,finalized=%d), want exact height 78 hash %x",
 			afterReplay.LastBlockHeight, afterReplay.AppHash, appHeight, appFinalHash, appFinalized, replayedHash)
 	}
-	if err := appConns.Stop(); err != nil {
-		t.Fatal(err)
+	if stopErr := appConns.Stop(); stopErr != nil {
+		t.Fatal(stopErr)
 	}
 	if closeErr := restoredBlocks.Close(); closeErr != nil {
 		t.Fatal(closeErr)

--- a/internal/abci/snapshot_sched_test.go
+++ b/internal/abci/snapshot_sched_test.go
@@ -865,8 +865,8 @@ func TestTakeVerifiedAcceptsExactCometReplayBoundaryRestoresAndReusesAfterRestar
 	// A fresh scheduler (the process-restart shape) must re-verify and reuse
 	// the published snapshot without quarantining or recapturing it.
 	restarted := newVerifiedSnapshotScheduler(t, dataDir, db)
-	if _, err := restarted.TakeVerified(context.Background(), 77, appHash[:], "restart-reuse", nil); err != nil {
-		t.Fatalf("restart could not reuse verified H/H+1 snapshot: %v", err)
+	if _, restartErr := restarted.TakeVerified(context.Background(), 77, appHash[:], "restart-reuse", nil); restartErr != nil {
+		t.Fatalf("restart could not reuse verified H/H+1 snapshot: %v", restartErr)
 	}
 	entries, err := os.ReadDir(filepath.Join(dataDir, "snapshots"))
 	if err != nil {

--- a/internal/abci/snapshot_sched_test.go
+++ b/internal/abci/snapshot_sched_test.go
@@ -17,10 +17,13 @@ import (
 	"time"
 
 	dbm "github.com/cometbft/cometbft-db"
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	cmtconsensus "github.com/cometbft/cometbft/consensus"
 	cmtcrypto "github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/privval"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	cmtproxy "github.com/cometbft/cometbft/proxy"
 	cmtstate "github.com/cometbft/cometbft/state"
 	cmtstore "github.com/cometbft/cometbft/store"
 	cmttypes "github.com/cometbft/cometbft/types"
@@ -31,6 +34,49 @@ import (
 	"github.com/l33tdawg/sage/internal/snapshot"
 	"github.com/l33tdawg/sage/internal/vault"
 )
+
+type restoredReplayProbeApp struct {
+	*abcitypes.BaseApplication
+	mu        sync.Mutex
+	height    int64
+	appHash   []byte
+	nextHash  []byte
+	pending   []byte
+	finalized int
+}
+
+func (a *restoredReplayProbeApp) Info(context.Context, *abcitypes.RequestInfo) (*abcitypes.ResponseInfo, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return &abcitypes.ResponseInfo{LastBlockHeight: a.height, LastBlockAppHash: append([]byte(nil), a.appHash...)}, nil
+}
+
+func (a *restoredReplayProbeApp) FinalizeBlock(_ context.Context, req *abcitypes.RequestFinalizeBlock) (*abcitypes.ResponseFinalizeBlock, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if req.Height != a.height+1 {
+		return nil, fmt.Errorf("replay height=%d, application height=%d", req.Height, a.height)
+	}
+	a.pending = append([]byte(nil), a.nextHash...)
+	a.finalized++
+	results := make([]*abcitypes.ExecTxResult, len(req.Txs))
+	for i := range results {
+		results[i] = &abcitypes.ExecTxResult{Code: abcitypes.CodeTypeOK}
+	}
+	return &abcitypes.ResponseFinalizeBlock{TxResults: results, AppHash: append([]byte(nil), a.pending...)}, nil
+}
+
+func (a *restoredReplayProbeApp) Commit(context.Context, *abcitypes.RequestCommit) (*abcitypes.ResponseCommit, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.pending) == 0 {
+		return nil, errors.New("commit called without a finalized replay block")
+	}
+	a.height++
+	a.appHash = append([]byte(nil), a.pending...)
+	a.pending = nil
+	return &abcitypes.ResponseCommit{}, nil
+}
 
 // seedTestDataDir builds a minimal SAGE data dir that snapshot.Take can
 // consume: badger/, sage.db, cometbft/data + cometbft/config. Returns
@@ -81,20 +127,25 @@ func seedTestDataDir(t *testing.T) (dataDir string, live *badger.DB) {
 }
 
 func seedVerifiedCometState(t *testing.T, dataDir string, height int64, appHash []byte) {
-	seedVerifiedCometStateWithAhead(t, dataDir, height, appHash, 0, nil)
+	seedVerifiedCometStateWithAhead(t, dataDir, height, appHash, 0, nil, nil)
 }
 
 func seedVerifiedCometReplayState(t *testing.T, dataDir string, height int64, appHash []byte, ahead int) {
 	t.Helper()
-	seedVerifiedCometStateWithAhead(t, dataDir, height, appHash, ahead, nil)
+	seedVerifiedCometStateWithAhead(t, dataDir, height, appHash, ahead, nil, nil)
 }
 
 func seedVerifiedCometReplayStateWithHeaderHash(t *testing.T, dataDir string, height int64, appHash, replayAppHash []byte) {
 	t.Helper()
-	seedVerifiedCometStateWithAhead(t, dataDir, height, appHash, 1, replayAppHash)
+	seedVerifiedCometStateWithAhead(t, dataDir, height, appHash, 1, replayAppHash, nil)
 }
 
-func seedVerifiedCometStateWithAhead(t *testing.T, dataDir string, height int64, appHash []byte, ahead int, replayAppHash []byte) {
+func seedVerifiedCometReplayStateWithEvidence(t *testing.T, dataDir string, height int64, appHash []byte, evidence []cmttypes.Evidence) {
+	t.Helper()
+	seedVerifiedCometStateWithAhead(t, dataDir, height, appHash, 1, nil, evidence)
+}
+
+func seedVerifiedCometStateWithAhead(t *testing.T, dataDir string, height int64, appHash []byte, ahead int, replayAppHash []byte, replayEvidence []cmttypes.Evidence) {
 	t.Helper()
 	configDir := filepath.Join(dataDir, "cometbft", "config")
 	priv := cmtcrypto.GenPrivKey()
@@ -168,7 +219,11 @@ func seedVerifiedCometStateWithAhead(t *testing.T, dataDir string, height int64,
 	previousCommit := seenCommit
 	for offset := 1; offset <= ahead; offset++ {
 		nextHeight := height + int64(offset)
-		nextBlock, makeErr := blockState.MakeBlock(nextHeight, nil, previousCommit, nil, pub.Address())
+		var evidence []cmttypes.Evidence
+		if offset == 1 {
+			evidence = replayEvidence
+		}
+		nextBlock, makeErr := blockState.MakeBlock(nextHeight, nil, previousCommit, evidence, pub.Address())
 		if makeErr != nil {
 			t.Fatal(makeErr)
 		}
@@ -210,7 +265,7 @@ func seedVerifiedCometStateWithAhead(t *testing.T, dataDir string, height int64,
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := cmtstate.NewStore(stateDB, cmtstate.StoreOptions{}).Save(capturedState); err != nil {
+	if err := cmtstate.NewStore(stateDB, cmtstate.StoreOptions{}).Bootstrap(capturedState); err != nil {
 		t.Fatal(err)
 	}
 	if err := stateDB.Close(); err != nil {
@@ -742,9 +797,10 @@ func TestTakeVerifiedAcceptsExactCometReplayBoundaryRestoresAndReusesAfterRestar
 	if err != nil {
 		t.Fatal(err)
 	}
-	restoredState, err := cmtstate.NewStore(restoredStateDB, cmtstate.StoreOptions{}).Load()
-	if closeErr := restoredStateDB.Close(); err != nil || closeErr != nil {
-		t.Fatalf("load restored CometBFT state: stateErr=%v closeErr=%v", err, closeErr)
+	restoredStateStore := cmtstate.NewStore(restoredStateDB, cmtstate.StoreOptions{})
+	restoredState, err := restoredStateStore.Load()
+	if err != nil {
+		t.Fatalf("load restored CometBFT state: %v", err)
 	}
 	restoredBlockDB, err := dbm.NewDB("blockstore", dbm.GoLevelDBBackend, filepath.Join(restoredDir, "cometbft", "data"))
 	if err != nil {
@@ -754,7 +810,55 @@ func TestTakeVerifiedAcceptsExactCometReplayBoundaryRestoresAndReusesAfterRestar
 	if restoredState.LastBlockHeight != 77 || restoredBlocks.Height() != 78 {
 		t.Fatalf("restored tuple = state %d / blockstore %d, want 77/78", restoredState.LastBlockHeight, restoredBlocks.Height())
 	}
+
+	// Drive CometBFT's production handshake over the restored databases and a
+	// deterministic ABCI application that honestly reports the captured H
+	// tuple. This exercises the actual ApplyBlock/FinalizeBlock/Commit/state-save
+	// path and proves the recovery point reaches one exact H+1 AppHash.
+	genesis, err := cmttypes.GenesisDocFromFile(filepath.Join(restoredDir, "cometbft", "config", "genesis.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayedHash := sha256.Sum256([]byte("restored-replay-height-78"))
+	probeApp := &restoredReplayProbeApp{
+		BaseApplication: abcitypes.NewBaseApplication(),
+		height:          77,
+		appHash:         append([]byte(nil), appHash[:]...),
+		nextHash:        append([]byte(nil), replayedHash[:]...),
+	}
+	appConns := cmtproxy.NewAppConns(cmtproxy.NewLocalClientCreator(probeApp), cmtproxy.NopMetrics())
+	if err := appConns.Start(); err != nil {
+		t.Fatal(err)
+	}
+	handshaker := cmtconsensus.NewHandshaker(restoredStateStore, restoredState, restoredBlocks, genesis)
+	if err := handshaker.HandshakeWithContext(context.Background(), appConns); err != nil {
+		t.Fatalf("real CometBFT handshake could not replay restored H+1: %v", err)
+	}
+	if handshaker.NBlocks() != 1 {
+		t.Fatalf("handshake replayed %d blocks, want exactly one", handshaker.NBlocks())
+	}
+	afterReplay, err := restoredStateStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	probeApp.mu.Lock()
+	appHeight, appFinalized := probeApp.height, probeApp.finalized
+	appFinalHash := append([]byte(nil), probeApp.appHash...)
+	probeApp.mu.Unlock()
+	replayedMeta := restoredBlocks.LoadBlockMeta(78)
+	if afterReplay.LastBlockHeight != 78 || !bytes.Equal(afterReplay.AppHash, replayedHash[:]) ||
+		replayedMeta == nil || !afterReplay.LastBlockID.Equals(replayedMeta.BlockID) ||
+		appHeight != 78 || appFinalized != 1 || !bytes.Equal(appFinalHash, replayedHash[:]) {
+		t.Fatalf("replayed state/app tuple = state(%d,%x) app(%d,%x,finalized=%d), want exact height 78 hash %x",
+			afterReplay.LastBlockHeight, afterReplay.AppHash, appHeight, appFinalHash, appFinalized, replayedHash)
+	}
+	if err := appConns.Stop(); err != nil {
+		t.Fatal(err)
+	}
 	if closeErr := restoredBlocks.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	if closeErr := restoredStateDB.Close(); closeErr != nil {
 		t.Fatal(closeErr)
 	}
 
@@ -795,6 +899,31 @@ func TestTakeVerifiedReplayBoundaryCancelIsReversibleAndRetryable(t *testing.T) 
 	}
 }
 
+func TestTakeVerifiedCancellationDuringConfirmationCannotPublish(t *testing.T) {
+	dataDir, db := seedTestDataDir(t)
+	defer func() { _ = db.Close() }()
+	appHash := sha256.Sum256([]byte("smoke:1present"))
+	seedVerifiedCometReplayState(t, dataDir, 77, appHash[:], 1)
+	sched := newVerifiedSnapshotScheduler(t, dataDir, db)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	confirmed := false
+	_, err := sched.TakeVerified(ctx, 77, appHash[:], "cancel-during-confirm", func(*snapshot.Manifest) error {
+		confirmed = true
+		cancel()
+		return nil
+	})
+	if !confirmed || !errors.Is(err, context.Canceled) {
+		t.Fatalf("confirmation cancellation: confirmed=%v err=%v", confirmed, err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dataDir, "snapshots", "77", snapshot.OKSentinel)); !os.IsNotExist(statErr) {
+		t.Fatalf("post-capture cancellation published a recovery point: %v", statErr)
+	}
+	if _, err := sched.TakeVerified(context.Background(), 77, appHash[:], "retry-after-confirm-cancel", nil); err != nil {
+		t.Fatalf("retry after confirmation cancellation: %v", err)
+	}
+}
+
 func TestTakeVerifiedRejectsMalformedAndGreaterThanOneReplayBoundaries(t *testing.T) {
 	appHash := sha256.Sum256([]byte("smoke:1present"))
 	for _, tc := range []struct {
@@ -814,7 +943,7 @@ func TestTakeVerifiedRejectsMalformedAndGreaterThanOneReplayBoundaries(t *testin
 			seed: func(t *testing.T, dataDir string) {
 				seedVerifiedCometReplayStateWithHeaderHash(t, dataDir, 77, appHash[:], []byte("wrong-replay-app-hash"))
 			},
-			want: "invalid CometBFT H/H+1 replay provenance (not a transient height race)",
+			want: "[provenance_corruption] invalid CometBFT H/H+1 replay provenance (not a transient height race)",
 		},
 		{
 			name: "replay seen commit block ID mismatch",
@@ -837,7 +966,18 @@ func TestTakeVerifiedRejectsMalformedAndGreaterThanOneReplayBoundaries(t *testin
 					t.Fatal(err)
 				}
 			},
-			want: "invalid CometBFT H/H+1 replay provenance (not a transient height race)",
+			want: "[provenance_corruption] invalid CometBFT H/H+1 replay provenance (not a transient height race)",
+		},
+		{
+			name: "non-empty replay evidence is retryable not silently accepted",
+			seed: func(t *testing.T, dataDir string) {
+				evidence, err := cmttypes.NewMockDuplicateVoteEvidence(1, time.Unix(1, 0).UTC(), "snapshot-test")
+				if err != nil {
+					t.Fatal(err)
+				}
+				seedVerifiedCometReplayStateWithEvidence(t, dataDir, 77, appHash[:], []cmttypes.Evidence{evidence})
+			},
+			want: "[retryable_capture] exact H/H+1 capture cannot yet be proven",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -13,10 +13,12 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
+	dbm "github.com/cometbft/cometbft-db"
 	cmtcrypto "github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/privval"
@@ -432,6 +434,25 @@ func TestTarZstdSubsetHonorsCanceledContext(t *testing.T) {
 	err := tarZstdSubset(ctx, root, []string{"state.db"}, filepath.Join(t.TempDir(), "comet.tar.zst"), Options{})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("tar did not stop on canceled snapshot context: %v", err)
+	}
+}
+
+func TestVerifyCometStateClassifiesUnreadableLiveCaptureAsRetryable(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"state.db", "blockstore.db"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("torn live database capture"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	archivePath := filepath.Join(t.TempDir(), "unreadable-live-capture.tar.zst")
+	if err := tarZstdSubset(context.Background(), root, []string{"state.db", "blockstore.db"}, archivePath, Options{}); err != nil {
+		t.Fatal(err)
+	}
+	expectedHash := sha256.Sum256([]byte("expected-app-state"))
+	err := verifyCometState(archivePath, string(dbm.GoLevelDBBackend), 77, expectedHash[:])
+	if err == nil || !strings.Contains(err.Error(), cometDiagnosticRetryableCapture) ||
+		!strings.Contains(err.Error(), "repeated failure indicates source corruption") {
+		t.Fatalf("unreadable live capture diagnostic = %v", err)
 	}
 }
 

--- a/internal/snapshot/verify.go
+++ b/internal/snapshot/verify.go
@@ -37,6 +37,7 @@ import (
 
 	dbm "github.com/cometbft/cometbft-db"
 	cmtjson "github.com/cometbft/cometbft/libs/json"
+	cmtlog "github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/privval"
 	cmtstate "github.com/cometbft/cometbft/state"
@@ -413,19 +414,112 @@ func verifyCometState(archivePath, backend string, expectedHeight int64, expecte
 	}
 	blockStore := cmtstore.NewBlockStore(blockDB)
 	defer func() { _ = blockStore.Close() }()
-	if blockStore.Height() != expectedHeight {
-		return fmt.Errorf("blockstore height=%d, expected %d", blockStore.Height(), expectedHeight)
+	blockHeight := blockStore.Height()
+	if blockHeight != expectedHeight && blockHeight != expectedHeight+1 {
+		return fmt.Errorf("unsupported or corrupt CometBFT capture: blockstore height=%d, application/state height=%d (only the exact restorable H/H+1 replay boundary is allowed)", blockHeight, expectedHeight)
 	}
+	if err := verifyCommittedCometTip(blockStore, state, expectedHeight); err != nil {
+		return err
+	}
+	if blockHeight == expectedHeight+1 {
+		if err := verifyCometReplayBoundary(blockStore, state, expectedHeight+1, expectedAppHash); err != nil {
+			return fmt.Errorf("invalid CometBFT H/H+1 replay provenance (not a transient height race): %w", err)
+		}
+	}
+	return nil
+}
+
+// verifyCommittedCometTip binds the persisted CometBFT state tuple at H to
+// the exact block ID and seen commit retained in the blockstore. This remains
+// mandatory even when the blockstore has already durably staged H+1.
+func verifyCommittedCometTip(blockStore *cmtstore.BlockStore, state cmtstate.State, expectedHeight int64) error {
 	meta := blockStore.LoadBlockMeta(expectedHeight)
 	if meta == nil || !meta.BlockID.Equals(state.LastBlockID) {
-		return errors.New("blockstore tip does not match state LastBlockID")
+		return errors.New("blockstore committed tip does not match state LastBlockID")
+	}
+	if err := meta.ValidateBasic(); err != nil {
+		return fmt.Errorf("blockstore committed tip metadata is invalid: %w", err)
 	}
 	seenCommit := blockStore.LoadSeenCommit(expectedHeight)
 	if seenCommit == nil || seenCommit.Height != expectedHeight || !seenCommit.BlockID.Equals(state.LastBlockID) {
-		return errors.New("blockstore tip is missing the matching seen commit")
+		return errors.New("blockstore committed tip is missing the matching seen commit")
 	}
 	if err := seenCommit.ValidateBasic(); err != nil {
-		return fmt.Errorf("blockstore tip seen commit is invalid: %w", err)
+		return fmt.Errorf("blockstore committed tip seen commit is invalid: %w", err)
+	}
+	return nil
+}
+
+// verifyCometReplayBoundary proves the one-block-ahead layout CometBFT itself
+// supports during startup handshake: application and state stores are at H,
+// while the blockstore has durably saved the complete, committed block H+1.
+// The restored node can therefore replay exactly one block. Merely observing a
+// height delta of one is insufficient; every identity and state-derived header
+// field needed by replay is checked before the snapshot can be published.
+func verifyCometReplayBoundary(blockStore *cmtstore.BlockStore, state cmtstate.State, replayHeight int64, expectedAppHash []byte) error {
+	meta := blockStore.LoadBlockMeta(replayHeight)
+	if meta == nil {
+		return fmt.Errorf("replay block %d metadata is missing", replayHeight)
+	}
+	if err := meta.ValidateBasic(); err != nil {
+		return fmt.Errorf("replay block %d metadata is invalid: %w", replayHeight, err)
+	}
+	if !meta.BlockID.IsComplete() {
+		return fmt.Errorf("replay block %d has an incomplete block ID", replayHeight)
+	}
+
+	block := blockStore.LoadBlock(replayHeight)
+	if block == nil {
+		return fmt.Errorf("replay block %d is missing", replayHeight)
+	}
+	if err := block.ValidateBasic(); err != nil {
+		return fmt.Errorf("replay block %d is invalid: %w", replayHeight, err)
+	}
+	if block.Height != replayHeight || !bytes.Equal(block.Hash(), meta.BlockID.Hash) {
+		return fmt.Errorf("replay block %d does not match its blockstore identity", replayHeight)
+	}
+	parts, err := block.MakePartSet(cmttypes.BlockPartSizeBytes)
+	if err != nil {
+		return fmt.Errorf("rebuild replay block %d part set: %w", replayHeight, err)
+	}
+	if !parts.Header().Equals(meta.BlockID.PartSetHeader) {
+		return fmt.Errorf("replay block %d part set does not match its block ID", replayHeight)
+	}
+
+	if block.ChainID != state.ChainID || !block.LastBlockID.Equals(state.LastBlockID) {
+		return fmt.Errorf("replay block %d is not the direct successor of state height %d", replayHeight, state.LastBlockHeight)
+	}
+	if !bytes.Equal(block.AppHash, expectedAppHash) ||
+		!bytes.Equal(block.ValidatorsHash, state.Validators.Hash()) ||
+		!bytes.Equal(block.NextValidatorsHash, state.NextValidators.Hash()) ||
+		!bytes.Equal(block.ConsensusHash, state.ConsensusParams.Hash()) ||
+		!bytes.Equal(block.LastResultsHash, state.LastResultsHash) {
+		return fmt.Errorf("replay block %d header does not match the captured application/state tuple", replayHeight)
+	}
+	if block.LastCommit == nil || block.LastCommit.Height != state.LastBlockHeight || !block.LastCommit.BlockID.Equals(state.LastBlockID) {
+		return fmt.Errorf("replay block %d does not carry the exact commit for state height %d", replayHeight, state.LastBlockHeight)
+	}
+	if err := state.LastValidators.VerifyCommit(state.ChainID, state.LastBlockID, state.LastBlockHeight, block.LastCommit); err != nil {
+		return fmt.Errorf("replay block %d last commit does not verify against captured validators: %w", replayHeight, err)
+	}
+
+	seenCommit := blockStore.LoadSeenCommit(replayHeight)
+	if seenCommit == nil || seenCommit.Height != replayHeight || !seenCommit.BlockID.Equals(meta.BlockID) {
+		return fmt.Errorf("replay block %d is missing its exact matching seen commit", replayHeight)
+	}
+	if err := seenCommit.ValidateBasic(); err != nil {
+		return fmt.Errorf("replay block %d seen commit is invalid: %w", replayHeight, err)
+	}
+	if err := state.Validators.VerifyCommit(state.ChainID, meta.BlockID, replayHeight, seenCommit); err != nil {
+		return fmt.Errorf("replay block %d seen commit does not verify against captured validators: %w", replayHeight, err)
+	}
+	// Run CometBFT's own replay-time state validation last. The explicit
+	// diagnostics above identify the common provenance failures; this closes
+	// the remaining proposer, time, evidence, and header invariants without
+	// executing the application or mutating either captured database.
+	blockExecutor := cmtstate.NewBlockExecutor(nil, cmtlog.NewNopLogger(), nil, nil, cmtstate.EmptyEvidencePool{}, nil)
+	if err := blockExecutor.ValidateBlock(state, block); err != nil {
+		return fmt.Errorf("replay block %d fails CometBFT state validation: %w", replayHeight, err)
 	}
 	return nil
 }

--- a/internal/snapshot/verify.go
+++ b/internal/snapshot/verify.go
@@ -97,6 +97,17 @@ type VerifyOptions struct {
 	ExpectedCometAppHash []byte
 }
 
+const (
+	cometDiagnosticRetryableCapture     = "[retryable_capture]"
+	cometDiagnosticProvenanceCorruption = "[provenance_corruption]"
+)
+
+type retryableCometCaptureError struct {
+	reason string
+}
+
+func (e *retryableCometCaptureError) Error() string { return e.reason }
+
 // Verify checks that the snapshot at dir is structurally complete and
 // functionally restorable. It does NOT modify the snapshot directory.
 //
@@ -387,43 +398,47 @@ func verifyCometState(archivePath, backend string, expectedHeight int64, expecte
 	// updater process.
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			err = fmt.Errorf("open captured CometBFT databases: %v", recovered)
+			err = fmt.Errorf("%s captured CometBFT databases were unreadable during live verification: %v; retry once after the live commit boundary settles (a repeated failure indicates source corruption)", cometDiagnosticRetryableCapture, recovered)
 		}
 	}()
 	stateDB, err := dbm.NewDB("state", dbm.BackendType(backend), root)
 	if err != nil {
-		return fmt.Errorf("open state DB: %w", err)
+		return fmt.Errorf("%s open captured state DB: %w; retry once after the live commit boundary settles (a repeated failure indicates source corruption)", cometDiagnosticRetryableCapture, err)
 	}
 	state, loadErr := cmtstate.NewStore(stateDB, cmtstate.StoreOptions{}).Load()
 	stateCloseErr := stateDB.Close()
 	if loadErr != nil {
-		return fmt.Errorf("load state DB: %w", loadErr)
+		return fmt.Errorf("%s load captured state DB: %w; retry once after the live commit boundary settles (a repeated failure indicates source corruption)", cometDiagnosticRetryableCapture, loadErr)
 	}
 	if stateCloseErr != nil {
 		return fmt.Errorf("close state DB: %w", stateCloseErr)
 	}
 	if state.LastBlockHeight != expectedHeight || !bytes.Equal(state.AppHash, expectedAppHash) {
-		return fmt.Errorf("state tuple is height=%d AppHash=%x, expected height=%d AppHash=%x", state.LastBlockHeight, state.AppHash, expectedHeight, expectedAppHash)
+		return fmt.Errorf("%s state tuple is height=%d AppHash=%x, expected height=%d AppHash=%x", cometDiagnosticProvenanceCorruption, state.LastBlockHeight, state.AppHash, expectedHeight, expectedAppHash)
 	}
 	if !state.LastBlockID.IsComplete() {
-		return errors.New("state has an incomplete LastBlockID")
+		return fmt.Errorf("%s state has an incomplete LastBlockID", cometDiagnosticProvenanceCorruption)
 	}
 	blockDB, err := dbm.NewDB("blockstore", dbm.BackendType(backend), root)
 	if err != nil {
-		return fmt.Errorf("open blockstore DB: %w", err)
+		return fmt.Errorf("%s open captured blockstore DB: %w; retry once after the live commit boundary settles (a repeated failure indicates source corruption)", cometDiagnosticRetryableCapture, err)
 	}
 	blockStore := cmtstore.NewBlockStore(blockDB)
 	defer func() { _ = blockStore.Close() }()
 	blockHeight := blockStore.Height()
 	if blockHeight != expectedHeight && blockHeight != expectedHeight+1 {
-		return fmt.Errorf("unsupported or corrupt CometBFT capture: blockstore height=%d, application/state height=%d (only the exact restorable H/H+1 replay boundary is allowed)", blockHeight, expectedHeight)
+		return fmt.Errorf("%s blockstore height=%d, application/state height=%d (only the exact restorable H/H+1 replay boundary is allowed)", cometDiagnosticProvenanceCorruption, blockHeight, expectedHeight)
 	}
 	if err := verifyCommittedCometTip(blockStore, state, expectedHeight); err != nil {
-		return err
+		return fmt.Errorf("%s committed state provenance: %w", cometDiagnosticProvenanceCorruption, err)
 	}
 	if blockHeight == expectedHeight+1 {
 		if err := verifyCometReplayBoundary(blockStore, state, expectedHeight+1, expectedAppHash); err != nil {
-			return fmt.Errorf("invalid CometBFT H/H+1 replay provenance (not a transient height race): %w", err)
+			var retryable *retryableCometCaptureError
+			if errors.As(err, &retryable) {
+				return fmt.Errorf("%s exact H/H+1 capture cannot yet be proven: %w", cometDiagnosticRetryableCapture, retryable)
+			}
+			return fmt.Errorf("%s invalid CometBFT H/H+1 replay provenance (not a transient height race): %w", cometDiagnosticProvenanceCorruption, err)
 		}
 	}
 	return nil
@@ -475,6 +490,9 @@ func verifyCometReplayBoundary(blockStore *cmtstore.BlockStore, state cmtstate.S
 	if err := block.ValidateBasic(); err != nil {
 		return fmt.Errorf("replay block %d is invalid: %w", replayHeight, err)
 	}
+	if len(block.Evidence.Evidence) != 0 {
+		return &retryableCometCaptureError{reason: fmt.Sprintf("replay block %d contains %d evidence item(s); offline verification deliberately rejects non-empty evidence because CometBFT's replay stub does not re-check captured evidence-pool expiry/duplicate semantics; retry after application/state reaches the block", replayHeight, len(block.Evidence.Evidence))}
+	}
 	if block.Height != replayHeight || !bytes.Equal(block.Hash(), meta.BlockID.Hash) {
 		return fmt.Errorf("replay block %d does not match its blockstore identity", replayHeight)
 	}
@@ -515,8 +533,9 @@ func verifyCometReplayBoundary(blockStore *cmtstore.BlockStore, state cmtstate.S
 	}
 	// Run CometBFT's own replay-time state validation last. The explicit
 	// diagnostics above identify the common provenance failures; this closes
-	// the remaining proposer, time, evidence, and header invariants without
-	// executing the application or mutating either captured database.
+	// the remaining proposer, time, and header invariants without executing the
+	// application or mutating either captured database. Evidence is proven empty
+	// above because this verifier intentionally has no permissive evidence stub.
 	blockExecutor := cmtstate.NewBlockExecutor(nil, cmtlog.NewNopLogger(), nil, nil, cmtstate.EmptyEvidencePool{}, nil)
 	if err := blockExecutor.ValidateBlock(state, block); err != nil {
 		return fmt.Errorf("replay block %d fails CometBFT state validation: %w", replayHeight, err)


### PR DESCRIPTION
Addresses the code portion of #154 without auto-closing the issue; signed installed-app upgrade and rollback evidence remains required.

## What changed

- accepts only the exact restorable application/state H plus blockstore H+1 boundary
- binds H and H+1 block, commit, validator, header, part-set, and AppHash provenance
- conservatively defers non-empty H+1 evidence instead of trusting a permissive replay stub
- runs a real CometBFT Handshaker replay in regression coverage
- distinguishes retryable live-capture races from provenance corruption
- prevents canceled verification from authorizing snapshot publication or updater mutation

## Verification

- frozen head: `9b16f1001f5b152183a8b808d3feefff281157da`
- tree: `48c042562191cc1d8397f4711d70f1cb7e1cf9fd`
- base: `2876c58cf547b3b6af49be297d799333962b57b3`
- internal snapshot suite passes
- exact H/H+1 replay, cancellation, malformed-boundary, and restart-reuse coverage passes
- non-network internal/abci suite passes
- two independent frozen-head reviewers: GO / GO

## Remaining acceptance boundary

Keep #154 open until the signed installed app has recorded snapshot capture, upgrade activation, readiness, and bounded rollback evidence.
