### PR TITLE
fix(tx): post oversized Comet broadcasts

### DIFF
--- a/internal/tx/comet_commit.go
+++ b/internal/tx/comet_commit.go
@@ -55,7 +55,7 @@ func cometBroadcastRequest(ctx context.Context, endpoint, method string, encoded
 		return nil, fmt.Errorf("encode Comet JSON-RPC request: %w", err)
 	}
 	if len(body) > CometRPCMaxRequestBytes {
-		return nil, fmt.Errorf("Comet JSON-RPC request body is %d bytes, exceeds %d-byte limit",
+		return nil, fmt.Errorf("comet JSON-RPC request body is %d bytes, exceeds %d-byte limit",
 			len(body), CometRPCMaxRequestBytes)
 	}
 
@@ -79,7 +79,7 @@ func validateCometJSONResponse(resp *http.Response) error {
 	// those known-compatible forms while refusing HTML and every other media
 	// type that commonly carries an intermediary error page.
 	if err != nil || (mediaType != "application/json" && mediaType != "text/plain") {
-		return fmt.Errorf("Comet RPC returned non-JSON content type %q", contentType)
+		return fmt.Errorf("comet RPC returned non-JSON content type %q", contentType)
 	}
 	return nil
 }

--- a/internal/tx/comet_commit.go
+++ b/internal/tx/comet_commit.go
@@ -1,16 +1,88 @@
 package tx
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
 )
+
+// CometRPCMaxRequestBytes mirrors CometBFT's production max_body_bytes. The
+// JSON-RPC POST envelope base64-expands the signed transaction, so enforce the
+// limit before handing any bytes to the transport. Oversized requests are a
+// definitive pre-send refusal and must not fence the signing key.
+const CometRPCMaxRequestBytes = 1_000_000
+
+// cometRPCMaxSafeURIBytes leaves headroom below CometBFT's production
+// max_header_bytes for the request line plus ordinary HTTP headers. Preserve
+// the established GET wire shape for small transactions, but move a signed
+// transaction to JSON-RPC POST before its hex query can approach that ceiling.
+const cometRPCMaxSafeURIBytes = 900_000
+
+func cometBroadcastRequest(ctx context.Context, endpoint, method string, encoded []byte) (*http.Request, error) {
+	legacyURL := fmt.Sprintf("%s/%s?tx=0x%s", endpoint, method, hex.EncodeToString(encoded))
+	if len(legacyURL) < cometRPCMaxSafeURIBytes {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, legacyURL, nil) // #nosec G107 -- configured local CometBFT RPC
+		if err != nil {
+			return nil, fmt.Errorf("build Comet RPC request: %s", classifyFenceCause(err))
+		}
+		return req, nil
+	}
+
+	envelope := struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      int    `json:"id"`
+		Method  string `json:"method"`
+		Params  struct {
+			Tx string `json:"tx"`
+		} `json:"params"`
+	}{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  method,
+	}
+	envelope.Params.Tx = base64.StdEncoding.EncodeToString(encoded)
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, fmt.Errorf("encode Comet JSON-RPC request: %w", err)
+	}
+	if len(body) > CometRPCMaxRequestBytes {
+		return nil, fmt.Errorf("Comet JSON-RPC request body is %d bytes, exceeds %d-byte limit",
+			len(body), CometRPCMaxRequestBytes)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body)) // #nosec G107 -- configured local CometBFT RPC
+	if err != nil {
+		return nil, fmt.Errorf("build Comet JSON-RPC request: %s", classifyFenceCause(err))
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+func validateCometJSONResponse(resp *http.Response) error {
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if contentType == "" {
+		return nil // Backward compatibility for older Comet/proxy deployments.
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	// Some older Comet/proxy deployments omit the header, and Go's minimal
+	// httptest-style handlers default valid JSON bodies to text/plain. Preserve
+	// those known-compatible forms while refusing HTML and every other media
+	// type that commonly carries an intermediary error page.
+	if err != nil || (mediaType != "application/json" && mediaType != "text/plain") {
+		return fmt.Errorf("Comet RPC returned non-JSON content type %q", contentType)
+	}
+	return nil
+}
 
 // CometCommitResult is a hash-bound, structurally complete CometBFT
 // /broadcast_tx_commit result. It is returned only after the response proves it
@@ -40,8 +112,8 @@ type strictCommitEnvelope struct {
 			Code *uint32 `json:"code"`
 			Log  string  `json:"log"`
 		} `json:"tx_result"`
-		Hash   string `json:"hash"`
-		Height int64  `json:"height,string"`
+		Hash   string      `json:"hash"`
+		Height CometHeight `json:"height"`
 	} `json:"result"`
 	Error *struct {
 		Message string `json:"message"`
@@ -61,10 +133,9 @@ func BroadcastCometCommit(ctx context.Context, cometRPC string, signingKey ed255
 		ctx = context.Background()
 	}
 	endpoint := strings.TrimRight(strings.TrimSpace(cometRPC), "/")
-	url := fmt.Sprintf("%s/broadcast_tx_commit?tx=0x%s", endpoint, hex.EncodeToString(encoded))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) // #nosec G107 -- configured local CometBFT RPC
+	req, err := cometBroadcastRequest(ctx, endpoint, "broadcast_tx_commit", encoded)
 	if err != nil {
-		return nil, fmt.Errorf("broadcast tx commit: could not build request (%s)", classifyFenceCause(err))
+		return nil, fmt.Errorf("broadcast tx commit: %w", err)
 	}
 
 	RegisterSubmittedTx(signingKey, encoded, CometTxResolver(endpoint))
@@ -76,6 +147,9 @@ func BroadcastCometCommit(ctx context.Context, cometRPC string, signingKey ed255
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("broadcast tx commit: unexpected status %s",
 			ScrubBroadcastText(resp.Status, encoded))
+	}
+	if err := validateCometJSONResponse(resp); err != nil {
+		return nil, fmt.Errorf("broadcast tx commit: %s", ScrubBroadcastText(err.Error(), encoded))
 	}
 
 	limited := &io.LimitedReader{R: resp.Body, N: CometRPCMaxResponseBytes + 1}
@@ -118,7 +192,7 @@ func BroadcastCometCommit(ctx context.Context, cometRPC string, signingKey ed255
 	wantHash := strings.ToUpper(hex.EncodeToString(want[:]))
 	result := &CometCommitResult{
 		Hash:         wantHash,
-		Height:       envelope.Result.Height,
+		Height:       int64(envelope.Result.Height),
 		CheckTxCode:  checkCode,
 		CheckTxLog:   checkLog,
 		TxResultCode: txCode,
@@ -147,10 +221,9 @@ func BroadcastCometSync(ctx context.Context, cometRPC string, signingKey ed25519
 		ctx = context.Background()
 	}
 	endpoint := strings.TrimRight(strings.TrimSpace(cometRPC), "/")
-	url := fmt.Sprintf("%s/broadcast_tx_sync?tx=0x%s", endpoint, hex.EncodeToString(encoded))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) // #nosec G107 -- configured local CometBFT RPC
+	req, err := cometBroadcastRequest(ctx, endpoint, "broadcast_tx_sync", encoded)
 	if err != nil {
-		return nil, fmt.Errorf("broadcast tx sync: could not build request (%s)", classifyFenceCause(err))
+		return nil, fmt.Errorf("broadcast tx sync: %w", err)
 	}
 
 	RegisterSubmittedTx(signingKey, encoded, CometTxResolver(endpoint))
@@ -161,6 +234,9 @@ func BroadcastCometSync(ctx context.Context, cometRPC string, signingKey ed25519
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("broadcast tx sync: unexpected status %s", ScrubBroadcastText(resp.Status, encoded))
+	}
+	if err := validateCometJSONResponse(resp); err != nil {
+		return nil, fmt.Errorf("broadcast tx sync: %s", ScrubBroadcastText(err.Error(), encoded))
 	}
 
 	limited := &io.LimitedReader{R: resp.Body, N: CometRPCMaxResponseBytes + 1}

--- a/internal/tx/comet_commit_test.go
+++ b/internal/tx/comet_commit_test.go
@@ -1,9 +1,12 @@
 package tx
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -61,6 +64,159 @@ func TestBroadcastCometCommitRequiresCompleteBoundProof(t *testing.T) {
 				t.Fatalf("malformed response produced result=%+v err=%v", got, err)
 			}
 		})
+	}
+}
+
+func TestBroadcastCometCommitAcceptsQuotedAndNumericHeights(t *testing.T) {
+	t.Parallel()
+
+	encoded := []byte("height-compatibility")
+	bound := cometHashHexForTest(encoded)
+	for _, tc := range []struct {
+		name   string
+		height string
+	}{
+		{name: "quoted", height: `"7"`},
+		{name: "numeric", height: `7`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprintf(w,
+					`{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":%q,"height":%s}}`,
+					bound, tc.height)
+			}))
+			defer rpc.Close()
+
+			got, err := BroadcastCometCommit(context.Background(), rpc.URL, nil, encoded)
+			if err != nil {
+				t.Fatalf("BroadcastCometCommit: %v", err)
+			}
+			if got.Height != 7 {
+				t.Fatalf("height = %d, want 7", got.Height)
+			}
+		})
+	}
+}
+
+func TestBroadcastCometCommitUsesBoundedJSONRPCPost(t *testing.T) {
+	t.Parallel()
+
+	// Match the exact signed-registry artifact scale that overflowed the old
+	// hex-in-URL transport while remaining below CometBFT's body limit as base64.
+	encoded := bytes.Repeat([]byte("x"), 680_269)
+	bound := cometHashHexForTest(encoded)
+	rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.RawQuery != "" {
+			t.Errorf("signed transaction leaked into query: %q", r.URL.RawQuery)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+		var request struct {
+			JSONRPC string `json:"jsonrpc"`
+			Method  string `json:"method"`
+			Params  struct {
+				Tx string `json:"tx"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(request.Params.Tx)
+		if err != nil {
+			t.Fatalf("decode request tx: %v", err)
+		}
+		if request.JSONRPC != "2.0" || request.Method != "broadcast_tx_commit" || !bytes.Equal(decoded, encoded) {
+			t.Fatalf("unexpected JSON-RPC request: version=%q method=%q tx_len=%d",
+				request.JSONRPC, request.Method, len(decoded))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w,
+			`{"jsonrpc":"2.0","id":1,"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":%q,"height":7}}`,
+			bound)
+	}))
+	defer rpc.Close()
+
+	got, err := BroadcastCometCommit(context.Background(), rpc.URL, nil, encoded)
+	if err != nil {
+		t.Fatalf("BroadcastCometCommit: %v", err)
+	}
+	if got.Height != 7 {
+		t.Fatalf("height = %d, want 7", got.Height)
+	}
+}
+
+func TestBroadcastCometCommitRejectsOversizedPostBeforeSend(t *testing.T) {
+	t.Parallel()
+
+	pub, key, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := bytes.Repeat([]byte("x"), 800_000)
+	_, err = BroadcastCometCommit(context.Background(), "http://127.0.0.1:1", key, encoded)
+	if err == nil || !strings.Contains(err.Error(), "exceeds 1000000-byte limit") {
+		t.Fatalf("oversized request error = %v", err)
+	}
+	if keyIsFenced(string(pub)) {
+		t.Fatal("pre-send oversized request fenced signing key")
+	}
+}
+
+func TestBroadcastCometSyncUsesBoundedJSONRPCPost(t *testing.T) {
+	t.Parallel()
+
+	encoded := bytes.Repeat([]byte("s"), 680_269)
+	bound := cometHashHexForTest(encoded)
+	rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.RawQuery != "" {
+			t.Errorf("request = %s %s, want POST without query", r.Method, r.URL.String())
+		}
+		var request struct {
+			Method string `json:"method"`
+			Params struct {
+				Tx string `json:"tx"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(request.Params.Tx)
+		if err != nil || request.Method != "broadcast_tx_sync" || !bytes.Equal(decoded, encoded) {
+			t.Fatalf("unexpected sync request: method=%q len=%d err=%v", request.Method, len(decoded), err)
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":1,"result":{"code":0,"hash":%q}}`, bound)
+	}))
+	defer rpc.Close()
+
+	got, err := BroadcastCometSync(context.Background(), rpc.URL, nil, encoded)
+	if err != nil || got == nil || got.Hash != bound {
+		t.Fatalf("BroadcastCometSync result=%+v err=%v", got, err)
+	}
+}
+
+func TestBroadcastCometCommitScrubsHostileContentType(t *testing.T) {
+	t.Parallel()
+
+	encoded := []byte("content-type-secret")
+	leaked := hex.EncodeToString(encoded)
+	rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; tx=0x"+leaked)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer rpc.Close()
+
+	_, err := BroadcastCometCommit(context.Background(), rpc.URL, nil, encoded)
+	if err == nil {
+		t.Fatal("hostile Content-Type was accepted")
+	}
+	if strings.Contains(err.Error(), leaked) {
+		t.Fatalf("error leaked signed transaction: %v", err)
 	}
 }
 

--- a/internal/tx/comet_height.go
+++ b/internal/tx/comet_height.go
@@ -30,7 +30,7 @@ func (h *CometHeight) UnmarshalJSON(data []byte) error {
 		}
 	} else {
 		if !json.Valid(raw) {
-			return fmt.Errorf("Comet height is not valid JSON")
+			return fmt.Errorf("comet height is not valid JSON")
 		}
 		decimal = string(raw)
 	}

--- a/internal/tx/comet_height.go
+++ b/internal/tx/comet_height.go
@@ -1,0 +1,44 @@
+package tx
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// CometHeight accepts the two integer encodings seen on CometBFT JSON-RPC
+// surfaces: a JSON string (the canonical encoding) or a JSON number. It stays
+// deliberately narrower than json.Number: fractions, exponents, null, booleans,
+// malformed strings, and values outside int64 are rejected.
+type CometHeight int64
+
+func (h *CometHeight) UnmarshalJSON(data []byte) error {
+	if h == nil {
+		return fmt.Errorf("cannot unmarshal Comet height into a nil receiver")
+	}
+
+	raw := bytes.TrimSpace(data)
+	if len(raw) == 0 {
+		return fmt.Errorf("Comet height is empty")
+	}
+
+	var decimal string
+	if raw[0] == '"' {
+		if err := json.Unmarshal(raw, &decimal); err != nil {
+			return fmt.Errorf("decode quoted Comet height: %w", err)
+		}
+	} else {
+		if !json.Valid(raw) {
+			return fmt.Errorf("Comet height is not valid JSON")
+		}
+		decimal = string(raw)
+	}
+
+	value, err := strconv.ParseInt(decimal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("decode Comet height %q: %w", decimal, err)
+	}
+	*h = CometHeight(value)
+	return nil
+}

--- a/internal/tx/comet_height.go
+++ b/internal/tx/comet_height.go
@@ -20,7 +20,7 @@ func (h *CometHeight) UnmarshalJSON(data []byte) error {
 
 	raw := bytes.TrimSpace(data)
 	if len(raw) == 0 {
-		return fmt.Errorf("Comet height is empty")
+		return fmt.Errorf("comet height is empty")
 	}
 
 	var decimal string

--- a/internal/tx/comet_height_test.go
+++ b/internal/tx/comet_height_test.go
@@ -1,0 +1,61 @@
+package tx
+
+import (
+	"encoding/json"
+	"math"
+	"strconv"
+	"testing"
+)
+
+func TestCometHeightAcceptsQuotedAndNumericInt64(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		wire string
+		want int64
+	}{
+		{name: "quoted", wire: `"42"`, want: 42},
+		{name: "numeric", wire: `42`, want: 42},
+		{name: "quoted negative", wire: `"-1"`, want: -1},
+		{name: "numeric negative", wire: `-1`, want: -1},
+		{name: "maximum", wire: strconv.FormatInt(math.MaxInt64, 10), want: math.MaxInt64},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got CometHeight
+			if err := json.Unmarshal([]byte(tc.wire), &got); err != nil {
+				t.Fatalf("Unmarshal(%s): %v", tc.wire, err)
+			}
+			if int64(got) != tc.want {
+				t.Fatalf("Unmarshal(%s) = %d, want %d", tc.wire, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCometHeightRejectsNonIntegerAndMalformedValues(t *testing.T) {
+	t.Parallel()
+
+	for _, wire := range []string{
+		`null`,
+		`true`,
+		`1.5`,
+		`1e3`,
+		`""`,
+		`"not-a-number"`,
+		`9223372036854775808`,
+		`"9223372036854775808"`,
+		`+1`,
+		`01`,
+	} {
+		wire := wire
+		t.Run(wire, func(t *testing.T) {
+			t.Parallel()
+			var got CometHeight
+			if err := json.Unmarshal([]byte(wire), &got); err == nil {
+				t.Fatalf("Unmarshal(%s) unexpectedly succeeded with %d", wire, got)
+			}
+		})
+	}
+}

--- a/internal/tx/nonce_fence.go
+++ b/internal/tx/nonce_fence.go
@@ -314,11 +314,11 @@ func txResolverFallback() TxResolveFunc {
 // cause is derived from err ONCE, at construction, and it is the only thing the
 // fence is allowed to know about the failure. err itself is never read by any
 // fence code path — not stored, not logged, not matched. That is structural
-// rather than a convention because err routinely CONTAINS THE SIGNED
-// TRANSACTION: net/http embeds the full request URL in its errors and a
-// broadcast URL is /broadcast_tx_commit?tx=0x<the whole encoded tx>. Deriving
-// the category here means no later edit to the fence can reintroduce the leak by
-// reaching for a "more helpful" message.
+// rather than a convention because historical GET broadcasters put the signed
+// transaction in the URL and net/http then embedded it in errors. Large
+// broadcasts now use JSON-RPC POST, but deriving the category here means no
+// later transport edit can reintroduce the leak by reaching for a "more
+// helpful" message.
 type indeterminateSubmit struct {
 	err     error
 	cause   fenceCause
@@ -394,10 +394,10 @@ func Indeterminate(err error, encoded []byte, resolve TxResolveFunc) error {
 // fenceCause is the ONLY thing a fence keeps about the error that raised it: a
 // category, never the message.
 //
-// KEEPING THE MESSAGE IS A DATA LEAK, NOT A STYLE CHOICE. Every CometBFT
-// broadcaster in this repo issues GET /broadcast_tx_commit?tx=0x<the entire
-// signed transaction>, and net/http embeds the full request URL in the
-// *url.Error it returns. Storing that error would put the signed bytes in the
+// KEEPING THE MESSAGE IS A DATA LEAK, NOT A STYLE CHOICE. Historical CometBFT
+// broadcasters in this repo issued GET requests containing the entire signed
+// transaction, and net/http embedded the full request URL in the *url.Error it
+// returned. Storing that error would put the signed bytes in the
 // fence record, in FencedSigners(), and in every "still held" line — and because
 // reconciliation now retries for as long as the fence stands, it would repeat
 // them forever and carry them into any support bundle. internal/voter already
@@ -1863,8 +1863,8 @@ func cometHashMismatchDetail(op, reported string, want [sha256.Size]byte) string
 // decoded.
 type cometTxLookup struct {
 	Result *struct {
-		Hash     string `json:"hash"`
-		Height   int64  `json:"height,string"`
+		Hash     string      `json:"hash"`
+		Height   CometHeight `json:"height"`
 		TxResult *struct {
 			Code *int   `json:"code"`
 			Log  string `json:"log"`
@@ -1889,8 +1889,8 @@ type cometBroadcastCommit struct {
 			Code *int   `json:"code"`
 			Log  string `json:"log"`
 		} `json:"tx_result"`
-		Hash   string `json:"hash"`
-		Height int64  `json:"height,string"`
+		Hash   string      `json:"hash"`
+		Height CometHeight `json:"height"`
 	} `json:"result"`
 	Error *struct {
 		Message string `json:"message"`
@@ -2178,10 +2178,9 @@ func checkTxRefusalIsPermanent(code int) bool { return code == checkTxNonceGateC
 // code is examined; a mismatch (or a missing hash) is UNRESOLVED — the fence
 // holds and the next attempt asks again.
 func cometResubmitOutcome(ctx context.Context, endpoint string, encoded []byte) (outcome TxOutcome, superseded bool, err error) {
-	url := fmt.Sprintf("%s/broadcast_tx_commit?tx=0x%s", endpoint, hex.EncodeToString(encoded))
 	wantHash := CometTxHash(encoded)
 	var res cometBroadcastCommit
-	resultOK, err := cometGetJSON(ctx, "comet re-submit", url, encoded, &res)
+	resultOK, err := cometBroadcastJSON(ctx, "comet re-submit", endpoint, "broadcast_tx_commit", encoded, &res)
 	if err != nil {
 		return TxOutcome{Verdict: TxVerdictUnresolved}, false, err
 	}
@@ -2268,18 +2267,15 @@ func cometResubmitOutcome(ctx context.Context, endpoint string, encoded []byte) 
 	}, false, nil
 }
 
-// cometGetJSON issues one RPC and RETURNS NO ERROR THAT COULD CONTAIN THE
-// TRANSACTION.
+// cometGetJSON and cometBroadcastJSON issue one RPC and RETURN NO ERROR THAT
+// COULD CONTAIN THE TRANSACTION.
 //
 // This is the origin of the leak that a cross-review caught, so the fix belongs
-// here rather than only at the fence boundary. The re-submit URL is
-// /broadcast_tx_commit?tx=0x<the entire signed transaction>, and net/http embeds
-// the full request URL in both the *url.Error from Do and the parse error from
-// NewRequestWithContext. Wrapping either with %w — which this function used to
-// do — put the whole signed transaction into the fence record, into every
-// retry's log line, and into any support bundle, repeating for as long as the
-// fence stood. internal/voter/broadcast.go declines to attach these errors for
-// exactly this reason; this is that rule at the fence's RPC boundary.
+// here rather than only at the fence boundary. The historical re-submit GET URL
+// carried the entire signed transaction and net/http embedded that URL in some
+// errors. Re-submission now uses a bounded JSON-RPC POST, but both helpers still
+// reduce transport failures to typed categories so no future request shape can
+// put signed bytes into a fence record or support bundle.
 //
 // What survives is a TYPED CATEGORY (transport / timeout / canceled / decode /
 // rpc) and, for an HTTP-level refusal, the status line. The caller already knows
@@ -2299,6 +2295,18 @@ func cometGetJSON(ctx context.Context, op, url string, encoded []byte, out any) 
 		// NOT %w: url.Error.Error() is `parse "<the whole URL>": ...`.
 		return false, fmt.Errorf("%s: could not build request (%s)", op, classifyFenceCause(err))
 	}
+	return cometDoJSON(op, req, encoded, out)
+}
+
+func cometBroadcastJSON(ctx context.Context, op, endpoint, method string, encoded []byte, out any) (resultOK bool, err error) {
+	req, err := cometBroadcastRequest(ctx, endpoint, method, encoded)
+	if err != nil {
+		return false, fmt.Errorf("%s: could not build request (%s)", op, classifyFenceCause(err))
+	}
+	return cometDoJSON(op, req, encoded, out)
+}
+
+func cometDoJSON(op string, req *http.Request, encoded []byte, out any) (resultOK bool, err error) {
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		// NOT %w, for the same reason. The category is what the retry loop and
@@ -2312,6 +2320,9 @@ func cometGetJSON(ctx context.Context, op, url string, encoded []byte, out any) 
 		// a hostile proxy writes it freely — scrub it like any other remote
 		// string.
 		return false, fmt.Errorf("%s: comet rpc returned %s", op, scrubFenceText(resp.Status, encoded))
+	}
+	if err := validateCometJSONResponse(resp); err != nil {
+		return false, fmt.Errorf("%s: %s", op, scrubFenceText(err.Error(), encoded))
 	}
 	// The body is read through a hard cap BEFORE the decoder sees it. This loop
 	// retries for as long as a fence stands — that is the design — so an


### PR DESCRIPTION
Fixes large signed transactions that exceed CometBFT's request-header ceiling when hex-encoded in a GET URL.\n\n- preserve the established GET wire shape below a conservative 900 KB URI threshold\n- switch large commit/sync broadcasts and nonce-fence re-submits to bounded JSON-RPC POST with base64 tx bytes\n- reject request bodies above the production 1,000,000-byte Comet limit before registration\n- accept strict quoted or numeric int64 response heights\n- validate and scrub response Content-Type before decoding\n- cover the 680,269-byte SkillRegistry artifact scale, sync POST, hostile headers, and pre-send refusal semantics\n\nValidation:\n- env GOCACHE=/private/tmp/sage-heightfix-gocache go test -timeout 600s ./...\n- git diff --check