### PR TITLE
chore(release): prepare v11.18.6 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,47 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.6
+
+**Updater snapshots now prove both supported CometBFT layouts before they are
+published or reused.** Application Badger and persisted consensus state must
+match at height `H` and agree on the application hash. A blockstore committed
+through `H` is accepted only after its `H` block ID and seen commit match that
+state. If the blockstore is durably one block ahead at `H+1`, SAGE additionally
+verifies the complete block and part identity, direct-parent and state-derived
+header fields, last and seen commits, validator signatures, and CometBFT's
+replay-time block validation. Regression coverage restores the candidate and
+runs the real CometBFT handshaker, proving exactly one replayed block and safe
+restart reuse. Malformed or more-than-one-ahead provenance is rejected, and an
+invalid prior publication is quarantined before a valid replacement can be
+published. Cancellation always blocks executable updater handoff, although a
+safe snapshot may already have been atomically published. Non-empty `H+1`
+evidence is retryable until application and state catch up.
+
+**Federation Retry now performs one bounded, exact-generation recovery
+workflow.** Concurrent operator clicks share the same route refresh and
+authenticated status probe. Direct and relay targets are frozen to the active
+JOIN generation, HTTP `401`/`403` and certificate/identity failures stop before
+re-probing, and a revoke or re-pair during the response invalidates the result.
+Typed dashboard diagnostics distinguish missing or expired route bundles,
+stale Direct routes, unavailable relays, trust-generation changes, and legacy
+connections that must be paired again. Ordinary polling and mutating requests
+do not enter this retry path.
+
+**Memory-reassignment audit failures no longer place request-controlled agent
+IDs in logs.** The source and target are represented by fixed 96-bit truncated
+SHA-256 fingerprints (24 lowercase hexadecimal characters), preserving stable
+incident correlation without allowing CR/LF or other control characters to
+forge log records.
+
+This patch does not change consensus state or application activation. The
+ceiling remains app-v26; **v11.18.6 introduces no app-v27**. The signer fence
+also remains process-local: unresolved submissions still require proof of fate,
+and crash/restart or a separate signing process is not claimed safe until
+durable cross-process pre-broadcast intent exists.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.6`. SDK 11.18.6.
+
 ## What's New in v11.18.5
 
 **Long-lived stdio MCP sessions now follow an installed SAGE upgrade without
@@ -1573,7 +1614,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.5`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.6`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.5
+  version: 11.18.6
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.5-acceptance
+ARG VERSION=v11.18.6-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.5 federation Docker acceptance
+# v11.18.6 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.5-acceptance
+        VERSION: v11.18.6-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.5"
+version = "11.18.6"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.5"
+version = "11.18.6"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.5",
+  "version": "11.18.6",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.5/app-v26. -->
+<!-- Reconciled through SAGE v11.18.6/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,3 +1,5 @@
+<!-- Verified against SAGE v11.18.6 federation behavior. -->
+
 # Connect your SAGE to another network
 
 This guide shows you how to link your whole SAGE to someone else's whole SAGE, then independently choose which existing domains may cross that trusted link. The two brains can connect on the same LAN or across the internet. In the app this lives under the **Federation** section (the federation icon in the sidebar). The transport introduced in v11.6 carries the same pinned mTLS protocol over libp2p, with direct-path discovery, NAT traversal, and Circuit Relay v2 fallback. The relay only carries encrypted bytes; it never receives the federation keys or plaintext memories.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.5
+# sage-gui v11.18.6
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.5 advertises 32 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.6 advertises 32 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.5 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.6 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -19,12 +19,48 @@ v11.18.4 adds one-call reply-aware inbox polling, mandatory exact-toolchain
 vulnerability gates, and conservative millisecond pipeline retention.
 v11.18.5 closes the remaining installed-binary/MCP-session skew by handing an
 unread request to the replacement runtime before stale tools can execute it.
-The supported consensus ceiling remains app-v26; **v11.18.5 does not introduce app-v27**.
+v11.18.6 adds exact CometBFT H and H/H+1 updater snapshot
+provenance/replay-boundary proof, bounded exact-generation federation Retry,
+and safe fingerprinting for memory-reassign failure logs. The supported
+consensus ceiling remains app-v26;
+**v11.18.6 does not introduce app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.6 patch
+
+v11.18.6 makes updater snapshot publication and reuse prove both supported
+CometBFT layouts. Application Badger and persisted consensus state must match
+at `H` and agree on the application hash. A blockstore committed through `H`
+is accepted only after its `H` block ID and seen commit match that state. If
+the blockstore is durably one block ahead at `H+1`, SAGE additionally verifies
+the complete block and part identity, direct-parent and state-derived header
+fields, last and seen commits, validator signatures, and CometBFT's replay-time
+block validation. Regression coverage restores the candidate and runs the real
+CometBFT handshaker, proving exactly one replayed block and safe restart reuse.
+Malformed or more-than-one-ahead provenance is rejected, and an invalid prior
+publication is quarantined before a valid replacement can be published.
+Cancellation always blocks executable updater handoff, although a safe snapshot
+may already have been atomically published. Non-empty `H+1` evidence is
+retryable until application and state catch up.
+
+Federation's operator Retry is now a separate bounded recovery contract rather
+than an alias for ordinary status polling. Concurrent waiters share one refresh
+and one authenticated re-probe, route targets remain frozen to the captured
+JOIN generation, security denials stop the workflow, and agreement/binding
+changes before or during the response invalidate it. Stable typed diagnostics
+drive Retry versus Pair again without retrying generic mutating requests.
+
+Memory-reassignment broadcast-failure logs now use fixed 96-bit truncated
+SHA-256 fingerprints (24 lowercase hexadecimal characters) instead of raw
+request-controlled agent IDs. This closes the two CodeQL log-injection findings
+while retaining a correlation handle. There is no new consensus application
+version. The process-local signer-fence residual is
+unchanged: crash/restart and independent signing processes remain outside the
+guarantee until durable cross-process pre-broadcast intent lands.
 
 ## v11.18.5 patch
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -96,6 +96,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.3 | Signer fence for same-key nonce ordering; no new app version; app-v26 remains the ceiling |
 | v11.18.4 | One-call reply-aware inbox, exact Go vulnerability gates, conservative pipeline retention; no new app version; app-v26 remains the ceiling |
 | v11.18.5 | Request-preserving stdio MCP runtime handoff and machine-readable coordination schema/version evidence; no new app version; app-v26 remains the ceiling |
+| v11.18.6 | Exact H and H/H+1 updater snapshot provenance/replay-boundary proof, bounded exact-generation federation Retry, and memory-reassign log hardening; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.5. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.6. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -33,7 +33,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.5 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.6 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -203,7 +203,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.5)
+## Related docs (reconciled through v11.18.6)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.5.
+Status: implementation contract through SAGE v11.18.6.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.5 authorization layer is off-consensus and does not require
+The current v11.18.6 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.5 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.6 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.5/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.6/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.5. Legacy organization/federation sections retain
+Verified against SAGE v11.18.6. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.5. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.6. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.5**.
+and is **not in v11.18.6**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.5. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.6. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.5 code (2026-08-09). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.6 code (2026-08-10). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.5.
+Reconciled against internal/mcp for SAGE v11.18.6.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.5. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.6. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.5
+**Package:** `sage-agent-sdk` **Version:** 11.18.6
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.5. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.6. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.5 lineage implementation (2026-08-09). -->
+<!-- Verified against SAGE v11.18.6 lineage implementation (2026-08-10). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.5 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.6 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.5"
+version = "11.18.6"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.5"
+__version__ = "11.18.6"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.5",
+  "version": "11.18.6",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.5",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.6",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.5';
+const SAGE_VERSION = 'v11.18.6';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
## SAGE v11.18.6 release preparation

This final metadata-only change prepares v11.18.6 after the updater snapshot fix (#172), exact-generation Federation Retry (#173), and CodeQL log-injection remediation (#174) landed on protected main.

### Release contents

- documents both supported updater snapshot layouts: aligned H and bounded one-ahead H/H+1
- records production replay-boundary validation separately from regression-only real Handshaker coverage
- documents exact-generation federation Retry recovery and typed diagnostics
- records fixed 96-bit truncated SHA-256 log fingerprints
- aligns Python SDK, server/OCI, dashboard, OpenAPI, Tauri/Cargo, acceptance metadata, README, roadmap, and upgrading guide at 11.18.6
- retains the app-v26 consensus ceiling; no app-v27
- preserves the native preview identity and the existing process-local signer-fence caveat

### Exact head

- head: c9313e8c6fad841b370b941037f95fbfa6376968
- tree: 5aab10e44c8f9961cd21cee4f4058acb7a688a56
- parent: protected main b69f03587d0153de7aaf946ab912bd4a8e91ee6c

The release tree is byte-identical to the independently reviewed synthetic release tree; only its parent was transplanted onto final protected main.

### Verification

- full npm suite: 256/256 passed
- release/version/workflow suite: 50/50 passed on this exact head
- focused snapshot scheduler, federation Retry, web log-hardening, Python SDK, Go module, and Cargo metadata checks passed during preparation/review
- two independent semantic release reviewers approved the exact release tree
- worktree and diff checks clean

No tag or release is created by this PR. The immutable v11.18.6 tag will be created only after exact-head PR CI and post-merge protected-main gates pass.
