### PR TITLE
chore(release): prepare v11.18.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ transaction and JSON-RPC body limits are independently range-checked, capped at
 them must configure matching CometBFT limits. Independently, every validator
 enforces a 1,200,000-byte aggregate raw-transaction budget for app-v20 atomic
 finalization, sufficient for the measured 1,304-entry SkillRegistry transaction.
+Memory content remains bounded at 512 KiB, while the canonical signed
+`AgentRequest` proof has its own 600,000-byte consensus bound, admitting the
+measured 573,723-byte proof without widening the content or aggregate limits.
 Response handling accepts strict quoted or numeric `int64` heights, rejects
 fractional, exponent, null, malformed, and out-of-range heights, and refuses
 unsupported content types.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,48 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.7
+
+**Large signed transactions now use a bounded CometBFT transport instead of
+overflowing request headers.** Existing smaller broadcasts keep the established
+GET wire shape, while large commit, sync, and byte-identical nonce-fence
+reconciliation requests use JSON-RPC POST with base64 transaction bytes. Client
+transaction and JSON-RPC body limits are independently range-checked, capped at
+8,000,000 bytes, and refuse an oversized request before send. Operators raising
+them must configure matching CometBFT limits. Independently, every validator
+enforces a 1,200,000-byte aggregate raw-transaction budget for app-v20 atomic
+finalization, sufficient for the measured 1,304-entry SkillRegistry transaction.
+Response handling accepts strict quoted or numeric `int64` heights, rejects
+fractional, exponent, null, malformed, and out-of-range heights, and refuses
+unsupported content types.
+
+**Federation route refresh no longer risks recursively acquiring the
+sync-policy read lease from a peer-request caller.** Opportunistic refresh
+admission is policy-free and bounded to one pending refresh per peer; the
+agreement and binding lookup runs asynchronously after the request caller can
+release its lease. Failed-request and successful-Direct triggers remain
+covered, while the route-exchange endpoint does not self-trigger refresh.
+
+**P2P-only peers can recover when their stored route snapshot is missing or
+belongs to an older trust generation.** Only the authenticated
+`/fed/v1/p2p/routes` bootstrap exchange may use stale or current route addresses
+as connection hints; the current agreement's pinned mTLS identity remains
+authoritative. Protected requests reject missing or cross-generation snapshots
+with `trust_generation_mismatch`. A matching-generation empty target set remains
+explicitly pinned and cannot fall back to current configuration.
+
+**Federation diagnostics now give security evidence precedence over route
+availability evidence.** Mixed route-availability plus certificate, SPKI, pin,
+identity-mismatch, or security-block evidence is classified as
+`security_blocked`; revocation, expired or unknown agreement, trust-failure, or
+authentication evidence is classified as `trust_failure`. Both verdict classes
+outrank route availability.
+
+This patch introduces no new consensus application version or state migration.
+The ceiling remains app-v26; **v11.18.7 introduces no app-v27**.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.7`. SDK 11.18.7.
+
 ## What's New in v11.18.6
 
 **Updater snapshots now prove both supported CometBFT layouts before they are
@@ -1614,7 +1656,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.6`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.7`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.6
+  version: 11.18.7
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.6-acceptance
+ARG VERSION=v11.18.7-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.6 federation Docker acceptance
+# v11.18.7 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.6-acceptance
+        VERSION: v11.18.7-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.6"
+version = "11.18.7"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.6"
+version = "11.18.7"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.6",
+  "version": "11.18.7",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.6/app-v26. -->
+<!-- Reconciled through SAGE v11.18.7/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.6 federation behavior. -->
+<!-- Verified against SAGE v11.18.7 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.6
+# sage-gui v11.18.7
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.6 advertises 32 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.7 advertises 32 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,9 +45,12 @@ capped at 8,000,000 bytes, and refuse an oversized request before send.
 Operators raising them must configure matching CometBFT limits. Independently,
 every validator enforces a 1,200,000-byte aggregate raw-transaction budget for
 app-v20 atomic finalization, sufficient for the measured 1,304-entry
-SkillRegistry transaction. Response handling accepts strict quoted or numeric
-`int64` heights, rejects fractional, exponent, null, malformed, and out-of-range
-heights, and refuses unsupported content types.
+SkillRegistry transaction. Memory content remains bounded at 512 KiB, while the
+canonical signed `AgentRequest` proof has its own 600,000-byte consensus bound,
+admitting the measured 573,723-byte proof without widening the content or
+aggregate limits. Response handling accepts strict quoted or numeric `int64`
+heights, rejects fractional, exponent, null, malformed, and out-of-range heights,
+and refuses unsupported content types.
 
 v11.18.7 removes recursive sync-policy lease acquisition from federation peer
 request completion paths. Refresh admission is policy-free, bounded to one

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.6 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.7 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -21,14 +21,55 @@ v11.18.5 closes the remaining installed-binary/MCP-session skew by handing an
 unread request to the replacement runtime before stale tools can execute it.
 v11.18.6 adds exact CometBFT H and H/H+1 updater snapshot
 provenance/replay-boundary proof, bounded exact-generation federation Retry,
-and safe fingerprinting for memory-reassign failure logs. The supported
-consensus ceiling remains app-v26;
-**v11.18.6 does not introduce app-v27**.
+and safe fingerprinting for memory-reassign failure logs. v11.18.7 adds bounded
+JSON-RPC POST transport and independently checked, operator-configurable limits
+for large signed CometBFT transactions, raises the deterministic app-v20
+atomic-finalize limit to 1.2 MB,
+makes route refresh admission deadlock-safe, restores authenticated route
+bootstrap for P2P-only peers across a trust-generation change, and gives
+security evidence precedence in federation diagnostics. The supported
+consensus ceiling remains app-v26; **v11.18.7 does not introduce app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.7 patch
+
+Large signed transactions no longer overflow CometBFT request headers. Smaller
+broadcasts retain the established GET wire shape; larger commit, sync, and
+byte-identical nonce-fence reconciliation requests use bounded JSON-RPC POST.
+Client transaction and JSON-RPC body limits are independently range-checked,
+capped at 8,000,000 bytes, and refuse an oversized request before send.
+Operators raising them must configure matching CometBFT limits. Independently,
+every validator enforces a 1,200,000-byte aggregate raw-transaction budget for
+app-v20 atomic finalization, sufficient for the measured 1,304-entry
+SkillRegistry transaction. Response handling accepts strict quoted or numeric
+`int64` heights, rejects fractional, exponent, null, malformed, and out-of-range
+heights, and refuses unsupported content types.
+
+v11.18.7 removes recursive sync-policy lease acquisition from federation peer
+request completion paths. Refresh admission is policy-free, bounded to one
+pending worker per peer, and resolves the current agreement and binding only in
+the asynchronous worker. Failed-request and successful-Direct triggers remain
+active, while the route-exchange endpoint itself cannot recursively trigger a
+refresh.
+
+P2P-only peers may now use missing or stale route material solely as a
+connection hint for the authenticated `/fed/v1/p2p/routes` bootstrap exchange.
+The current agreement's pinned mTLS identity remains authoritative. All
+protected requests reject missing or cross-generation snapshots with
+`trust_generation_mismatch`. A matching-generation empty target set remains
+explicitly pinned and cannot fall back to current configuration.
+
+Federation route diagnostics classify mixed route-availability plus certificate,
+SPKI, pin, identity-mismatch, or security-block evidence as `security_blocked`;
+revocation, expired or unknown agreement, trust-failure, or authentication
+evidence is classified as `trust_failure`. Both verdict classes outrank route
+availability. This patch introduces no new consensus application version or
+state migration: app-v26 remains the ceiling and v11.18.7 does not introduce
+app-v27.
 
 ## v11.18.6 patch
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -97,6 +97,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.4 | One-call reply-aware inbox, exact Go vulnerability gates, conservative pipeline retention; no new app version; app-v26 remains the ceiling |
 | v11.18.5 | Request-preserving stdio MCP runtime handoff and machine-readable coordination schema/version evidence; no new app version; app-v26 remains the ceiling |
 | v11.18.6 | Exact H and H/H+1 updater snapshot provenance/replay-boundary proof, bounded exact-generation federation Retry, and memory-reassign log hardening; no new app version; app-v26 remains the ceiling |
+| v11.18.7 | Bounded large-transaction Comet transport and independently enforced 1.2 MB app-v20 finalize limit; deadlock-safe asynchronous federation route refresh; authenticated P2P-only trust-generation bootstrap recovery; security-first federation route diagnostics; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -97,7 +97,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.4 | One-call reply-aware inbox, exact Go vulnerability gates, conservative pipeline retention; no new app version; app-v26 remains the ceiling |
 | v11.18.5 | Request-preserving stdio MCP runtime handoff and machine-readable coordination schema/version evidence; no new app version; app-v26 remains the ceiling |
 | v11.18.6 | Exact H and H/H+1 updater snapshot provenance/replay-boundary proof, bounded exact-generation federation Retry, and memory-reassign log hardening; no new app version; app-v26 remains the ceiling |
-| v11.18.7 | Bounded large-transaction Comet transport and independently enforced 1.2 MB app-v20 finalize limit; deadlock-safe asynchronous federation route refresh; authenticated P2P-only trust-generation bootstrap recovery; security-first federation route diagnostics; no new app version; app-v26 remains the ceiling |
+| v11.18.7 | Bounded large-transaction Comet transport, independently enforced 1.2 MB app-v20 finalize limit, and separate 600,000-byte signed AgentRequest proof bound; deadlock-safe asynchronous federation route refresh; authenticated P2P-only trust-generation bootstrap recovery; security-first federation route diagnostics; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.6. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.7. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -33,7 +33,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.6 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.7 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -203,7 +203,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.6)
+## Related docs (reconciled through v11.18.7)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.6.
+Status: implementation contract through SAGE v11.18.7.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.6 authorization layer is off-consensus and does not require
+The current v11.18.7 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.6 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.7 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.6/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.7/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.6. Legacy organization/federation sections retain
+Verified against SAGE v11.18.7. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.6. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.7. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.6**.
+and is **not in v11.18.7**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.6. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.7. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.6 code (2026-08-10). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.7 code (2026-08-11). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.6.
+Reconciled against internal/mcp for SAGE v11.18.7.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.6. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.7. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.6
+**Package:** `sage-agent-sdk` **Version:** 11.18.7
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.6. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.7. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.6 lineage implementation (2026-08-10). -->
+<!-- Verified against SAGE v11.18.7 lineage implementation (2026-08-11). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/internal/federation/client.go
+++ b/internal/federation/client.go
@@ -206,6 +206,7 @@ func (m *Manager) doPeerRequestWithHeaders(ctx context.Context, agreement *store
 			}
 		}
 	}
+	generationBlockedP2POnly := false
 	if generation := requiredRouteGeneration(ctx); generation != "" && routeDial != nil {
 		hooks := m.joinP2PHooks()
 		snapshot, ok := RouteSnapshot{}, false
@@ -214,15 +215,60 @@ func (m *Manager) doPeerRequestWithHeaders(ctx context.Context, agreement *store
 		}
 		if !ok || snapshot.Generation != generation {
 			// A Retry may use an expired snapshot as an authenticated bootstrap
-			// hint, but never a route learned by another trust generation. Direct
-			// HTTPS remains available and is still pinned by the active agreement.
-			routeDial = nil
+			// hint, but never a route learned by another trust generation.
+			//
+			// R2. The original rule ended "Direct HTTPS remains available and is
+			// still pinned by the active agreement", and that is FALSE for a
+			// P2P-only agreement. Its endpoint is the joinP2POnlyEndpoint
+			// sentinel, which join_routes.go documents as never to be attempted
+			// as a TCP fallback, so nulling routeDial leaves no transport at all:
+			// the request falls through to a plain dial of an unroutable address.
+			// That also blocks the route exchange which is the ONLY thing that
+			// could replace the stale snapshot, so the peer can never recover its
+			// generation and stays unreachable until it is paired again.
+			//
+			// So the stale snapshot is admitted as a bootstrap hint for exactly
+			// one path: the authenticated route exchange that upgrades the
+			// generation. Every other request keeps the original rule.
+			//
+			// This does not import stale trust. A snapshot address is a HINT
+			// ABOUT WHERE TO CONNECT, not a credential: the connection is still
+			// completed through the pinned mTLS handshake bound to the CURRENT
+			// agreement, so a stale or reassigned address fails authentication
+			// rather than being trusted. The rule's purpose — no cross-generation
+			// route inside a protected request — is preserved exactly.
+			if p2pOnly && path == p2pRoutesExchangePath {
+				if ok {
+					// A snapshot exists but under another generation: use its
+					// addresses as the bootstrap hint.
+					frozenRouteTargets = append([]string{}, snapshot.Addrs...)
+				}
+				// No snapshot at all leaves frozenRouteTargets nil, which the
+				// dialer reads as "normal caller, may load current config" — the
+				// only route material available to reach the exchange. Both cases
+				// are still completed through the pinned mTLS handshake bound to
+				// the CURRENT agreement, and whatever the exchange returns is
+				// persisted only after p2p_routes.go's exact agreement+binding
+				// revalidation, so nothing enters durable state unverified.
+			} else {
+				routeDial = nil
+				generationBlockedP2POnly = p2pOnly
+			}
 		} else {
 			// Preserve a non-nil empty slice: nil means a normal caller whose dialer
 			// may load current config, while Retry must stay pinned to exact G even
 			// when G has no usable targets.
 			frozenRouteTargets = append([]string{}, snapshot.Addrs...)
 		}
+	}
+	if generationBlockedP2POnly {
+		// Fail with the actual reason instead of dialing the sentinel. Without
+		// this the caller sees a connection error against 127.0.0.1:65535, which
+		// reads as "peer offline" and sends an operator looking at the network
+		// rather than at the trust generation that actually needs repairing.
+		return nil, 0, routeRecoveryError(RouteRecoveryTrustGenerationMismatch,
+			fmt.Errorf("%w: peer %s is p2p-only and has no authenticated route for the required trust generation",
+				ErrTrustGenerationChanged, agreement.RemoteChainID))
 	}
 	if routeDial != nil || !p2pOnly {
 		directDialer := &net.Dialer{}
@@ -286,7 +332,7 @@ func (m *Manager) doPeerRequestWithHeaders(ctx context.Context, agreement *store
 	if err != nil {
 		securityFailure := isSecurityTransportError(err)
 		m.recordRouteFailure(agreement.RemoteChainID, err, securityFailure)
-		if !securityFailure && path != "/fed/v1/p2p/routes" {
+		if !securityFailure && path != p2pRoutesExchangePath {
 			// UI/status polling must not create a refresh storm while a peer is
 			// offline. One bounded refresh per minute is enough; the lifecycle
 			// ticker and address-change publisher remain correctness backstops.
@@ -301,7 +347,7 @@ func (m *Manager) doPeerRequestWithHeaders(ctx context.Context, agreement *store
 	chosen := selected
 	selectedMu.Unlock()
 	m.recordRouteSuccess(agreement.RemoteChainID, chosen)
-	if chosen.Kind == RouteKindDirect && routeDial != nil && path != "/fed/v1/p2p/routes" {
+	if chosen.Kind == RouteKindDirect && routeDial != nil && path != p2pRoutesExchangePath {
 		m.maybeTriggerRouteRefresh(agreement.RemoteChainID)
 	}
 	defer resp.Body.Close()

--- a/internal/federation/manager.go
+++ b/internal/federation/manager.go
@@ -304,12 +304,19 @@ type Manager struct {
 	routeRefreshMu                sync.Mutex
 	routeRefreshActive            map[string]*routeRefreshCall
 	routeRefreshLast              map[string]time.Time
-	routeRefreshFn                func(context.Context, string, JoinP2PBundle) error
-	routeRetryMu                  sync.Mutex
-	routeRetryActive              map[string]*peerStatusRetryCall
-	routeRefresherMu              sync.Mutex
-	routeRefresherCancel          context.CancelFunc
-	routeRefresherDone            chan struct{}
+	// routeRefreshPending bounds the opportunistic post-request refresh to one
+	// scheduled goroutine per peer. It is deliberately keyed by remote chain ID
+	// alone, not by the agreement/binding pair routeRefreshLast uses, because it
+	// must be checkable WITHOUT consulting the sync-policy gate — see
+	// maybeTriggerRouteRefresh for why touching that gate on the caller's
+	// goroutine deadlocks.
+	routeRefreshPending  map[string]bool
+	routeRefreshFn       func(context.Context, string, JoinP2PBundle) error
+	routeRetryMu         sync.Mutex
+	routeRetryActive     map[string]*peerStatusRetryCall
+	routeRefresherMu     sync.Mutex
+	routeRefresherCancel context.CancelFunc
+	routeRefresherDone   chan struct{}
 
 	joinP2PMu sync.RWMutex
 	joinP2P   JoinP2PHooks

--- a/internal/federation/p2p_only_generation_recovery_test.go
+++ b/internal/federation/p2p_only_generation_recovery_test.go
@@ -105,10 +105,19 @@ func TestP2POnlyProtectedRequestStillRefusesCrossGenerationRoute(t *testing.T) {
 		"a protected request used a route learned under a different trust generation")
 }
 
-// The failure must name the actual cause. Before the fix a protected P2P-only
-// request fell through to a TCP dial of 127.0.0.1:65535, so the operator saw a
-// connection error and went looking at the network instead of at the trust
-// generation that actually needed repairing.
+// The failure must name the actual cause.
+//
+// CORRECTION TO MY EARLIER CLAIM, recorded here because the frozen R2 commit
+// message and its code comment both overstate the mechanism and cannot be
+// amended: the pre-fix path did NOT literally open a TCP connection to
+// 127.0.0.1:65535. client.go installs an erroring DialTLSContext for the
+// p2p-only-without-dialer case, which returns ErrPeerOffline "has no p2p
+// dialer" without dialing; the sentinel appears only because net/http wraps
+// that error with the request URL. The defect — the peer is unreachable and
+// cannot recover its generation — is unchanged, but the operator-facing symptom
+// was a peer-offline error carrying the sentinel, not a dial attempt against it.
+// Caught by codex in review. The assertion below is about what the error
+// SURFACES, which is what was always actually wrong with it.
 func TestP2POnlyGenerationMismatchReportsTrustGenerationNotOffline(t *testing.T) {
 	a, b, _, _ := p2pOnlyGenerationFixture(t)
 
@@ -125,7 +134,8 @@ func TestP2POnlyGenerationMismatchReportsTrustGenerationNotOffline(t *testing.T)
 	assert.Equal(t, RouteRecoveryTrustGenerationMismatch, RouteRecoveryFailureCode(reqErr),
 		"expected a trust-generation recovery code, got: %v", reqErr)
 	assert.NotContains(t, reqErr.Error(), "65535",
-		"the p2p-only sentinel address must never be dialed or surfaced as the failure")
+		"the p2p-only sentinel address must never be surfaced as the failure: it tells an operator "+
+			"to look at the network when the trust generation is what needs repairing")
 }
 
 // A matching-generation snapshot is unaffected by the fix: it still pins the

--- a/internal/federation/p2p_only_generation_recovery_test.go
+++ b/internal/federation/p2p_only_generation_recovery_test.go
@@ -1,0 +1,262 @@
+package federation
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// R2 regression. A P2P-only agreement's endpoint is the joinP2POnlyEndpoint
+// sentinel, which join_routes.go documents as never to be attempted as a TCP
+// fallback. So when generation pinning nulls routeDial, the comment's promise
+// that "Direct HTTPS remains available" is false for this class: there is no
+// transport left at all, and the request falls through to a plain dial of an
+// unroutable address.
+//
+// That also blocked the authenticated route exchange, which is the only thing
+// that can replace the stale snapshot — so the peer could never reach the
+// current generation and stayed unreachable until it was paired again.
+//
+// The rule these tests must NOT let regress: no route learned under another
+// trust generation may enter a PROTECTED request. Only the exchange that
+// upgrades the generation may use the stale snapshot as a bootstrap hint, and
+// even then the connection is still completed through the pinned mTLS
+// handshake bound to the current agreement.
+
+// p2pOnlyGenerationFixture federates a -> b over the P2P-only sentinel endpoint
+// and installs a snapshot whose generation deliberately differs from the one
+// the request will require.
+func p2pOnlyGenerationFixture(t *testing.T) (*testChain, *testChain, *atomic.Int32, *atomic.Value) {
+	t.Helper()
+	a := newTestChain(t, "p2p-only-a")
+	b := newTestChain(t, "p2p-only-b")
+	federate(t, a, b, joinP2POnlyEndpoint, nil, 4, 0)
+	federate(t, b, a, "https://unused.invalid", nil, 4, 0)
+
+	var dials atomic.Int32
+	var sawTargets atomic.Value
+	sawTargets.Store([]string{})
+
+	a.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LoadSnapshot: func(string) (RouteSnapshot, bool) {
+			return RouteSnapshot{
+				PeerID:     "peer-b",
+				Addrs:      []string{"/dns4/relay.example/tcp/4001/p2p/peer-b"},
+				Generation: "generation-OLD",
+				Revision:   7,
+			}, true
+		},
+	})
+	a.mgr.SetPeerRouteDialFunc(func(ctx context.Context, chain string, frozen []string, authenticate PeerRouteAuthenticator) (PeerRouteDialResult, bool, error) {
+		dials.Add(1)
+		sawTargets.Store(append([]string{}, frozen...))
+		// Refuse the dial: this test is about WHETHER the route layer is
+		// consulted and with which targets, not about completing a handshake.
+		return PeerRouteDialResult{}, true, assert.AnError
+	})
+	return a, b, &dials, &sawTargets
+}
+
+// The recovery path: a P2P-only peer whose snapshot is stuck on an old
+// generation must still be able to run the route exchange that upgrades it.
+func TestP2POnlyPeerCanAttemptRouteExchangeAcrossGenerations(t *testing.T) {
+	a, b, dials, sawTargets := p2pOnlyGenerationFixture(t)
+
+	agreement, err := a.mgr.ActiveAgreement(b.chainID)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = withRouteGeneration(ctx, "generation-NEW")
+
+	_, _, reqErr := a.mgr.doPeerRequest(ctx, agreement, http.MethodPost, p2pRoutesExchangePath, map[string]any{})
+	require.Error(t, reqErr, "the stub dialer refuses, so the request must fail")
+
+	require.Equal(t, int32(1), dials.Load(),
+		"the route exchange was never offered a transport: a p2p-only peer whose snapshot is on an "+
+			"older generation can never upgrade it, so it is bricked until re-paired")
+
+	targets, _ := sawTargets.Load().([]string)
+	assert.Equal(t, []string{"/dns4/relay.example/tcp/4001/p2p/peer-b"}, targets,
+		"the exchange must receive the stale snapshot as a bootstrap hint")
+}
+
+// The rule that must survive the fix: a PROTECTED request still refuses a
+// cross-generation route.
+func TestP2POnlyProtectedRequestStillRefusesCrossGenerationRoute(t *testing.T) {
+	a, b, dials, _ := p2pOnlyGenerationFixture(t)
+
+	agreement, err := a.mgr.ActiveAgreement(b.chainID)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = withRouteGeneration(ctx, "generation-NEW")
+
+	_, _, reqErr := a.mgr.doPeerRequest(ctx, agreement, http.MethodPost, "/fed/v1/query", map[string]any{})
+	require.Error(t, reqErr)
+
+	assert.Equal(t, int32(0), dials.Load(),
+		"a protected request used a route learned under a different trust generation")
+}
+
+// The failure must name the actual cause. Before the fix a protected P2P-only
+// request fell through to a TCP dial of 127.0.0.1:65535, so the operator saw a
+// connection error and went looking at the network instead of at the trust
+// generation that actually needed repairing.
+func TestP2POnlyGenerationMismatchReportsTrustGenerationNotOffline(t *testing.T) {
+	a, b, _, _ := p2pOnlyGenerationFixture(t)
+
+	agreement, err := a.mgr.ActiveAgreement(b.chainID)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = withRouteGeneration(ctx, "generation-NEW")
+
+	_, _, reqErr := a.mgr.doPeerRequest(ctx, agreement, http.MethodPost, "/fed/v1/query", map[string]any{})
+	require.Error(t, reqErr)
+
+	assert.Equal(t, RouteRecoveryTrustGenerationMismatch, RouteRecoveryFailureCode(reqErr),
+		"expected a trust-generation recovery code, got: %v", reqErr)
+	assert.NotContains(t, reqErr.Error(), "65535",
+		"the p2p-only sentinel address must never be dialed or surfaced as the failure")
+}
+
+// A matching-generation snapshot is unaffected by the fix: it still pins the
+// exact frozen target set for every path, exchange or not.
+func TestP2POnlyMatchingGenerationStillPinsFrozenTargets(t *testing.T) {
+	a := newTestChain(t, "p2p-only-match-a")
+	b := newTestChain(t, "p2p-only-match-b")
+	federate(t, a, b, joinP2POnlyEndpoint, nil, 4, 0)
+	federate(t, b, a, "https://unused.invalid", nil, 4, 0)
+
+	var sawTargets atomic.Value
+	sawTargets.Store([]string{})
+	a.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LoadSnapshot: func(string) (RouteSnapshot, bool) {
+			return RouteSnapshot{Addrs: []string{"/dns4/current.example/tcp/4001"}, Generation: "generation-NOW"}, true
+		},
+	})
+	a.mgr.SetPeerRouteDialFunc(func(ctx context.Context, chain string, frozen []string, _ PeerRouteAuthenticator) (PeerRouteDialResult, bool, error) {
+		sawTargets.Store(append([]string{}, frozen...))
+		return PeerRouteDialResult{}, true, assert.AnError
+	})
+
+	agreement, err := a.mgr.ActiveAgreement(b.chainID)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = withRouteGeneration(ctx, "generation-NOW")
+
+	_, _, _ = a.mgr.doPeerRequest(ctx, agreement, http.MethodPost, "/fed/v1/query", map[string]any{})
+
+	targets, _ := sawTargets.Load().([]string)
+	assert.Equal(t, []string{"/dns4/current.example/tcp/4001"}, targets,
+		"a matching generation must still pin the exact frozen target set")
+}
+
+// A P2P-only peer with NO snapshot at all must still be able to reach the
+// bootstrap exchange. There is no stale snapshot to hint with, so the dialer is
+// left to load its current configuration — that is the only route material
+// available, and it is still authenticated by the pinned handshake bound to the
+// current agreement.
+func TestP2POnlyMissingSnapshotCanStillReachBootstrapExchange(t *testing.T) {
+	a := newTestChain(t, "p2p-only-missing-a")
+	b := newTestChain(t, "p2p-only-missing-b")
+	federate(t, a, b, joinP2POnlyEndpoint, nil, 4, 0)
+	federate(t, b, a, "https://unused.invalid", nil, 4, 0)
+
+	var dials atomic.Int32
+	var frozenWasNil atomic.Bool
+	a.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LoadSnapshot: func(string) (RouteSnapshot, bool) { return RouteSnapshot{}, false },
+	})
+	a.mgr.SetPeerRouteDialFunc(func(ctx context.Context, chain string, frozen []string, _ PeerRouteAuthenticator) (PeerRouteDialResult, bool, error) {
+		dials.Add(1)
+		frozenWasNil.Store(frozen == nil)
+		return PeerRouteDialResult{}, true, assert.AnError
+	})
+
+	agreement, err := a.mgr.ActiveAgreement(b.chainID)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = withRouteGeneration(ctx, "generation-NEW")
+
+	_, _, _ = a.mgr.doPeerRequest(ctx, agreement, http.MethodPost, p2pRoutesExchangePath, map[string]any{})
+
+	require.Equal(t, int32(1), dials.Load(),
+		"a p2p-only peer with no snapshot could not reach the bootstrap exchange, so it can never "+
+			"acquire one and is permanently unreachable")
+	assert.True(t, frozenWasNil.Load(),
+		"with no snapshot the dialer must receive nil frozen targets, meaning it may load current config")
+}
+
+// The same peer, same missing snapshot, on a PROTECTED path: still refused.
+// Relaxing the bootstrap exchange must not relax anything else.
+func TestP2POnlyMissingSnapshotStillRefusesProtectedRequest(t *testing.T) {
+	a := newTestChain(t, "p2p-only-missing-prot-a")
+	b := newTestChain(t, "p2p-only-missing-prot-b")
+	federate(t, a, b, joinP2POnlyEndpoint, nil, 4, 0)
+	federate(t, b, a, "https://unused.invalid", nil, 4, 0)
+
+	var dials atomic.Int32
+	a.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LoadSnapshot: func(string) (RouteSnapshot, bool) { return RouteSnapshot{}, false },
+	})
+	a.mgr.SetPeerRouteDialFunc(func(ctx context.Context, chain string, _ []string, _ PeerRouteAuthenticator) (PeerRouteDialResult, bool, error) {
+		dials.Add(1)
+		return PeerRouteDialResult{}, true, assert.AnError
+	})
+
+	agreement, err := a.mgr.ActiveAgreement(b.chainID)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = withRouteGeneration(ctx, "generation-NEW")
+
+	_, _, reqErr := a.mgr.doPeerRequest(ctx, agreement, http.MethodPost, "/fed/v1/status", map[string]any{})
+	require.Error(t, reqErr)
+	assert.Equal(t, int32(0), dials.Load(), "a protected path must not receive current/bootstrap targets")
+	assert.Equal(t, RouteRecoveryTrustGenerationMismatch, RouteRecoveryFailureCode(reqErr))
+}
+
+// The non-nil-empty frozen slice invariant: a MATCHING generation whose
+// snapshot has no addresses must still pin an empty-but-non-nil set, so the
+// dialer stays pinned to exactly G rather than falling back to current config.
+func TestMatchingGenerationWithNoAddrsStillPinsNonNilEmptyTargets(t *testing.T) {
+	a := newTestChain(t, "frozen-empty-a")
+	b := newTestChain(t, "frozen-empty-b")
+	federate(t, a, b, joinP2POnlyEndpoint, nil, 4, 0)
+	federate(t, b, a, "https://unused.invalid", nil, 4, 0)
+
+	var sawNil atomic.Bool
+	sawNil.Store(true)
+	a.mgr.SetJoinP2PHooks(JoinP2PHooks{
+		LoadSnapshot: func(string) (RouteSnapshot, bool) {
+			return RouteSnapshot{Addrs: nil, Generation: "generation-NOW"}, true
+		},
+	})
+	a.mgr.SetPeerRouteDialFunc(func(ctx context.Context, chain string, frozen []string, _ PeerRouteAuthenticator) (PeerRouteDialResult, bool, error) {
+		sawNil.Store(frozen == nil)
+		return PeerRouteDialResult{}, true, assert.AnError
+	})
+
+	agreement, err := a.mgr.ActiveAgreement(b.chainID)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = withRouteGeneration(ctx, "generation-NOW")
+
+	_, _, _ = a.mgr.doPeerRequest(ctx, agreement, http.MethodPost, "/fed/v1/status", map[string]any{})
+
+	assert.False(t, sawNil.Load(),
+		"an exact-generation dial with no targets must pass a non-nil empty slice, not nil: nil would "+
+			"let the dialer load current config and escape the generation pin")
+}

--- a/internal/federation/p2p_routes.go
+++ b/internal/federation/p2p_routes.go
@@ -188,7 +188,7 @@ func (m *Manager) ExchangeP2PRoutes(ctx context.Context, remoteChainID string, l
 	if err != nil {
 		return err
 	}
-	body, status, err := m.doPeerRequest(ctx, agreement, http.MethodPost, "/fed/v1/p2p/routes", &local)
+	body, status, err := m.doPeerRequest(ctx, agreement, http.MethodPost, p2pRoutesExchangePath, &local)
 	if err != nil {
 		return err
 	}

--- a/internal/federation/route_refresh_deadlock_test.go
+++ b/internal/federation/route_refresh_deadlock_test.go
@@ -1,0 +1,165 @@
+package federation
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+// R1 regression. maybeTriggerRouteRefresh is called from INSIDE
+// doPeerRequestWithHeaders, and several callers hold the sync-policy READ lease
+// across that peer request. Resolving the agreement/binding also takes that
+// read lease, so doing it on the caller's goroutine is a recursive RLock.
+//
+// Go's sync.RWMutex blocks new readers the moment a writer queues, so the
+// recursive acquisition deadlocks against a writer that is itself waiting for
+// the caller's RUnlock. LockSyncPolicyRead is a bare RLock with no context and
+// no try-variant, so nothing times out and nothing can cancel it: both
+// goroutines hang for the life of the process and the gate is wedged for every
+// other reader, including all inbound federation handlers.
+//
+// These tests fail by TIMING OUT rather than by asserting, which is the only
+// honest way to test a deadlock — so every one of them is bounded.
+
+func policyGateStore(t *testing.T) *store.SQLiteStore {
+	t.Helper()
+	sqlite, err := store.NewSQLiteStore(context.Background(), filepath.Join(t.TempDir(), "policy-gate.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlite.Close() })
+	return sqlite
+}
+
+// The core invariant, tested deterministically with no race window: while a
+// policy WRITER holds the gate, maybeTriggerRouteRefresh must still return
+// promptly on the calling goroutine. Before the fix it blocked here forever,
+// because its first statement acquired the read lease.
+func TestMaybeTriggerRouteRefreshDoesNotBlockCallerOnPolicyGate(t *testing.T) {
+	sqlite := policyGateStore(t)
+	m := &Manager{memStore: sqlite}
+
+	unlockWriter := sqlite.LockSyncPolicyWrite()
+	defer unlockWriter()
+
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		m.maybeTriggerRouteRefresh("peer-chain-a")
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("maybeTriggerRouteRefresh blocked on the caller's goroutine while a policy writer " +
+			"held the gate: it is acquiring the sync-policy read lease inline, which deadlocks " +
+			"when the caller already holds that lease across the peer request")
+	}
+}
+
+// The full interleaving the audit described, end to end: a reader holds the
+// lease across a simulated peer request, a writer queues behind it, and the
+// post-request refresh fires. All three must complete.
+func TestRouteRefreshSurvivesWriterQueuedBehindRequestHoldingReader(t *testing.T) {
+	sqlite := policyGateStore(t)
+	m := &Manager{memStore: sqlite}
+
+	writerQueued := make(chan struct{})
+	writerDone := make(chan struct{})
+	readerDone := make(chan struct{})
+
+	// Goroutine A: the request-holding reader, e.g. AvailableRecallDomains.
+	go func() {
+		defer close(readerDone)
+		readerUnlock := sqlite.LockSyncPolicyRead()
+
+		// The writer queues while A still holds the read lease. From here on,
+		// Go's RWMutex refuses every new reader — including a recursive one.
+		<-writerQueued
+		time.Sleep(50 * time.Millisecond)
+
+		// This is the call that used to deadlock, made while the lease is held.
+		m.maybeTriggerRouteRefresh("peer-chain-b")
+
+		readerUnlock()
+	}()
+
+	// Goroutine B: a policy writer, e.g. an automatic journal-pull ingest.
+	go func() {
+		defer close(writerDone)
+		close(writerQueued)
+		unlock := sqlite.LockSyncPolicyWrite()
+		unlock()
+	}()
+
+	for name, done := range map[string]chan struct{}{"reader": readerDone, "writer": writerDone} {
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("%s goroutine never completed: the sync-policy gate is wedged, which is the "+
+				"federation-wide deadlock this regression exists to prevent", name)
+		}
+	}
+}
+
+// Both trigger sites in doPeerRequestWithHeaders must be safe, not just the one
+// a reviewer happened to look at: the transport-failure path and the
+// Direct-route success path.
+func TestBothRouteRefreshTriggerSitesAreCallerSafe(t *testing.T) {
+	sqlite := policyGateStore(t)
+	m := &Manager{memStore: sqlite}
+
+	unlockWriter := sqlite.LockSyncPolicyWrite()
+	defer unlockWriter()
+
+	// Both sites reach the same entry point; calling it repeatedly under a held
+	// writer proves neither can block the request goroutine.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.maybeTriggerRouteRefresh("peer-failure-path")
+		m.maybeTriggerRouteRefresh("peer-direct-success-path")
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a route-refresh trigger site blocked the caller while a policy writer held the gate")
+	}
+}
+
+// The per-peer admission guard must bound pending refreshes to one goroutine
+// per peer, so a stalled gate cannot accumulate goroutines under request load.
+// Without it, moving the work off-thread would trade a deadlock for a leak.
+func TestRouteRefreshSchedulesAtMostOnePendingRefreshPerPeer(t *testing.T) {
+	sqlite := policyGateStore(t)
+	m := &Manager{memStore: sqlite}
+
+	// Hold the gate so every scheduled goroutine parks inside the lease and the
+	// pending set cannot drain while we measure it.
+	unlockWriter := sqlite.LockSyncPolicyWrite()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.maybeTriggerRouteRefresh("same-peer")
+		}()
+	}
+	wg.Wait()
+
+	m.routeRefreshMu.Lock()
+	pending := len(m.routeRefreshPending)
+	m.routeRefreshMu.Unlock()
+
+	if pending > 1 {
+		t.Fatalf("50 concurrent triggers for one peer scheduled %d pending refreshes, want at most 1", pending)
+	}
+
+	unlockWriter()
+}

--- a/internal/federation/route_refresh_deadlock_test.go
+++ b/internal/federation/route_refresh_deadlock_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -132,15 +133,30 @@ func TestBothRouteRefreshTriggerSitesAreCallerSafe(t *testing.T) {
 	}
 }
 
-// The per-peer admission guard must bound pending refreshes to one goroutine
-// per peer, so a stalled gate cannot accumulate goroutines under request load.
-// Without it, moving the work off-thread would trade a deadlock for a leak.
-func TestRouteRefreshSchedulesAtMostOnePendingRefreshPerPeer(t *testing.T) {
+// The per-peer admission guard must admit exactly ONE worker per peer while a
+// gate is stalled, so moving the refresh off-thread cannot trade a deadlock for
+// a goroutine pile-up under request load.
+//
+// This asserts WORKERS ADMITTED, not len(routeRefreshPending). The map cannot
+// distinguish the cases: an admitted worker and a rejected duplicate both leave
+// one key under the same chain ID, so len is 1 with the guard working AND 1
+// with duplicate-rejection removed, and 0 with the guard deleted outright. An
+// assertion on that map passes under every mutation it is supposed to catch.
+func TestRouteRefreshAdmitsExactlyOneWorkerPerPeerUnderLoad(t *testing.T) {
 	sqlite := policyGateStore(t)
 	m := &Manager{memStore: sqlite}
 
-	// Hold the gate so every scheduled goroutine parks inside the lease and the
-	// pending set cannot drain while we measure it.
+	var entered atomic.Int32
+	firstEntered := make(chan struct{})
+	var once sync.Once
+	setRouteRefreshWorkerEntry(func(string) {
+		entered.Add(1)
+		once.Do(func() { close(firstEntered) })
+	})
+	t.Cleanup(func() { setRouteRefreshWorkerEntry(nil) })
+
+	// Hold the gate so the admitted worker parks inside the lease and cannot
+	// finish and clear its pending slot while the others are still arriving.
 	unlockWriter := sqlite.LockSyncPolicyWrite()
 
 	var wg sync.WaitGroup
@@ -153,34 +169,58 @@ func TestRouteRefreshSchedulesAtMostOnePendingRefreshPerPeer(t *testing.T) {
 	}
 	wg.Wait()
 
-	m.routeRefreshMu.Lock()
-	pending := len(m.routeRefreshPending)
-	m.routeRefreshMu.Unlock()
-
-	if pending > 1 {
-		t.Fatalf("50 concurrent triggers for one peer scheduled %d pending refreshes, want at most 1", pending)
+	// Every caller must have returned — none may block behind the writer.
+	select {
+	case <-firstEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no refresh worker was ever admitted")
 	}
 
+	// Give any wrongly-admitted duplicates time to arrive before counting.
+	time.Sleep(200 * time.Millisecond)
+	if got := entered.Load(); got != 1 {
+		t.Fatalf("%d workers entered runScheduledRouteRefresh for one peer, want exactly 1: "+
+			"the admission guard is not rejecting duplicates, so a stalled gate accumulates goroutines", got)
+	}
+
+	// Releasing the writer lets the single worker finish and clean up after
+	// itself, so a later trigger for the same peer is admitted again.
 	unlockWriter()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		m.routeRefreshMu.Lock()
+		n := len(m.routeRefreshPending)
+		m.routeRefreshMu.Unlock()
+		if n == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("the pending slot was never released, so this peer can never schedule another refresh")
 }
 
-// The remediation must be CENTRAL, not caller-specific. Four production chains
-// hold the sync-policy read lease across a peer request and therefore reach the
-// inline refresh:
+// SHARED-ENTRY COVERAGE, SOURCE-TRACED — read the limitation before trusting it.
+//
+// This test drives the shared entry point directly. It does NOT execute the
+// four production chains below; their identification is by source reading, not
+// by this test. So it proves the shared helper is safe for any caller holding
+// the policy lease, which is the property the central fix relies on — and it
+// proves nothing about whether those chains still route through the helper.
+// End-to-end execution of the two doPeerRequestWithHeaders trigger sites lives
+// in route_refresh_trigger_e2e_test.go; sync-outbox e2e is not covered.
+//
+// The chains, traced in source at v11.18.6:
 //
 //	client.go:447  /fed/v1/query        (also holds the Badger lease)
 //	client.go:525  /fed/v1/query/available
 //	client.go:658  /fed/v1/query/plan
 //	sync_outbox.go:955 -> push at :1087 -> SyncPush -> doPeerRequest
 //
-// The last one is the sync OUTBOX: it runs on a background cadence rather than
-// a user query, and it holds the domain-ownership lease alongside the policy
-// lease. A fix applied at any single call site would have left the other three
-// deadlocking, which is why the guard lives in maybeTriggerRouteRefresh itself.
-//
-// This test pins that property at the shared entry point: with a policy writer
-// queued, the refresh trigger must not block ANY caller, whatever lease that
-// caller happens to be holding.
+// The last is the sync OUTBOX: a background cadence rather than a user query,
+// holding the domain-ownership lease alongside the policy lease. A fix applied
+// at any single call site would have left the others deadlocking, which is why
+// the guard lives in maybeTriggerRouteRefresh itself — and why an incomplete
+// enumeration (mine originally missed the outbox) stopped mattering.
 func TestRouteRefreshRemediationIsCentralNotCallerSpecific(t *testing.T) {
 	sqlite := policyGateStore(t)
 	m := &Manager{memStore: sqlite}

--- a/internal/federation/route_refresh_deadlock_test.go
+++ b/internal/federation/route_refresh_deadlock_test.go
@@ -163,3 +163,53 @@ func TestRouteRefreshSchedulesAtMostOnePendingRefreshPerPeer(t *testing.T) {
 
 	unlockWriter()
 }
+
+// The remediation must be CENTRAL, not caller-specific. Four production chains
+// hold the sync-policy read lease across a peer request and therefore reach the
+// inline refresh:
+//
+//	client.go:447  /fed/v1/query        (also holds the Badger lease)
+//	client.go:525  /fed/v1/query/available
+//	client.go:658  /fed/v1/query/plan
+//	sync_outbox.go:955 -> push at :1087 -> SyncPush -> doPeerRequest
+//
+// The last one is the sync OUTBOX: it runs on a background cadence rather than
+// a user query, and it holds the domain-ownership lease alongside the policy
+// lease. A fix applied at any single call site would have left the other three
+// deadlocking, which is why the guard lives in maybeTriggerRouteRefresh itself.
+//
+// This test pins that property at the shared entry point: with a policy writer
+// queued, the refresh trigger must not block ANY caller, whatever lease that
+// caller happens to be holding.
+func TestRouteRefreshRemediationIsCentralNotCallerSpecific(t *testing.T) {
+	sqlite := policyGateStore(t)
+	m := &Manager{memStore: sqlite}
+
+	unlockWriter := sqlite.LockSyncPolicyWrite()
+	defer unlockWriter()
+
+	// One goroutine per known lock-holding chain, all hitting the shared entry
+	// point while the writer holds the gate.
+	chains := []string{
+		"query-chain",           // client.go:447
+		"query-available-chain", // client.go:525
+		"query-plan-chain",      // client.go:658
+		"sync-outbox-chain",     // sync_outbox.go:955 -> SyncPush
+	}
+	done := make(chan string, len(chains))
+	for _, chain := range chains {
+		go func(c string) {
+			m.maybeTriggerRouteRefresh(c)
+			done <- c
+		}(chain)
+	}
+
+	for range chains {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("a lock-holding caller blocked on the route-refresh trigger: the remediation is " +
+				"not central, so at least one of the four known chains can still deadlock")
+		}
+	}
+}

--- a/internal/federation/route_refresh_trigger_e2e_test.go
+++ b/internal/federation/route_refresh_trigger_e2e_test.go
@@ -141,9 +141,33 @@ func TestDirectSuccessTriggerAdmitsRefreshWorkerWithWriterHeld(t *testing.T) {
 	}
 }
 
+// watchRouteRefreshWorkersForChain is the zero-assertion counterpart of
+// watchRouteRefreshWorkers: it counts admissions for ONE remote chain only.
+//
+// The filter is load-bearing for a "must stay zero" test. The seam is a package
+// global, so with a reachable peer BOTH chains' managers report through it, and
+// an unrelated admission on the serving side would read as the defect. Scoping
+// to the requesting side's remote chain ID keeps the assertion about the guard
+// under test and nothing else.
+func watchRouteRefreshWorkersForChain(t *testing.T, remoteChainID string) *atomic.Int32 {
+	t.Helper()
+	var entered atomic.Int32
+	setRouteRefreshWorkerEntry(func(chainID string) {
+		if chainID == remoteChainID {
+			entered.Add(1)
+		}
+	})
+	t.Cleanup(func() { setRouteRefreshWorkerEntry(nil) })
+	return &entered
+}
+
 // The route-exchange path must NOT self-trigger a refresh, or an exchange would
 // schedule another exchange. Both production triggers guard on
-// `path != p2pRoutesExchangePath`; this pins that guard.
+// `path != p2pRoutesExchangePath`; this pins the TRANSPORT-ERROR one.
+//
+// It cannot pin the other: an unreachable peer never reaches the Direct-success
+// trigger at all, so deleting that guard leaves this test green. The
+// Direct-success half is covered by the reachable-peer test below.
 func TestRouteExchangePathDoesNotSelfTriggerRefresh(t *testing.T) {
 	a := newTestChain(t, "trigger-noself-a")
 	b := newTestChain(t, "trigger-noself-b")
@@ -160,4 +184,48 @@ func TestRouteExchangePathDoesNotSelfTriggerRefresh(t *testing.T) {
 
 	time.Sleep(300 * time.Millisecond)
 	require.Zero(t, entered.Load(), "the route exchange scheduled its own refresh, which recurses")
+}
+
+// The Direct-success half of the no-self-trigger guard (client.go: the
+// `chosen.Kind == RouteKindDirect && routeDial != nil && path !=
+// p2pRoutesExchangePath` branch). This needs the SAME fixture shape as
+// TestDirectSuccessTriggerAdmitsRefreshWorkerWithWriterHeld — a reachable peer
+// so Direct wins, and a non-nil dialer so the branch is entered — but drives
+// the exchange path and asserts the refresh is NOT scheduled.
+//
+// Deleting `&& path != p2pRoutesExchangePath` from the Direct-success trigger
+// makes this test fail; the unreachable-peer test above stays green under that
+// same mutation, which is why both are needed.
+func TestDirectSuccessRouteExchangeDoesNotSelfTriggerRefresh(t *testing.T) {
+	a := newTestChain(t, "trigger-noself-direct-a")
+	b := newTestChain(t, "trigger-noself-direct-b")
+	var served atomic.Int32
+	server := startCountedFederationServer(t, b, &served)
+	federate(t, a, b, server.URL, nil, 4, 0)
+	federate(t, b, a, "https://unused.invalid", nil, 4, 0)
+
+	// Non-nil but always-failing, exactly as in the Direct-success trigger test:
+	// the reachable Direct candidate wins the race while routeDial stays non-nil.
+	a.mgr.SetPeerRouteDialFunc(func(ctx context.Context, chain string, _ []string, _ PeerRouteAuthenticator) (PeerRouteDialResult, bool, error) {
+		return PeerRouteDialResult{}, true, context.DeadlineExceeded
+	})
+
+	entered := watchRouteRefreshWorkersForChain(t, b.chainID)
+
+	agreement, err := a.mgr.ActiveAgreement(b.chainID)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	_, _, _ = a.mgr.doPeerRequest(ctx, agreement, http.MethodPost, p2pRoutesExchangePath, map[string]any{})
+
+	// Without this the test is vacuous: if Direct never won, the guarded branch
+	// was never reached and zero admissions proves nothing. The exchange
+	// handler's own status code is irrelevant — the trigger sits before the
+	// response body is read, so being served at all is what matters.
+	require.Positive(t, served.Load(), "the peer never served the exchange request, so the Direct-success "+
+		"branch was never reached and this test is not exercising its guard")
+
+	time.Sleep(300 * time.Millisecond)
+	require.Zero(t, entered.Load(), "a successful Direct route exchange scheduled another refresh, "+
+		"which schedules another exchange")
 }

--- a/internal/federation/route_refresh_trigger_e2e_test.go
+++ b/internal/federation/route_refresh_trigger_e2e_test.go
@@ -1,0 +1,163 @@
+package federation
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+// R1 end-to-end trigger coverage.
+//
+// The earlier tests called maybeTriggerRouteRefresh directly, which proves the
+// shared helper is safe but proves NOTHING about the two production call sites:
+// delete either trigger from doPeerRequestWithHeaders and a helper-level test
+// stays green. These drive real requests through doPeerRequestWithHeaders with
+// a policy writer holding the gate, and assert both that the request completes
+// bounded and that a refresh worker was actually admitted.
+//
+// Deleting either production trigger makes the corresponding test fail.
+
+// watchRouteRefreshWorkers installs the worker-entry seam and returns a counter
+// plus a channel closed on the first admission.
+func watchRouteRefreshWorkers(t *testing.T) (*atomic.Int32, chan struct{}) {
+	t.Helper()
+	var entered atomic.Int32
+	first := make(chan struct{})
+	var closeOnce atomic.Bool
+	setRouteRefreshWorkerEntry(func(string) {
+		entered.Add(1)
+		if closeOnce.CompareAndSwap(false, true) {
+			close(first)
+		}
+	})
+	t.Cleanup(func() { setRouteRefreshWorkerEntry(nil) })
+	return &entered, first
+}
+
+func chainPolicyStore(t *testing.T, c *testChain) *store.SQLiteStore {
+	t.Helper()
+	ss, ok := c.mem.(*store.SQLiteStore)
+	require.True(t, ok, "test chain's MemStore must be a SQLiteStore to hold its policy gate")
+	return ss
+}
+
+// TRIGGER SITE (a): the non-security transport-error path in
+// doPeerRequestWithHeaders. An unreachable peer produces a plain dial failure,
+// which is not a security failure, so the refresh trigger fires.
+func TestTransportErrorTriggerAdmitsRefreshWorkerWithWriterHeld(t *testing.T) {
+	a := newTestChain(t, "trigger-transport-a")
+	b := newTestChain(t, "trigger-transport-b")
+	// Deliberately unreachable: a closed port on loopback gives a prompt
+	// connection-refused rather than a slow timeout.
+	federate(t, a, b, "https://127.0.0.1:1", nil, 4, 0)
+	federate(t, b, a, "https://unused.invalid", nil, 4, 0)
+
+	entered, firstEntry := watchRouteRefreshWorkers(t)
+
+	// A policy writer holds the gate for the whole request. Before R1 this is
+	// precisely the state in which the inline refresh deadlocked.
+	unlockWriter := chainPolicyStore(t, a).LockSyncPolicyWrite()
+	defer unlockWriter()
+
+	agreement, err := a.mgr.ActiveAgreement(b.chainID)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, _, _ = a.mgr.doPeerRequest(ctx, agreement, http.MethodPost, "/fed/v1/query", map[string]any{})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the request never completed while a policy writer held the gate: the transport-error " +
+			"trigger is still doing policy work on the request goroutine")
+	}
+
+	select {
+	case <-firstEntry:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("no refresh worker was admitted from the transport-error path (entered=%d): the "+
+			"trigger at that call site is missing", entered.Load())
+	}
+}
+
+// TRIGGER SITE (b): the Direct-route success path. Requires a REACHABLE peer so
+// the direct candidate wins, and a non-nil route dialer, because the trigger is
+// guarded on `chosen.Kind == RouteKindDirect && routeDial != nil`.
+func TestDirectSuccessTriggerAdmitsRefreshWorkerWithWriterHeld(t *testing.T) {
+	a := newTestChain(t, "trigger-direct-a")
+	b := newTestChain(t, "trigger-direct-b")
+	var served atomic.Int32
+	server := startCountedFederationServer(t, b, &served)
+	federate(t, a, b, server.URL, nil, 4, 0)
+	federate(t, b, a, "https://unused.invalid", nil, 4, 0)
+
+	// Non-nil dialer that always fails, so the reachable Direct candidate wins
+	// the race while routeDial stays non-nil — exactly the trigger's condition.
+	a.mgr.SetPeerRouteDialFunc(func(ctx context.Context, chain string, _ []string, _ PeerRouteAuthenticator) (PeerRouteDialResult, bool, error) {
+		return PeerRouteDialResult{}, true, context.DeadlineExceeded
+	})
+
+	entered, firstEntry := watchRouteRefreshWorkers(t)
+
+	unlockWriter := chainPolicyStore(t, a).LockSyncPolicyWrite()
+	defer unlockWriter()
+
+	agreement, err := a.mgr.ActiveAgreement(b.chainID)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer cancel()
+		_, _, _ = a.mgr.doPeerRequest(ctx, agreement, http.MethodPost, "/fed/v1/query", map[string]any{})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("the request never completed while a policy writer held the gate: the Direct-success " +
+			"trigger is still doing policy work on the request goroutine")
+	}
+
+	require.Positive(t, served.Load(), "the peer never served the request, so Direct did not win and "+
+		"this test is not exercising the Direct-success trigger at all")
+
+	select {
+	case <-firstEntry:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("no refresh worker was admitted from the Direct-success path (entered=%d): the "+
+			"trigger at that call site is missing", entered.Load())
+	}
+}
+
+// The route-exchange path must NOT self-trigger a refresh, or an exchange would
+// schedule another exchange. Both production triggers guard on
+// `path != p2pRoutesExchangePath`; this pins that guard.
+func TestRouteExchangePathDoesNotSelfTriggerRefresh(t *testing.T) {
+	a := newTestChain(t, "trigger-noself-a")
+	b := newTestChain(t, "trigger-noself-b")
+	federate(t, a, b, "https://127.0.0.1:1", nil, 4, 0)
+	federate(t, b, a, "https://unused.invalid", nil, 4, 0)
+
+	entered, _ := watchRouteRefreshWorkers(t)
+
+	agreement, err := a.mgr.ActiveAgreement(b.chainID)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _, _ = a.mgr.doPeerRequest(ctx, agreement, http.MethodPost, p2pRoutesExchangePath, map[string]any{})
+
+	time.Sleep(300 * time.Millisecond)
+	require.Zero(t, entered.Load(), "the route exchange scheduled its own refresh, which recurses")
+}

--- a/internal/federation/routes.go
+++ b/internal/federation/routes.go
@@ -662,7 +662,63 @@ func (m *Manager) triggerRouteRefresh(remoteChainID string) {
 	m.triggerRouteRefreshWithContext(context.Background(), remoteChainID, nil)
 }
 
+// maybeTriggerRouteRefresh schedules an opportunistic route refresh after a
+// peer request. It is called from INSIDE doPeerRequestWithHeaders, and that is
+// the whole reason it must not do any work on the caller's goroutine.
+//
+// THE DEADLOCK THIS SHAPE EXISTS TO PREVENT. Resolving the agreement/binding
+// takes the sync-policy read lease (routeRefreshAgreementBinding ->
+// LockSyncPolicyRead), and several callers ALREADY hold that same RWMutex read
+// lock across the peer request — e.g. AvailableRecallDomains takes it before
+// doPeerRequest and releases it only after. Taking it again here is a recursive
+// RLock. Go's sync.RWMutex blocks new readers as soon as a writer queues, so:
+// the caller holds RLock, a writer (a journal-pull ingest, a re-pair, a policy
+// change) blocks behind it, this second RLock then blocks behind that writer,
+// and the writer is waiting on the caller's RUnlock that can now never happen.
+// Both goroutines hang forever, and because LockSyncPolicyRead is a bare RLock
+// with no context and no try-variant there is no timeout and no cancellation
+// path out of it. The gate is then wedged for every other reader, including all
+// inbound federation handlers, until the process restarts.
+//
+// p2p_routes.go states the invariant directly: never hold the policy lease
+// across the network request. Doing the lookup on a fresh goroutine keeps that
+// true — the caller returns and releases its RLock, the queued writer drains,
+// and the scheduled goroutine then acquires the lease normally.
+//
+// The admission check below is deliberately cheap and policy-free so it can run
+// on the caller's goroutine, and it bounds this to one pending refresh per peer
+// so a stalled gate cannot accumulate goroutines under request load. The
+// agreement/binding-keyed once-per-minute dedup still applies, inside the
+// goroutine, where consulting the gate is safe.
 func (m *Manager) maybeTriggerRouteRefresh(remoteChainID string) {
+	if !m.transportIsEnabled() {
+		return
+	}
+	m.routeRefreshMu.Lock()
+	if m.routeRefreshPending == nil {
+		m.routeRefreshPending = make(map[string]bool)
+	}
+	if m.routeRefreshPending[remoteChainID] {
+		m.routeRefreshMu.Unlock()
+		return
+	}
+	m.routeRefreshPending[remoteChainID] = true
+	m.routeRefreshMu.Unlock()
+
+	go func() {
+		defer func() {
+			m.routeRefreshMu.Lock()
+			delete(m.routeRefreshPending, remoteChainID)
+			m.routeRefreshMu.Unlock()
+		}()
+		m.runScheduledRouteRefresh(remoteChainID)
+	}()
+}
+
+// runScheduledRouteRefresh is maybeTriggerRouteRefresh's body, executed on its
+// own goroutine. Everything here may block on the sync-policy gate; nothing
+// here may be called from a goroutine that already holds it.
+func (m *Manager) runScheduledRouteRefresh(remoteChainID string) {
 	agreement, binding, err := m.routeRefreshAgreementBinding(context.Background(), remoteChainID)
 	if err != nil {
 		m.recordRouteFailure(remoteChainID, err, errors.Is(err, ErrTrustGenerationChanged))

--- a/internal/federation/routes.go
+++ b/internal/federation/routes.go
@@ -722,10 +722,42 @@ func (m *Manager) maybeTriggerRouteRefresh(remoteChainID string) {
 	}()
 }
 
+// routeRefreshWorkerEntry is a TEST SEAM and is nil in production. It fires at
+// the top of runScheduledRouteRefresh, BEFORE the sync-policy read lease is
+// taken.
+//
+// It exists because the admission guard cannot be observed from the
+// routeRefreshPending map: an admitted worker and a rejected duplicate both
+// leave exactly one key under the same chain ID, so len(pending) is 1 either
+// way and is 0 with the guard deleted entirely. A test asserting on that map
+// therefore passes whether the guard works, half-works, or is absent. Counting
+// entries here is the only way to distinguish those, which is what makes the
+// guard's regression test mutation-sensitive.
+var (
+	routeRefreshWorkerEntryMu sync.Mutex
+	routeRefreshWorkerEntryFn func(remoteChainID string)
+)
+
+func setRouteRefreshWorkerEntry(fn func(remoteChainID string)) {
+	routeRefreshWorkerEntryMu.Lock()
+	routeRefreshWorkerEntryFn = fn
+	routeRefreshWorkerEntryMu.Unlock()
+}
+
+func noteRouteRefreshWorkerEntry(remoteChainID string) {
+	routeRefreshWorkerEntryMu.Lock()
+	fn := routeRefreshWorkerEntryFn
+	routeRefreshWorkerEntryMu.Unlock()
+	if fn != nil {
+		fn(remoteChainID)
+	}
+}
+
 // runScheduledRouteRefresh is maybeTriggerRouteRefresh's body, executed on its
 // own goroutine. Everything here may block on the sync-policy gate; nothing
 // here may be called from a goroutine that already holds it.
 func (m *Manager) runScheduledRouteRefresh(remoteChainID string) {
+	noteRouteRefreshWorkerEntry(remoteChainID)
 	agreement, binding, err := m.routeRefreshAgreementBinding(context.Background(), remoteChainID)
 	if err != nil {
 		m.recordRouteFailure(remoteChainID, err, errors.Is(err, ErrTrustGenerationChanged))

--- a/internal/federation/routes.go
+++ b/internal/federation/routes.go
@@ -29,6 +29,13 @@ const (
 	RouteStateUnknown         = "unknown"
 )
 
+// p2pRoutesExchangePath is the authenticated route-exchange endpoint. It is a
+// named constant because three separate guards key off it — the two
+// post-request refresh triggers must not recurse into it, and the R2 bootstrap
+// hint admits a stale-generation snapshot for this path ONLY. A literal that
+// drifted from the registered route would silently disable all three.
+const p2pRoutesExchangePath = "/fed/v1/p2p/routes"
+
 var (
 	ErrLegacyRouteBinding     = errors.New("legacy federation connection must be paired again to enable secure relay")
 	ErrTrustGenerationChanged = errors.New("federation trust generation changed during route recovery")

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -104,7 +104,7 @@ func (m *Manager) Router() http.Handler {
 		r.Post("/fed/v1/sync/group/member-invite/accept", m.handleMemberInviteAccept)
 		r.Post("/fed/v1/sync/group/member-invite/bootstrap", m.handleMemberBootstrap)
 		r.Put("/fed/v1/sync/policy", m.handleSyncPolicy) // v11.6 host-controlled sync
-		r.Post("/fed/v1/p2p/routes", m.handleP2PRoutes)  // v11.6 authenticated LAN roaming upgrade
+		r.Post(p2pRoutesExchangePath, m.handleP2PRoutes) // v11.6 authenticated LAN roaming upgrade
 	})
 	// The pre-agreement JOIN ceremony routes sit behind joinAuth, NOT peerAuth
 	// (no active agreement exists yet during a join).

--- a/scripts/federation-route-state.test.mjs
+++ b/scripts/federation-route-state.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  classifyFederationFailure,
   federationConnectionActionIntent,
   federationConnectionRoute,
   federationRoutePresentation,
@@ -111,4 +112,66 @@ test('legacy repair routes to re-pair while ordinary failures route to retry', (
   assert.equal(federationConnectionActionIntent({ state: 'offline' }), 'retry');
   assert.equal(federationConnectionActionIntent({ state: 'security_blocked' }), 'retry');
   assert.equal(federationConnectionActionIntent({ state: 'relay' }), 'toggle_pause');
+});
+
+// R3. One federated failure routinely carries BOTH security and
+// route-availability text, because doPeerRequest races a p2p attempt and a
+// direct attempt and joins both errors into a single message. Before R3 the
+// availability regexes were tested first, so a pinned-trust mismatch that also
+// lacked a p2p route was reported as the benign warn-tone 'route_bundle_missing'
+// — telling an operator to look at their network when SAGE had actually refused
+// the peer's identity.
+test('security evidence outranks route-availability text in a combined failure', () => {
+  const combined = 'peer chain-b unreachable: peer has no configured p2p route; '
+    + 'x509: certificate signed by unknown authority';
+
+  assert.equal(classifyFederationFailure({ error: combined }), 'security_blocked');
+});
+
+test('each security marker wins over each availability marker', () => {
+  const securityMarkers = [
+    'x509: certificate signed by unknown authority',
+    'spki pin does not match',
+    'pin mismatch for peer',
+    'identity mismatch on peer certificate',
+  ];
+  const availabilityMarkers = [
+    'peer has no configured p2p route',
+    'no p2p dialer for peer',
+    'route bundle is missing',
+    'relay unavailable',
+    'direct route is stale',
+  ];
+
+  for (const security of securityMarkers) {
+    for (const availability of availabilityMarkers) {
+      assert.equal(
+        classifyFederationFailure({ error: `${availability}; ${security}` }),
+        'security_blocked',
+        `"${availability}" must not outrank "${security}"`,
+      );
+    }
+  }
+});
+
+test('trust failures also outrank route-availability text', () => {
+  assert.equal(
+    classifyFederationFailure({ error: 'peer has no configured p2p route; agreement revoked' }),
+    'trust_failure',
+  );
+});
+
+test('availability text alone still classifies as availability', () => {
+  assert.equal(
+    classifyFederationFailure({ error: 'peer has no configured p2p route' }),
+    'route_bundle_missing',
+  );
+  assert.equal(classifyFederationFailure({ error: 'relay unavailable' }), 'relay_unavailable');
+});
+
+test('a security failure presents as danger, not a routing warning', () => {
+  const combined = 'peer has no configured p2p route; x509: certificate signed by unknown authority';
+  const view = federationRoutePresentation({ state: classifyFederationFailure({ error: combined }) });
+
+  assert.equal(view.tone, 'danger');
 });

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.6 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.7 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.6"
+version = "11.18.7"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.6"
+__version__ = "11.18.7"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.6",
+  "version": "11.18.7",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.6",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.7",
       "transport": {
         "type": "stdio"
       }

--- a/web/federation_route_status.go
+++ b/web/federation_route_status.go
@@ -26,6 +26,34 @@ func federationDashboardFailureState(err error, route federation.RouteDiagnostic
 	case errors.Is(err, federation.ErrTrustGenerationChanged),
 		strings.Contains(message, "trust generation"):
 		return "trust_generation_mismatch"
+	// R3. SECURITY EVIDENCE OUTRANKS ROUTE-AVAILABILITY EVIDENCE, and the order
+	// of these cases is the whole mechanism.
+	//
+	// A single failure routinely carries BOTH kinds of text: doPeerRequest races
+	// a p2p attempt and a direct attempt and joins both errors, so one message
+	// can read "peer has no configured p2p route ... x509: certificate signed by
+	// unknown authority". These security cases used to sit BELOW the
+	// availability cases, so that message matched "no configured p2p route"
+	// first and the dashboard rendered a warn-tone "Routes missing", telling the
+	// operator to go look at their network — when the truth was a pinned-trust
+	// mismatch that SAGE refused to talk to.
+	//
+	// A security verdict that presents as a benign availability gap is the worst
+	// failure this switch can produce, so both security classes are evaluated
+	// before any availability class. Availability text remains in the message
+	// either way; only which verdict is REPORTED changes.
+	case strings.Contains(message, "certificate"),
+		strings.Contains(message, "spki"),
+		strings.Contains(message, "pin mismatch"),
+		strings.Contains(message, "identity mismatch"),
+		strings.Contains(message, "security block"):
+		return "security_blocked"
+	case strings.Contains(message, "revoked"),
+		strings.Contains(message, "expired agreement"),
+		strings.Contains(message, "unknown agreement"),
+		strings.Contains(message, "trust") && strings.Contains(message, "fail"),
+		strings.Contains(message, "authentication"):
+		return "trust_failure"
 	case strings.Contains(message, "route snapshot") && strings.Contains(message, "expired"):
 		return "route_bundle_expired"
 	case strings.Contains(message, "no configured p2p route"),
@@ -40,18 +68,6 @@ func federationDashboardFailureState(err error, route federation.RouteDiagnostic
 		strings.Contains(message, "node locked"),
 		strings.Contains(message, "unlock this sage"):
 		return "locked"
-	case strings.Contains(message, "certificate"),
-		strings.Contains(message, "spki"),
-		strings.Contains(message, "pin mismatch"),
-		strings.Contains(message, "identity mismatch"),
-		strings.Contains(message, "security block"):
-		return "security_blocked"
-	case strings.Contains(message, "revoked"),
-		strings.Contains(message, "expired agreement"),
-		strings.Contains(message, "unknown agreement"),
-		strings.Contains(message, "trust") && strings.Contains(message, "fail"),
-		strings.Contains(message, "authentication"):
-		return "trust_failure"
 	case strings.Contains(message, "old peer"),
 		strings.Contains(message, "older peer"),
 		strings.Contains(message, "unsupported"),

--- a/web/federation_route_status_precedence_test.go
+++ b/web/federation_route_status_precedence_test.go
@@ -1,0 +1,95 @@
+package web
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/l33tdawg/sage/internal/federation"
+)
+
+// R3. A single federated failure routinely carries BOTH security and
+// route-availability text: doPeerRequest races a p2p attempt and a direct
+// attempt and joins both errors into one message. Before R3 the availability
+// cases were evaluated first, so a pinned-trust mismatch that also lacked a
+// p2p route was reported as the benign "route_bundle_missing" — an operator
+// was sent to look at their network when SAGE had refused the peer's identity.
+//
+// These tests pin the precedence, not the individual classifications.
+
+func TestSecurityEvidenceOutranksRouteAvailabilityText(t *testing.T) {
+	securityMarkers := map[string]string{
+		"certificate":       "x509: certificate signed by unknown authority",
+		"spki":              "spki pin does not match",
+		"pin mismatch":      "pin mismatch for peer chain-b",
+		"identity mismatch": "identity mismatch on peer certificate",
+		"security block":    "security block: peer identity refused",
+	}
+	availabilityMarkers := []string{
+		"peer has no configured p2p route",
+		"no p2p dialer for peer chain-b",
+		"route bundle is missing",
+		"relay unavailable",
+		"direct route is stale",
+	}
+
+	for name, security := range securityMarkers {
+		for _, availability := range availabilityMarkers {
+			t.Run(fmt.Sprintf("%s_over_%s", name, availability), func(t *testing.T) {
+				// Availability text FIRST, which is the real wire order: the p2p
+				// attempt fails before the direct attempt's TLS error arrives.
+				err := fmt.Errorf("peer chain-b unreachable: %s; %s", availability, security)
+				if got := federationDashboardFailureState(err, federation.RouteDiagnostics{}); got != "security_blocked" {
+					t.Fatalf("got %q, want security_blocked — a security verdict was reported as a "+
+						"routing gap for: %v", got, err)
+				}
+			})
+		}
+	}
+}
+
+func TestTrustFailureAlsoOutranksRouteAvailabilityText(t *testing.T) {
+	for _, trust := range []string{
+		"agreement revoked",
+		"expired agreement",
+		"unknown agreement",
+		"authentication failed",
+	} {
+		err := fmt.Errorf("peer has no configured p2p route; %s", trust)
+		if got := federationDashboardFailureState(err, federation.RouteDiagnostics{}); got != "trust_failure" {
+			t.Fatalf("%q: got %q, want trust_failure", trust, got)
+		}
+	}
+}
+
+// The reordering must not swallow availability failures that carry no security
+// evidence — those are still exactly what they say they are.
+func TestAvailabilityTextAloneStillClassifiesAsAvailability(t *testing.T) {
+	for message, want := range map[string]string{
+		"peer has no configured p2p route":   "route_bundle_missing",
+		"no p2p dialer for peer chain-b":     "route_bundle_missing",
+		"route snapshot expired for peer":    "route_bundle_expired",
+		"relay unavailable for peer chain-b": "relay_unavailable",
+		"direct route is stale for peer":     "stale_direct",
+		"vault is locked; unlock this sage":  "locked",
+	} {
+		if got := federationDashboardFailureState(errors.New(message), federation.RouteDiagnostics{}); got != want {
+			t.Fatalf("%q: got %q, want %q", message, got, want)
+		}
+	}
+}
+
+// Cases that were already ABOVE the availability group must keep their
+// precedence — the reorder moved security up, it must not have moved these down.
+func TestTrustGenerationAndLegacyKeepPrecedenceOverAvailability(t *testing.T) {
+	if got := federationDashboardFailureState(
+		errors.New("peer has no configured p2p route; trust generation changed"),
+		federation.RouteDiagnostics{}); got != "trust_generation_mismatch" {
+		t.Fatalf("got %q, want trust_generation_mismatch", got)
+	}
+	if got := federationDashboardFailureState(
+		errors.New("no p2p dialer; legacy federation connection must be paired again"),
+		federation.RouteDiagnostics{}); got != "legacy_repair_required" {
+		t.Fatalf("got %q, want legacy_repair_required", got)
+	}
+}

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.6';
+const SAGE_VERSION = 'v11.18.7';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace

--- a/web/static/js/federation-route-state.js
+++ b/web/static/js/federation-route-state.js
@@ -85,12 +85,24 @@ export function classifyFederationFailure(error, fallback = 'route_failure') {
   if (/vault.*lock|node.*lock|unlock.*sage/.test(message)) return 'locked';
   if (/legacy federation connection|paired again.*secure relay/.test(message)) return 'legacy_repair_required';
   if (/trust generation/.test(message)) return 'trust_generation_mismatch';
+  // R3. Security evidence outranks route-availability evidence, matching
+  // federationDashboardFailureState in web/federation_route_status.go. The
+  // invariant the two classifiers must share is exactly this relative order:
+  // if they disagree, the dashboard and the server report different verdicts
+  // for the same failure. (The 'locked' case sits earlier here than in the Go
+  // switch. That divergence predates R3 and is left alone; it is a node-state
+  // check, not route-availability text, so it does not affect this ordering.)
+  //
+  // One failure often carries both kinds of text, because a raced p2p+direct
+  // attempt joins both errors into one message. Evaluated in the old order, a
+  // pinned-certificate mismatch that also lacked a p2p route rendered as the
+  // warn-tone 'route_bundle_missing' instead of 'security_blocked'.
+  if (/certificate|spki|pin mismatch|identity mismatch|security block/.test(message)) return 'security_blocked';
+  if (/revoked|expired agreement|unknown agreement|trust.*fail|authentication/.test(message)) return 'trust_failure';
   if (/route snapshot.*expired/.test(message)) return 'route_bundle_expired';
   if (/no configured p2p route|no p2p dialer|route bundle.*missing/.test(message)) return 'route_bundle_missing';
   if (/relay.*(unavailable|failed)/.test(message)) return 'relay_unavailable';
   if (/direct.*(stale|unavailable)/.test(message)) return 'stale_direct';
-  if (/certificate|spki|pin mismatch|identity mismatch|security block/.test(message)) return 'security_blocked';
-  if (/revoked|expired agreement|unknown agreement|trust.*fail|authentication/.test(message)) return 'trust_failure';
   if (/old peer|older peer|unsupported|not implemented/.test(message) || error && error.status === 501) return 'old_peer';
   if (/disabled|federation is off|listener.*off/.test(message)) return 'disabled';
   if (/offline|timed? out|timeout|refused|unreachable|no route|network/.test(message)) return 'offline';


### PR DESCRIPTION
## Summary
- preserve and merge the independently reviewed federation fixes through e28b9ee8
- include current main fixes for bounded large Comet broadcasts, app-v20 aggregate transaction limits, and the separate signed AgentRequest proof bound from PRs #176–#179
- align server, SDK, desktop, web, OpenAPI, acceptance, and documentation metadata at 11.18.7
- document that app-v26 remains the ceiling and no app-v27 or state migration is introduced

## Validation
- full Go suite: pass
- required race suites: pass
- npm test: 261/261 pass
- natter race: pass
- native-shell cargo test: 16/16 pass; clippy clean with workflow staging
- Python SDK: 170/170 pass; wheel/sdist build and twine check pass
- Linux-equivalent golangci-lint: clean
- pinned Go 1.25.12 govulncheck root/natter: zero called vulnerabilities
- version alignment/release workflow contract: 40/40 pass
- git diff --check and go mod tidy: clean
- post-cutoff PR #179 focused resource-limit tests x10 and full internal/abci: pass

Release cutoff refreshed to origin/main f67e1c88 after PR #179 merged. The reviewed federation commit identities remain in ancestry; this branch was merged, not rebased.