### PR TITLE
chore(release): prepare v11.18.9 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.9
+
+**Ambiguous CometBFT commit and sync outcomes are now typed at the shared
+broadcaster boundary.** Transport, status, RPC, decode, shape, hash-binding, and
+missing-height failures return `ErrSubmitIndeterminate` for valid signing keys,
+while the existing live-registration path remains an independent fence
+backstop. Pre-send request-construction failures remain definitive and do not
+fence a key over bytes that never reached a transport.
+
+**Federation sync now fails closed if its commit broadcaster ever violates its
+contract by returning neither a result nor an error.** The exact signer and
+encoded transaction remain fenced until reconciliation proves their fate,
+instead of releasing the key for a potentially in-flight transaction. A new
+cross-package decoder contract also pins the HTTP prologue shared by
+`internal/tx` and the CEREBRUM web path while recording their deliberate verdict
+and envelope-tolerance differences.
+
+This patch introduces no new consensus application version or state migration.
+The ceiling remains app-v26; **v11.18.9 introduces no app-v27**.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.9`. SDK 11.18.9.
+
 ## What's New in v11.18.8
 
 **CometBFT transaction submissions no longer permit Go's HTTP transport to
@@ -1685,7 +1707,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.8`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.9`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.8
+  version: 11.18.9
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.8-acceptance
+ARG VERSION=v11.18.9-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.8 federation Docker acceptance
+# v11.18.9 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.8-acceptance
+        VERSION: v11.18.9-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.8"
+version = "11.18.9"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.8"
+version = "11.18.9"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.8",
+  "version": "11.18.9",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.8/app-v26. -->
+<!-- Reconciled through SAGE v11.18.9/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.8 federation behavior. -->
+<!-- Verified against SAGE v11.18.9 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.8
+# sage-gui v11.18.9
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.8 advertises 32 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.9 advertises 32 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.8 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.9 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -31,13 +31,34 @@ security evidence precedence in federation diagnostics. The supported
 v11.18.8 transport seam prevents transparent HTTP redelivery across every
 fenced Comet submission path, preserves signer-fence restart diagnostics, and
 makes MCP reply polling recover from unsafe or unverifiable forward watermarks
-instead of reporting a false empty page. The supported consensus ceiling
-remains app-v26; **v11.18.8 does not introduce app-v27**.
+instead of reporting a false empty page. v11.18.9 types every ambiguous shared
+Comet commit or sync outcome as indeterminate, fails closed if federation sync
+ever receives neither a result nor an error, and pins the deliberate decoder
+differences between the shared transaction package and CEREBRUM. The supported
+consensus ceiling remains app-v26; **v11.18.9 does not introduce app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.9 patch
+
+Ambiguous CometBFT commit and sync outcomes are now typed at the shared
+broadcaster boundary. Transport, status, RPC, decode, shape, hash-binding, and
+missing-height failures return `ErrSubmitIndeterminate` for valid signing keys,
+while the existing live-registration path remains an independent fence
+backstop. Pre-send request-construction failures remain definitive because no
+bytes reached a transport.
+
+Federation sync now fails closed if its commit broadcaster violates its
+contract by returning neither a result nor an error. The exact signer and
+encoded transaction remain fenced until reconciliation proves their fate. A
+cross-package decoder contract pins the shared HTTP prologue while recording
+the deliberate verdict and envelope-tolerance differences between
+`internal/tx` and the CEREBRUM web path. This patch introduces no new consensus
+application version or state migration: app-v26 remains the ceiling and
+v11.18.9 does not introduce app-v27.
 
 ## v11.18.8 patch
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -99,6 +99,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.6 | Exact H and H/H+1 updater snapshot provenance/replay-boundary proof, bounded exact-generation federation Retry, and memory-reassign log hardening; no new app version; app-v26 remains the ceiling |
 | v11.18.7 | Bounded large-transaction Comet transport, independently enforced 1.2 MB app-v20 finalize limit, and separate 600,000-byte signed AgentRequest proof bound; deadlock-safe asynchronous federation route refresh; authenticated P2P-only trust-generation bootstrap recovery; security-first federation route diagnostics; no new app version; app-v26 remains the ceiling |
 | v11.18.8 | Non-reusing HTTP/1.1 seam across fenced Comet submissions, signer-fence-first restart diagnostics, unsafe MCP reply-watermark recovery, and post-send passive inbox snapshots; no new app version; app-v26 remains the ceiling |
+| v11.18.9 | Typed indeterminate Comet commit/sync outcomes, fail-closed federation nil-result fencing, and cross-package commit-decoder drift contracts; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.8. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.9. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -33,7 +33,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.8 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.9 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -203,7 +203,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.8)
+## Related docs (reconciled through v11.18.9)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.8.
+Status: implementation contract through SAGE v11.18.9.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.8 authorization layer is off-consensus and does not require
+The current v11.18.9 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.8 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.9 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.8/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.9/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.8. Legacy organization/federation sections retain
+Verified against SAGE v11.18.9. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.8. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.9. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.8**.
+and is **not in v11.18.9**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.8. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.9. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.8 code (2026-08-11). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.9 code (2026-08-12). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.8.
+Reconciled against internal/mcp for SAGE v11.18.9.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.8. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.9. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.8
+**Package:** `sage-agent-sdk` **Version:** 11.18.9
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.8. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.9. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.8 lineage implementation (2026-08-11). -->
+<!-- Verified against SAGE v11.18.9 lineage implementation (2026-08-12). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.8 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.9 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.8"
+version = "11.18.9"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.8"
+__version__ = "11.18.9"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.8",
+  "version": "11.18.9",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.8",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.9",
       "transport": {
         "type": "stdio"
       }

--- a/web/comet_commit_decoder_drift_test.go
+++ b/web/comet_commit_decoder_drift_test.go
@@ -977,3 +977,88 @@ func TestCometCommitDecoderDrift_VerdictContractsStayDeliberatelySplit(t *testin
 		assert.Equal(t, "applied", out.bLog)
 	})
 }
+
+// TestCometCommitDecoderDrift_RemoteLogsAreScrubbedByBoth pins the
+// ScrubBroadcastText call sites that carry node-supplied logs back to callers.
+// The other log fixtures in this file are scrub-invariant, so this witness
+// deliberately embeds the signed transaction in the shape a reverse proxy can
+// echo from a broadcast request line.
+func TestCometCommitDecoderDrift_RemoteLogsAreScrubbedByBoth(t *testing.T) {
+	signed := []byte("a2a-log-scrub-witness")
+	leakedHex := hex.EncodeToString(signed)
+	leak := "upstream refused: GET /broadcast_tx_commit?tx=0x" + leakedHex
+
+	assertNoLeak := func(t *testing.T, where, got string) {
+		t.Helper()
+		assert.NotContains(t, got, leakedHex,
+			where+" handed back a node-supplied log containing the signed transaction verbatim")
+		assert.NotContains(t, strings.ToUpper(got), strings.ToUpper(leakedHex),
+			where+" leaked the signed transaction in a different hex case")
+	}
+
+	t.Run("CheckTx refusal log", func(t *testing.T) {
+		out := driveBothCommitDecoders(t, signed, http.StatusOK, "application/json",
+			func(r *http.Request) string { return commitEnvelope(r, 2, leak, 0, "", 0) })
+
+		require.NoError(t, out.aErr)
+		require.NotNil(t, out.aResult)
+		assertNoLeak(t, "internal/tx CheckTxLog", out.aResult.CheckTxLog)
+
+		require.Error(t, out.bErr)
+		assertNoLeak(t, "web CheckTx refusal error", out.bErr.Error())
+	})
+
+	t.Run("FinalizeBlock refusal log", func(t *testing.T) {
+		out := driveBothCommitDecoders(t, signed, http.StatusOK, "application/json",
+			func(r *http.Request) string { return commitEnvelope(r, 0, "", 5, leak, 12) })
+
+		require.NoError(t, out.aErr)
+		require.NotNil(t, out.aResult)
+		assertNoLeak(t, "internal/tx TxResultLog", out.aResult.TxResultLog)
+
+		require.Error(t, out.bErr)
+		assertNoLeak(t, "web FinalizeBlock refusal error", out.bErr.Error())
+	})
+
+	t.Run("success log is exactly as remote-controlled as a failure log", func(t *testing.T) {
+		out := driveBothCommitDecoders(t, signed, http.StatusOK, "application/json",
+			func(r *http.Request) string { return commitEnvelopeOK(r, 12, leak) })
+
+		require.NoError(t, out.aErr)
+		require.NotNil(t, out.aResult)
+		require.NoError(t, out.bErr)
+		assertNoLeak(t, "internal/tx TxResultLog on success", out.aResult.TxResultLog)
+		assertNoLeak(t, "web success log", out.bLog)
+		assert.Equal(t, out.aResult.TxResultLog, out.bLog,
+			"the two decoders scrubbed the same node-supplied log differently")
+	})
+}
+
+// TestCometCommitDecoderDrift_AbsentContentTypeIsToleratedByA reaches the
+// backward-compatibility leg that an empty Header value cannot exercise: Go
+// otherwise sniffs the JSON body as text/plain. Decoder A deliberately accepts
+// a genuinely absent Content-Type while decoder B does not inspect the header.
+func TestCometCommitDecoderDrift_AbsentContentTypeIsToleratedByA(t *testing.T) {
+	signed := []byte("a2a-absent-content-type")
+	sum := tx.CometTxHash(signed)
+	bound := strings.ToUpper(hex.EncodeToString(sum[:]))
+
+	rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header()["Content-Type"] = nil
+		_, _ = fmt.Fprint(w, commitEnvelopeOK(r, 9, "applied"))
+	}))
+	t.Cleanup(rpc.Close)
+
+	resp, err := http.Get(rpc.URL) //nolint:noctx // probe: prove the header really is absent
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Empty(t, resp.Header.Get("Content-Type"),
+		"the test requires a response with no Content-Type; Go sniffed one instead")
+
+	aResult, aErr := tx.BroadcastCometCommit(context.Background(), rpc.URL, nil, signed)
+	require.NoError(t, aErr,
+		"internal/tx refused a response with no Content-Type despite its compatibility contract")
+	require.NotNil(t, aResult)
+	assert.Equal(t, bound, aResult.Hash)
+	assert.Equal(t, int64(9), aResult.Height)
+}

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.8';
+const SAGE_VERSION = 'v11.18.9';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
Prepares lockstep release metadata for SAGE v11.18.9 after the protected merge of PR #184.\n\n- bumps all 29 established release-facing metadata files from 11.18.8 to 11.18.9\n- documents typed indeterminate Comet commit/sync outcomes, fail-closed federation nil-result fencing, and the cross-package decoder drift contract\n- preserves app-v26 as the consensus ceiling; no app-v27 or state migration\n\nLocal verification:\n- version alignment, release workflow, and release recovery contracts: 50/50 green\n- JSON metadata parse: green\n- focused Go packages internal/tx, internal/federation, web, cmd/sage-gui: green\n- git diff --check: green