### PR TITLE
fix(abci): separate signed request proof bound

### DIFF
--- a/internal/abci/appv20_resource_limits.go
+++ b/internal/abci/appv20_resource_limits.go
@@ -14,9 +14,13 @@ const (
 	// These consensus bounds keep attacker-controlled strings from multiplying
 	// into oversized Badger keys across a 100-validator stats update. They are
 	// activated only for a block routed through the app-v20 atomic ceremony/path.
-	maxAppV20IdentifierBytes    = 512
-	maxAppV20MetadataBytes      = 64 << 10
-	maxAppV20ContentBytes       = 512 << 10
+	maxAppV20IdentifierBytes = 512
+	maxAppV20MetadataBytes   = 64 << 10
+	maxAppV20ContentBytes    = 512 << 10
+	// AgentRequest is the canonical signed HTTP proof envelope. It includes
+	// request framing around Content, so it needs a separate bound while the
+	// memory-content and aggregate raw-transaction limits remain unchanged.
+	maxAppV20AgentRequestBytes  = 600_000
 	maxAppV20EncodedRecordBytes = 64 << 10
 	maxAppV20CollectionItems    = 64
 	maxAppV20Validators         = 100
@@ -107,14 +111,14 @@ func id(field, value string) struct {
 
 // validateAppV20TxResources bounds every payload field that can become a
 // consensus key, be duplicated into several consensus values, or carry a large
-// metadata allocation. The block's independent 1 MiB raw-byte cap remains the
+// metadata allocation. The block's independent 1.2 MB raw-byte cap remains the
 // aggregate bound. Validation runs before proof claims, nonces, or handlers.
 func validateAppV20TxResources(parsed *tx.ParsedTx) error { //nolint:gocyclo // explicit wire-family audit is safer than reflection
 	if parsed == nil {
 		return nil
 	}
-	if len(parsed.AgentRequest) > maxAppV20ContentBytes {
-		return fmt.Errorf("agent request has %d bytes, limit %d", len(parsed.AgentRequest), maxAppV20ContentBytes)
+	if len(parsed.AgentRequest) > maxAppV20AgentRequestBytes {
+		return fmt.Errorf("agent request has %d bytes, limit %d", len(parsed.AgentRequest), maxAppV20AgentRequestBytes)
 	}
 	if len(parsed.AgentNonce) > maxAppV20IdentifierBytes {
 		return fmt.Errorf("agent nonce has %d bytes, limit %d", len(parsed.AgentNonce), maxAppV20IdentifierBytes)

--- a/internal/abci/appv20_resource_limits_test.go
+++ b/internal/abci/appv20_resource_limits_test.go
@@ -61,6 +61,22 @@ func TestAppV20ResourceLimitsRejectLargeHashInsideSmallEnoughBlock(t *testing.T)
 	commitGovernanceReplayBlock(t, h.app)
 }
 
+func TestAppV20ResourceLimitsUseSeparateAgentRequestProofBound(t *testing.T) {
+	const registryV20AgentRequestBytes = 573_723
+
+	assert.Equal(t, 512<<10, maxAppV20ContentBytes, "memory content keeps its 512 KiB consensus bound")
+	assert.Equal(t, 1_200_000, maxAppV20AtomicFinalizeTxBytes, "aggregate raw transaction bound remains unchanged")
+	require.NoError(t, validateAppV20TxResources(&tx.ParsedTx{
+		AgentRequest: make([]byte, registryV20AgentRequestBytes),
+	}))
+
+	err := validateAppV20TxResources(&tx.ParsedTx{
+		AgentRequest: make([]byte, maxAppV20AgentRequestBytes+1),
+	})
+	require.Error(t, err)
+	assert.Equal(t, "agent request has 600001 bytes, limit 600000", err.Error())
+}
+
 func TestAppV20UpgradeReadinessRejectsOversizedLegacyConsensusState(t *testing.T) {
 	app, admin, _, _ := setupAppV8Chain(t, 5)
 	app.appV19AppliedHeight = 6


### PR DESCRIPTION
## Summary

- Keep app-v20 memory content bounded at 512 KiB.
- Add a separate 600,000-byte consensus bound for the canonical signed HTTP AgentRequest proof.
- Preserve the independent 1,200,000-byte aggregate raw transaction ceiling.
- Cover the measured 573,723-byte SkillRegistry v20 proof and reject 600,001 bytes.

## Production evidence

The immutable SkillRegistry v20 transaction is 1,092,149 raw bytes and passed the transport and aggregate block limits after #176–#178. CheckTx then rejected only the signed AgentRequest proof: 573,723 bytes against the prior shared 524,288-byte content bound. This patch separates proof framing from memory content without widening content or aggregate transaction budgets.

## Validation

- `go test ./internal/abci -run 'TestAppV20ResourceLimitsUseSeparateAgentRequestProofBound|TestAppV20ResourceLimitsRejectLargeHashInsideSmallEnoughBlock' -count=1`
- `go test ./internal/abci -count=1` (147.070s)
- Independent read-only audit: no blockers.
