### PR TITLE
chore(release): prepare v11.18.10 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.10
+
+**Multiple MCP runtimes sharing one agent identity can no longer silently lose
+track of claimed messages.** Every MCP conversation now has an opaque claimant
+session ID. Atomic inbox claims persist that session in passive history, an
+explicit compare-and-swap handoff transfers work between runtimes, and a stale
+former owner is rejected if it tries to reply after ownership moved. Receive
+tokens remain replay-safe after a lost response, while legacy direct REST
+clients retain their existing agent-level compatibility path.
+
+**CEREBRUM can render the agent message bus as a live connectome inside the 3D
+brain.** Registered agents become domain-coloured neurons, directed channels
+become traffic-weighted synapses, and hub agents settle toward the core. The
+view consumes the existing RBAC-filtered synapse projection, drops ghost edges,
+and fences asynchronous mode switches so a slow memory response can never be
+displayed as connectome data.
+
+This patch introduces no new consensus application version or state migration.
+The ceiling remains app-v26; **v11.18.10 introduces no app-v27**.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.10`. SDK 11.18.10.
+
 ## What's New in v11.18.9
 
 **Ambiguous CometBFT commit and sync outcomes are now typed at the shared
@@ -1707,7 +1729,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.9`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.10`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ view consumes the existing RBAC-filtered synapse projection, drops ghost edges,
 and fences asynchronous mode switches so a slow memory response can never be
 displayed as connectome data.
 
+**Upgrade-watchdog submissions can no longer hold a signing key's nonce lease
+for the process lifetime when CometBFT wedges.** One bounded context now covers
+both lease acquisition and the broadcast. A deadline after submission remains
+a typed indeterminate outcome, so the exact signer and bytes stay fenced until
+their fate is reconciled; elapsed time never releases the key fail-open.
+
 This patch introduces no new consensus application version or state migration.
 The ceiling remains app-v26; **v11.18.10 introduces no app-v27**.
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.9
+  version: 11.18.10
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/cmd/sage-gui/upgrade_watchdog.go
+++ b/cmd/sage-gui/upgrade_watchdog.go
@@ -64,6 +64,13 @@ import (
 // 6<=7 ⇒ stop.)
 const upgradeTargetAppVersion uint64 = 6
 
+// upgradeWatchdogBroadcastTimeout bounds both acquisition of the per-key
+// nonce lease and the CometBFT submission performed while holding it. A
+// deadline that fires after submission begins is typed indeterminate by the
+// shared broadcaster, so the exact key and bytes remain fenced until their
+// fate is reconciled; elapsed time never releases the lease fail-open.
+const upgradeWatchdogBroadcastTimeout = 60 * time.Second
+
 // upgradeWatchdogConfig is everything the watchdog needs. Constructed
 // in runServe after the agent key is loaded and CometBFT is up.
 type upgradeWatchdogConfig struct {
@@ -73,6 +80,11 @@ type upgradeWatchdogConfig struct {
 	CometRPC      string             // e.g. "http://127.0.0.1:26657"
 	TickInterval  time.Duration      // default 30s if zero
 	Logger        zerolog.Logger
+
+	// BroadcastTimeout overrides upgradeWatchdogBroadcastTimeout in tests.
+	// Production leaves it zero so every watchdog submission uses the shared
+	// bounded default.
+	BroadcastTimeout time.Duration
 
 	// ResolveSigningKey returns the signing identity for this individual tx.
 	// The serving node wires this to consensus Root state plus the local key
@@ -115,6 +127,14 @@ type upgradeWatchdogConfig struct {
 	// watchdog goroutine before stores close. Nil keeps the historical detached
 	// goroutine behavior for short-lived tests and CLI callers.
 	StartWorker func(func())
+}
+
+func upgradeWatchdogBroadcastContext(ctx context.Context, cfg upgradeWatchdogConfig) (context.Context, context.CancelFunc) {
+	timeout := cfg.BroadcastTimeout
+	if timeout <= 0 {
+		timeout = upgradeWatchdogBroadcastTimeout
+	}
+	return context.WithTimeout(ctx, timeout)
 }
 
 func startUpgradeWorker(cfg upgradeWatchdogConfig, fn func()) {
@@ -356,7 +376,9 @@ func proposeForAutoAdvance(ctx context.Context, cfg upgradeWatchdogConfig, targe
 		return autoAdvanceTransient
 	}
 	var res *broadcastCommitResp
-	err = tx.WithNonceLease(ctx, signingKey, func(nonce uint64) error {
+	broadcastCtx, cancel := upgradeWatchdogBroadcastContext(ctx, cfg)
+	defer cancel()
+	err = tx.WithNonceLease(broadcastCtx, signingKey, func(nonce uint64) error {
 		ptx, buildErr := buildUpgradeProposeTxWithNonce(cfg, target, signingKey, nonce)
 		if buildErr != nil {
 			return fmt.Errorf("build propose tx: %w", buildErr)
@@ -365,7 +387,7 @@ func proposeForAutoAdvance(ctx context.Context, cfg upgradeWatchdogConfig, targe
 		if encodeErr != nil {
 			return fmt.Errorf("encode propose tx: %w", encodeErr)
 		}
-		res, buildErr = broadcastTxCommitWithSigner(ctx, cfg.CometRPC, signingKey, encoded)
+		res, buildErr = broadcastTxCommitWithSigner(broadcastCtx, cfg.CometRPC, signingKey, encoded)
 		return buildErr
 	})
 	if err != nil {
@@ -462,12 +484,14 @@ func ensureOperatorAdminRegistered(ctx context.Context, cfg upgradeWatchdogConfi
 		return
 	}
 	var res *broadcastCommitResp
-	err = tx.WithNonceLease(ctx, signingKey, func(nonce uint64) error {
+	broadcastCtx, cancel := upgradeWatchdogBroadcastContext(ctx, cfg)
+	defer cancel()
+	err = tx.WithNonceLease(broadcastCtx, signingKey, func(nonce uint64) error {
 		encoded, buildErr := buildOperatorRegisterTxWithNonce(signingKey, nonce)
 		if buildErr != nil {
 			return fmt.Errorf("build admin register tx: %w", buildErr)
 		}
-		res, buildErr = broadcastTxCommitWithSigner(ctx, cfg.CometRPC, signingKey, encoded)
+		res, buildErr = broadcastTxCommitWithSigner(broadcastCtx, cfg.CometRPC, signingKey, encoded)
 		return buildErr
 	})
 	if err != nil {
@@ -485,12 +509,14 @@ func sendHeartbeatTx(ctx context.Context, cfg upgradeWatchdogConfig) {
 	if err != nil {
 		return
 	}
-	_ = tx.WithNonceLease(ctx, signingKey, func(nonce uint64) error {
+	broadcastCtx, cancel := upgradeWatchdogBroadcastContext(ctx, cfg)
+	defer cancel()
+	_ = tx.WithNonceLease(broadcastCtx, signingKey, func(nonce uint64) error {
 		encoded, buildErr := buildOperatorRegisterTxWithNonce(signingKey, nonce)
 		if buildErr != nil {
 			return buildErr
 		}
-		_, buildErr = broadcastTxSync(ctx, cfg.CometRPC, signingKey, encoded)
+		_, buildErr = broadcastTxSync(broadcastCtx, cfg.CometRPC, signingKey, encoded)
 		return buildErr
 	})
 }
@@ -616,7 +642,9 @@ func maybeProposeUpgrade(ctx context.Context, cfg upgradeWatchdogConfig) bool {
 		return false
 	}
 	var res *broadcastSyncResp
-	err = tx.WithNonceLease(ctx, signingKey, func(nonce uint64) error {
+	broadcastCtx, cancel := upgradeWatchdogBroadcastContext(ctx, cfg)
+	defer cancel()
+	err = tx.WithNonceLease(broadcastCtx, signingKey, func(nonce uint64) error {
 		parsedTx, buildErr := buildUpgradeProposeTxWithNonce(
 			cfg, upgradeTargetAppVersion, signingKey, nonce,
 		)
@@ -627,7 +655,7 @@ func maybeProposeUpgrade(ctx context.Context, cfg upgradeWatchdogConfig) bool {
 		if encodeErr != nil {
 			return fmt.Errorf("encode propose tx: %w", encodeErr)
 		}
-		res, buildErr = broadcastTxSync(ctx, cfg.CometRPC, signingKey, encoded)
+		res, buildErr = broadcastTxSync(broadcastCtx, cfg.CometRPC, signingKey, encoded)
 		return buildErr
 	})
 	if err != nil {

--- a/cmd/sage-gui/upgrade_watchdog_deadline_source_test.go
+++ b/cmd/sage-gui/upgrade_watchdog_deadline_source_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUpgradeWatchdogBroadcastContextIsBounded(t *testing.T) {
+	ctx, cancel := upgradeWatchdogBroadcastContext(context.Background(), upgradeWatchdogConfig{
+		BroadcastTimeout: 20 * time.Millisecond,
+	})
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		if ctx.Err() != context.DeadlineExceeded {
+			t.Fatalf("broadcast context error = %v, want deadline exceeded", ctx.Err())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watchdog broadcast context did not enforce its deadline")
+	}
+}
+
+func TestEveryUpgradeWatchdogBroadcastSharesOneDeadlineAcrossLeaseAndRPC(t *testing.T) {
+	sourceBytes, err := os.ReadFile("upgrade_watchdog.go")
+	if err != nil {
+		t.Fatalf("read upgrade watchdog source: %v", err)
+	}
+	source := string(sourceBytes)
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "upgrade_watchdog.go", source, 0)
+	if err != nil {
+		t.Fatalf("parse upgrade watchdog source: %v", err)
+	}
+
+	wantBroadcast := map[string]string{
+		"proposeForAutoAdvance":         "broadcastTxCommitWithSigner(broadcastCtx,",
+		"ensureOperatorAdminRegistered": "broadcastTxCommitWithSigner(broadcastCtx,",
+		"sendHeartbeatTx":               "broadcastTxSync(broadcastCtx,",
+		"maybeProposeUpgrade":           "broadcastTxSync(broadcastCtx,",
+	}
+	seen := make(map[string]bool, len(wantBroadcast))
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		wantRPC, ok := wantBroadcast[fn.Name.Name]
+		if !ok {
+			continue
+		}
+		start := fset.Position(fn.Pos()).Offset
+		end := fset.Position(fn.End()).Offset
+		body := source[start:end]
+		for _, marker := range []string{
+			"broadcastCtx, cancel := upgradeWatchdogBroadcastContext(ctx, cfg)",
+			"defer cancel()",
+			"tx.WithNonceLease(broadcastCtx,",
+			wantRPC,
+		} {
+			if !strings.Contains(body, marker) {
+				t.Errorf("%s does not keep one bounded context across lease and RPC; missing %q", fn.Name.Name, marker)
+			}
+		}
+		seen[fn.Name.Name] = true
+	}
+	for name := range wantBroadcast {
+		if !seen[name] {
+			t.Errorf("did not inspect watchdog broadcaster %s", name)
+		}
+	}
+}

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.9-acceptance
+ARG VERSION=v11.18.10-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.9 federation Docker acceptance
+# v11.18.10 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.9-acceptance
+        VERSION: v11.18.10-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.9"
+version = "11.18.10"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.9"
+version = "11.18.10"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.9",
+  "version": "11.18.10",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.9/app-v26. -->
+<!-- Reconciled through SAGE v11.18.10/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.9 federation behavior. -->
+<!-- Verified against SAGE v11.18.10 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.9
+# sage-gui v11.18.10
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.9 advertises 32 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.10 advertises 32 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.9 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.10 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -35,12 +35,34 @@ instead of reporting a false empty page. v11.18.9 types every ambiguous shared
 Comet commit or sync outcome as indeterminate, fails closed if federation sync
 ever receives neither a result nor an error, and pins the deliberate decoder
 differences between the shared transaction package and CEREBRUM. The supported
-consensus ceiling remains app-v26; **v11.18.9 does not introduce app-v27**.
+v11.18.10 message control plane attributes every claim to an opaque MCP session,
+supports compare-and-swap ownership handoff, rejects replies from a stale former
+owner, and preserves passive recovery after a lost response. CEREBRUM also
+projects its RBAC-filtered agent channels as a traffic-weighted 3D connectome.
+The supported consensus ceiling remains app-v26; **v11.18.10 does not introduce
+app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.10 patch
+
+Canonical message claims now record an opaque claimant-session identity rather
+than only the shared agent identity. Concurrent runtimes still get exactly one
+claim winner; passive history exposes the winning session, an explicit atomic
+handoff compare-and-swaps ownership, and stale sessions cannot complete work
+after handoff. Receive-token replay and legacy direct-client compatibility are
+preserved.
+
+CEREBRUM adds an operator connectome mode backed by the existing
+`/v1/dashboard/network/synapses` projection. Agents render as neurons and
+directed message channels as traffic-weighted synapses, with both-endpoint RBAC
+filtering preserved. Mode requests are generation-fenced so slow or reordered
+responses cannot cross the memory/connectome boundary. This patch introduces
+no new consensus application version or state migration: app-v26 remains the
+ceiling and v11.18.10 does not introduce app-v27.
 
 ## v11.18.9 patch
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,6 +64,11 @@ responses cannot cross the memory/connectome boundary. This patch introduces
 no new consensus application version or state migration: app-v26 remains the
 ceiling and v11.18.10 does not introduce app-v27.
 
+The upgrade watchdog now applies one bounded context across nonce-lease
+acquisition and each of its four CometBFT broadcasts. Deadline expiry after a
+submission begins stays typed indeterminate and retains the exact signer/bytes
+fence; the lease is never released merely because time elapsed.
+
 ## v11.18.9 patch
 
 Ambiguous CometBFT commit and sync outcomes are now typed at the shared

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -99,6 +99,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.6 | Exact H and H/H+1 updater snapshot provenance/replay-boundary proof, bounded exact-generation federation Retry, and memory-reassign log hardening; no new app version; app-v26 remains the ceiling |
 | v11.18.7 | Bounded large-transaction Comet transport, independently enforced 1.2 MB app-v20 finalize limit, and separate 600,000-byte signed AgentRequest proof bound; deadlock-safe asynchronous federation route refresh; authenticated P2P-only trust-generation bootstrap recovery; security-first federation route diagnostics; no new app version; app-v26 remains the ceiling |
 | v11.18.8 | Non-reusing HTTP/1.1 seam across fenced Comet submissions, signer-fence-first restart diagnostics, unsafe MCP reply-watermark recovery, and post-send passive inbox snapshots; no new app version; app-v26 remains the ceiling |
+| v11.18.10 | Same-agent MCP claimant-session ownership and atomic handoff, stale-session reply rejection, passive recovery, and the CEREBRUM agent-connectome view; no new app version; app-v26 remains the ceiling |
 | v11.18.9 | Typed indeterminate Comet commit/sync outcomes, fail-closed federation nil-result fencing, and cross-package commit-decoder drift contracts; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -99,8 +99,8 @@ Use this to work out how far your chain has to climb.
 | v11.18.6 | Exact H and H/H+1 updater snapshot provenance/replay-boundary proof, bounded exact-generation federation Retry, and memory-reassign log hardening; no new app version; app-v26 remains the ceiling |
 | v11.18.7 | Bounded large-transaction Comet transport, independently enforced 1.2 MB app-v20 finalize limit, and separate 600,000-byte signed AgentRequest proof bound; deadlock-safe asynchronous federation route refresh; authenticated P2P-only trust-generation bootstrap recovery; security-first federation route diagnostics; no new app version; app-v26 remains the ceiling |
 | v11.18.8 | Non-reusing HTTP/1.1 seam across fenced Comet submissions, signer-fence-first restart diagnostics, unsafe MCP reply-watermark recovery, and post-send passive inbox snapshots; no new app version; app-v26 remains the ceiling |
-| v11.18.10 | Same-agent MCP claimant-session ownership and atomic handoff, stale-session reply rejection, passive recovery, and the CEREBRUM agent-connectome view; no new app version; app-v26 remains the ceiling |
 | v11.18.9 | Typed indeterminate Comet commit/sync outcomes, fail-closed federation nil-result fencing, and cross-package commit-decoder drift contracts; no new app version; app-v26 remains the ceiling |
+| v11.18.10 | Same-agent MCP claimant-session ownership and atomic handoff, stale-session reply rejection, passive recovery, and the CEREBRUM agent-connectome view; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -100,7 +100,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.7 | Bounded large-transaction Comet transport, independently enforced 1.2 MB app-v20 finalize limit, and separate 600,000-byte signed AgentRequest proof bound; deadlock-safe asynchronous federation route refresh; authenticated P2P-only trust-generation bootstrap recovery; security-first federation route diagnostics; no new app version; app-v26 remains the ceiling |
 | v11.18.8 | Non-reusing HTTP/1.1 seam across fenced Comet submissions, signer-fence-first restart diagnostics, unsafe MCP reply-watermark recovery, and post-send passive inbox snapshots; no new app version; app-v26 remains the ceiling |
 | v11.18.9 | Typed indeterminate Comet commit/sync outcomes, fail-closed federation nil-result fencing, and cross-package commit-decoder drift contracts; no new app version; app-v26 remains the ceiling |
-| v11.18.10 | Same-agent MCP claimant-session ownership and atomic handoff, stale-session reply rejection, passive recovery, and the CEREBRUM agent-connectome view; no new app version; app-v26 remains the ceiling |
+| v11.18.10 | Same-agent MCP claimant-session ownership and atomic handoff, stale-session reply rejection, passive recovery, the CEREBRUM agent-connectome view, and bounded upgrade-watchdog broadcasts that retain indeterminate signer fencing; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.9. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.10. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -33,7 +33,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.9 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.10 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -203,7 +203,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.9)
+## Related docs (reconciled through v11.18.10)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.9.
+Status: implementation contract through SAGE v11.18.10.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.9 authorization layer is off-consensus and does not require
+The current v11.18.10 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.9 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.10 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.9/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.10/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.9. Legacy organization/federation sections retain
+Verified against SAGE v11.18.10. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.9. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.10. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.9**.
+and is **not in v11.18.10**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.9. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.10. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.9 code (2026-08-12). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.10 code (2026-08-12). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.9.
+Reconciled against internal/mcp for SAGE v11.18.10.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.9. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.10. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.9
+**Package:** `sage-agent-sdk` **Version:** 11.18.10
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.9. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.10. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.9 lineage implementation (2026-08-12). -->
+<!-- Verified against SAGE v11.18.10 lineage implementation (2026-08-12). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -73,6 +73,22 @@ test('release-facing version metadata stays aligned', () => {
   }
 });
 
+test('upgrade release table stays in ascending semantic-version order', () => {
+  const releases = [...read('docs/UPGRADING.md').matchAll(/^\| v(\d+)\.(\d+)\.(\d+) \|/gm)]
+    .map((match) => match.slice(1).map(Number));
+  assert.ok(releases.length > 1, 'docs/UPGRADING.md is missing the release table');
+  for (let index = 1; index < releases.length; index += 1) {
+    const previous = releases[index - 1];
+    const current = releases[index];
+    assert.ok(
+      current[0] > previous[0]
+        || (current[0] === previous[0] && current[1] > previous[1])
+        || (current[0] === previous[0] && current[1] === previous[1] && current[2] > previous[2]),
+      `docs/UPGRADING.md release table is out of order: v${previous.join('.')} before v${current.join('.')}`,
+    );
+  }
+});
+
 test('v11.18 user, recovery, federation, and SDK guides stay aligned', () => {
   const architecture = read('docs/ARCHITECTURE.md');
   const roadmap = read('docs/ROADMAP.md');

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.9 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.10 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.9"
+version = "11.18.10"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.9"
+__version__ = "11.18.10"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.9",
+  "version": "11.18.10",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.9",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.10",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.9';
+const SAGE_VERSION = 'v11.18.10';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
## Release payload

- Ship the same-agent MCP coordination fix from #190: claimant-session ownership, exactly-one claim semantics, atomic handoff, stale-session reply rejection, passive recovery, and lost-response compatibility.
- Ship the CEREBRUM connectome work from #181 and #188: the RBAC-filtered synapse projection plus the 3D agent/message-bus view, including generation-fenced mode switching and ghost-edge defense.
- Ship #192's bounded upgrade-watchdog broadcasts: one deadline spans nonce-lease acquisition and RPC, while post-submission timeout remains typed indeterminate and fenced.
- Align all release-facing metadata, SDK/container/native-shell versions, and operator documentation at v11.18.10.

## Consensus and migration

- No new consensus application version.
- No state migration.
- app-v26 remains the supported ceiling; this release does not introduce app-v27.

## Verification

- Independent exact-head metadata review: GO.
- Release/version/recovery contract tests: 51/51.
- Frontend/static suite: 271/271.
- Focused Go and race gates: green.
- Full `cmd/sage-gui` plus watchdog/indeterminate fence race gates: green.
- Upgrade chronology regression is mutation-sensitive.

The release tag will be created only after this exact integrated head lands on protected `main` and all required checks pass.
