### PR TITLE
fix(sse): keep retrieval activity contentless

### DIFF
--- a/api/rest/memory_handler.go
+++ b/api/rest/memory_handler.go
@@ -1986,24 +1986,15 @@ func (s *Server) handleQueryMemory(w http.ResponseWriter, r *http.Request) {
 
 	// Emit recall event for SSE chain activity log with full retrieved memory details
 	if s.OnEvent != nil && len(results) > 0 {
-		domain := req.DomainTag
-		if domain == "" && len(results) > 0 {
-			domain = results[0].DomainTag
-		}
-		// Build rich detail for expandable chain activity rows
-		retrieved := make([]map[string]any, 0, len(results))
-		for _, r := range results {
-			retrieved = append(retrieved, map[string]any{
-				"memory_id":  r.MemoryID,
-				"content":    r.Content,
-				"domain":     r.DomainTag,
-				"confidence": r.ConfidenceScore,
-				"type":       r.MemoryType,
-			})
-		}
-		s.OnEvent("recall", "", domain, fmt.Sprintf("%d memories retrieved", len(results)), map[string]any{
-			"retrieved": retrieved,
-		})
+		// CONTENTLESS BY CONSTRUCTION. These results were already filtered by
+		// THIS caller's clearance and domain ACL, and SSEBroadcaster is a global
+		// fan-out with no subscriber identity — web/sse.go Subscribe() takes no
+		// arguments and Broadcast sends identical bytes to every client — so
+		// anything placed here is republished to every connected dashboard.
+		// Only the event type and a result COUNT may cross this boundary: never
+		// memory ids, content, confidence or type, and never the caller-derived
+		// domain, which is itself authorization-scoped metadata.
+		emitContentlessRetrievalActivity(s.OnEvent, "recall", len(results))
 	}
 
 	resp := QueryMemoryResponse{
@@ -2707,23 +2698,15 @@ func (s *Server) handleSearchMemory(w http.ResponseWriter, r *http.Request) {
 
 	// Emit search event for SSE chain activity log
 	if s.OnEvent != nil && len(results) > 0 {
-		domain := req.DomainTag
-		if domain == "" && len(results) > 0 {
-			domain = results[0].DomainTag
-		}
-		retrieved := make([]map[string]any, 0, len(results))
-		for _, r := range results {
-			retrieved = append(retrieved, map[string]any{
-				"memory_id":  r.MemoryID,
-				"content":    r.Content,
-				"domain":     r.DomainTag,
-				"confidence": r.ConfidenceScore,
-				"type":       r.MemoryType,
-			})
-		}
-		s.OnEvent("search", "", domain, fmt.Sprintf("%d memories found via text search", len(results)), map[string]any{
-			"retrieved": retrieved,
-		})
+		// CONTENTLESS BY CONSTRUCTION. These results were already filtered by
+		// THIS caller's clearance and domain ACL, and SSEBroadcaster is a global
+		// fan-out with no subscriber identity — web/sse.go Subscribe() takes no
+		// arguments and Broadcast sends identical bytes to every client — so
+		// anything placed here is republished to every connected dashboard.
+		// Only the event type and a result COUNT may cross this boundary: never
+		// memory ids, content, confidence or type, and never the caller-derived
+		// domain, which is itself authorization-scoped metadata.
+		emitContentlessRetrievalActivity(s.OnEvent, "search", len(results))
 	}
 
 	resp := QueryMemoryResponse{
@@ -3043,23 +3026,15 @@ func (s *Server) handleHybridSearchMemory(w http.ResponseWriter, r *http.Request
 	}
 
 	if s.OnEvent != nil && len(results) > 0 {
-		domain := req.DomainTag
-		if domain == "" {
-			domain = results[0].DomainTag
-		}
-		retrieved := make([]map[string]any, 0, len(results))
-		for _, r := range results {
-			retrieved = append(retrieved, map[string]any{
-				"memory_id":  r.MemoryID,
-				"content":    r.Content,
-				"domain":     r.DomainTag,
-				"confidence": r.ConfidenceScore,
-				"type":       r.MemoryType,
-			})
-		}
-		s.OnEvent("hybrid", "", domain, fmt.Sprintf("%d memories retrieved via hybrid search", len(results)), map[string]any{
-			"retrieved": retrieved,
-		})
+		// CONTENTLESS BY CONSTRUCTION. These results were already filtered by
+		// THIS caller's clearance and domain ACL, and SSEBroadcaster is a global
+		// fan-out with no subscriber identity — web/sse.go Subscribe() takes no
+		// arguments and Broadcast sends identical bytes to every client — so
+		// anything placed here is republished to every connected dashboard.
+		// Only the event type and a result COUNT may cross this boundary: never
+		// memory ids, content, confidence or type, and never the caller-derived
+		// domain, which is itself authorization-scoped metadata.
+		emitContentlessRetrievalActivity(s.OnEvent, "hybrid", len(results))
 	}
 
 	resp := QueryMemoryResponse{

--- a/api/rest/sse_retrieval_activity.go
+++ b/api/rest/sse_retrieval_activity.go
@@ -1,0 +1,45 @@
+package rest
+
+import "fmt"
+
+// emitContentlessRetrievalActivity is the ONLY sanctioned way for a memory
+// retrieval path (recall, text search, hybrid search) to announce activity on
+// the dashboard event stream.
+//
+// WHY THIS EXISTS AS A CHOKE POINT RATHER THAN THREE INLINE CALLS.
+// Retrieval results are filtered by the CALLING agent's clearance and domain
+// ACL. The dashboard stream they are announced on is a GLOBAL FAN-OUT with no
+// subscriber identity: web/sse.go's Subscribe() takes no arguments, its client
+// map value is struct{}{}, and Broadcast marshals one payload and pushes
+// identical bytes to every connected client. There is therefore no place to
+// enforce "who may see this" on that path, and no per-subscriber dimension a
+// test could assert on. The only durable defence is to ensure nothing worth
+// protecting is put in.
+//
+// These three sites previously published memory_id, content, domain,
+// confidence and type for every result, plus the caller-derived domain in the
+// event's Domain field. The stock dashboard rendered that content verbatim in
+// its expandable Chain Activity rows, so one agent's authorized read set was
+// republished to every connected dashboard.
+//
+// WHAT MAY CROSS THIS BOUNDARY: the event type, and a count. Nothing else.
+// A count discloses only that a retrieval of some size happened, which the
+// activity indicator exists to convey. Adding any per-result field, the
+// caller's domain, or a free-form string built from result data reintroduces
+// the disclosure — the accompanying wire-level tests fail if it does.
+//
+// Deliberately NOT solved here: making the broadcaster identity-aware. That is
+// a larger change, and a per-call-site discipline is only as good as the next
+// call site. Until the broadcaster carries subscriber identity, every new
+// emitter is a fresh opportunity for this bug.
+func emitContentlessRetrievalActivity(onEvent EventCallback, eventType string, resultCount int) {
+	if onEvent == nil {
+		return
+	}
+	// Positional contract of EventCallback is
+	// (eventType, memoryID, domain, content, data). memoryID and domain are
+	// held empty on purpose: both are authorization-scoped. content carries the
+	// count only, and data is nil so no structured result material can ride
+	// along.
+	onEvent(eventType, "", "", fmt.Sprintf("%d memories", resultCount), nil)
+}

--- a/api/rest/sse_retrieval_activity_test.go
+++ b/api/rest/sse_retrieval_activity_test.go
@@ -1,0 +1,204 @@
+package rest
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/web"
+)
+
+// sentinelPlaintext is deliberately distinctive so a leak cannot hide inside
+// ordinary fixture words. If this string reaches a serialized SSE frame, memory
+// content that was filtered for ONE caller has been republished to EVERY
+// connected dashboard.
+const sentinelPlaintext = "ZZQX-SENTINEL-PLAINTEXT-do-not-broadcast-7f3a"
+
+// forbiddenValuesInFrame are VALUES that must never appear anywhere in a
+// serialized frame. Deliberately values and not field names: SSEEvent.MemoryID
+// is tagged json:"memory_id" WITHOUT omitempty, so the empty KEY is present in
+// every frame by construction. Asserting on the key name would fail on a
+// correct frame and would have to be loosened — which is exactly how a
+// substring check stops meaning anything. The field is instead pinned by exact
+// value in assertContentlessFrame below.
+var forbiddenValuesInFrame = []string{
+	sentinelPlaintext,
+	"retrieved",
+	"secret-domain",
+}
+
+// assertContentlessFrame parses one frame and pins the EXACT permitted shape:
+// an event type, an empty memory id, and a count-only content string. Any
+// domain, any data payload, or any populated memory id is a disclosure.
+func assertContentlessFrame(t *testing.T, frame, wantType string) {
+	t.Helper()
+	_, dataLine, ok := strings.Cut(frame, "data: ")
+	require.True(t, ok, "frame must carry a data line, got:\n%s", frame)
+	dataLine = strings.TrimSpace(dataLine)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(dataLine), &payload),
+		"frame data must be valid JSON, got: %s", dataLine)
+
+	require.Equal(t, wantType, payload["type"], "event type")
+	require.Equal(t, "", payload["memory_id"],
+		"memory_id must be empty: it is authorization-scoped")
+	require.NotContains(t, payload, "domain",
+		"the caller-derived domain must not cross the global stream")
+	require.NotContains(t, payload, "data",
+		"no structured result material may cross the global stream")
+
+	content, _ := payload["content"].(string)
+	require.Regexp(t, `^[0-9]+ memories$`, content,
+		"content may carry a COUNT and nothing else, got %q", content)
+
+	// Nothing beyond the three permitted keys may appear.
+	for k := range payload {
+		require.Contains(t, []string{"type", "memory_id", "content"}, k,
+			"unexpected key %q in a contentless activity frame: %s", k, dataLine)
+	}
+}
+
+// wireHarness connects the REAL production bridge — the same shape as
+// cmd/sage-gui/node.go's restServer.OnEvent — to a REAL web.SSEBroadcaster, and
+// captures the exact bytes a subscriber would receive. Asserting on a stubbed
+// callback would only prove what this package passes; the disclosure happens at
+// the serialized frame, so that is what is inspected.
+type wireHarness struct {
+	broadcaster *web.SSEBroadcaster
+	client      chan []byte
+}
+
+func newWireHarness(t *testing.T, srv *Server) *wireHarness {
+	t.Helper()
+	b := web.NewSSEBroadcaster()
+	ch := b.Subscribe()
+	require.NotNil(t, ch, "subscriber channel")
+	t.Cleanup(func() { b.CloseAll() })
+
+	srv.OnEvent = func(eventType, memoryID, domain, content string, data any) {
+		b.Broadcast(web.SSEEvent{
+			Type:     web.EventType(eventType),
+			MemoryID: memoryID,
+			Domain:   domain,
+			Content:  content,
+			Data:     data,
+		})
+	}
+	return &wireHarness{broadcaster: b, client: ch}
+}
+
+// frames drains everything currently queued for the subscriber.
+func (h *wireHarness) frames(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	deadline := time.After(500 * time.Millisecond)
+	for {
+		select {
+		case msg := <-h.client:
+			out = append(out, string(msg))
+		case <-deadline:
+			return out
+		default:
+			return out
+		}
+	}
+}
+
+func seedSentinelMemory(srv *Server, store *mockMemoryStore) {
+	rec := committedFact("mem-sentinel", sentinelPlaintext, 0.95, time.Now())
+	rec.DomainTag = "secret-domain"
+	store.memories["mem-sentinel"] = rec
+	_ = srv
+}
+
+// TestRetrievalActivityFramesCarryNoCallerAuthorizedContent is the release-gate
+// regression for the plaintext disclosure: recall, text search and hybrid search
+// each announced activity on the identity-free global stream while carrying the
+// full content, id, domain, confidence and type of every result the CALLER was
+// authorized to see. The stock dashboard rendered that content verbatim.
+//
+// All three paths are driven end to end and the SERIALIZED frames are searched.
+func TestRetrievalActivityFramesCarryNoCallerAuthorizedContent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		body any
+	}{
+		{"recall", "/v1/memory/query", QueryMemoryRequest{Embedding: []float32{0.1, 0.2, 0.3}, TopK: 10}},
+		{"search", "/v1/memory/search", SearchMemoryRequest{Query: "sentinel", TopK: 10}},
+		{"hybrid", "/v1/memory/hybrid", HybridSearchMemoryRequest{Query: "sentinel", Embedding: []float32{0.1, 0.2, 0.3}, TopK: 10}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, store, _ := newTestServer(t, "")
+			seedSentinelMemory(srv, store)
+			h := newWireHarness(t, srv)
+
+			postJSON(t, srv, tc.path, tc.body)
+
+			frames := h.frames(t)
+			require.NotEmpty(t, frames,
+				"precondition: a retrieval with results must still emit an activity frame — "+
+					"otherwise this test proves nothing about what the frame contains")
+
+			joined := strings.Join(frames, "\n")
+			for _, forbidden := range forbiddenValuesInFrame {
+				require.NotContains(t, joined, forbidden,
+					"serialized SSE frame must not carry caller-authorized material (%q); frame was:\n%s",
+					forbidden, joined)
+			}
+			require.Len(t, frames, 1, "exactly one activity frame per retrieval")
+			assertContentlessFrame(t, frames[0], tc.name)
+		})
+	}
+}
+
+// TestRetrievalActivityEmitsNothingWithoutResults pins the zero-result path.
+// An empty retrieval must not announce anything at all: a frame that fires on
+// zero results would disclose that a caller searched and found nothing, and it
+// would also mean the count is not the only variable crossing the boundary.
+func TestRetrievalActivityEmitsNothingWithoutResults(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		body any
+	}{
+		{"recall", "/v1/memory/query", QueryMemoryRequest{Embedding: []float32{0.9, 0.9, 0.9}, TopK: 10, MinConfidence: 0.999}},
+		{"search", "/v1/memory/search", SearchMemoryRequest{Query: "no-such-term-anywhere", TopK: 10, MinConfidence: 0.999}},
+		{"hybrid", "/v1/memory/hybrid", HybridSearchMemoryRequest{Query: "no-such-term-anywhere", Embedding: []float32{0.9, 0.9, 0.9}, TopK: 10, MinConfidence: 0.999}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _, _ := newTestServer(t, "")
+			h := newWireHarness(t, srv)
+
+			postJSON(t, srv, tc.path, tc.body)
+
+			require.Empty(t, h.frames(t), "a retrieval with no results must emit no activity frame")
+		})
+	}
+}
+
+// TestRetrievalActivityHasNoReplayForLateSubscriber pins the absence of replay.
+// The stream has no history and drops on slow delivery, so a subscriber that
+// connects AFTER a broadcast must receive nothing. This matters for the
+// disclosure question: if frames were replayed, a client connecting later would
+// inherit activity from a window it was not present for.
+func TestRetrievalActivityHasNoReplayForLateSubscriber(t *testing.T) {
+	srv, store, _ := newTestServer(t, "")
+	seedSentinelMemory(srv, store)
+	h := newWireHarness(t, srv)
+
+	postJSON(t, srv, "/v1/memory/query", QueryMemoryRequest{Embedding: []float32{0.1, 0.2, 0.3}, TopK: 10})
+	require.NotEmpty(t, h.frames(t), "precondition: the first subscriber received the frame")
+
+	late := h.broadcaster.Subscribe()
+	require.NotNil(t, late)
+	select {
+	case msg := <-late:
+		t.Fatalf("a subscriber that connected after the broadcast must receive nothing, got: %s", msg)
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -7733,7 +7733,12 @@ function ChainActivityLog({ sse }) {
                         const info = typeIcons[ev.type] || typeIcons.connection;
                         const isExpanded = expandedEvent === ev.id;
                         const accessDetail = ev.type === 'access' ? ev.data?.data : null;
-                        const hasDetail = ev.data?.data?.full_content || ev.data?.data?.retrieved || accessDetail;
+                        // NOTE: `retrieved` is deliberately absent. Retrieval activity events are
+                        // contentless by design — recall/search/hybrid results are filtered per
+                        // CALLER, while this stream is a global fan-out, so result bodies must
+                        // never be published to it. Keeping the branch alive here would silently
+                        // start rendering plaintext again the moment a payload reappeared.
+                        const hasDetail = ev.data?.data?.full_content || accessDetail;
                         return html`
                             <div class="chain-event ${isExpanded ? 'expanded' : ''}" key=${ev.id}
                                  onClick=${() => hasDetail && setExpandedEvent(isExpanded ? null : ev.id)}>
@@ -7755,20 +7760,6 @@ function ChainActivityLog({ sse }) {
                                         <div style="display:flex;gap:12px;margin-top:4px;">
                                             ${ev.data.data.memory_type ? html`<span style="font-size:10px;color:var(--text-muted);">Type: <strong>${ev.data.data.memory_type}</strong></span>` : ''}
                                             ${ev.data.data.confidence ? html`<span style="font-size:10px;color:var(--text-muted);">Confidence: <strong>${(ev.data.data.confidence * 100).toFixed(0)}%</strong></span>` : ''}
-                                        </div>
-                                    </div>
-                                ` : ''}
-                                ${isExpanded && ev.type === 'recall' && ev.data?.data?.retrieved ? html`
-                                    <div class="chain-event-expand" onClick=${(e) => e.stopPropagation()}>
-                                        <div class="chain-event-expand-label">Retrieved Memories (${ev.data.data.retrieved.length})</div>
-                                        <div class="chain-event-retrieved">
-                                            ${ev.data.data.retrieved.map((m, i) => html`
-                                                <div class="chain-event-retrieved-item" key=${i}>
-                                                    <code>${m.memory_id?.slice(0, 8)}...</code>
-                                                    <span class="chain-event-domain" style="font-size:9px;">${m.domain}</span>
-                                                    <span class="retrieved-content">${m.content?.slice(0, 150)}${m.content?.length > 150 ? '...' : ''}</span>
-                                                </div>
-                                            `)}
                                         </div>
                                     </div>
                                 ` : ''}


### PR DESCRIPTION
## Summary
- replace recall/search/hybrid result payload broadcasts with contentless activity counts
- remove the dashboard's plaintext retrieved-memory expansion path
- add real wire-level SSE regressions for all three retrieval paths, zero results, and no replay

## Security boundary
The dashboard SSE route remains operator-only. This removes caller-authorized memory content and per-result metadata from the identity-free broadcaster without adding another data endpoint or broadening access.

## Verification
- full api/rest and web suites
- npm test/static checks
- go vet, gofmt, go build
- mutation checks for restored arrays, domain/ID smuggling, alternate string channel, and zero-result emission

Draft pending independent exact-head review and hosted gates.