### PR TITLE
fix(cerebrum): key the local connectome on chain ids, not provider labels

### DIFF
--- a/internal/store/pipe_synapses.go
+++ b/internal/store/pipe_synapses.go
@@ -38,7 +38,7 @@ type PipeSynapse struct {
 // The %s slot carries an INDEXED BY hint. It is needed rather than decorative:
 // SAGE never runs ANALYZE or PRAGMA optimize, so sqlite_stat1 does not exist on
 // a production node, and without statistics the planner prefers a seek on
-// idx_pipe_to_provider (to_provider=”) — which matches nearly every local row —
+// idx_pipe_to_provider on an empty to_provider — which matches nearly every local row —
 // and then sorts through a temp b-tree. Measured on an unanalysed database the
 // hint is the difference between that and a covering index-order scan.
 const pipeSynapseAggregation = `
@@ -64,7 +64,7 @@ const pipeSynapseIndexHint = "INDEXED BY idx_pipe_synapse_local"
 // almost every real local edge: on a live node it returned 3 of 30 edges and
 // hid 359 of 363 local rows. source_chain_id/destination_chain_id are the
 // fields that actually denote a cross-chain row, and both are NOT NULL
-// DEFAULT ”, so the comparison has no NULL-semantics trap.
+// DEFAULT with an empty string, so the comparison has no NULL-semantics trap.
 func (s *SQLiteStore) GetPipeSynapses(ctx context.Context) ([]PipeSynapse, error) {
 	// migratePipeline creates indexes best-effort and discards the error, so the
 	// hint must not become a hard dependency: an INDEXED BY naming an absent

--- a/internal/store/pipe_synapses.go
+++ b/internal/store/pipe_synapses.go
@@ -45,7 +45,7 @@ const pipeSynapseAggregation = `
 	SELECT from_agent, to_agent, COUNT(*), MAX(created_at)
 	FROM pipeline_messages %s
 	WHERE from_agent != '' AND to_agent != ''
-	  AND from_provider = '' AND to_provider = ''
+	  AND source_chain_id = '' AND destination_chain_id = ''
 	GROUP BY from_agent, to_agent`
 
 const pipeSynapseIndexHint = "INDEXED BY idx_pipe_synapse_local"
@@ -53,8 +53,18 @@ const pipeSynapseIndexHint = "INDEXED BY idx_pipe_synapse_local"
 // GetPipeSynapses aggregates local agent-to-agent bus traffic into a directed
 // weighted adjacency list: one row per (from_agent, to_agent) pair with a
 // retained-message count and the most-recent timestamp. Federated (cross-chain)
-// rows — which carry a from_provider/to_provider or an empty local agent — are
-// excluded; this is the local connectome. Pure read; touches no consensus state.
+// rows are excluded; this is the local connectome. Pure read; touches no
+// consensus state.
+//
+// LOCALITY IS KEYED ON THE CHAIN IDS, NOT ON THE PROVIDER, and the distinction
+// is not cosmetic. from_provider/to_provider hold the AGENT'S PROVIDER LABEL —
+// SAGE_PROVIDER flows from the generated MCP launcher into agent registration
+// and is stamped onto every send — so "claude-code" or "codex" appears on
+// ordinary LOCAL traffic. Restricting on empty providers therefore excluded
+// almost every real local edge: on a live node it returned 3 of 30 edges and
+// hid 359 of 363 local rows. source_chain_id/destination_chain_id are the
+// fields that actually denote a cross-chain row, and both are NOT NULL
+// DEFAULT ”, so the comparison has no NULL-semantics trap.
 func (s *SQLiteStore) GetPipeSynapses(ctx context.Context) ([]PipeSynapse, error) {
 	// migratePipeline creates indexes best-effort and discards the error, so the
 	// hint must not become a hard dependency: an INDEXED BY naming an absent

--- a/internal/store/pipe_synapses_test.go
+++ b/internal/store/pipe_synapses_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -234,31 +235,119 @@ func TestGetPipeSynapsesStillExcludesCrossChainEdges(t *testing.T) {
 	require.Len(t, syn, 1, "exactly the local edge survives, got: %v", edges)
 }
 
-// TestPipeSynapseIndexIsRedefinedOnUpgrade covers the migration hazard rather
-// than the query. A node upgraded from v11.18.9 already has
-// idx_pipe_synapse_local under the OLD partial WHERE, and CREATE INDEX IF NOT
-// EXISTS is a no-op against an existing name. Without the explicit DROP the
-// stale index survives, SQLite declines to use it because its restriction no
-// longer matches the query, and the INDEXED BY hint quietly degrades to a scan
-// on a table that only grows.
-func TestPipeSynapseIndexIsRedefinedOnUpgrade(t *testing.T) {
+// TestCanonicalLocalSendReachesConnectome drives the PRODUCTION WRITER, not
+// InsertPipeline. The bug this file exists to prevent was never about how rows
+// are shaped by hand — it was about what SendLocalMessage actually persists for
+// a normally-installed agent, whose Provider is stamped from SAGE_PROVIDER and
+// arrives as "claude-code" or "codex". A test that inserts its own rows can
+// agree with a broken predicate indefinitely, which is exactly what the
+// original suite did.
+func TestCanonicalLocalSendReachesConnectome(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)
 
-	// Reproduce the v11.18.9 on-disk state exactly.
-	_, err := s.conn.ExecContext(ctx, `DROP INDEX IF EXISTS idx_pipe_synapse_local`)
+	now := time.Now().UTC()
+	// The exact shape the canonical path produces for an MCP agent: a provider
+	// label on the sender, no chain ids, no to_provider.
+	sent, replayed, err := s.SendLocalMessage(ctx, "idem-connectome-1", &PipelineMessage{
+		FromAgent:    "alice",
+		FromProvider: "claude-code",
+		ToAgent:      "bob",
+		Intent:       "work",
+		Payload:      "hi",
+		Status:       "pending",
+		CreatedAt:    now,
+		ExpiresAt:    now.Add(time.Hour),
+	})
 	require.NoError(t, err)
-	_, err = s.conn.ExecContext(ctx, `CREATE INDEX idx_pipe_synapse_local
+	require.False(t, replayed)
+	require.NotNil(t, sent)
+	require.Equal(t, "claude-code", sent.FromProvider,
+		"precondition: the canonical writer really does persist the provider label")
+
+	syn, err := s.GetPipeSynapses(ctx)
+	require.NoError(t, err)
+	require.Len(t, syn, 1, "a canonical local send must appear in the connectome, got: %v", syn)
+	require.Equal(t, "alice", syn[0].FromAgent)
+	require.Equal(t, "bob", syn[0].ToAgent)
+	require.Equal(t, int64(1), syn[0].Count)
+}
+
+// TestPipeSynapseIndexIsRedefinedAcrossRestarts covers the upgrade hazard the
+// way an upgrade actually happens: a persistent database is CLOSED and REOPENED
+// so the real open path runs the migrations. Calling migratePipeline directly
+// would prove only that the statement executes, not that a v11.18.9 database on
+// disk converges when the new binary opens it.
+//
+// The second reopen is not redundant. CREATE INDEX IF NOT EXISTS is a no-op
+// against an index already present under the same name, so an unconditional
+// DROP must be shown to be idempotent — a restart must not thrash the index or
+// leave it missing.
+func TestPipeSynapseIndexIsRedefinedAcrossRestarts(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upgrade.db")
+
+	indexDDL := func(s *SQLiteStore) string {
+		var ddl string
+		require.NoError(t, s.conn.QueryRowContext(ctx,
+			`SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_pipe_synapse_local'`).Scan(&ddl))
+		return ddl
+	}
+
+	// 1. Stand up a database and put it in the exact v11.18.9 on-disk state.
+	old, err := NewSQLiteStore(ctx, dbPath)
+	require.NoError(t, err)
+	_, err = old.conn.ExecContext(ctx, `DROP INDEX IF EXISTS idx_pipe_synapse_local`)
+	require.NoError(t, err)
+	_, err = old.conn.ExecContext(ctx, `CREATE INDEX idx_pipe_synapse_local
 		ON pipeline_messages(from_agent, to_agent, created_at)
 		WHERE from_agent != '' AND to_agent != '' AND from_provider = '' AND to_provider = ''`)
 	require.NoError(t, err)
+	require.Contains(t, indexDDL(old), "from_provider", "precondition: the stale index is on disk")
+	require.NoError(t, old.Close())
 
-	// Re-run the migration the way an upgrade does.
-	s.migratePipeline(ctx)
+	// 2. Reopen with the current code — this is the upgrade.
+	upgraded, err := NewSQLiteStore(ctx, dbPath)
+	require.NoError(t, err)
+	ddl := indexDDL(upgraded)
+	require.Contains(t, ddl, "source_chain_id", "the upgrade must redefine the index")
+	require.NotContains(t, ddl, "from_provider", "the stale provider restriction must not survive")
 
-	var ddl string
-	require.NoError(t, s.conn.QueryRowContext(ctx,
-		`SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_pipe_synapse_local'`).Scan(&ddl))
-	require.Contains(t, ddl, "source_chain_id", "the upgraded index must carry the new restriction")
-	require.NotContains(t, ddl, "from_provider", "the stale provider restriction must not survive the upgrade")
+	// The upgraded index must actually serve the query, not merely exist.
+	base := time.Now().UTC().Truncate(time.Second)
+	for i := 0; i < 200; i++ {
+		require.NoError(t, upgraded.InsertPipeline(ctx, &PipelineMessage{
+			PipeID:    fmt.Sprintf("up-%d", i),
+			FromAgent: fmt.Sprintf("agent-%d", i%7),
+			ToAgent:   fmt.Sprintf("peer-%d", i%5),
+			Payload:   "hi", Status: "pending",
+			CreatedAt: base, ExpiresAt: base.Add(time.Hour),
+		}))
+	}
+	rows, err := upgraded.conn.QueryContext(ctx,
+		"EXPLAIN QUERY PLAN "+fmt.Sprintf(pipeSynapseAggregation, pipeSynapseIndexHint))
+	require.NoError(t, err)
+	var plan string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		plan += detail + "\n"
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+	require.Contains(t, plan, "idx_pipe_synapse_local", "upgraded index must serve the query, plan:\n"+plan)
+	require.NotContains(t, plan, "TEMP B-TREE", "plan:\n"+plan)
+	require.NoError(t, upgraded.Close())
+
+	// 3. Restart again: the unconditional DROP must be idempotent.
+	restarted, err := NewSQLiteStore(ctx, dbPath)
+	require.NoError(t, err)
+	defer restarted.Close() //nolint:errcheck
+	ddl2 := indexDDL(restarted)
+	require.Equal(t, ddl, ddl2, "a second restart must leave the index definition unchanged")
+
+	syn, err := restarted.GetPipeSynapses(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, syn, "the connectome must still resolve after two restarts")
 }

--- a/internal/store/pipe_synapses_test.go
+++ b/internal/store/pipe_synapses_test.go
@@ -35,8 +35,15 @@ func TestGetPipeSynapses(t *testing.T) {
 	require.NoError(t, s.InsertPipeline(ctx, mk("p2", "alice", "bob", base.Add(time.Minute))))
 	require.NoError(t, s.InsertPipeline(ctx, mk("p3", "alice", "bob", base.Add(2*time.Minute))))
 	require.NoError(t, s.InsertPipeline(ctx, mk("p4", "bob", "alice", base)))
+	// A cross-chain row as the FEDERATED SEND PATH ACTUALLY WRITES ONE. This
+	// fixture previously set ToProvider="other-chain", which production never
+	// does: api/rest/pipe_handler.go:548-549 CLEARS ToProvider and sets
+	// DestinationChainID on the federated branch. Modelling federation with a
+	// provider label made this test agree with a predicate that was wrong in
+	// both directions — it hid local provider-labelled edges, and it would have
+	// admitted real federated rows, whose providers are empty.
 	fed := mk("p5", "alice", "remote", base)
-	fed.ToProvider = "other-chain" // cross-chain → not part of the local connectome
+	fed.DestinationChainID = "sage-personal-otherchain"
 	require.NoError(t, s.InsertPipeline(ctx, fed))
 
 	syn, err := s.GetPipeSynapses(ctx)
@@ -138,4 +145,120 @@ func TestGetPipeSynapsesFallsBackWhenIndexMissing(t *testing.T) {
 	require.NoError(t, err, "connectome must degrade to an unhinted scan, not fail")
 	require.Len(t, syn, 1)
 	require.Equal(t, int64(1), syn[0].Count)
+}
+
+// TestGetPipeSynapsesIncludesProviderBearingLocalEdges is the regression this
+// aggregation shipped without, and its absence is why the connectome went out
+// showing roughly a tenth of the graph.
+//
+// from_provider/to_provider carry the AGENT'S PROVIDER LABEL, not a federation
+// marker: SAGE_PROVIDER flows from the generated MCP launcher into agent
+// registration and is stamped onto every send, so ordinary local traffic
+// arrives tagged "claude-code" or "codex". The original predicate restricted to
+// empty providers and therefore hid almost every real edge. Measured on a live
+// node before the fix: 3 edges returned out of 30, with 359 of 363 local rows
+// excluded.
+//
+// Every edge below is LOCAL — no chain ids — and all three must be returned.
+func TestGetPipeSynapsesIncludesProviderBearingLocalEdges(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	base := time.Now().UTC().Truncate(time.Second)
+	mk := func(id, from, to, fromProv, toProv string) *PipelineMessage {
+		return &PipelineMessage{
+			PipeID: id, FromAgent: from, ToAgent: to,
+			FromProvider: fromProv, ToProvider: toProv,
+			Payload: "hi", Status: "pending",
+			CreatedAt: base, ExpiresAt: base.Add(time.Hour),
+		}
+	}
+	// The shapes a real node actually produces, all local.
+	require.NoError(t, s.InsertPipeline(ctx, mk("lp1", "alice", "bob", "claude-code", "")))
+	require.NoError(t, s.InsertPipeline(ctx, mk("lp2", "bob", "carol", "codex", "")))
+	require.NoError(t, s.InsertPipeline(ctx, mk("lp3", "carol", "dave", "claude-code", "codex")))
+	// And one with no provider at all, which the old predicate also allowed.
+	require.NoError(t, s.InsertPipeline(ctx, mk("lp4", "dave", "erin", "", "")))
+
+	syn, err := s.GetPipeSynapses(ctx)
+	require.NoError(t, err)
+
+	edges := make(map[string]bool, len(syn))
+	for _, e := range syn {
+		edges[e.FromAgent+"|"+e.ToAgent] = true
+	}
+
+	require.True(t, edges["alice|bob"], "a local edge whose sender carries a provider label must be included")
+	require.True(t, edges["bob|carol"], "provider label 'codex' is not a federation marker")
+	require.True(t, edges["carol|dave"], "both endpoints carrying provider labels is still a local edge")
+	require.True(t, edges["dave|erin"], "the provider-less shape must keep working")
+	require.Len(t, syn, 4, "every local edge is part of the local connectome, got: %v", edges)
+}
+
+// TestGetPipeSynapsesStillExcludesCrossChainEdges pins the other half of the
+// contract. Widening the predicate must not turn the local connectome into a
+// federated one — the fix would be just as wrong in that direction.
+func TestGetPipeSynapsesStillExcludesCrossChainEdges(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	base := time.Now().UTC().Truncate(time.Second)
+	mk := func(id, from, to string) *PipelineMessage {
+		return &PipelineMessage{
+			PipeID: id, FromAgent: from, ToAgent: to,
+			Payload: "hi", Status: "pending",
+			CreatedAt: base, ExpiresAt: base.Add(time.Hour),
+		}
+	}
+	local := mk("cc-local", "alice", "bob")
+	require.NoError(t, s.InsertPipeline(ctx, local))
+
+	inbound := mk("cc-in", "remote", "bob")
+	inbound.SourceChainID = "sage-personal-otherchain"
+	require.NoError(t, s.InsertPipeline(ctx, inbound))
+
+	outbound := mk("cc-out", "alice", "remote")
+	outbound.DestinationChainID = "sage-personal-otherchain"
+	require.NoError(t, s.InsertPipeline(ctx, outbound))
+
+	syn, err := s.GetPipeSynapses(ctx)
+	require.NoError(t, err)
+
+	edges := make(map[string]bool, len(syn))
+	for _, e := range syn {
+		edges[e.FromAgent+"|"+e.ToAgent] = true
+	}
+	require.True(t, edges["alice|bob"], "the local edge is still returned")
+	require.False(t, edges["remote|bob"], "an inbound cross-chain edge is not part of the LOCAL connectome")
+	require.False(t, edges["alice|remote"], "an outbound cross-chain edge is not part of the LOCAL connectome")
+	require.Len(t, syn, 1, "exactly the local edge survives, got: %v", edges)
+}
+
+// TestPipeSynapseIndexIsRedefinedOnUpgrade covers the migration hazard rather
+// than the query. A node upgraded from v11.18.9 already has
+// idx_pipe_synapse_local under the OLD partial WHERE, and CREATE INDEX IF NOT
+// EXISTS is a no-op against an existing name. Without the explicit DROP the
+// stale index survives, SQLite declines to use it because its restriction no
+// longer matches the query, and the INDEXED BY hint quietly degrades to a scan
+// on a table that only grows.
+func TestPipeSynapseIndexIsRedefinedOnUpgrade(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	// Reproduce the v11.18.9 on-disk state exactly.
+	_, err := s.conn.ExecContext(ctx, `DROP INDEX IF EXISTS idx_pipe_synapse_local`)
+	require.NoError(t, err)
+	_, err = s.conn.ExecContext(ctx, `CREATE INDEX idx_pipe_synapse_local
+		ON pipeline_messages(from_agent, to_agent, created_at)
+		WHERE from_agent != '' AND to_agent != '' AND from_provider = '' AND to_provider = ''`)
+	require.NoError(t, err)
+
+	// Re-run the migration the way an upgrade does.
+	s.migratePipeline(ctx)
+
+	var ddl string
+	require.NoError(t, s.conn.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_pipe_synapse_local'`).Scan(&ddl))
+	require.Contains(t, ddl, "source_chain_id", "the upgraded index must carry the new restriction")
+	require.NotContains(t, ddl, "from_provider", "the stale provider restriction must not survive the upgrade")
 }

--- a/internal/store/pipe_synapses_test.go
+++ b/internal/store/pipe_synapses_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -310,8 +311,8 @@ func TestPipeSynapseIndexIsRedefinedAcrossRestarts(t *testing.T) {
 	upgraded, err := NewSQLiteStore(ctx, dbPath)
 	require.NoError(t, err)
 	ddl := indexDDL(upgraded)
-	require.Contains(t, ddl, "source_chain_id", "the upgrade must redefine the index")
-	require.NotContains(t, ddl, "from_provider", "the stale provider restriction must not survive")
+	require.Equal(t, wantSynapseIndexWhere, normalizeIndexWhere(ddl),
+		"the upgraded index must pin the EXACT partial contract, got DDL:\n"+ddl)
 
 	// The upgraded index must actually serve the query, not merely exist.
 	base := time.Now().UTC().Truncate(time.Second)
@@ -346,8 +347,61 @@ func TestPipeSynapseIndexIsRedefinedAcrossRestarts(t *testing.T) {
 	defer restarted.Close() //nolint:errcheck
 	ddl2 := indexDDL(restarted)
 	require.Equal(t, ddl, ddl2, "a second restart must leave the index definition unchanged")
+	require.Equal(t, wantSynapseIndexWhere, normalizeIndexWhere(ddl2),
+		"the exact partial contract must survive a second restart, got DDL:\n"+ddl2)
+
+	// Semantic check after the restarts: the aggregation still answers exactly,
+	// including excluding both federated directions. The DDL assertions above
+	// pin the index CONTRACT; this pins the RESULT, and the two are independent
+	// — a widened partial index still returns correct rows, because the query's
+	// own WHERE does the filtering. That is precisely why the DDL has to be
+	// asserted exactly rather than inferred from query output.
+	seed := time.Now().UTC().Truncate(time.Second)
+	mkRow := func(id, from, to string) *PipelineMessage {
+		return &PipelineMessage{
+			PipeID: id, FromAgent: from, ToAgent: to,
+			Payload: "hi", Status: "pending",
+			CreatedAt: seed, ExpiresAt: seed.Add(time.Hour),
+		}
+	}
+	localRow := mkRow("post-local", "zoe", "yan")
+	localRow.FromProvider = "claude-code" // provider-labelled but local
+	require.NoError(t, restarted.InsertPipeline(ctx, localRow))
+	inbound := mkRow("post-in", "remote-a", "yan")
+	inbound.SourceChainID = "sage-personal-otherchain"
+	require.NoError(t, restarted.InsertPipeline(ctx, inbound))
+	outbound := mkRow("post-out", "zoe", "remote-b")
+	outbound.DestinationChainID = "sage-personal-otherchain"
+	require.NoError(t, restarted.InsertPipeline(ctx, outbound))
 
 	syn, err := restarted.GetPipeSynapses(ctx)
 	require.NoError(t, err)
-	require.NotEmpty(t, syn, "the connectome must still resolve after two restarts")
+	postEdges := make(map[string]bool, len(syn))
+	for _, e := range syn {
+		postEdges[e.FromAgent+"|"+e.ToAgent] = true
+	}
+	require.True(t, postEdges["zoe|yan"], "a provider-labelled local edge must resolve after two restarts")
+	require.False(t, postEdges["remote-a|yan"], "inbound federated must stay excluded after restarts")
+	require.False(t, postEdges["zoe|remote-b"], "outbound federated must stay excluded after restarts")
+}
+
+// wantSynapseIndexWhere is the EXACT partial restriction idx_pipe_synapse_local
+// must carry, whitespace-normalized. Asserted as an equality rather than with
+// Contains/NotContains on purpose: substring checks let a widened predicate
+// through. Dropping the destination_chain_id clause, for instance, still leaves
+// an index that EXPLAIN happily names and that produces correct query results —
+// because the query's own WHERE does the filtering — while silently admitting
+// outbound-federated rows into the index and breaking the partial/covering
+// contract the INDEXED BY hint depends on.
+const wantSynapseIndexWhere = "WHERE from_agent != '' AND to_agent != '' AND source_chain_id = '' AND destination_chain_id = ''"
+
+// normalizeIndexWhere extracts the WHERE clause from an index DDL and collapses
+// whitespace, so the assertion pins semantics rather than the formatting of the
+// CREATE INDEX statement.
+func normalizeIndexWhere(ddl string) string {
+	idx := strings.Index(ddl, "WHERE")
+	if idx < 0 {
+		return "(no WHERE clause: " + strings.Join(strings.Fields(ddl), " ") + ")"
+	}
+	return strings.Join(strings.Fields(ddl[idx:]), " ")
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -6174,9 +6174,21 @@ func (s *SQLiteStore) migratePipeline(ctx context.Context) {
 	//
 	// The WHERE clause must stay byte-identical to the query's restriction or
 	// SQLite silently declines to use the index.
+	// The v11.18.9 definition of this index restricted on empty from_provider/
+	// to_provider, which turned out to exclude almost all local traffic because
+	// those columns carry the agent's provider label rather than a federation
+	// marker. The predicate now keys on the chain ids instead.
+	//
+	// DROP FIRST, DELIBERATELY. CREATE INDEX IF NOT EXISTS is a no-op against an
+	// index that already exists under this name with the OLD partial WHERE, so
+	// without the drop an upgraded node would silently keep a partial index that
+	// no longer matches the query — SQLite would decline to use it and the
+	// INDEXED BY hint would fall back to a full scan. Precedent: the same
+	// drop-then-recreate is used for idx_pipe_transport_proof_once.
+	_, _ = s.writeExecContext(ctx, `DROP INDEX IF EXISTS idx_pipe_synapse_local`)
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_pipe_synapse_local
 		ON pipeline_messages(from_agent, to_agent, created_at)
-		WHERE from_agent != '' AND to_agent != '' AND from_provider = '' AND to_provider = ''`)
+		WHERE from_agent != '' AND to_agent != '' AND source_chain_id = '' AND destination_chain_id = ''`)
 }
 
 // migratePipelineTerminalRetention makes the terminal-state transition, rather


### PR DESCRIPTION
**Draft — not for merge without codex's review.** Codex holds merge authority and is independently verifying this finding.

## The defect

`GetPipeSynapses` restricted the connectome to rows with empty `from_provider`/`to_provider`, on the stated premise that federated cross-chain rows are the ones carrying a provider. **That premise is false in both directions.**

`from_provider`/`to_provider` hold the **agent's provider label**, not a federation marker. `SAGE_PROVIDER` flows from the generated MCP launcher into agent registration (`internal/mcp/tools.go:3114`) and is stamped onto every send (`api/rest/messages_handler.go:94-96,:114`), so ordinary local traffic arrives tagged `claude-code` or `codex`.

Meanwhile the federated send path does the opposite of what the comment assumed — it **clears** `ToProvider` and sets `DestinationChainID`:

```go
// api/rest/pipe_handler.go:548-549
req.ToProvider = ""
req.DestinationChainID = remoteTarget.ChainID
```

So the old predicate **hid local traffic** and **admitted federated traffic**.

## Measured on a live node, before this change

| | |
|---|---|
| local agent-to-agent rows | 363 |
| excluded by the old predicate | **359** |
| edges the endpoint returned | **3** |
| …of which were actually cross-chain, counted as local | **1** |
| genuine local edges hidden | 26 |

Provider distribution, all with no chain ids so unambiguously local: `codex→(empty)` 206, `claude-code→(empty)` 133, `audit→(empty)` 20, `(empty)→(empty)` **4**.

## The fix

Locality keys on `source_chain_id`/`destination_chain_id`, which is what actually denotes a cross-chain row. Both are `NOT NULL DEFAULT ''`, so there is no NULL-semantics trap (verified: 0 NULLs across 404 live rows).

**The index `DROP` is deliberate and load-bearing.** `CREATE INDEX IF NOT EXISTS` is a no-op against an index that already exists under the same name with the old partial `WHERE`. Without the drop, an upgraded v11.18.9 node keeps a stale partial index that no longer matches the query, SQLite declines to use it, and the `INDEXED BY` hint quietly degrades to a full scan on a table that only grows. Same drop-then-recreate precedent as `idx_pipe_transport_proof_once`.

## The old test agreed with the bug

The existing fixture built its "federated" row as `fed.ToProvider = "other-chain"` — which production never writes. Test and code shared one wrong assumption and so confirmed each other. It now models federation the way the federated send path actually writes it.

## Coverage, each mutation-verified

| test | mutation that breaks it |
|---|---|
| `…IncludesProviderBearingLocalEdges` | revert to the provider predicate |
| `…StillExcludesCrossChainEdges` | revert to the provider predicate (**proves the inclusion half**) |
| `…UsesCoveringIndex` | revert predicate, or drop the `INDEXED BY` hint |
| `…IndexIsRedefinedOnUpgrade` | remove the `DROP INDEX` |

Reverting the predicate fails **both** the inclusion and exclusion assertions — the leak is demonstrated, not argued.

## Gates

`./internal/store` full suite green (102s) · `./web` synapse tests green · `-race -count=2` green · `go vet`, `gofmt`, `go build ./...` clean.

## Scope

Deliberately **not** included: the app-v23 `seeAll` question, the existing global-stream leak, and event-wiring coverage — all reported separately and all codex's call. This PR changes one predicate and its index.