### PR TITLE
fix: suppress deactivated content gate warning

### DIFF
--- a/internal/abci/app.go
+++ b/internal/abci/app.go
@@ -2089,9 +2089,9 @@ type armContext struct{ app *SageApp }
 func (c armContext) RoleResolver() func(agentID string) string { return c.app.RoleResolver() }
 
 // ContentValidationEnforcementWarning returns a non-empty operator warning when
-// this node will NOT enforce the Layer-2 content-validation gate on a chain that
-// has already activated it — i.e. the app-v7 fork is live (appV7AppliedHeight > 0)
-// but no validator registry is compiled in. Such a node is internally consistent
+// this node will NOT enforce the Layer-2 content-validation gate while its
+// bounded consensus window is live — app-v7 is active, app-v14 has not yet
+// deactivated it, and no validator registry is compiled in. Such a node is internally consistent
 // and MUST stay bootable (a generic-only fleet is a valid deployment), so this is
 // an advisory, not a fatal guard: returning an error here would brick a healthy
 // app-v7 chain on restart.
@@ -2103,7 +2103,7 @@ func (c armContext) RoleResolver() func(agentID string) string { return c.app.Ro
 // so operators ensure every validator runs the same registry-wired build before
 // activating app-v7. Returns "" when there is nothing to warn about.
 func (app *SageApp) ContentValidationEnforcementWarning() string {
-	if app.appV7AppliedHeight > 0 && app.contentValidators == nil {
+	if app.appV7AppliedHeight > 0 && app.appV14AppliedHeight == 0 && app.contentValidators == nil {
 		return fmt.Sprintf(
 			"content-validation fork app-v7 is active at height %d but this node has no "+
 				"content-validator registry compiled in: it will NOT enforce the Layer-2 gate. "+

--- a/internal/abci/content_guard_test.go
+++ b/internal/abci/content_guard_test.go
@@ -8,30 +8,34 @@ import (
 )
 
 // TestContentValidationEnforcementWarning pins the non-fatal advisory: it returns
-// a warning ONLY when the app-v7 fork is active but no registry is compiled in
-// (this node won't enforce) — and stays empty (bootable, no noise) for every
-// other shape, including the default node and a correctly-wired enforcing node.
+// a warning ONLY while the app-v7 through app-v14 enforcement window is live
+// but no registry is compiled in (this node won't enforce) — and stays empty
+// after app-v14 deactivates the gate, including on inherited app-v26 chains.
 func TestContentValidationEnforcementWarning(t *testing.T) {
 	reg := contentvalidator.NewContentValidatorRegistry()
 
 	cases := []struct {
-		name        string
-		validators  *contentvalidator.ContentValidatorRegistry
-		appV7Height int64
-		wantWarn    bool
+		name         string
+		validators   *contentvalidator.ContentValidatorRegistry
+		appV7Height  int64
+		appV14Height int64
+		wantWarn     bool
 	}{
-		{"default: no fork, no registry", nil, 0, false},
+		{"default: no fork, no registry", nil, 0, 0, false},
 		// The flagged case: fork active but this node has no registry → won't
 		// enforce. Must warn, but (tested elsewhere) must NOT block boot.
-		{"app-v7 active, no registry warns", nil, 100, true},
-		{"app-v7 active, registry wired is silent", reg, 100, false},
-		{"no fork, registry wired is silent", reg, 0, false},
+		{"app-v7 active, no registry warns", nil, 100, 0, true},
+		{"app-v7 active, registry wired is silent", reg, 100, 0, false},
+		{"app-v14 deactivated, no registry is silent", nil, 100, 200, false},
+		{"app-v14 deactivated, registry wired is silent", reg, 100, 200, false},
+		{"no fork, registry wired is silent", reg, 0, 0, false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			app := &SageApp{}
 			app.appV7AppliedHeight = tc.appV7Height
+			app.appV14AppliedHeight = tc.appV14Height
 			app.SetContentValidators(tc.validators)
 
 			warn := app.ContentValidationEnforcementWarning()


### PR DESCRIPTION
## Summary

- suppress ContentValidationEnforcementWarning once app-v14 has deactivated the app-v7 content-validation gate
- retain the warning during the actual app-v7 through app-v14 enforcement window when no registry is compiled in
- add explicit lifecycle regression coverage for both registry and no-registry cases

## Why

An inherited app-v26 node running the official stock image correctly has no content-validator registry, but 11.18.10 can still print the old app-v7 divergence advisory. The actual submission predicate already disables the gate after app-v14, so this is a stale operational warning only: no active consensus or acceptance-path defect.

## Verification

- go test ./internal/abci -run TestContentValidationEnforcementWarning
- full go test ./internal/abci
- mutation proof: removing the app-v14 deactivation clause makes the new deactivated/no-registry case fail
- git diff --check