### PR TITLE
ci: checksum every Windows release executable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1185,7 +1185,9 @@ jobs:
           )
           while IFS= read -r executable; do
             checksum="${executable}.sha256"
-            test -f "${checksum}" && test ! -L "${checksum}" && test -s "${checksum}"
+            test -f "${checksum}"
+            test ! -L "${checksum}"
+            test -s "${checksum}"
             read -r published_hash published_name checksum_extra < "${checksum}"
             test -z "${checksum_extra:-}"
             test "${published_name}" = "$(basename "${executable}")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -855,7 +855,10 @@ jobs:
           cd dist/windows-amd64
           cp "SAGE-${RELEASE_TAG}-Windows-Setup.exe" "SAGE-Windows-Setup.exe"
           for file in "SAGE-${RELEASE_TAG}-Windows-Setup.exe" \
-                      "SAGE-Windows-Setup.exe"; do
+                      "SAGE-Windows-Setup.exe" \
+                      "sage-cli.exe" \
+                      "sage-gui.exe" \
+                      "sage-launcher.exe"; do
             sha256sum "${file}" > "${file}.sha256"
             sha256sum -c "${file}.sha256"
           done
@@ -1180,6 +1183,9 @@ jobs:
             cd staged/release-assets-goreleaser
             sha256sum -c checksums.txt
           )
+          while IFS= read -r executable; do
+            test -s "${executable}.sha256"
+          done < <(find staged/release-assets-windows -maxdepth 1 -type f -name '*.exe' -print | sort)
           while IFS= read -r checksum; do
             (
               cd "$(dirname "${checksum}")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1184,7 +1184,12 @@ jobs:
             sha256sum -c checksums.txt
           )
           while IFS= read -r executable; do
-            test -s "${executable}.sha256"
+            checksum="${executable}.sha256"
+            test -f "${checksum}" && test ! -L "${checksum}" && test -s "${checksum}"
+            read -r published_hash published_name checksum_extra < "${checksum}"
+            test -z "${checksum_extra:-}"
+            test "${published_name}" = "$(basename "${executable}")"
+            test "${published_hash}" = "$(sha256sum "${executable}" | awk '{print $1}')"
           done < <(find staged/release-assets-windows -maxdepth 1 -type f -name '*.exe' -print | sort)
           while IFS= read -r checksum; do
             (

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1066,7 +1066,10 @@ test('every published Windows executable has a verified SHA-256 sidecar', () => 
     /find staged\/release-assets-windows -maxdepth 1 -type f -name '\*\.exe' -print \| sort/,
   );
   assert.match(publication, /checksum="\$\{executable\}\.sha256"/);
-  assert.match(publication, /test -f "\$\{checksum\}" && test ! -L "\$\{checksum\}" && test -s "\$\{checksum\}"/);
+  assert.match(publication, /^\s+test -f "\$\{checksum\}"$/m);
+  assert.match(publication, /^\s+test ! -L "\$\{checksum\}"$/m);
+  assert.match(publication, /^\s+test -s "\$\{checksum\}"$/m);
+  assert.doesNotMatch(publication, /test -f "\$\{checksum\}"\s*&&/);
   assert.match(publication, /read -r published_hash published_name checksum_extra < "\$\{checksum\}"/);
   assert.match(publication, /test -z "\$\{checksum_extra:-\}"/);
   assert.match(publication, /test "\$\{published_name\}" = "\$\(basename "\$\{executable\}"\)"/);

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1042,6 +1042,32 @@ test('all private artifacts converge at one publication gate', () => {
   assert.match(job('publication-gate'), /remote != local/);
 });
 
+test('every published Windows executable has a verified SHA-256 sidecar', () => {
+  const windows = job('windows-exe');
+  for (const executable of [
+    'SAGE-${RELEASE_TAG}-Windows-Setup.exe',
+    'SAGE-Windows-Setup.exe',
+    'sage-cli.exe',
+    'sage-gui.exe',
+    'sage-launcher.exe',
+  ]) {
+    assert.match(
+      windows,
+      new RegExp(`"${executable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`),
+      `Windows staging must generate a checksum for ${executable}`,
+    );
+  }
+  assert.match(windows, /sha256sum "\$\{file\}" > "\$\{file\}\.sha256"/);
+  assert.match(windows, /sha256sum -c "\$\{file\}\.sha256"/);
+
+  const publication = job('publication-gate');
+  assert.match(
+    publication,
+    /find staged\/release-assets-windows -maxdepth 1 -type f -name '\*\.exe' -print \| sort/,
+  );
+  assert.match(publication, /test -s "\$\{executable\}\.sha256"/);
+});
+
 test('public mutations are serial, resumable, and downstream of the gate', () => {
   assertNeeds('stage-github-release', ['publication-gate', 'release-metadata']);
   assert.match(job('stage-github-release'), /gh release create/);

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1065,7 +1065,12 @@ test('every published Windows executable has a verified SHA-256 sidecar', () => 
     publication,
     /find staged\/release-assets-windows -maxdepth 1 -type f -name '\*\.exe' -print \| sort/,
   );
-  assert.match(publication, /test -s "\$\{executable\}\.sha256"/);
+  assert.match(publication, /checksum="\$\{executable\}\.sha256"/);
+  assert.match(publication, /test -f "\$\{checksum\}" && test ! -L "\$\{checksum\}" && test -s "\$\{checksum\}"/);
+  assert.match(publication, /read -r published_hash published_name checksum_extra < "\$\{checksum\}"/);
+  assert.match(publication, /test -z "\$\{checksum_extra:-\}"/);
+  assert.match(publication, /test "\$\{published_name\}" = "\$\(basename "\$\{executable\}"\)"/);
+  assert.match(publication, /test "\$\{published_hash\}" = "\$\(sha256sum "\$\{executable\}" \| awk '\{print \$1\}'\)"/);
 });
 
 test('public mutations are serial, resumable, and downstream of the gate', () => {

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1044,6 +1044,10 @@ test('all private artifacts converge at one publication gate', () => {
 
 test('every published Windows executable has a verified SHA-256 sidecar', () => {
   const windows = job('windows-exe');
+  const checksumLoopMatch = windows.match(/for file in ([\s\S]*?); do\n([\s\S]*?)\n\s+done/);
+  assert.ok(checksumLoopMatch, 'missing Windows executable checksum loop');
+  const checksumInputs = checksumLoopMatch[1];
+  const checksumBody = checksumLoopMatch[2];
   for (const executable of [
     'SAGE-${RELEASE_TAG}-Windows-Setup.exe',
     'SAGE-Windows-Setup.exe',
@@ -1052,13 +1056,18 @@ test('every published Windows executable has a verified SHA-256 sidecar', () => 
     'sage-launcher.exe',
   ]) {
     assert.match(
-      windows,
+      checksumInputs,
       new RegExp(`"${executable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`),
       `Windows staging must generate a checksum for ${executable}`,
     );
   }
-  assert.match(windows, /sha256sum "\$\{file\}" > "\$\{file\}\.sha256"/);
-  assert.match(windows, /sha256sum -c "\$\{file\}\.sha256"/);
+  assert.equal(
+    [...checksumInputs.matchAll(/"([^"\n]+\.exe)"/g)].length,
+    5,
+    'Windows checksum loop must contain exactly the five published executables',
+  );
+  assert.match(checksumBody, /sha256sum "\$\{file\}" > "\$\{file\}\.sha256"/);
+  assert.match(checksumBody, /sha256sum -c "\$\{file\}\.sha256"/);
 
   const publication = job('publication-gate');
   assert.match(


### PR DESCRIPTION
## What
- publish SHA-256 sidecars for `sage-cli.exe`, `sage-gui.exe`, and `sage-launcher.exe`
- retain sidecars for versioned and stable-name Windows installers
- fail the private publication gate when any staged Windows `.exe` lacks a sidecar
- pin the complete executable set and publication wiring with a source regression

## Why
The v11.18.10 post-public audit found these three bare Windows executables were the only release artifacts without published checksum coverage. The same gap existed in v11.18.8 and v11.18.9.

## Verification
- `npm test` — 272/272
- focused release workflow tests — 37/37
- `git diff --check`
- mutation: removing `sage-cli.exe` from checksum generation fails the new regression

Target: v11.18.11. This PR remains separate from issue #182 step 3 live connectome firing.