### PR TITLE
fix(abci): admit bounded large registry transactions

### DIFF
--- a/internal/abci/appv20_atomic_finalize.go
+++ b/internal/abci/appv20_atomic_finalize.go
@@ -8,9 +8,12 @@ const (
 	// Every strict post-app-v20 block commits as one Badger transaction. These
 	// consensus limits bound both transaction count and raw input retained while
 	// the block is evaluated. The raw-byte ceiling is intentionally independent
-	// of CometBFT's protobuf MaxTxBytes limit; both must be satisfied.
+	// of CometBFT's protobuf MaxTxBytes limit; both must be satisfied. 1.2 MB is
+	// large enough for a fully signed, 1,304-entry SkillRegistry transaction
+	// (currently 1,092,149 bytes) while retaining a deterministic bounded atomic
+	// working set on every validator.
 	maxAppV20AtomicFinalizeEntries = 64
-	maxAppV20AtomicFinalizeTxBytes = 1 << 20
+	maxAppV20AtomicFinalizeTxBytes = 1_200_000
 )
 
 const appV20AtomicFinalizeBudgetCode uint32 = 110

--- a/internal/abci/appv20_atomic_finalize_test.go
+++ b/internal/abci/appv20_atomic_finalize_test.go
@@ -519,6 +519,27 @@ func TestAppV20AtomicFinalizeBudgetRejectsEntryCountBeforeMutation(t *testing.T)
 	assert.Zero(t, nonce)
 }
 
+func TestAppV20AtomicFinalizeBudgetAdmitsGovernedRegistryEnvelope(t *testing.T) {
+	const registryV20RawBytes = 1_092_149
+	require.Less(t, registryV20RawBytes, maxAppV20AtomicFinalizeTxBytes)
+
+	registryTx := make([]byte, registryV20RawBytes)
+	assert.True(t, appV20AtomicFinalizeBudget([][]byte{registryTx}))
+	assert.True(t, validateAppV20Proposal([][]byte{registryTx}))
+	assert.Len(t, prepareAppV20Proposal(
+		[][]byte{registryTx},
+		int64(maxAppV20AtomicFinalizeTxBytes)+1024,
+	), 1)
+
+	tooLarge := make([]byte, maxAppV20AtomicFinalizeTxBytes+1)
+	assert.False(t, appV20AtomicFinalizeBudget([][]byte{tooLarge}))
+	assert.False(t, validateAppV20Proposal([][]byte{tooLarge}))
+	assert.Empty(t, prepareAppV20Proposal(
+		[][]byte{tooLarge},
+		int64(maxAppV20AtomicFinalizeTxBytes)+2048,
+	))
+}
+
 func TestAppV20PrepareAndProcessProposalEnforceGlobalAtomicBudget(t *testing.T) {
 	h := newGovernanceReplayHarness(t)
 	blockTime := time.Unix(15_402, 0).UTC()


### PR DESCRIPTION
Raises the deterministic App-v20 atomic-finalize raw transaction budget from 1 MiB to 1.2 MB, aligned with the bounded Comet/client ceilings introduced in #177.\n\nThe exact signed 1,304-entry SkillRegistry v20 transaction measures 1,092,149 raw bytes. It now passes CheckTx and the proposal/finalize budget while transactions over 1,200,000 bytes remain rejected on every validator. The live chain block max is 22,020,096 bytes, so this remains well inside consensus block capacity.\n\nValidation:\n- focused App-v20 boundary/governance tests pass\n- go test ./internal/abci passes (130.881s)\n\nNo schema, app-version, or state migration.