### PR TITLE
fix: harden indeterminate Comet outcomes

### DIFF
--- a/internal/federation/manager.go
+++ b/internal/federation/manager.go
@@ -343,6 +343,10 @@ type Manager struct {
 	// calls: each blocks up to the commit timeout, so an unbounded push flood
 	// would otherwise pin a goroutine per push. A small pool caps the hold.
 	broadcastSem chan struct{}
+	// syncBroadcastCommitFn is a narrow test seam for an impossible-today
+	// broadcaster contract violation. Nil production always calls the shared
+	// typed broadcaster; tests inject (nil, nil) to pin fail-closed handling.
+	syncBroadcastCommitFn func(context.Context, string, ed25519.PrivateKey, []byte) (*tx.CometCommitResult, error)
 	// legacyPipeStatusFallbackSem serializes the one compatibility path where a
 	// v11.13.0 peer ignores the compact named-lookup status preference and sends
 	// its historical full contact snapshot.

--- a/internal/federation/sync_broadcast_nil_result_test.go
+++ b/internal/federation/sync_broadcast_nil_result_test.go
@@ -1,7 +1,13 @@
 package federation
 
 import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/l33tdawg/sage/internal/tx"
 )
@@ -25,6 +31,64 @@ func TestClassifySyncBroadcastNilResultIsIndeterminateNotRetry(t *testing.T) {
 	}
 	if got != syncBcastIndeterminate {
 		t.Fatalf("nil result classified as %v, want syncBcastIndeterminate", got)
+	}
+}
+
+func TestNilSyncBroadcastResultFencesExactSignerAndBytes(t *testing.T) {
+	m, _ := newSyncTestManager(t, &scriptedComet{responses: []string{cometOK}})
+	// Keep reconciliation unable to manufacture proof while the assertions run.
+	m.cometRPC = "http://127.0.0.1:1"
+	var submittedKey ed25519.PrivateKey
+	var submittedBytes []byte
+	m.syncBroadcastCommitFn = func(
+		_ context.Context,
+		_ string,
+		key ed25519.PrivateKey,
+		encoded []byte,
+	) (*tx.CometCommitResult, error) {
+		submittedKey = append(ed25519.PrivateKey(nil), key...)
+		submittedBytes = append([]byte(nil), encoded...)
+		return nil, nil
+	}
+
+	item := syncItem("nil-result", "hr", "fence the exact impossible-result submission")
+	outcome, hash := m.broadcastSyncSubmit(syncMemoryID("chain-b", item.OriginMemoryID), &item)
+	if outcome != SyncOutcomeRetry || hash != "" {
+		t.Fatalf("nil result returned outcome=%q hash=%q, want retry with no hash", outcome, hash)
+	}
+	if !submittedKey.Equal(m.agentKey) {
+		t.Fatal("test seam did not receive the manager's exact signing key")
+	}
+	if len(submittedBytes) == 0 {
+		t.Fatal("test seam received no encoded transaction bytes")
+	}
+	wantHash := tx.CometTxHash(submittedBytes)
+	wantSigner := hex.EncodeToString(m.agentPub)
+	found := false
+	for _, held := range tx.FencedSigners() {
+		if held.SignerPubKeyHex == wantSigner {
+			found = true
+			if held.TxHash != strings.ToUpper(hex.EncodeToString(wantHash[:])) {
+				t.Fatalf("fenced tx hash=%q, want exact submitted bytes hash %X", held.TxHash, wantHash)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("nil result released signer %s instead of fencing it", wantSigner)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	allocated := false
+	err := tx.WithNonceLease(waitCtx, m.agentKey, func(uint64) error {
+		allocated = true
+		return nil
+	})
+	if allocated {
+		t.Fatal("same-key waiter allocated past the nil-result fence")
+	}
+	if !errors.Is(err, tx.ErrSignerFenced) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("same-key waiter got %v, want ErrSignerFenced with deadline cause", err)
 	}
 }
 

--- a/internal/federation/sync_broadcast_nil_result_test.go
+++ b/internal/federation/sync_broadcast_nil_result_test.go
@@ -1,0 +1,61 @@
+package federation
+
+import (
+	"testing"
+
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+// A3: a nil CometCommitResult must never be classified as a retryable
+// consensus verdict.
+//
+// This condition is unreachable today — BroadcastCometCommit never returns
+// (nil, nil), so the caller returns on the error before classification. The
+// test exists precisely because that is a property of ANOTHER package's
+// contract, not of this one. If the broadcaster ever gains a path that returns
+// no result and no error, the old behavior would have released the signing key
+// on an outcome nothing observed, silently. This fails instead.
+func TestClassifySyncBroadcastNilResultIsIndeterminateNotRetry(t *testing.T) {
+	got := classifySyncBroadcast(nil)
+
+	if got == syncBcastRetry {
+		t.Fatal("nil result classified as syncBcastRetry: the caller's default arm treats that " +
+			"as exact-hash-bound with the registration already retired, and releases the signer. " +
+			"A nil result satisfies none of those conditions.")
+	}
+	if got != syncBcastIndeterminate {
+		t.Fatalf("nil result classified as %v, want syncBcastIndeterminate", got)
+	}
+}
+
+// The classes that DO represent a real verdict must stay distinct from the
+// indeterminate one, so a future edit cannot quietly fold "no proof" into any
+// of them.
+func TestSyncBroadcastIndeterminateIsDistinctFromEveryVerdictClass(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  syncBcastClass
+	}{
+		{"committed", classifySyncBroadcast(&tx.CometCommitResult{})},
+		{"checktx nonce race", classifySyncBroadcast(&tx.CometCommitResult{CheckTxCode: 4})},
+		{"checktx other refusal", classifySyncBroadcast(&tx.CometCommitResult{CheckTxCode: 9})},
+		{"finalize nonce race", classifySyncBroadcast(&tx.CometCommitResult{TxResultCode: 4})},
+		{"finalize other refusal", classifySyncBroadcast(&tx.CometCommitResult{TxResultCode: 9})},
+		{"finalize duplicate", classifySyncBroadcast(&tx.CometCommitResult{
+			TxResultCode: 11, TxResultLog: "already reached terminal status",
+		})},
+		{"finalize scope reject", classifySyncBroadcast(&tx.CometCommitResult{
+			TxResultCode: 11, TxResultLog: "no write access to domain",
+		})},
+		{"finalize unrecognised code 11", classifySyncBroadcast(&tx.CometCommitResult{
+			TxResultCode: 11, TxResultLog: "something new nobody has seen",
+		})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got == syncBcastIndeterminate {
+				t.Fatalf("a non-nil hash-bound result was classified indeterminate, "+
+					"which now fences the signing key: %v", tc.got)
+			}
+		})
+	}
+}

--- a/internal/federation/sync_server.go
+++ b/internal/federation/sync_server.go
@@ -855,7 +855,11 @@ func (m *Manager) broadcastSyncSubmit(localID string, item *SyncItem) (string, s
 			if buildErr != nil {
 				return fmt.Errorf("build sync submit tx: %w", buildErr)
 			}
-			commitResult, broadcastErr := tx.BroadcastCometCommit(leaseCtx, m.cometRPC, signingKey, encoded)
+			broadcastCommit := tx.BroadcastCometCommit
+			if m.syncBroadcastCommitFn != nil {
+				broadcastCommit = m.syncBroadcastCommitFn
+			}
+			commitResult, broadcastErr := broadcastCommit(leaseCtx, m.cometRPC, signingKey, encoded)
 			if broadcastErr != nil {
 				m.logger.Warn().Err(broadcastErr).Str("local", localID).Msg("sync: submit broadcast failed")
 				// Every error return is ambiguous. The shared broadcaster leaves the
@@ -888,7 +892,7 @@ func (m *Manager) broadcastSyncSubmit(localID string, item *SyncItem) (string, s
 				// than releasing the signer on an outcome nothing observed.
 				// Returning here is the fail-CLOSED direction: the item stays
 				// retryable, but the key is held until the fate is proven.
-				return errSyncBroadcastNoResult
+				return tx.Indeterminate(errSyncBroadcastNoResult, encoded, tx.CometTxResolver(m.cometRPC))
 			default:
 				// Every result here is exact-hash-bound and its registration has
 				// already been retired, so an unrecognised consensus refusal remains

--- a/internal/federation/sync_server.go
+++ b/internal/federation/sync_server.go
@@ -882,6 +882,13 @@ func (m *Manager) broadcastSyncSubmit(localID string, item *SyncItem) (string, s
 				// bytes. The shared broadcaster already retired registration;
 				// leave the item retryable without fencing the signer.
 				result = SyncOutcomeRetry
+			case syncBcastIndeterminate:
+				// No verdict at all. Return an error so WithNonceLease fences
+				// these exact bytes off the still-live registration, rather
+				// than releasing the signer on an outcome nothing observed.
+				// Returning here is the fail-CLOSED direction: the item stays
+				// retryable, but the key is held until the fate is proven.
+				return errSyncBroadcastNoResult
 			default:
 				// Every result here is exact-hash-bound and its registration has
 				// already been retired, so an unrecognised consensus refusal remains
@@ -981,6 +988,12 @@ func syncStoredMemoryType(s string) string {
 }
 
 // Broadcast outcome classes for a sync admit.
+// errSyncBroadcastNoResult is returned when the broadcaster hands back neither
+// an error nor a result. It carries no server-controlled text by construction,
+// and it exists as a named value so the fence it raises is greppable rather
+// than anonymous.
+var errSyncBroadcastNoResult = errors.New("sync submit broadcast returned no result and no error")
+
 type syncBcastClass int
 
 const (
@@ -989,6 +1002,12 @@ const (
 	syncBcastScopeReject
 	syncBcastNonceRace
 	syncBcastRetry
+	// syncBcastIndeterminate is the class for a result this function cannot
+	// reason about at all. It exists so that "no proof" can never be spelled
+	// the same way as "proved retryable": every other class in this list is a
+	// statement about a hash-bound consensus verdict, and collapsing an absent
+	// result into one of them is the fail-open this classifier exists to refuse.
+	syncBcastIndeterminate
 )
 
 // classifySyncBroadcast maps a structurally complete, exact-hash-bound Comet
@@ -1002,7 +1021,22 @@ const (
 // reach this function and therefore fence the exact bytes.
 func classifySyncBroadcast(result *tx.CometCommitResult) syncBcastClass {
 	if result == nil {
-		return syncBcastRetry
+		// UNREACHABLE TODAY, AND DELIBERATELY NOT TRUSTED TO STAY THAT WAY.
+		// BroadcastCometCommit never returns (nil, nil): every nil result is
+		// paired with a non-nil error, which the caller returns before reaching
+		// here. But this classifier's entire job is refusing to infer a verdict
+		// it was not given, and a nil result is the purest case of having no
+		// verdict — the registration was never retired and the bytes may be in
+		// a mempool right now.
+		//
+		// It previously returned syncBcastRetry, which the caller's default arm
+		// treats as "exact-hash-bound, registration already retired, safe to
+		// retry without fencing". Every clause of that is false for a nil
+		// result, so a future change to the broadcaster's contract would have
+		// turned this into a silent fail-open that released the signer.
+		// Routing it to its own class makes that impossible without an explicit
+		// edit to the caller's switch.
+		return syncBcastIndeterminate
 	}
 	if result.CheckTxCode != 0 {
 		if result.CheckTxCode == 4 {

--- a/internal/federation/sync_server_test.go
+++ b/internal/federation/sync_server_test.go
@@ -810,7 +810,16 @@ func TestClassifySyncBroadcast(t *testing.T) {
 		result := &tx.CometCommitResult{TxResultCode: c.code, TxResultLog: c.log}
 		assert.Equal(t, c.want, classifySyncBroadcast(result), c.log)
 	}
-	assert.Equal(t, syncBcastRetry, classifySyncBroadcast(nil))
+	// A3 CHANGED THIS ASSERTION, deliberately. It previously required
+	// syncBcastRetry for a nil result, which pinned the defect in place: the
+	// caller's default arm treats syncBcastRetry as "exact-hash-bound, the
+	// registration was already retired, safe to release the signer", and a nil
+	// result satisfies none of those. The condition is unreachable today
+	// because BroadcastCometCommit never returns (nil, nil), but that is a
+	// guarantee owned by another package, and this classifier's job is to
+	// refuse to infer verdicts it was not given. See
+	// sync_broadcast_nil_result_test.go.
+	assert.Equal(t, syncBcastIndeterminate, classifySyncBroadcast(nil))
 	assert.Equal(t, syncBcastOK, classifySyncBroadcast(&tx.CometCommitResult{}))
 	assert.Equal(t, syncBcastNonceRace, classifySyncBroadcast(&tx.CometCommitResult{CheckTxCode: 4, CheckTxLog: "arbitrary"}))
 	assert.Equal(t, syncBcastRetry, classifySyncBroadcast(&tx.CometCommitResult{CheckTxCode: 11, CheckTxLog: "nonce too low"}),

--- a/internal/tx/comet_commit.go
+++ b/internal/tx/comet_commit.go
@@ -49,13 +49,74 @@ type strictCommitEnvelope struct {
 	} `json:"error"`
 }
 
+// indeterminateBroadcast returns the wrapper used for every outcome that
+// cannot prove where the transaction ended up.
+//
+// WHY THIS EXISTS AS A TYPE RATHER THAN A SIDE EFFECT. Registration goes live
+// one line before http.Do, so historically an unwrapped error still fenced:
+// WithNonceLease's registration backstop (nonce.go:402-413) picks up any live
+// registration when submit returns non-nil. That backstop is real and stays,
+// but it is POSITIONAL — it holds only because of where RegisterSubmittedTx
+// sits and because every caller propagates the error unchanged. Both are
+// assumptions a future edit can break silently, and trusting callers to
+// propagate is exactly what failed in the federation P0 this fence was built
+// for. Typing the error makes the guarantee structural: errors.Is(err,
+// ErrSubmitIndeterminate) is true at the point the ambiguity arises, whether or
+// not a registration happens to be live.
+//
+// WHY IT REFUSES THE SAME INPUTS AS RegisterSubmittedTx, EXACTLY. The guard
+// below mirrors nonce.go:480 in BOTH of its halves, and both halves are
+// load-bearing:
+//
+//   - len(encoded) == 0: Indeterminate would happily wrap zero bytes, but
+//     fenceSubmission then records no tx hash and no nonce, and reconciliation
+//     dead-ends on errNoEncodedTx forever. That is a fence that can never be
+//     proven and so is held for the life of the process. RegisterSubmittedTx
+//     documents this refusal in as many words — "a permanent hold bought with
+//     no evidence". Today an empty encode returns a bare error and nothing
+//     fences; typing it unconditionally would convert a harmless no-op into a
+//     permanent key outage.
+//
+//   - a key WithNonceLease would reject: such a key cannot hold a lease, so any
+//     broadcast made with it necessarily runs under a lease held by a DIFFERENT
+//     key. WithNonceLease's typed path fences the LEASE's key (nonce.go:401)
+//     using THESE bytes, so typing here would fence signer B over a transaction
+//     belonging to signer A. The registration backstop cannot do that, because
+//     it is keyed by the broadcasting pubkey. Typing unconditionally would swap
+//     a missing fence for a wrong-key fence, which is a new defect, not a fix.
+//
+// Keeping the two guards identical is what makes A1 purely additive: the set of
+// outcomes that fence is unchanged, and only the MECHANISM by which they fence
+// becomes typed rather than positional.
+//
+// The wrapped message is returned VERBATIM by indeterminateSubmit.Error(), so
+// no operator-visible text changes and no caller's existing classification of
+// that text breaks.
+func indeterminateBroadcast(signingKey ed25519.PrivateKey, encoded []byte, endpoint string) func(error) error {
+	// Mirror of RegisterSubmittedTx's guard (nonce.go:480). If these two ever
+	// diverge, one of the fence mechanisms starts covering inputs the other
+	// refuses — which is precisely the asymmetry A1 exists to remove.
+	if len(signingKey) != ed25519.PrivateKeySize || len(encoded) == 0 {
+		return func(err error) error { return err }
+	}
+	return func(err error) error {
+		return Indeterminate(err, encoded, CometTxResolver(endpoint))
+	}
+}
+
 // BroadcastCometCommit is the strict shared commit protocol for non-web
 // adopters. It MUST be called inside WithNonceLease for signingKey.
 //
-// Registration happens at the last boundary before http.Do. Any transport,
-// status, RPC, decode, shape, hash, or height failure therefore leaves the
-// registration live; WithNonceLease fences the exact bytes even if the caller
-// forgets to wrap the error. A hash-bound rejection explicitly clears it.
+// Every outcome that cannot prove the transaction's fate is returned wrapped as
+// a typed indeterminate error (see indeterminateBroadcast), so WithNonceLease
+// fences the exact bytes on the TYPE rather than on the caller having
+// propagated it unchanged. Registration still goes live at the last boundary
+// before http.Do and still acts as a second, independent backstop. A hash-bound
+// rejection explicitly clears it.
+//
+// The two pre-send failures — a request that could not be built — stay bare on
+// purpose: nothing reached a transport, so fencing there would take a signing
+// key out of service over a malformed endpoint string.
 func BroadcastCometCommit(ctx context.Context, cometRPC string, signingKey ed25519.PrivateKey, encoded []byte) (*CometCommitResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -64,52 +125,62 @@ func BroadcastCometCommit(ctx context.Context, cometRPC string, signingKey ed255
 	url := fmt.Sprintf("%s/broadcast_tx_commit?tx=0x%s", endpoint, hex.EncodeToString(encoded))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) // #nosec G107 -- configured local CometBFT RPC
 	if err != nil {
+		// Deliberately NOT indeterminate, and deliberately above the fence
+		// helper so it cannot become so by accident: this runs before
+		// RegisterSubmittedTx and before any dial, so nothing was handed to a
+		// transport. Typing it indeterminate would fence a signing key over a
+		// malformed endpoint string that never put a byte on the wire.
 		return nil, fmt.Errorf("broadcast tx commit: could not build request (%s)", classifyFenceCause(err))
 	}
+
+	// Everything below this line may have reached consensus. fence() marks that
+	// explicitly instead of relying on the live registration alone — see the
+	// function comment for why the positional guarantee was not enough.
+	fence := indeterminateBroadcast(signingKey, encoded, endpoint)
 
 	RegisterSubmittedTx(signingKey, encoded, CometTxResolver(endpoint))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("broadcast tx commit: %s", classifyFenceCause(err))
+		return nil, fence(fmt.Errorf("broadcast tx commit: %s", classifyFenceCause(err)))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("broadcast tx commit: unexpected status %s",
-			ScrubBroadcastText(resp.Status, encoded))
+		return nil, fence(fmt.Errorf("broadcast tx commit: unexpected status %s",
+			ScrubBroadcastText(resp.Status, encoded)))
 	}
 
 	limited := &io.LimitedReader{R: resp.Body, N: CometRPCMaxResponseBytes + 1}
 	decoder := json.NewDecoder(limited)
 	var envelope strictCommitEnvelope
 	if err := decoder.Decode(&envelope); err != nil {
-		return nil, fmt.Errorf("decode broadcast commit response: %s",
-			ScrubBroadcastText(err.Error(), encoded))
+		return nil, fence(fmt.Errorf("decode broadcast commit response: %s",
+			ScrubBroadcastText(err.Error(), encoded)))
 	}
 	if trailingErr := decoder.Decode(&struct{}{}); trailingErr == nil {
-		return nil, errors.New("decode broadcast commit response: multiple JSON values")
+		return nil, fence(errors.New("decode broadcast commit response: multiple JSON values"))
 	} else if !errors.Is(trailingErr, io.EOF) {
-		return nil, fmt.Errorf("decode broadcast commit response: trailing data: %s",
-			ScrubBroadcastText(trailingErr.Error(), encoded))
+		return nil, fence(fmt.Errorf("decode broadcast commit response: trailing data: %s",
+			ScrubBroadcastText(trailingErr.Error(), encoded)))
 	}
 	if limited.N <= 0 {
-		return nil, fmt.Errorf("broadcast commit response body exceeded %d bytes", CometRPCMaxResponseBytes)
+		return nil, fence(fmt.Errorf("broadcast commit response body exceeded %d bytes", CometRPCMaxResponseBytes))
 	}
 	if envelope.Error != nil {
 		message := ScrubBroadcastText(envelope.Error.Message, encoded)
 		data := ScrubBroadcastText(envelope.Error.Data, encoded)
 		if data != "" {
-			return nil, fmt.Errorf("broadcast error: %s: %s", message, data)
+			return nil, fence(fmt.Errorf("broadcast error: %s: %s", message, data))
 		}
-		return nil, fmt.Errorf("broadcast error: %s", message)
+		return nil, fence(fmt.Errorf("broadcast error: %s", message))
 	}
 	if envelope.Result == nil || envelope.Result.CheckTx == nil || envelope.Result.TxResult == nil ||
 		envelope.Result.CheckTx.Code == nil || envelope.Result.TxResult.Code == nil {
-		return nil, errors.New("broadcast commit response omitted result, check_tx, tx_result, or verdict code")
+		return nil, fence(errors.New("broadcast commit response omitted result, check_tx, tx_result, or verdict code"))
 	}
 
 	want := CometTxHash(encoded)
 	if !CometReportedHashMatches(envelope.Result.Hash, want) {
-		return nil, errors.New(cometHashMismatchDetail("broadcast commit", envelope.Result.Hash, want))
+		return nil, fence(errors.New(cometHashMismatchDetail("broadcast commit", envelope.Result.Hash, want)))
 	}
 	checkCode := *envelope.Result.CheckTx.Code
 	txCode := *envelope.Result.TxResult.Code
@@ -129,7 +200,12 @@ func BroadcastCometCommit(ctx context.Context, cometRPC string, signingKey ed255
 		return result, nil
 	}
 	if envelope.Result.Height <= 0 {
-		return nil, errors.New("broadcast commit response reported no committed height")
+		// The strongest indeterminate in this file, and the easiest to misread
+		// as a failure. Reaching here means CheckTx returned 0, which is
+		// positive proof the node ADMITTED these bytes to its mempool and will
+		// gossip them. The missing height says only that this response cannot
+		// name the block — not that no block will ever contain it.
+		return nil, fence(errors.New("broadcast commit response reported no committed height"))
 	}
 	if txCode != 0 {
 		ClearSubmittedTx(signingKey)
@@ -139,9 +215,13 @@ func BroadcastCometCommit(ctx context.Context, cometRPC string, signingKey ed255
 }
 
 // BroadcastCometSync applies the same on-wire registration, bounded
-// single-document decoding, hash binding, and scrubbing to
-// /broadcast_tx_sync. A bound CheckTx refusal is definitive and retires the
-// registration; every other failure remains live for WithNonceLease to fence.
+// single-document decoding, hash binding, scrubbing, and typed indeterminate
+// wrapping to /broadcast_tx_sync. A bound CheckTx refusal is definitive and
+// retires the registration; every other failure is returned as a typed
+// indeterminate error AND leaves the registration live for WithNonceLease.
+//
+// Note this returns admission, not commitment: a code-0 sync response proves
+// only that CheckTx accepted the bytes into the mempool.
 func BroadcastCometSync(ctx context.Context, cometRPC string, signingKey ed25519.PrivateKey, encoded []byte) (*CometSyncResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -150,17 +230,24 @@ func BroadcastCometSync(ctx context.Context, cometRPC string, signingKey ed25519
 	url := fmt.Sprintf("%s/broadcast_tx_sync?tx=0x%s", endpoint, hex.EncodeToString(encoded))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) // #nosec G107 -- configured local CometBFT RPC
 	if err != nil {
+		// Pre-registration, pre-dial: definitively not sent. See the matching
+		// comment in BroadcastCometCommit for why this one stays bare.
 		return nil, fmt.Errorf("broadcast tx sync: could not build request (%s)", classifyFenceCause(err))
 	}
+
+	fence := indeterminateBroadcast(signingKey, encoded, endpoint)
 
 	RegisterSubmittedTx(signingKey, encoded, CometTxResolver(endpoint))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("broadcast tx sync: %s", classifyFenceCause(err))
+		return nil, fence(fmt.Errorf("broadcast tx sync: %s", classifyFenceCause(err)))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("broadcast tx sync: unexpected status %s", ScrubBroadcastText(resp.Status, encoded))
+		// Load-bearing for sync in particular: CometBFT delivers mempool-level
+		// refusals as HTTP 500 + a JSON-RPC error envelope, so genuine node
+		// refusals leave through here rather than through a verdict code.
+		return nil, fence(fmt.Errorf("broadcast tx sync: unexpected status %s", ScrubBroadcastText(resp.Status, encoded)))
 	}
 
 	limited := &io.LimitedReader{R: resp.Body, N: CometRPCMaxResponseBytes + 1}
@@ -177,31 +264,31 @@ func BroadcastCometSync(ctx context.Context, cometRPC string, signingKey ed25519
 		} `json:"error"`
 	}
 	if err := decoder.Decode(&envelope); err != nil {
-		return nil, fmt.Errorf("decode broadcast sync response: %s", ScrubBroadcastText(err.Error(), encoded))
+		return nil, fence(fmt.Errorf("decode broadcast sync response: %s", ScrubBroadcastText(err.Error(), encoded)))
 	}
 	if trailingErr := decoder.Decode(&struct{}{}); trailingErr == nil {
-		return nil, errors.New("decode broadcast sync response: multiple JSON values")
+		return nil, fence(errors.New("decode broadcast sync response: multiple JSON values"))
 	} else if !errors.Is(trailingErr, io.EOF) {
-		return nil, fmt.Errorf("decode broadcast sync response: trailing data: %s",
-			ScrubBroadcastText(trailingErr.Error(), encoded))
+		return nil, fence(fmt.Errorf("decode broadcast sync response: trailing data: %s",
+			ScrubBroadcastText(trailingErr.Error(), encoded)))
 	}
 	if limited.N <= 0 {
-		return nil, fmt.Errorf("broadcast sync response body exceeded %d bytes", CometRPCMaxResponseBytes)
+		return nil, fence(fmt.Errorf("broadcast sync response body exceeded %d bytes", CometRPCMaxResponseBytes))
 	}
 	if envelope.Error != nil {
 		message := ScrubBroadcastText(envelope.Error.Message, encoded)
 		data := ScrubBroadcastText(envelope.Error.Data, encoded)
 		if data != "" {
-			return nil, fmt.Errorf("broadcast sync error: %s: %s", message, data)
+			return nil, fence(fmt.Errorf("broadcast sync error: %s: %s", message, data))
 		}
-		return nil, fmt.Errorf("broadcast sync error: %s", message)
+		return nil, fence(fmt.Errorf("broadcast sync error: %s", message))
 	}
 	if envelope.Result == nil || envelope.Result.Code == nil {
-		return nil, errors.New("broadcast sync response omitted result or CheckTx verdict code")
+		return nil, fence(errors.New("broadcast sync response omitted result or CheckTx verdict code"))
 	}
 	want := CometTxHash(encoded)
 	if !CometReportedHashMatches(envelope.Result.Hash, want) {
-		return nil, errors.New(cometHashMismatchDetail("broadcast sync", envelope.Result.Hash, want))
+		return nil, fence(errors.New(cometHashMismatchDetail("broadcast sync", envelope.Result.Hash, want)))
 	}
 	code := *envelope.Result.Code
 	log := ScrubBroadcastText(envelope.Result.Log, encoded)

--- a/internal/tx/comet_commit_indeterminate_test.go
+++ b/internal/tx/comet_commit_indeterminate_test.go
@@ -1,0 +1,364 @@
+package tx
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A1: every outcome of the shared broadcasters that cannot prove the
+// transaction's fate must be TYPED indeterminate, not merely non-nil.
+//
+// These tests exist because the pre-existing suite could not tell the
+// difference. TestSharedCometBroadcastersFenceMalformedOnWireResponse proves
+// end-to-end fencing for exactly ONE response shape and does it through the
+// registration backstop, so deleting the typed wrapper entirely would leave it
+// green. Asserting err != nil is not coverage of a classification.
+
+// indeterminateCommitCases are the commit-side responses that leave the
+// transaction's fate unknown. Each must fence.
+func indeterminateCommitCases(bound, valid string) []struct {
+	name   string
+	status int
+	body   string
+} {
+	return []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"transport-level non-200", 500, valid},
+		{"non-200 with empty body", 502, ``},
+		{"malformed json", 200, `{"result":`},
+		{"multiple json values", 200, valid + ` {}`},
+		{"trailing garbage", 200, valid + ` garbage`},
+		{"rpc error envelope with data", 200, `{"error":{"message":"boom","data":"detail"}}`},
+		{"rpc error envelope without data", 200, `{"error":{"message":"boom"}}`},
+		{"omitted result", 200, `{}`},
+		{"null result", 200, `{"result":null}`},
+		{"null check_tx", 200, `{"result":{"check_tx":null,"tx_result":{"code":0},"hash":"` + bound + `","height":"7"}}`},
+		{"null tx_result", 200, `{"result":{"check_tx":{"code":0},"tx_result":null,"hash":"` + bound + `","height":"7"}}`},
+		{"absent verdict code", 200, `{"result":{"check_tx":{},"tx_result":{"code":0},"hash":"` + bound + `","height":"7"}}`},
+		{"hash names another tx", 200, `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"AB12","height":"7"}}`},
+		{"empty hash", 200, `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"","height":"7"}}`},
+		// Admitted to the mempool (CheckTx 0) but no block named. The single
+		// most dangerous one to misread as a failure.
+		{"admitted but heightless", 200, `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"` + bound + `","height":"0"}}`},
+	}
+}
+
+func indeterminateSyncCases(bound, valid string) []struct {
+	name   string
+	status int
+	body   string
+} {
+	return []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"transport-level non-200", 500, valid},
+		{"non-200 with empty body", 502, ``},
+		{"malformed json", 200, `{"result":`},
+		{"multiple json values", 200, valid + ` {}`},
+		{"trailing garbage", 200, valid + ` garbage`},
+		{"rpc error envelope with data", 200, `{"error":{"message":"boom","data":"detail"}}`},
+		{"rpc error envelope without data", 200, `{"error":{"message":"boom"}}`},
+		{"omitted result", 200, `{}`},
+		{"null result", 200, `{"result":null}`},
+		{"absent verdict code", 200, `{"result":{"hash":"` + bound + `"}}`},
+		{"hash names another tx", 200, `{"result":{"code":0,"hash":"AB12"}}`},
+		{"empty hash", 200, `{"result":{"code":0,"hash":""}}`},
+	}
+}
+
+func TestSharedCometCommitTypesEveryIndeterminateOutcome(t *testing.T) {
+	encoded := []byte("a1-commit-indeterminate")
+	sum := CometTxHash(encoded)
+	bound := strings.ToUpper(hex.EncodeToString(sum[:]))
+	valid := `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"` + bound + `","height":"7"}}`
+
+	for _, tc := range indeterminateCommitCases(bound, valid) {
+		t.Run(tc.name, func(t *testing.T) {
+			rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			defer rpc.Close()
+
+			_, key, genErr := ed25519.GenerateKey(nil)
+			if genErr != nil {
+				t.Fatal(genErr)
+			}
+			got, err := BroadcastCometCommit(context.Background(), rpc.URL, key, encoded)
+			if got != nil {
+				t.Fatalf("indeterminate outcome returned a result: %+v", got)
+			}
+			if err == nil {
+				t.Fatal("indeterminate outcome returned nil error")
+			}
+			if !errors.Is(err, ErrSubmitIndeterminate) {
+				t.Fatalf("outcome is not TYPED indeterminate: %v\n"+
+					"a bare error here fences only while the registration happens to be live", err)
+			}
+		})
+	}
+}
+
+func TestSharedCometSyncTypesEveryIndeterminateOutcome(t *testing.T) {
+	encoded := []byte("a1-sync-indeterminate")
+	sum := CometTxHash(encoded)
+	bound := strings.ToUpper(hex.EncodeToString(sum[:]))
+	valid := `{"result":{"code":0,"hash":"` + bound + `"}}`
+
+	for _, tc := range indeterminateSyncCases(bound, valid) {
+		t.Run(tc.name, func(t *testing.T) {
+			rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			defer rpc.Close()
+
+			_, key, genErr := ed25519.GenerateKey(nil)
+			if genErr != nil {
+				t.Fatal(genErr)
+			}
+			got, err := BroadcastCometSync(context.Background(), rpc.URL, key, encoded)
+			if got != nil {
+				t.Fatalf("indeterminate outcome returned a result: %+v", got)
+			}
+			if err == nil {
+				t.Fatal("indeterminate outcome returned nil error")
+			}
+			if !errors.Is(err, ErrSubmitIndeterminate) {
+				t.Fatalf("outcome is not TYPED indeterminate: %v", err)
+			}
+		})
+	}
+}
+
+// The transport failure is the canonical fence case and cannot be produced by a
+// response body, so it gets its own test: point at a closed listener.
+func TestSharedCometBroadcastersTypeTransportFailure(t *testing.T) {
+	rpc := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	dead := rpc.URL
+	rpc.Close() // nothing is listening now
+
+	encoded := []byte("a1-transport-failure")
+	_, key, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, cErr := BroadcastCometCommit(context.Background(), dead, key, encoded); !errors.Is(cErr, ErrSubmitIndeterminate) {
+		t.Fatalf("commit transport failure not typed indeterminate: %v", cErr)
+	}
+	if _, sErr := BroadcastCometSync(context.Background(), dead, key, encoded); !errors.Is(sErr, ErrSubmitIndeterminate) {
+		t.Fatalf("sync transport failure not typed indeterminate: %v", sErr)
+	}
+}
+
+// A pre-send failure must NOT be typed. Fencing a signing key because an
+// endpoint string was malformed would take the key out of service over a
+// transaction that never reached a socket.
+func TestSharedCometBroadcastersDoNotTypePreSendFailures(t *testing.T) {
+	encoded := []byte("a1-pre-send")
+	_, key, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A control character makes http.NewRequestWithContext fail during URL
+	// parsing, which is the only pre-registration error path in either function.
+	badEndpoint := "http://cometbft\x7finvalid.local"
+
+	_, cErr := BroadcastCometCommit(context.Background(), badEndpoint, key, encoded)
+	if cErr == nil {
+		t.Fatal("malformed endpoint returned nil error")
+	}
+	if errors.Is(cErr, ErrSubmitIndeterminate) {
+		t.Fatalf("pre-send failure was typed indeterminate and would fence the key: %v", cErr)
+	}
+
+	_, sErr := BroadcastCometSync(context.Background(), badEndpoint, key, encoded)
+	if sErr == nil {
+		t.Fatal("malformed endpoint returned nil error")
+	}
+	if errors.Is(sErr, ErrSubmitIndeterminate) {
+		t.Fatalf("pre-send failure was typed indeterminate and would fence the key: %v", sErr)
+	}
+}
+
+// The typed wrapper must refuse EXACTLY the inputs RegisterSubmittedTx refuses
+// (nonce.go:480), and this test pins both halves of that guard. It is the
+// decision, not an implementation detail: getting either half wrong turns A1
+// from an additive hardening into a new defect.
+//
+//   - empty encoded: typing it would raise a fence carrying no hash and no
+//     nonce, which reconciliation can never prove, so the key would be held for
+//     the life of the process. Today it is a harmless bare error.
+//   - a key WithNonceLease would reject: such a key cannot hold its own lease,
+//     so the enclosing lease belongs to a DIFFERENT signer, and the typed path
+//     fences the LEASE's key. Typing here would fence signer B over signer A's
+//     transaction.
+//
+// In both cases the correct behavior is the status quo: a bare error, no fence.
+func TestIndeterminateWrapperRefusesExactlyWhatRegistrationRefuses(t *testing.T) {
+	rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"result":`) // undecodable => indeterminate shape
+	}))
+	defer rpc.Close()
+
+	_, goodKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		key     ed25519.PrivateKey
+		encoded []byte
+	}{
+		{"nil signing key", nil, []byte("a1-gate")},
+		{"short signing key", ed25519.PrivateKey([]byte{1, 2, 3}), []byte("a1-gate")},
+		{"empty encoded with a valid key", goodKey, nil},
+		{"zero-length encoded with a valid key", goodKey, []byte{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, cErr := BroadcastCometCommit(context.Background(), rpc.URL, tc.key, tc.encoded)
+			if cErr == nil {
+				t.Fatal("commit: expected an error")
+			}
+			if errors.Is(cErr, ErrSubmitIndeterminate) {
+				t.Fatalf("commit: wrapper typed an input RegisterSubmittedTx refuses to track, "+
+					"which raises a fence nothing can ever prove: %v", cErr)
+			}
+
+			_, sErr := BroadcastCometSync(context.Background(), rpc.URL, tc.key, tc.encoded)
+			if sErr == nil {
+				t.Fatal("sync: expected an error")
+			}
+			if errors.Is(sErr, ErrSubmitIndeterminate) {
+				t.Fatalf("sync: wrapper typed an input RegisterSubmittedTx refuses to track: %v", sErr)
+			}
+		})
+	}
+}
+
+// The guard above must stay bug-for-bug identical to RegisterSubmittedTx's.
+// If someone tightens or loosens one, this fails rather than letting the two
+// fence mechanisms cover different input sets.
+func TestIndeterminateWrapperGuardMatchesRegistrationGuard(t *testing.T) {
+	_, goodKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sentinel := errors.New("probe")
+
+	for _, tc := range []struct {
+		name      string
+		key       ed25519.PrivateKey
+		encoded   []byte
+		wantTyped bool
+	}{
+		{"valid key and bytes", goodKey, []byte("x"), true},
+		{"valid key, empty bytes", goodKey, nil, false},
+		{"nil key, valid bytes", nil, []byte("x"), false},
+		{"short key, valid bytes", ed25519.PrivateKey([]byte{9}), []byte("x"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// What the wrapper decides.
+			wrapped := indeterminateBroadcast(tc.key, tc.encoded, "http://127.0.0.1:1")(sentinel)
+			gotTyped := errors.Is(wrapped, ErrSubmitIndeterminate)
+
+			// What the registration decides, observed through its own behavior.
+			ClearSubmittedTx(tc.key)
+			RegisterSubmittedTx(tc.key, tc.encoded, nil)
+			gotRegistered := takeRegisteredSubmission(pubKeyOf(tc.key)) != nil
+
+			if gotTyped != tc.wantTyped {
+				t.Fatalf("wrapper typed=%v, want %v", gotTyped, tc.wantTyped)
+			}
+			if gotTyped != gotRegistered {
+				t.Fatalf("guards diverged: wrapper typed=%v but registration tracked=%v; "+
+					"the two fence mechanisms now cover different inputs", gotTyped, gotRegistered)
+			}
+		})
+	}
+}
+
+// pubKeyOf mirrors the key derivation takeRegisteredSubmission is keyed by,
+// without panicking on the short/nil keys this test deliberately feeds it.
+func pubKeyOf(sk ed25519.PrivateKey) string {
+	if len(sk) != ed25519.PrivateKeySize {
+		return ""
+	}
+	pub, ok := sk.Public().(ed25519.PublicKey)
+	if !ok {
+		return ""
+	}
+	return string(pub)
+}
+
+// Definitive verdicts must stay definitive. If wrapping leaked onto these, every
+// ordinary consensus rejection would fence the signer and turn a rejected
+// transaction into an outage for that key.
+func TestSharedCometBroadcastersDoNotTypeDefinitiveVerdicts(t *testing.T) {
+	encoded := []byte("a1-definitive")
+	sum := CometTxHash(encoded)
+	bound := strings.ToUpper(hex.EncodeToString(sum[:]))
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"CheckTx refusal", `{"result":{"check_tx":{"code":9},"tx_result":{"code":0},"hash":"` + bound + `","height":"0"}}`},
+		{"in-block FinalizeBlock refusal", `{"result":{"check_tx":{"code":0},"tx_result":{"code":9},"hash":"` + bound + `","height":"7"}}`},
+		{"committed", `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"` + bound + `","height":"7"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			defer rpc.Close()
+			_, key, genErr := ed25519.GenerateKey(nil)
+			if genErr != nil {
+				t.Fatal(genErr)
+			}
+			got, err := BroadcastCometCommit(context.Background(), rpc.URL, key, encoded)
+			if err != nil {
+				t.Fatalf("definitive verdict returned an error: %v", err)
+			}
+			if got == nil {
+				t.Fatal("definitive verdict returned no result")
+			}
+		})
+	}
+}
+
+// The typed wrapper must be invisible in the message. Several web handlers
+// surface submit's error text to operators verbatim, and WithNonceLease's
+// contract is that submit's error comes back undecorated.
+func TestIndeterminateWrapperPreservesOperatorVisibleText(t *testing.T) {
+	_, key, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inner := errors.New("broadcast tx commit: connection reset by peer")
+	wrapped := indeterminateBroadcast(key, []byte("bytes"), "http://127.0.0.1:1")(inner)
+
+	if wrapped.Error() != inner.Error() {
+		t.Fatalf("wrapper changed operator-visible text:\n got: %q\nwant: %q", wrapped.Error(), inner.Error())
+	}
+	if !errors.Is(wrapped, ErrSubmitIndeterminate) {
+		t.Fatal("wrapper did not carry the indeterminate sentinel")
+	}
+	if !errors.Is(wrapped, inner) {
+		t.Fatal("wrapper broke the error chain: errors.Is no longer finds the wrapped cause")
+	}
+}

--- a/web/comet_commit_decoder_drift_test.go
+++ b/web/comet_commit_decoder_drift_test.go
@@ -1,0 +1,979 @@
+package web
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/tx"
+)
+
+// A/B COMMIT-DECODER DRIFT CONTRACT
+//
+// Two independent decoders read the SAME /broadcast_tx_commit envelope:
+//
+//	A = tx.BroadcastCometCommit          (internal/tx/comet_commit.go)
+//	B = broadcastTxCommitWebContext      (web/rbac_signing.go)
+//
+// They are NOT redundant and must never be merged. A DESCRIBES what a node
+// said: a hash-bound non-zero verdict code comes back as a *value* and the
+// caller decides what it means. B returns a VERDICT that five handlers act on
+// directly: the same envelope comes back as a definitive error, and everything
+// short of proof comes back typed indeterminate so the signer fence engages.
+// That split is the whole reason both exist.
+//
+// What they DO share is the HTTP prologue — status, content bounds, JSON
+// framing, the JSON-RPC error envelope, structural completeness — and that
+// shared region drifted apart once already: web/ formatted the raw error
+// envelope while internal/tx scrubbed the identical surface, and the closed
+// signed-transaction leak came back at the second origin. Nothing in either
+// package's existing tests pins a single prologue message on either side
+// (internal/tx/comet_commit_test.go asserts only `err != nil`;
+// web/rbac_false_success_test.go asserts only `isIndeterminateCommitError`), so
+// a rewording on one side is invisible to CI today. This file is that pin.
+//
+// It has exactly two kinds of assertion, and the second is as load-bearing as
+// the first:
+//
+//  1. AGREEMENT. For the shapes both decoders classify identically today, the
+//     rendered message is pinned as a literal AND compared A-to-B. Rewording
+//     either side, or deleting a check from either side, fails here.
+//  2. RECORDED DIFFERENCE. For every shape where the two legitimately differ,
+//     BOTH strings are pinned as literals. Widening the gap fails (the changed
+//     literal). Silently CLOSING the gap also fails (the other literal, plus an
+//     explicit NotEqual). These rows are not bugs waiting to be fixed — they
+//     are the contract. If a production change deliberately converges a pair,
+//     the row must be updated in that same commit, which is precisely the
+//     review event this file exists to force.
+//
+// PACKAGE CHOICE. B is unexported, so a test that drives B through its real
+// entry point must live in package web. A is exported and web already depends
+// on internal/tx, so package web is the only place BOTH decoders can be driven
+// honestly, through their real entry points, with no re-implementation and no
+// widening of B's visibility. The cost is that `go test ./internal/tx` alone
+// does not run this file; a change to A is caught by `go test ./web`. That is
+// the right trade: exporting B, or copying either decoder's branch ladder into
+// a helper here, would make the test agree with a copy instead of with the code.
+//
+// NIL SIGNING KEY. Every call below passes a nil signing key. tx.Register-
+// SubmittedTx and tx.ClearSubmittedTx are no-ops for a key that is not
+// ed25519.PrivateKeySize (internal/tx/nonce.go:480, :527), so this file
+// exercises only the decode/classification path and leaves NOTHING in
+// internal/tx's process-global registration map — no fence is raised, so
+// fenceResolvingRPC's drain is neither needed nor appropriate here. That the
+// classifications actually engage the fence is already covered end to end by
+// web/rbac_false_success_test.go, web/signer_fence_surface_test.go and
+// internal/tx/comet_commit_test.go, and is deliberately not re-asserted here.
+// The same nil-key idiom is already used by both sides' delivery tests
+// (internal/tx/comet_commit_test.go:62, web/comet_submit_delivery_test.go:107).
+
+// commitDecoderOutcome is one wire response as seen by BOTH decoders. Their
+// return shapes differ on purpose (A hands back a *tx.CometCommitResult it
+// makes no judgement about; B hands back the three fields a handler reports),
+// so the outcome carries both rather than flattening them into a common shape
+// that would quietly assert they are the same kind of answer.
+type commitDecoderOutcome struct {
+	aResult *tx.CometCommitResult
+	aErr    error
+
+	bHash   string
+	bHeight int64
+	bLog    string
+	bErr    error
+}
+
+// driveBothCommitDecoders answers A and B from ONE stub, so the comparison is
+// against byte-identical wire input rather than two fixtures that merely look
+// alike. body receives the request because the bound-hash fixtures
+// (commit_commit_stub_test.go's commitEnvelope family) derive the hash from the
+// tx=0x bytes actually submitted, and both decoders send the same small-tx GET.
+//
+// contentType is set verbatim when non-empty; passing "" leaves Go to sniff,
+// which is a different case entirely and is exercised on its own below.
+func driveBothCommitDecoders(t *testing.T, signed []byte, status int, contentType string, body func(*http.Request) string) commitDecoderOutcome {
+	t.Helper()
+	rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+		}
+		_, _ = fmt.Fprint(w, body(r))
+	}))
+	t.Cleanup(rpc.Close)
+
+	var out commitDecoderOutcome
+	out.aResult, out.aErr = tx.BroadcastCometCommit(context.Background(), rpc.URL, nil, signed)
+	out.bHash, out.bHeight, out.bLog, out.bErr = broadcastTxCommitWebContext(
+		context.Background(), rpc.URL, nil, signed)
+	return out
+}
+
+// staticBody adapts a fixed body to driveBothCommitDecoders' request-aware
+// signature for the majority of rows that do not need the submitted bytes.
+func staticBody(body string) func(*http.Request) string {
+	return func(*http.Request) string { return body }
+}
+
+func commitDecoderErrText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// TestCometCommitDecoderDrift_SharedShapesStayByteIdentical pins the prologue
+// region where the two decoders are genuinely one contract expressed twice.
+//
+// Each row asserts the message TWICE over: as a literal (so rewording either
+// side fails, even if both are reworded together) and as an A==B equality (so
+// rewording exactly one side fails with a message that names the drift). A row
+// also fails if either decoder stops classifying the shape at all, because the
+// nil-error case renders as "" and cannot match the literal.
+//
+// The rows are ordered as the two ladders evaluate them, which is itself part
+// of the contract: status, then framing, then the RPC error envelope. Both
+// files check them in that order today, and a reordering that moved, say, the
+// oversize check above the trailing-data check would change which message a
+// body-with-both-faults produces on one side only.
+func TestCometCommitDecoderDrift_SharedShapesStayByteIdentical(t *testing.T) {
+	signed := []byte("a2a-prologue-contract")
+	signedHex := hex.EncodeToString(signed)
+	sum := tx.CometTxHash(signed)
+	bound := strings.ToUpper(hex.EncodeToString(sum[:]))
+	valid := `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"` + bound + `","height":"7"}}`
+
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{
+			// A NON-200 IS NEVER PROOF, on either side, no matter how good the
+			// body looks. Both decoders read resp.Status (not just the code)
+			// through the same scrubber, so the rendered message is identical
+			// down to the reason phrase. Only the Go TYPE differs — B wraps it
+			// in commitIndeterminateError — and that wrapper is deliberately
+			// message-invisible, which is exactly why a string pin is needed
+			// here rather than a type assertion.
+			name:   "non-200 with a parseable success body",
+			status: 500,
+			body:   valid,
+			want:   "broadcast tx commit: unexpected status 500 Internal Server Error",
+		},
+		{
+			// Single-document framing. A second value means something between
+			// the node and us is concatenating responses; neither decoder may
+			// adopt the first one.
+			name:   "second empty JSON document",
+			status: 200,
+			body:   valid + ` {}`,
+			want:   "decode broadcast commit response: multiple JSON values",
+		},
+		{
+			name:   "second complete Comet envelope",
+			status: 200,
+			body:   valid + ` ` + valid,
+			want:   "decode broadcast commit response: multiple JSON values",
+		},
+		{
+			// Both decode the TRAILER into &struct{}{} — the same target type
+			// — which is why even the substituted stdlib text matches. Change
+			// either target and this row diverges immediately.
+			name:   "trailing garbage after a complete envelope",
+			status: 200,
+			body:   valid + ` garbage`,
+			want:   "decode broadcast commit response: trailing data: invalid character 'g' looking for beginning of value",
+		},
+		{
+			name:   "trailing JSON array after a complete envelope",
+			status: 200,
+			body:   valid + ` [1,2]`,
+			want:   "decode broadcast commit response: trailing data: json: cannot unmarshal array into Go value of type struct {}",
+		},
+		{
+			// Truncation mid-document. Note this is ALSO how an oversized body
+			// cut off mid-document reports on both sides — the oversize branch
+			// is reachable only when the document parses cleanly and the reader
+			// still drained cap+1 bytes.
+			name:   "truncated document",
+			status: 200,
+			body:   `{"result":`,
+			want:   "decode broadcast commit response: unexpected EOF",
+		},
+		{
+			name:   "empty body",
+			status: 200,
+			body:   ``,
+			want:   "decode broadcast commit response: EOF",
+		},
+		{
+			// A proxy's plain-text error page. Both reach the decoder because
+			// text/plain is an accepted content type on A's side; the HTML
+			// variant is where the two ladders split and is asserted
+			// separately.
+			name:   "non-JSON prose body",
+			status: 200,
+			body:   `oops: gateway timeout`,
+			want:   "decode broadcast commit response: invalid character 'o' looking for beginning of value",
+		},
+		{
+			name:   "rpc error envelope with data",
+			status: 200,
+			body:   `{"error":{"message":"request failed","data":"untrusted"}}`,
+			want:   "broadcast error: request failed: untrusted",
+		},
+		{
+			name:   "rpc error envelope without data",
+			status: 200,
+			body:   `{"error":{"message":"request failed"}}`,
+			want:   "broadcast error: request failed",
+		},
+		{
+			// THE REGRESSION THIS WHOLE FILE DESCENDS FROM. Message and Data
+			// are remote-controlled: a reverse proxy in front of CometBFT can
+			// answer 200 with an envelope echoing the request line, which on
+			// this endpoint IS the entire signed transaction. web/ once
+			// formatted that verbatim while internal/tx scrubbed it. Both must
+			// redact, and must redact to the same text — an asymmetry here is
+			// how the closed leak returns at one origin only.
+			name:   "rpc error envelope echoing the signed transaction",
+			status: 200,
+			body:   `{"error":{"message":"GET /broadcast_tx_commit?tx=0x` + signedHex + `"}}`,
+			want:   "broadcast error: GET /broadcast_tx_commit?tx=0x[redacted signed tx]",
+		},
+		{
+			// The one place the two ladders are structurally different yet
+			// observably identical, so it is pinned rather than trusted: A
+			// branches on the POST-scrub data (comet_commit.go:285), B on the
+			// RAW data (rbac_signing.go:311). They agree only because no
+			// scrubbing pass can empty a non-empty string — the control-rune
+			// pass maps to a space rather than deleting. A U+0001 data field is
+			// the minimal witness: raw non-empty, scrubbed to a single space,
+			// so both must take the with-data branch. If scrubbing ever starts
+			// trimming, A silently drops to the no-data branch while B does
+			// not, and this row is the only thing that notices.
+			//
+			// The want ends in two spaces: one from the ": " separator, one
+			// from the scrubbed control rune.
+			name:   "rpc error envelope whose data scrubs to whitespace",
+			status: 200,
+			body:   `{"error":{"message":"boom","data":"\u0001"}}`,
+			want:   "broadcast error: boom:  ",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := driveBothCommitDecoders(t, signed, tc.status, "application/json", staticBody(tc.body))
+
+			require.Error(t, out.aErr, "internal/tx stopped classifying a shape web/ still refuses")
+			require.Error(t, out.bErr, "web/ stopped classifying a shape internal/tx still refuses")
+			assert.Nil(t, out.aResult, "a refused shape must hand internal/tx's caller no result")
+			assert.Empty(t, out.bHash, "a refused shape must hand web/'s caller no hash")
+			assert.Zero(t, out.bHeight, "a refused shape must hand web/'s caller no height")
+			assert.Empty(t, out.bLog, "a refused shape must hand web/'s caller no log")
+
+			assert.Equal(t, tc.want, out.aErr.Error(),
+				"internal/tx reworded a shared prologue message; the two decoders now describe "+
+					"the same wire response differently")
+			assert.Equal(t, tc.want, out.bErr.Error(),
+				"web/ reworded a shared prologue message; the two decoders now describe "+
+					"the same wire response differently")
+			assert.Equal(t, out.aErr.Error(), out.bErr.Error(),
+				"the shared prologue drifted: same bytes, two different messages")
+
+			// B types every prologue refusal indeterminate even with this nil-key
+			// fixture. Production A also returns a typed ErrSubmitIndeterminate
+			// when given a valid signing key; its exact RegisterSubmittedTx guard
+			// deliberately leaves nil-key calls bare. This cross-decoder test
+			// therefore asserts B's marker only. A's valid-key typing is pinned in
+			// internal/tx/comet_commit_indeterminate_test.go.
+			assert.True(t, isIndeterminateCommitError(out.bErr),
+				"a prologue refusal proves nothing about the transaction's fate and must stay "+
+					"indeterminate so the signer fence engages: %v", out.bErr)
+		})
+	}
+}
+
+// TestCometCommitDecoderDrift_RecordedStringAsymmetries pins the shapes both
+// decoders classify with DELIBERATELY different words.
+//
+// Read this as a ledger, not a defect list. Every pair here is intentional: B
+// speaks to an operator through a 502 body, A speaks to an adopter's fence
+// logic. What must not happen is silent movement — a reword that makes the two
+// converge is as much a signal as one that makes them diverge further, because
+// convergence usually means someone "fixed" one side by copying the other and
+// took its epistemics along with the text.
+//
+// Two rows here are structural rather than cosmetic and matter most:
+// "CheckTx rejection with the wrong hash" and "FinalizeBlock rejection with a
+// bound hash but no height" pin the single largest asymmetry between the two —
+// A binds the reported hash ONCE, up front, before any verdict code is read
+// (comet_commit.go:295), so an unbound envelope can never reach a code branch;
+// B computes `bound` and consults it separately inside each verdict branch
+// (rbac_signing.go:352). Moving A's gate below its code reads, or hoisting B's
+// above them, changes which message these rows produce.
+func TestCometCommitDecoderDrift_RecordedStringAsymmetries(t *testing.T) {
+	signed := []byte("a2a-prologue-contract")
+	sum := tx.CometTxHash(signed)
+	bound := strings.ToUpper(hex.EncodeToString(sum[:]))
+	wantPrefix := hex.EncodeToString(sum[:])[:8]
+
+	wrongSum := tx.CometTxHash([]byte("someone-else-entirely"))
+	wrongHash := strings.ToUpper(hex.EncodeToString(wrongSum[:]))
+	wrongPrefix := hex.EncodeToString(wrongSum[:])[:8]
+
+	valid := `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"` + bound + `","height":"7"}}`
+
+	for _, tc := range []struct {
+		name  string
+		body  string
+		wantA string
+		wantB string
+	}{
+		{
+			// Same trigger, same cap, same position in the ladder (after the
+			// trailing-data check on both sides); B appends a clause naming
+			// what it refuses to do. Recorded so that a change to the cap or to
+			// the phrasing on one side is visible.
+			name:  "oversized body",
+			body:  valid + strings.Repeat(" ", tx.CometRPCMaxResponseBytes+1),
+			wantA: fmt.Sprintf("broadcast commit response body exceeded %d bytes", tx.CometRPCMaxResponseBytes),
+			wantB: fmt.Sprintf("broadcast commit response body exceeded %d bytes; refusing to treat it "+
+				"as a CometBFT envelope", tx.CometRPCMaxResponseBytes),
+		},
+		{
+			// A's envelope models result as a POINTER, so "no result at all" is
+			// a condition it can name; B's is a VALUE struct, so it can only
+			// speak about the nested verdicts. A's message therefore lists
+			// `result` and B's does not — a difference in what each decoder is
+			// physically able to observe, not a difference in taste.
+			name:  "envelope missing both nested verdicts",
+			body:  `{"result":{"hash":"` + bound + `","height":"7"}}`,
+			wantA: "broadcast commit response omitted result, check_tx, tx_result, or verdict code",
+			wantB: "broadcast commit response omitted check_tx, tx_result, or verdict code: " +
+				"cannot prove this transaction's fate",
+		},
+		{
+			// The same pair for an explicitly null result. This row exists to
+			// record that B CANNOT distinguish `"result":null` from `{}` from a
+			// present-but-empty result: its value struct collapses all three
+			// into one branch. If B ever grows a *struct here, its message will
+			// change and this row will say so.
+			name:  "explicitly null result",
+			body:  `{"result":null}`,
+			wantA: "broadcast commit response omitted result, check_tx, tx_result, or verdict code",
+			wantB: "broadcast commit response omitted check_tx, tx_result, or verdict code: " +
+				"cannot prove this transaction's fate",
+		},
+		{
+			// The replayed-proxy success. Both refuse; A phrases it as "a
+			// different transaction" through the shared fence diagnostic
+			// (cometHashMismatchDetail), B as "does not match the transaction
+			// sent". Both render `want` and `got` through the SAME exported
+			// helpers, so the two eight-character prefixes must agree even
+			// though the sentences do not — that shared rendering is asserted
+			// implicitly by both literals carrying identical prefixes.
+			name: "success envelope about a different transaction",
+			body: `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"` + wrongHash + `","height":"7"}}`,
+			wantA: "broadcast commit answered about a different transaction (want " + wantPrefix +
+				"…, got " + wrongPrefix + "…): not proof of this one's fate",
+			wantB: "broadcast commit response hash does not match the transaction sent (want " +
+				wantPrefix + "…, got " + wrongPrefix + "…)",
+		},
+		{
+			// An absent hash is its own shape in B and folds into the single
+			// hash gate in A, where HexHashPrefix renders the empty value as
+			// "(no hex characters)". Two different decompositions of the same
+			// fact; both must keep refusing it.
+			name:  "success envelope carrying no hash",
+			body:  `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"","height":"7"}}`,
+			wantA: "broadcast commit answered about a different transaction (want " + wantPrefix + "…, got (no hex characters)…): not proof of this one's fate",
+			wantB: "broadcast commit response carried no transaction hash: cannot prove this transaction committed",
+		},
+		{
+			// SUB-DIVERGENCE IN THE `got` RENDERING, and the only row where the
+			// two prefixes legitimately differ. A passes the RAW reported hash
+			// to HexHashPrefix; B passes the already-NormalizeCometHash'd
+			// value, and NormalizeCometHash strips exactly one 0x prefix. So a
+			// doubly-prefixed hash renders as 0abcd123 for A (the surviving
+			// "0" of the second prefix, then the hex) and abcd1234 for B.
+			//
+			// Recorded rather than fixed: both are honest hex-filtered prefixes
+			// of remote text, neither is used for comparison (the binding
+			// predicate is shared and normalizes identically on both sides),
+			// and pinning it is how a future change to either the normalizer or
+			// to which value gets handed to the renderer becomes visible.
+			name:  "doubly 0x-prefixed hash renders differently on each side",
+			body:  `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"0x0xABCD1234","height":"7"}}`,
+			wantA: "broadcast commit answered about a different transaction (want " + wantPrefix + "…, got 0abcd123…): not proof of this one's fate",
+			wantB: "broadcast commit response hash does not match the transaction sent (want " + wantPrefix + "…, got abcd1234…)",
+		},
+		{
+			// Bound hash, zero codes, no block. Same refusal, different words;
+			// B's names what it cannot prove because its string reaches an
+			// operator.
+			name:  "bound success envelope at height zero",
+			body:  `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"` + bound + `","height":"0"}}`,
+			wantA: "broadcast commit response reported no committed height",
+			wantB: "broadcast commit response reported no block height: cannot prove this transaction committed",
+		},
+		{
+			// STRUCTURAL. A's hash gate runs before any code is read, so this
+			// replayed CheckTx refusal is refused as a hash mismatch and A never
+			// learns there was a rejection in it at all. B reaches its CheckTx
+			// branch first and refuses it there, with a message that names the
+			// rejection. Same safety outcome by two different routes — and the
+			// route is the thing being pinned. If A's gate ever moved below the
+			// code reads, A would adopt someone else's refusal as definitive,
+			// clear the registration, and release the lease over bytes still in
+			// flight: the exact silent Code 4 loss both files exist to prevent.
+			name: "CheckTx rejection about a different transaction",
+			body: `{"result":{"check_tx":{"code":2,"log":"unauthorized"},"tx_result":{"code":0},"hash":"` + wrongHash + `","height":"0"}}`,
+			wantA: "broadcast commit answered about a different transaction (want " + wantPrefix +
+				"…, got " + wrongPrefix + "…): not proof of this one's fate",
+			wantB: "broadcast commit response reported a CheckTx rejection for a different transaction (want " +
+				wantPrefix + "…, got " + wrongPrefix + "…): not proof of this one's fate",
+		},
+		{
+			// STRUCTURAL, the other direction. Bound hash, so A gets past its
+			// gate, sees checkCode == 0, and refuses on the missing height with
+			// its generic no-height message — it never reaches the FinalizeBlock
+			// code. B folds the binding and the height into one predicate
+			// inside the FinalizeBlock branch and reports both facts. A
+			// FinalizeBlock verdict IS inclusion in a block, so height 0 is a
+			// shape no real node produces; both must refuse it, and each does so
+			// from a different position in its ladder.
+			name:  "FinalizeBlock rejection with a bound hash but no block height",
+			body:  `{"result":{"check_tx":{"code":0},"tx_result":{"code":5,"log":"refused"},"hash":"` + bound + `","height":"0"}}`,
+			wantA: "broadcast commit response reported no committed height",
+			wantB: "broadcast commit response reported a FinalizeBlock rejection that is not bound to this " +
+				"transaction (hash match true, height 0): not proof of its fate",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := driveBothCommitDecoders(t, signed, http.StatusOK, "application/json", staticBody(tc.body))
+
+			require.Error(t, out.aErr, "internal/tx stopped refusing a shape it must still refuse")
+			require.Error(t, out.bErr, "web/ stopped refusing a shape it must still refuse")
+			assert.Nil(t, out.aResult)
+			assert.Empty(t, out.bHash)
+			assert.Zero(t, out.bHeight)
+
+			assert.Equal(t, tc.wantA, out.aErr.Error(),
+				"internal/tx's half of a RECORDED difference moved. If this was intentional, update "+
+					"this row in the same commit; if it was a copy from web/, the two decoders are "+
+					"being merged and must not be")
+			assert.Equal(t, tc.wantB, out.bErr.Error(),
+				"web/'s half of a RECORDED difference moved. If this was intentional, update this row "+
+					"in the same commit; if it was a copy from internal/tx, the two decoders are being "+
+					"merged and must not be")
+			assert.NotEqual(t, out.aErr.Error(), out.bErr.Error(),
+				"these two messages are deliberately different — they became identical, which means "+
+					"one decoder's wording (and possibly its epistemics) was pulled into the other")
+
+			assert.True(t, isIndeterminateCommitError(out.bErr),
+				"an unproven commit must stay indeterminate on web/'s side so the fence engages: %v", out.bErr)
+		})
+	}
+}
+
+// TestCometCommitDecoderDrift_EnvelopeTypeDivergenceIsRecorded pins the drift
+// that lives in the STRUCT DEFINITIONS rather than in any branch: identical
+// bytes on the wire, and one decoder errors where the other succeeds.
+//
+//	A: Height tx.CometHeight  (JSON string OR number, rejects null)
+//	   Code   *uint32         (rejects negatives and >2^32-1 at decode)
+//	B: Height int64 `json:"height,string"` (JSON string ONLY, tolerates null)
+//	   Code   *int            (accepts both)
+//
+// None of these are currently reachable from a real CometBFT node, which always
+// quotes height and always reports codes in uint32 range. They are reachable
+// from a proxy, a mock, or a future node version — and the point of pinning
+// them is that the decoders' TOLERANCE for each other's inputs is a real
+// property that must not shift unnoticed. If someone "aligns" B's height tag to
+// accept numbers, the numeric row's wantB stops being an error and this test
+// says so; the fix is to decide whether A and B should converge here and record
+// it, not to let CI stay silent.
+func TestCometCommitDecoderDrift_EnvelopeTypeDivergenceIsRecorded(t *testing.T) {
+	signed := []byte("a2a-prologue-contract")
+	sum := tx.CometTxHash(signed)
+	bound := strings.ToUpper(hex.EncodeToString(sum[:]))
+
+	for _, tc := range []struct {
+		name string
+		body string
+		// wantAErr == "" means A must SUCCEED; wantAHeight is then checked.
+		wantAErr    string
+		wantAHeight int64
+		// wantBErr is always non-empty here: every row is a shape B refuses,
+		// though not always at the same stage as A.
+		wantBErr string
+		// bDefinitive marks the one row where B's refusal is a real consensus
+		// verdict rather than "we cannot tell" — it must NOT fence.
+		bDefinitive bool
+	}{
+		{
+			// A accepts an unquoted height because tx.CometHeight takes either
+			// encoding; B's ,string tag refuses it before any verdict is read.
+			// Not a defect on either side: A widened deliberately for adopters
+			// whose proxy re-serializes, B stayed narrow. It is a divergence in
+			// what counts as a well-formed envelope, so it is recorded.
+			name:        "unquoted numeric height",
+			body:        `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"` + bound + `","height":7}}`,
+			wantAErr:    "",
+			wantAHeight: 7,
+			wantBErr: "decode broadcast commit response: json: invalid use of ,string struct tag, " +
+				"trying to unmarshal unquoted value into int64",
+		},
+		{
+			// The mirror image, and the more interesting one: a null height is
+			// a DECODE failure for A and decodes cleanly to 0 for B, which then
+			// refuses it two branches later on the height check. Same final
+			// safety outcome, reached at completely different points in the
+			// ladder — which is why the messages are pinned rather than a
+			// shared "both errored" assertion.
+			name:     "explicitly null height",
+			body:     `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"` + bound + `","height":null}}`,
+			wantAErr: `decode broadcast commit response: decode Comet height "null": strconv.ParseInt: parsing "null": invalid syntax`,
+			wantBErr: "broadcast commit response reported no block height: cannot prove this transaction committed",
+		},
+		{
+			// THE SHARPEST ROW. A's *uint32 makes a negative code a decode
+			// failure — an unreadable answer, so production A returns a typed
+			// indeterminate error and leaves the registration live as an
+			// independent backstop. B's *int accepts -1 as a genuine rejection
+			// code and returns a DEFINITIVE error that retires the
+			// registration. Identical bytes, opposite consequences for the
+			// signing key.
+			//
+			// This is recorded, not reconciled, because the two are answering
+			// different questions: A is asked "is this a well-formed CometBFT
+			// envelope", B is asked "what do I tell the operator". But it is
+			// exactly the kind of asymmetry that should never move by accident,
+			// because tightening B here would turn ordinary rejections into
+			// fences and loosening A would let a malformed envelope through.
+			name:        "negative CheckTx code",
+			body:        `{"result":{"check_tx":{"code":-1,"log":"denied"},"tx_result":{"code":0},"hash":"` + bound + `","height":"7"}}`,
+			wantAErr:    "decode broadcast commit response: json: cannot unmarshal number -1 into Go struct field .result.check_tx.code of type uint32",
+			wantBErr:    "tx rejected in CheckTx (code -1): denied",
+			bDefinitive: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := driveBothCommitDecoders(t, signed, http.StatusOK, "application/json", staticBody(tc.body))
+
+			if tc.wantAErr == "" {
+				require.NoError(t, out.aErr,
+					"internal/tx stopped accepting an envelope encoding it deliberately tolerates")
+				require.NotNil(t, out.aResult)
+				assert.Equal(t, tc.wantAHeight, out.aResult.Height)
+				assert.Equal(t, bound, out.aResult.Hash,
+					"the returned hash must be the locally derived one, never the reported field")
+			} else {
+				require.Error(t, out.aErr,
+					"internal/tx started accepting an envelope encoding it deliberately refuses")
+				assert.Nil(t, out.aResult)
+				assert.Equal(t, tc.wantAErr, commitDecoderErrText(out.aErr),
+					"internal/tx's envelope tolerance changed; A and B now disagree differently about "+
+						"the same bytes than this row records")
+			}
+
+			require.Error(t, out.bErr, "web/ started accepting an envelope encoding it refuses today")
+			assert.Empty(t, out.bHash)
+			assert.Zero(t, out.bHeight)
+			assert.Equal(t, tc.wantBErr, commitDecoderErrText(out.bErr),
+				"web/'s envelope tolerance changed; A and B now disagree differently about the same "+
+					"bytes than this row records")
+
+			assert.Equal(t, !tc.bDefinitive, isIndeterminateCommitError(out.bErr),
+				"web/ changed whether this shape fences the signing key, which is a far larger change "+
+					"than the message it reports: %v", out.bErr)
+		})
+	}
+}
+
+// TestCometCommitDecoderDrift_ContentTypeValidationIsDecoderAOnly records the
+// single asymmetry that can flip the OUTCOME rather than just the wording.
+//
+// A calls validateCometJSONResponse (comet_commit.go:262): an empty
+// Content-Type passes for older proxies, application/json and text/plain pass,
+// and everything else — including an unparseable header — is refused before the
+// body is touched. B has no counterpart anywhere: `mime` is not imported by any
+// file in web/, and mime.ParseMediaType occurs exactly once in the repo.
+//
+// So for one class of response — an HTTP 200 carrying a perfectly valid,
+// hash-bound, positive-height commit envelope under a non-JSON Content-Type — A
+// errors and fences while B reports a SUCCESSFUL COMMIT. That is asserted here
+// literally, including B's success, because pretending otherwise would make the
+// test a wish rather than a record.
+//
+// If this test starts failing because B grew a content-type check, that is a
+// deliberate production change and this file must be updated in the same
+// commit. If it starts failing because A's check was removed or loosened, that
+// is a regression: A's gate is what stops an intermediary's HTML error page
+// served at 200 from being handed to a JSON decoder in the first place.
+func TestCometCommitDecoderDrift_ContentTypeValidationIsDecoderAOnly(t *testing.T) {
+	signed := []byte("a2a-prologue-contract")
+	sum := tx.CometTxHash(signed)
+	bound := strings.ToUpper(hex.EncodeToString(sum[:]))
+	valid := `{"result":{"check_tx":{"code":0},"tx_result":{"code":0},"hash":"` + bound + `","height":"7"}}`
+
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		body        string
+		wantAErr    string
+		// wantBErr == "" means B must return a SUCCESSFUL commit for these bytes.
+		wantBErr string
+	}{
+		{
+			// THE OUTCOME FLIP. Same bytes, same status: A refuses, B commits.
+			name:        "valid envelope served as text/html",
+			contentType: "text/html; charset=utf-8",
+			body:        valid,
+			wantAErr:    `broadcast tx commit: comet RPC returned non-JSON content type "text/html; charset=utf-8"`,
+			wantBErr:    "",
+		},
+		{
+			// An unparseable header is refused by A on the ParseMediaType error
+			// leg, not the media-type comparison. B never looks.
+			name:        "valid envelope served under an unparseable content type",
+			contentType: "application/json;;",
+			body:        valid,
+			wantAErr:    `broadcast tx commit: comet RPC returned non-JSON content type "application/json;;"`,
+			wantBErr:    "",
+		},
+		{
+			// The common case: an intermediary's HTML error page at 200. Both
+			// refuse — but as DIFFERENT SHAPES, which is the observable
+			// consequence of the missing gate. A never reads the body; B
+			// reports a JSON syntax error. Recorded so that a change to either
+			// ladder that made these converge is visible.
+			name:        "html error page served as text/html",
+			contentType: "text/html; charset=utf-8",
+			body:        `<html>oops</html>`,
+			wantAErr:    `broadcast tx commit: comet RPC returned non-JSON content type "text/html; charset=utf-8"`,
+			wantBErr:    "decode broadcast commit response: invalid character '<' looking for beginning of value",
+		},
+		{
+			// CONTROL ROW. With the header a real node sends, the gate is
+			// invisible and both decoders commit the same transaction. Without
+			// this row a change that made A refuse EVERYTHING would still pass
+			// the rows above.
+			name:        "valid envelope served as application/json",
+			contentType: "application/json",
+			body:        valid,
+			wantAErr:    "",
+			wantBErr:    "",
+		},
+		{
+			// Empty Content-Type is explicitly tolerated by A for older
+			// Comet/proxy deployments, so this must also commit on both sides.
+			// (Go's httptest sniffs a JSON body to text/plain when the handler
+			// sets nothing, which A also accepts — hence the header is cleared
+			// here by serving a body Go sniffs as text/plain either way; the
+			// assertion is that A does not refuse it.)
+			name:        "valid envelope with a sniffed content type",
+			contentType: "",
+			body:        valid,
+			wantAErr:    "",
+			wantBErr:    "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := driveBothCommitDecoders(t, signed, http.StatusOK, tc.contentType, staticBody(tc.body))
+
+			if tc.wantAErr == "" {
+				require.NoError(t, out.aErr, "internal/tx refused a content type it must accept")
+				require.NotNil(t, out.aResult)
+				assert.Equal(t, bound, out.aResult.Hash)
+				assert.Equal(t, int64(7), out.aResult.Height)
+			} else {
+				require.Error(t, out.aErr,
+					"internal/tx's content-type gate is gone; an intermediary's non-JSON page at 200 "+
+						"now reaches the JSON decoder")
+				assert.Nil(t, out.aResult)
+				assert.Equal(t, tc.wantAErr, out.aErr.Error())
+			}
+
+			if tc.wantBErr == "" {
+				require.NoError(t, out.bErr,
+					"web/ grew a content-type check. That may be the right change, but it closes a "+
+						"RECORDED gap between the two decoders and this row must be updated with it")
+				assert.Equal(t, bound, out.bHash)
+				assert.Equal(t, int64(7), out.bHeight)
+			} else {
+				require.Error(t, out.bErr)
+				assert.Equal(t, tc.wantBErr, out.bErr.Error())
+				assert.Empty(t, out.bHash)
+			}
+		})
+	}
+}
+
+// TestCometCommitDecoderDrift_TransportCauseVocabulariesStayDisjoint pins the
+// prologue's other recorded difference: both decoders classify a transport
+// failure by TYPE, in the same order, from the same shared transport
+// (tx.DoCometSubmission) — and then render the result through two vocabularies
+// that share no word.
+//
+//	classifyFenceCause  -> "timeout" | "canceled" | "transport" | "decode" | "rpc"
+//	commitTransportCause-> "timed out waiting for commit" | "the request was canceled" |
+//	                       "the connection to the node failed" | "the request to the node failed"
+//
+// This is deliberate and must stay: A's value is a typed fenceCause that drives
+// fence logic, B's is prose for an operator-facing 502. The danger is not the
+// difference, it is that both messages carry the IDENTICAL prefix
+// "broadcast tx commit: " that the non-200 shape also uses — so anything
+// downstream matching on that prefix cannot tell a status from a transport
+// failure, and a reword on one side is undetectable without a pin like this.
+//
+// Only the two deterministic buckets are driven here (deadline, cancel). The
+// "connection failed" bucket is exercised through the reset-before-headers
+// case; A's `decode` bucket has no counterpart in B at all and is unreachable
+// from Do in practice (net/http returns *url.Error, which satisfies net.Error,
+// and the net check runs first on both sides), so it is deliberately not
+// asserted — see the report accompanying this file.
+func TestCometCommitDecoderDrift_TransportCauseVocabulariesStayDisjoint(t *testing.T) {
+	signed := []byte("a2a-prologue-transport")
+
+	t.Run("expired deadline", func(t *testing.T) {
+		rpc := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done() // never answer; let the client's deadline decide
+		}))
+		t.Cleanup(rpc.Close)
+
+		ctxA, cancelA := context.WithTimeout(context.Background(), 75*time.Millisecond)
+		defer cancelA()
+		_, aErr := tx.BroadcastCometCommit(ctxA, rpc.URL, nil, signed)
+
+		ctxB, cancelB := context.WithTimeout(context.Background(), 75*time.Millisecond)
+		defer cancelB()
+		_, _, _, bErr := broadcastTxCommitWebContext(ctxB, rpc.URL, nil, signed)
+
+		require.Error(t, aErr)
+		require.Error(t, bErr)
+		assert.Equal(t, "broadcast tx commit: timeout", aErr.Error(),
+			"internal/tx's fence cause vocabulary moved; the fence records this category, not this text")
+		assert.Equal(t, "broadcast tx commit: timed out waiting for commit", bErr.Error(),
+			"web/'s operator-facing transport vocabulary moved")
+		assert.NotEqual(t, aErr.Error(), bErr.Error(),
+			"the two transport vocabularies are deliberately disjoint")
+		assert.True(t, isIndeterminateCommitError(bErr),
+			"a timed-out commit may already be in a block: indeterminate, so the fence holds")
+	})
+
+	t.Run("caller canceled", func(t *testing.T) {
+		rpc := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}))
+		t.Cleanup(rpc.Close)
+
+		// Canceled BEFORE the call, so Do fails immediately and both sides take
+		// the context.Canceled leg that precedes their net.Error check.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, aErr := tx.BroadcastCometCommit(ctx, rpc.URL, nil, signed)
+		_, _, _, bErr := broadcastTxCommitWebContext(ctx, rpc.URL, nil, signed)
+
+		require.Error(t, aErr)
+		require.Error(t, bErr)
+		assert.Equal(t, "broadcast tx commit: canceled", aErr.Error())
+		assert.Equal(t, "broadcast tx commit: the request was canceled", bErr.Error())
+		assert.NotEqual(t, aErr.Error(), bErr.Error())
+		assert.True(t, isIndeterminateCommitError(bErr),
+			"a closed browser tab is not proof the node refused the transaction")
+	})
+
+	t.Run("connection reset before response headers", func(t *testing.T) {
+		// Reuses web/comet_submit_delivery_test.go's raw HTTP/1.1 node, the one
+		// fault httptest cannot express: the request is read IN FULL and then
+		// the connection is reset before any status line. This is the most
+		// dangerous transport shape — the bytes are already at the node — and
+		// it is the bucket both decoders label most differently.
+		node := newKillableWebCometNode(t)
+		node.killTx.Store(hex.EncodeToString(signed))
+
+		_, aErr := tx.BroadcastCometCommit(context.Background(), node.url(), nil, signed)
+		_, _, _, bErr := broadcastTxCommitWebContext(context.Background(), node.url(), nil, signed)
+
+		require.Error(t, aErr, "a submission whose response never arrived reported success")
+		require.Error(t, bErr, "a submission whose response never arrived reported success")
+		assert.Equal(t, "broadcast tx commit: transport", aErr.Error())
+		assert.Equal(t, "broadcast tx commit: the connection to the node failed", bErr.Error())
+		assert.NotEqual(t, aErr.Error(), bErr.Error())
+		assert.True(t, isIndeterminateCommitError(bErr),
+			"the bytes reached the kernel; a broken connection is the case the fence exists for")
+
+		// Neither message may carry the request URL — which on this endpoint is
+		// the entire signed transaction. Both sides refuse %w here for exactly
+		// this reason, and this is the assertion that keeps it true when
+		// somebody "improves" the error by wrapping the cause.
+		for _, err := range []error{aErr, bErr} {
+			assert.NotContains(t, err.Error(), hex.EncodeToString(signed),
+				"the signed transaction leaked into a transport error")
+			assert.NotContains(t, err.Error(), "tx=0x",
+				"the broadcast URL leaked into a transport error")
+		}
+	})
+}
+
+// TestCometCommitDecoderDrift_SelfImposedDeadlineIsDecoderBOnly records that B
+// bounds its own wait and A does not.
+//
+// B applies rbacCommitTimeout() (60s default, SAGE_TX_COMMIT_TIMEOUT_MS) on top
+// of the caller's context, because a closed browser tab must not leave a server
+// goroutine parked. A takes the caller's context unmodified and its client sets
+// no Timeout at all, deliberately: broadcast_tx_commit legitimately blocks until
+// the transaction is in a block, and a client-level deadline there would cap it
+// silently for every adopter.
+//
+// The consequence, and the thing being pinned: B can MANUFACTURE the
+// DeadlineExceeded transport shape — and therefore a fence — on a response A is
+// still patiently waiting for. Giving A a default timeout, or removing B's,
+// would change which of the two fences first on a slow single-validator commit,
+// and neither change would be visible in any existing test.
+func TestCometCommitDecoderDrift_SelfImposedDeadlineIsDecoderBOnly(t *testing.T) {
+	t.Setenv("SAGE_TX_COMMIT_TIMEOUT_MS", "150")
+	signed := []byte("a2a-prologue-self-deadline")
+
+	rpc := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(rpc.Close)
+
+	// A is given a context with NO deadline. It must still be blocked when B has
+	// already given up.
+	aCtx, cancelA := context.WithCancel(context.Background())
+	aDone := make(chan error, 1)
+	go func() {
+		_, err := tx.BroadcastCometCommit(aCtx, rpc.URL, nil, signed)
+		aDone <- err
+	}()
+
+	_, _, _, bErr := broadcastTxCommitWebContext(context.Background(), rpc.URL, nil, signed)
+	require.Error(t, bErr, "web/'s self-imposed commit deadline no longer fires")
+	assert.Equal(t, "broadcast tx commit: timed out waiting for commit", bErr.Error(),
+		"web/ stopped bounding its own wait, or reworded the bucket it lands in")
+	assert.True(t, isIndeterminateCommitError(bErr),
+		"giving up waiting is not proof the node refused: indeterminate, so the fence holds")
+
+	select {
+	case err := <-aDone:
+		t.Fatalf("internal/tx returned %v while its caller's context was still live: it has acquired "+
+			"a deadline of its own, which silently caps broadcast_tx_commit for every adopter", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	cancelA()
+	select {
+	case <-aDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("internal/tx did not unblock after its caller's context was canceled")
+	}
+}
+
+// TestCometCommitDecoderDrift_VerdictContractsStayDeliberatelySplit is the
+// guard against the wrong fix.
+//
+// Everything above pins the region where the two decoders are one contract. This
+// pins the region where they are TWO, and where a well-meaning "let's share the
+// decoder" refactor would do real damage in either direction:
+//
+//   - Make A return an error for a hash-bound rejection and every adopter that
+//     reads a CheckTx code off the result loses it — A exists to DESCRIBE.
+//   - Make B return a value for one and the five handlers that dispatch on
+//     isIndeterminateCommitError silently start treating a consensus rejection
+//     as a success — B exists to VERDICT.
+//
+// The single point where they MUST agree is asserted last: on a real success,
+// both return the LOCALLY derived uppercase hash and the same height. Neither
+// echoes result.hash, so a proxy's formatting never reaches a caller.
+//
+// Fixtures come from web/comet_commit_stub_test.go's commitEnvelope family
+// rather than hand-rolled bodies: it derives the hash from the tx=0x bytes on
+// the request, exactly as a real node computes it locally on EVERY return,
+// including refusals. A placeholder hash here would fence instead of exercising
+// the verdict.
+func TestCometCommitDecoderDrift_VerdictContractsStayDeliberatelySplit(t *testing.T) {
+	signed := []byte("a2a-verdict-contract")
+	sum := tx.CometTxHash(signed)
+	bound := strings.ToUpper(hex.EncodeToString(sum[:]))
+
+	t.Run("hash-bound CheckTx rejection", func(t *testing.T) {
+		out := driveBothCommitDecoders(t, signed, http.StatusOK, "application/json",
+			func(r *http.Request) string { return commitEnvelope(r, 2, "unauthorized", 0, "", 0) })
+
+		// A DESCRIBES: no error, the codes handed to the caller verbatim. Note
+		// the height is 0 and A does not care — a CheckTx refusal never reached
+		// a block, and A's no-height check is reached only when checkCode == 0.
+		require.NoError(t, out.aErr,
+			"internal/tx turned a hash-bound CheckTx rejection into an error. That is web/'s "+
+				"contract, not A's: adopters read the code off the result")
+		require.NotNil(t, out.aResult)
+		assert.Equal(t, uint32(2), out.aResult.CheckTxCode)
+		assert.Equal(t, "unauthorized", out.aResult.CheckTxLog)
+		assert.Equal(t, bound, out.aResult.Hash)
+
+		// B VERDICTS: a definitive error the handlers may act on, explicitly NOT
+		// indeterminate — marking it so would fence the signing key on every
+		// ordinary validation failure.
+		require.Error(t, out.bErr,
+			"web/ stopped reporting a hash-bound CheckTx rejection as a failure; five handlers "+
+				"would now treat a refused transaction as applied")
+		assert.Equal(t, "tx rejected in CheckTx (code 2): unauthorized", out.bErr.Error())
+		assert.False(t, isIndeterminateCommitError(out.bErr),
+			"a bound rejection IS proof of this transaction's fate; fencing on it would trap the key")
+		assert.Empty(t, out.bHash)
+		assert.Zero(t, out.bHeight)
+	})
+
+	t.Run("hash-bound FinalizeBlock rejection in a block", func(t *testing.T) {
+		out := driveBothCommitDecoders(t, signed, http.StatusOK, "application/json",
+			func(r *http.Request) string { return commitEnvelope(r, 0, "", 5, "refused", 12) })
+
+		require.NoError(t, out.aErr,
+			"internal/tx turned a hash-bound in-block rejection into an error")
+		require.NotNil(t, out.aResult)
+		assert.Equal(t, uint32(5), out.aResult.TxResultCode)
+		assert.Equal(t, "refused", out.aResult.TxResultLog)
+		assert.Equal(t, int64(12), out.aResult.Height)
+
+		require.Error(t, out.bErr, "web/ stopped reporting an in-block rejection as a failure")
+		assert.Equal(t, "tx rejected in FinalizeBlock (code 5): refused", out.bErr.Error())
+		assert.False(t, isIndeterminateCommitError(out.bErr),
+			"an in-block rejection is fully decided; nothing is in flight to fence")
+	})
+
+	t.Run("full success is the one answer both must agree on", func(t *testing.T) {
+		out := driveBothCommitDecoders(t, signed, http.StatusOK, "application/json",
+			func(r *http.Request) string { return commitEnvelopeOK(r, 12, "applied") })
+
+		require.NoError(t, out.aErr)
+		require.NotNil(t, out.aResult)
+		require.NoError(t, out.bErr)
+
+		assert.Equal(t, bound, out.aResult.Hash)
+		assert.Equal(t, bound, out.bHash)
+		assert.Equal(t, out.aResult.Hash, out.bHash,
+			"the two decoders returned different hashes for the same committed transaction")
+		assert.Equal(t, out.aResult.Height, out.bHeight,
+			"the two decoders returned different heights for the same committed transaction")
+		assert.Equal(t, out.aResult.TxResultLog, out.bLog,
+			"both must hand back the SCRUBBED FinalizeBlock log; a committed transaction's log is "+
+				"exactly as remote-controlled as a failed one's")
+		assert.Equal(t, int64(12), out.bHeight)
+		assert.Equal(t, "applied", out.bLog)
+	})
+}


### PR DESCRIPTION
## Summary
- return typed indeterminate errors from shared Comet commit/sync broadcasters while preserving the live-registration backstop
- fail closed and fence exact signer bytes if federation sync ever observes an impossible nil commit result
- pin the deliberately shared and deliberately divergent commit decoder contracts across internal/tx and web

## Verification
- go test ./internal/tx ./internal/federation ./web ./cmd/sage-gui -count=1
- go test -race ./web -run '^TestCometCommitDecoderDrift_' -count=1
- go test -race ./internal/tx ./internal/federation -run 'Indeterminate|NilSyncBroadcast|SignerFence|Broadcast' -count=1
- go vet ./...
- gofmt -l api cmd internal web (clean)
- mutation: changing either decoder's shared multiple-JSON message independently fails the drift contract; both mutations restored

## Notes
- preserves frozen A1/A3 commit identities through merge commit 2e76160e
- no consensus application version or migration change
- full go test ./... reached one pre-existing internal/mcp background-teardown DB Closed panic; isolated internal/mcp rerun passed
- broad full-package -race exceeded Go's default 10m timeout in slow federation/web suites without a race report; focused changed-path race gates above pass