### PR TITLE
fix(tx): allow matched internal Comet limits

### DIFF
--- a/internal/tx/comet_commit.go
+++ b/internal/tx/comet_commit.go
@@ -12,6 +12,8 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 )
 
@@ -21,6 +23,14 @@ import (
 // definitive pre-send refusal and must not fence the signing key.
 const CometRPCMaxRequestBytes = 1_000_000
 
+// CometMaxTxBytes mirrors CometBFT's default mempool max_tx_bytes. Operators
+// may raise both limits in lockstep for an internal, authenticated RPC plane,
+// but the client remains fail-closed unless its explicit environment matches
+// the CometBFT configuration.
+const CometMaxTxBytes = 1_048_576
+
+const maxConfiguredCometBytes = 8_000_000
+
 // cometRPCMaxSafeURIBytes leaves headroom below CometBFT's production
 // max_header_bytes for the request line plus ordinary HTTP headers. Preserve
 // the established GET wire shape for small transactions, but move a signed
@@ -28,6 +38,14 @@ const CometRPCMaxRequestBytes = 1_000_000
 const cometRPCMaxSafeURIBytes = 900_000
 
 func cometBroadcastRequest(ctx context.Context, endpoint, method string, encoded []byte) (*http.Request, error) {
+	maxTxBytes, limitErr := configuredCometByteLimit("SAGE_COMET_MAX_TX_BYTES", CometMaxTxBytes)
+	if limitErr != nil {
+		return nil, limitErr
+	}
+	if len(encoded) > maxTxBytes {
+		return nil, fmt.Errorf("comet transaction is %d bytes, exceeds %d-byte limit", len(encoded), maxTxBytes)
+	}
+
 	legacyURL := fmt.Sprintf("%s/%s?tx=0x%s", endpoint, method, hex.EncodeToString(encoded))
 	if len(legacyURL) < cometRPCMaxSafeURIBytes {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, legacyURL, nil) // #nosec G107 -- configured local CometBFT RPC
@@ -54,9 +72,13 @@ func cometBroadcastRequest(ctx context.Context, endpoint, method string, encoded
 	if err != nil {
 		return nil, fmt.Errorf("encode Comet JSON-RPC request: %w", err)
 	}
-	if len(body) > CometRPCMaxRequestBytes {
+	maxRequestBytes, err := configuredCometByteLimit("SAGE_COMET_RPC_MAX_BODY_BYTES", CometRPCMaxRequestBytes)
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxRequestBytes {
 		return nil, fmt.Errorf("comet JSON-RPC request body is %d bytes, exceeds %d-byte limit",
-			len(body), CometRPCMaxRequestBytes)
+			len(body), maxRequestBytes)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body)) // #nosec G107 -- configured local CometBFT RPC
@@ -66,6 +88,18 @@ func cometBroadcastRequest(ctx context.Context, endpoint, method string, encoded
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	return req, nil
+}
+
+func configuredCometByteLimit(name string, fallback int) (int, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return fallback, nil
+	}
+	limit, err := strconv.Atoi(raw)
+	if err != nil || limit < fallback || limit > maxConfiguredCometBytes {
+		return 0, fmt.Errorf("invalid %s: require integer in [%d,%d]", name, fallback, maxConfiguredCometBytes)
+	}
+	return limit, nil
 }
 
 func validateCometJSONResponse(resp *http.Response) error {

--- a/internal/tx/comet_commit_test.go
+++ b/internal/tx/comet_commit_test.go
@@ -167,6 +167,51 @@ func TestBroadcastCometCommitRejectsOversizedPostBeforeSend(t *testing.T) {
 	}
 }
 
+func TestBroadcastCometCommitHonorsMatchedInternalLimits(t *testing.T) {
+	t.Setenv("SAGE_COMET_MAX_TX_BYTES", "1200000")
+	t.Setenv("SAGE_COMET_RPC_MAX_BODY_BYTES", "1600000")
+
+	// This is the measured SkillRegistry v20 request scale: the 1,456,274-byte
+	// JSON-RPC body bounds the raw signed transaction at 1,092,150 bytes.
+	encoded := bytes.Repeat([]byte("v"), 1_092_150)
+	bound := cometHashHexForTest(encoded)
+	rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.ContentLength; got != 1_456_274 {
+			t.Errorf("Content-Length = %d, want 1456274", got)
+		}
+		var request struct {
+			Params struct {
+				Tx string `json:"tx"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(request.Params.Tx)
+		if err != nil || !bytes.Equal(decoded, encoded) {
+			t.Fatalf("decoded tx len=%d err=%v", len(decoded), err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w,
+			`{"jsonrpc":"2.0","id":1,"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":%q,"height":7}}`,
+			bound)
+	}))
+	defer rpc.Close()
+
+	got, err := BroadcastCometCommit(context.Background(), rpc.URL, nil, encoded)
+	if err != nil || got == nil || got.Height != 7 {
+		t.Fatalf("BroadcastCometCommit result=%+v err=%v", got, err)
+	}
+}
+
+func TestBroadcastCometCommitRejectsInvalidConfiguredLimits(t *testing.T) {
+	t.Setenv("SAGE_COMET_MAX_TX_BYTES", "not-a-number")
+	_, err := BroadcastCometCommit(context.Background(), "http://127.0.0.1:1", nil, []byte("tx"))
+	if err == nil || !strings.Contains(err.Error(), "invalid SAGE_COMET_MAX_TX_BYTES") {
+		t.Fatalf("invalid configured limit error = %v", err)
+	}
+}
+
 func TestBroadcastCometSyncUsesBoundedJSONRPCPost(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The bounded POST transport correctly refused the real signed SkillRegistry v20 transaction before send: its JSON-RPC body is 1,456,274 bytes (raw tx <=1,092,150), above Comet defaults.\n\nThis adds fail-closed, explicitly configured limits:\n- SAGE_COMET_MAX_TX_BYTES (default 1,048,576)\n- SAGE_COMET_RPC_MAX_BODY_BYTES (default 1,000,000)\n\nOverrides may only raise defaults and are capped at 8 MB. Production will use the narrow matched values 1,200,000 and 1,600,000 on an internal unexposed Comet RPC plane, with all validators configured identically. Invalid/mismatched client configuration refuses before send.\n\nValidation: go test ./internal/tx passes; regression covers the measured 1,456,274-byte request and asserts exact decoded transaction bytes.