### PR TITLE
fix(cerebrum): open the connectome with a dimmer default skull

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "check:js": "node scripts/check-static-js.mjs",
-    "test": "npm run check:js && node --test scripts/access-controls-ui.test.mjs scripts/appv23-linked-message-ui.test.mjs scripts/appv23-policy.test.mjs scripts/bulk-sequence.test.mjs scripts/cerebrum-shell.test.mjs scripts/chrome-extension-contract.test.mjs scripts/connectome-mapping.test.mjs scripts/domain-inventory.test.mjs scripts/federation-acceptance-contract.test.mjs scripts/federation-flow.test.mjs scripts/federation-peer-capabilities.test.mjs scripts/federation-route-state.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/governance-retry.test.mjs scripts/release-recovery-workflow.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/task-reorder.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
+    "test": "npm run check:js && node --test scripts/access-controls-ui.test.mjs scripts/appv23-linked-message-ui.test.mjs scripts/appv23-policy.test.mjs scripts/bulk-sequence.test.mjs scripts/cerebrum-shell.test.mjs scripts/chrome-extension-contract.test.mjs scripts/connectome-mapping.test.mjs scripts/mode-hull.test.mjs scripts/domain-inventory.test.mjs scripts/federation-acceptance-contract.test.mjs scripts/federation-flow.test.mjs scripts/federation-peer-capabilities.test.mjs scripts/federation-route-state.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/governance-retry.test.mjs scripts/release-recovery-workflow.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/task-reorder.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/mode-hull.test.mjs
+++ b/scripts/mode-hull.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import { createModeHull } from '../web/static/js/mode-hull.js';
+
+// Per-view skull-opacity state for the CEREBRUM brain. These tests pin the four
+// behaviours the review called for: correct initial per-view defaults, the slider
+// reflecting the active view's value, a manual adjustment persisting across a mode
+// round trip, and per-view state staying independent. Half the coverage is the
+// pure state machine (createModeHull); half is source wiring in mri-brain.js, so
+// reverting EITHER the module logic OR its wiring fails a test — the regression the
+// first cut of this change lacked.
+
+const DEFAULTS = { memory: 0.08, connectome: 0.03 };
+
+test('initial per-view values are the defaults', () => {
+  const h = createModeHull(DEFAULTS);
+  assert.equal(h.valueFor('memory'), 0.08);
+  assert.equal(h.valueFor('connectome'), 0.03);
+});
+
+test('a recorded manual value persists across a mode round trip', () => {
+  const h = createModeHull(DEFAULTS);
+  // operator drags the SKULL slider while in the connectome
+  h.record('connectome', 0.2);
+  // ... toggles to memory and back — the connectome value must survive
+  assert.equal(h.valueFor('memory'), 0.08);
+  assert.equal(h.valueFor('connectome'), 0.2, 'manual choice retained across the round trip');
+});
+
+test('per-view state is independent — recording one view never moves the other', () => {
+  const h = createModeHull(DEFAULTS);
+  h.record('memory', 0.5);
+  assert.equal(h.valueFor('memory'), 0.5);
+  assert.equal(h.valueFor('connectome'), 0.03, 'connectome untouched by a memory adjustment');
+  h.record('connectome', 0.01);
+  assert.equal(h.valueFor('memory'), 0.5, 'memory untouched by a connectome adjustment');
+  assert.equal(h.valueFor('connectome'), 0.01);
+});
+
+test('unknown modes fall back to a default rather than undefined', () => {
+  const h = createModeHull(DEFAULTS);
+  assert.equal(h.valueFor('nope'), 0.08);
+  h.record('nope', 0.9);                 // no-op for an unknown view
+  assert.equal(h.valueFor('memory'), 0.08);
+  assert.equal(h.valueFor('connectome'), 0.03);
+});
+
+test('defaults() returns a copy, not the live state', () => {
+  const h = createModeHull(DEFAULTS);
+  const d = h.defaults();
+  d.memory = 999;
+  assert.equal(h.valueFor('memory'), 0.08, 'mutating the returned defaults must not leak into state');
+});
+
+// --- Source wiring: mri-brain.js must USE the state, not slam a fixed default ---
+const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
+
+test('mri-brain seeds per-view defaults (memory 0.08, connectome 0.03) via createModeHull', () => {
+  assert.match(mriSource, /createModeHull\(\s*\{\s*memory:\s*0\.08,\s*connectome:\s*0\.03\s*\}\s*\)/,
+    'the two initial defaults must come from createModeHull');
+});
+
+test('mode toggle recalls the view value (not a constant) and reflects it on the slider', () => {
+  // setMode reads hullState.valueFor(...) then updates the .b-op slider + hull
+  assert.match(mriSource, /hullState\.valueFor\(mode\)/, 'setMode/init must read the remembered value');
+  assert.match(mriSource, /opEl\.value\s*=\s*sliderUnits\(/, 'the slider must reflect the recalled value');
+});
+
+test('a manual slider adjustment is recorded for the active view', () => {
+  // the .b-op oninput handler must persist the operator choice per view
+  assert.match(mriSource, /\.b-op'\)\.oninput=function\(\)\{[^}]*hullState\.record\(mode,/,
+    'dragging the SKULL slider must record the value for the active view');
+});
+
+test('the initial hull opacity is seeded from the state, not a hardcoded 0.08', () => {
+  assert.match(mriSource, /curOpacity\s*=\s*hullState\.valueFor\(mode\)/,
+    'curOpacity must initialize from the per-view state');
+});
+
+// Extract a function body by brace matching, so a wiring assertion is SCOPED to
+// that function — a whole-file grep would still pass if the call had drifted into
+// a different function, which is exactly the gap this closes.
+function functionBody(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name}() not found in source`);
+  const open = src.indexOf('{', start);
+  let depth = 0;
+  let i = open;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) break;
+  }
+  return src.slice(open + 1, i);
+}
+
+// The regression the previous cut missed: setMode() must APPLY the recalled
+// opacity to the visible hull, not merely move the slider. Scoped to the setMode
+// body and bound to the SAME nextOpacity variable, so deleting or substituting
+// setHullOpacity(nextOpacity) fails — the slider and the 3D hull cannot drift
+// apart on a mode toggle.
+test('setMode binds the recalled opacity through BOTH the slider and the hull material', () => {
+  const body = functionBody(mriSource, 'setMode');
+  assert.match(body, /const nextOpacity\s*=\s*hullState\.valueFor\(mode\)/,
+    'setMode must recall the per-view opacity into nextOpacity');
+  assert.match(body, /opEl\.value\s*=\s*sliderUnits\(nextOpacity\)/,
+    'the slider must reflect the recalled nextOpacity');
+  assert.match(body, /setHullOpacity\(nextOpacity\)/,
+    'the visible hull must be updated with the SAME nextOpacity — deleting or substituting this must fail');
+});

--- a/web/static/js/mode-hull.js
+++ b/web/static/js/mode-hull.js
@@ -1,0 +1,27 @@
+// Per-view skull-opacity state for the CEREBRUM brain. Each view (memory graph,
+// connectome) keeps its OWN session opacity, seeded from a per-view default. The
+// defaults differ — the memory graph wants a prominent anatomical hull, the
+// connectome a recessed one so its synapse wiring reads — but once an operator
+// drags the SKULL slider, that choice is remembered for the view they set it in
+// and recalled the next time they return to it, independent of the other view.
+//
+// Pure and dependency-free (no DOM) so the behaviour is unit-testable in
+// isolation, mirroring mri-layout.js / connectome-map.js.
+//
+// `defaults` maps view name -> initial opacity (0..1). `valueFor(mode)` returns
+// that view's current opacity; `record(mode, opacity)` stores a manual choice for
+// one view without touching the other. Unknown modes fall back to the first
+// default so a caller never gets undefined.
+export function createModeHull(defaults) {
+  const fallback = Object.values(defaults)[0];
+  const state = { ...defaults };
+  return {
+    valueFor(mode) {
+      return Object.prototype.hasOwnProperty.call(state, mode) ? state[mode] : fallback;
+    },
+    record(mode, opacity) {
+      if (Object.prototype.hasOwnProperty.call(state, mode)) state[mode] = opacity;
+    },
+    defaults() { return { ...defaults }; },
+  };
+}

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -18,6 +18,7 @@
 import { THREE, ForceGraph3D, UnrealBloomPass } from '/ui/js/vendor/sage-graph.bundle.js';
 import { MRI_LAYOUT, mriDepthForAge, mriVerticalPosition } from '/ui/js/mri-layout.js';
 import { createGraphLoadCoordinator, mapConnectome } from '/ui/js/connectome-map.js';
+import { createModeHull } from '/ui/js/mode-hull.js';
 
 const LINK_TYPES = {
   supports:    { color: '#5ee2a0', label: 'supports',    typed: true },
@@ -308,6 +309,13 @@ export function mountMriBrain(container, opts = {}) {
   const SYNAPSE_URL = opts.synapseUrl || '/v1/dashboard/network/synapses';
   const allowConnectome = opts.allowConnectome !== false;
   let mode = opts.mode === 'connectome' ? 'connectome' : 'memory';
+  // Per-view skull opacity. The memory graph keeps the anatomical hull prominent
+  // (0.08); the connectome's payload is the WIRING, so it starts dimmer (0.03) so
+  // synapses read on open. These are only INITIAL defaults — a manual SKULL
+  // adjustment is remembered per view and recalled on the next toggle back, so a
+  // round trip never discards the operator's choice (see mode-hull.js).
+  const hullState = createModeHull({ memory: 0.08, connectome: 0.03 });
+  const sliderUnits = o => String(Math.round(o * 100));
 
   const root = document.createElement('div');
   root.className = 'mrib';
@@ -345,6 +353,8 @@ export function mountMriBrain(container, opts = {}) {
     <div class="tip"></div>
     <div class="flag"></div>`;
   container.appendChild(root);
+  // Reflect the active view's skull opacity on the slider from the start.
+  { const _op = root.querySelector('.b-op'); if (_op) _op.value = sliderUnits(hullState.valueFor(mode)); }
   const $ = s => root.querySelector(s);
   const escapeHtml = s => String(s==null?'':s).replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 
@@ -564,7 +574,7 @@ export function mountMriBrain(container, opts = {}) {
 
   let Graph = null, controls = null, disposed = false, flow = true, scanning = true;
   let lastNodeClickAt = 0, graphPointerDown = null;
-  let hullMat = null, brainMat = null, surfMat = null, curOpacity = 0.08;
+  let hullMat = null, brainMat = null, surfMat = null, curOpacity = hullState.valueFor(mode);
   let focusMarker = null, focusRingTexture = null;
   let currentDomain = null;                 // drill-down lobe (null = overview)
   const baseUrl = fetchUrl;
@@ -1221,13 +1231,19 @@ export function mountMriBrain(container, opts = {}) {
     currentDomain = null;
     focusId=null; focusSet=null; hideExplorePanel(); clearFocusMarker();
     updateModeChrome();
+    // Recall this view's remembered skull opacity (its default, or the operator's
+    // last manual choice for this view) and reflect it on the slider, so a round
+    // trip preserves each view's setting independently.
+    const nextOpacity = hullState.valueFor(mode);
+    const opEl = $('.b-op'); if (opEl) opEl.value = sliderUnits(nextOpacity);
+    setHullOpacity(nextOpacity);
     if (Graph) { load(); zoomOut(); }
     else acquireInitialGraph();
   }
 
   $('.b-rot').onclick=function(){ scanning=!scanning; if(controls) controls.autoRotate=scanning; this.textContent=scanning?'⏸ pause':'▶ scan'; };
   $('.b-flow').onclick=function(){ flow=!flow; if(Graph) Graph.linkDirectionalParticles(linkParticlesFor); this.textContent=flow?'⚡ flow: on':'⚡ flow: off'; };
-  $('.b-op').oninput=function(){ setHullOpacity(this.value/100); };
+  $('.b-op').oninput=function(){ const o=this.value/100; setHullOpacity(o); hullState.record(mode, o); };
   if (allowConnectome) $('.b-mode').onclick=function(){ setMode(mode==='connectome'?'memory':'connectome'); };
 
   return function cleanup(){


### PR DESCRIPTION
## What

Connectome mode now opens with a dimmer default skull (0.03) than the memory graph (0.08), so the synapse wiring reads immediately instead of being drowned by the bright anatomical wireframe.

## Why

The connectome's value is the wiring — agents as neurons, message-bus channels as weighted synapses. At the memory view's default skull opacity the dense hull mesh visually dominates the thinner synapses, so on first open the operator mostly sees wireframe and has to reach for the SKULL slider before the graph's point is legible. The two views want different defaults: the memory graph benefits from a prominent anatomical hull (dense nodes, age-depth); the connectome from a recessed one.

## How

- `MODE_HULL = { memory: 8, connectome: 3 }` (slider units; value/100 = opacity). `curOpacity` initializes from the active mode, the slider reflects it from mount, and `setMode()` applies the target view's default (and updates the slider) on toggle.
- Still fully user-adjustable via the SKULL slider from either default.

## Determinism / safety

Frontend-only, connectome-scoped. No Go/consensus path touched. The memory view is byte-for-byte unchanged (still 0.08).

## Tests

`npm test` green (272). Verified headless (Chromium/SwiftShader): the connectome opens with synapses legible against a recessed hull, hubs at the core, neurons by domain; memory view unchanged.

## Context

Follows #188 (connectome view). Aesthetic default — happy to tune the exact value to your eye; the per-view mechanism is the point.
