### PR TITLE
fix(mcp): surface pending inbox work in bookend mode

### DIFF
--- a/cmd/sage-gui/hook.go
+++ b/cmd/sage-gui/hook.go
@@ -100,13 +100,16 @@ const (
 // can say that the check was unavailable instead of manufacturing a zero.
 func runHookInboxStatus() error {
 	var inbox struct {
-		Count  int  `json:"count"`
-		Unread bool `json:"unread"`
+		Count  *int  `json:"count"`
+		Unread *bool `json:"unread"`
 	}
 	if err := hookSignedJSON(http.MethodGet, "/v1/pipe/history/inbox?count_only=1", nil, &inbox); err != nil {
 		return fmt.Errorf("inbox status unavailable: %w", err)
 	}
-	if !inbox.Unread || inbox.Count <= 0 {
+	if inbox.Count == nil || inbox.Unread == nil || *inbox.Count < 0 || (*inbox.Count > 0) != *inbox.Unread {
+		return fmt.Errorf("inbox status unavailable: invalid count probe response")
+	}
+	if *inbox.Count == 0 {
 		return nil
 	}
 	seed, err := loadHookSeed()
@@ -116,7 +119,7 @@ func runHookInboxStatus() error {
 	priv := ed25519.NewKeyFromSeed(seed)
 	pub, _ := priv.Public().(ed25519.PublicKey) //nolint:errcheck
 	fmt.Printf("SAGE inbox: %d unread item(s) for exact agent %s (runtime %s). Call sage_inbox with a fresh poll before reporting no new messages.\n",
-		inbox.Count, hex.EncodeToString(pub), version)
+		*inbox.Count, hex.EncodeToString(pub), version)
 	return nil
 }
 

--- a/cmd/sage-gui/hook.go
+++ b/cmd/sage-gui/hook.go
@@ -53,6 +53,11 @@ func runHook() error {
 			return nil
 		}
 		return runHookSessionEnd()
+	case "inbox-status":
+		if len(args) > 1 {
+			return fmt.Errorf("hook inbox-status: unexpected arguments")
+		}
+		return runHookInboxStatus()
 	default:
 		return fmt.Errorf("hook: unknown subcommand %q", args[0])
 	}
@@ -61,6 +66,7 @@ func runHook() error {
 func printHookUsage() {
 	fmt.Fprintln(os.Stdout, "Usage: sage-gui hook session-start [--domain DOMAIN]")
 	fmt.Fprintln(os.Stdout, "       sage-gui hook session-end")
+	fmt.Fprintln(os.Stdout, "       sage-gui hook inbox-status")
 }
 
 func hookSessionStartDomain(args []string) (string, error) {
@@ -87,6 +93,32 @@ const (
 	hookHTTPTimeout = 3 * time.Second
 	hookRecentLimit = 10
 )
+
+// runHookInboxStatus emits a payload-free coordination pointer for the exact
+// ordinary-agent identity used by this hook. It never claims work. Silence
+// means an authoritative zero; failures return non-zero so the shell wrapper
+// can say that the check was unavailable instead of manufacturing a zero.
+func runHookInboxStatus() error {
+	var inbox struct {
+		Count  int  `json:"count"`
+		Unread bool `json:"unread"`
+	}
+	if err := hookSignedJSON(http.MethodGet, "/v1/pipe/history/inbox?count_only=1", nil, &inbox); err != nil {
+		return fmt.Errorf("inbox status unavailable: %w", err)
+	}
+	if !inbox.Unread || inbox.Count <= 0 {
+		return nil
+	}
+	seed, err := loadHookSeed()
+	if err != nil {
+		return fmt.Errorf("resolve hook identity: %w", err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub, _ := priv.Public().(ed25519.PublicKey) //nolint:errcheck
+	fmt.Printf("SAGE inbox: %d unread item(s) for exact agent %s (runtime %s). Call sage_inbox with a fresh poll before reporting no new messages.\n",
+		inbox.Count, hex.EncodeToString(pub), version)
+	return nil
+}
 
 // runHookSessionStart fetches recent committed memories and prints a context
 // block on stdout. Claude Code injects stdout from SessionStart hooks into the

--- a/cmd/sage-gui/hook_test.go
+++ b/cmd/sage-gui/hook_test.go
@@ -185,6 +185,19 @@ func TestHookInboxStatusZeroIsSilentAndFailureIsNotZero(t *testing.T) {
 	assert.NotContains(t, err.Error(), "count 0")
 }
 
+func TestHookInboxStatusRejectsIncompleteOrInconsistentProbe(t *testing.T) {
+	for _, body := range []string{`{"count":2}`, `{"unread":true}`, `{"count":2,"unread":false}`, `{"count":0,"unread":true}`} {
+		t.Run(body, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = io.WriteString(w, body) }))
+			defer srv.Close()
+			withTestSageEnv(t, srv.URL)
+			err := runHookInboxStatus()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid count probe response")
+		})
+	}
+}
+
 func writeHookTestSeed(t *testing.T, path string) []byte {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700))

--- a/cmd/sage-gui/hook_test.go
+++ b/cmd/sage-gui/hook_test.go
@@ -151,6 +151,40 @@ func TestHookSessionStart_MissingKeyReturnsError(t *testing.T) {
 	require.Error(t, err, "no key file → soft-fail back to nudge")
 }
 
+func TestHookInboxStatusIsPayloadFreeAndIdentityScoped(t *testing.T) {
+	var requestedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.RequestURI()
+		assert.NotEmpty(t, r.Header.Get("X-Agent-ID"))
+		_ = json.NewEncoder(w).Encode(map[string]any{"count": 2, "unread": true})
+	}))
+	defer srv.Close()
+	keyPath := withTestSageEnv(t, srv.URL)
+	seed, err := os.ReadFile(keyPath)
+	require.NoError(t, err)
+	pub := ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)
+
+	stdout := captureStdout(t, func() { require.NoError(t, runHookInboxStatus()) })
+	assert.Equal(t, "/v1/pipe/history/inbox?count_only=1", requestedPath)
+	assert.Contains(t, stdout, "2 unread item(s)")
+	assert.Contains(t, stdout, hex.EncodeToString(pub))
+	assert.Contains(t, stdout, "Call sage_inbox with a fresh poll")
+	assert.NotContains(t, stdout, "sentinel-payload")
+	assert.NotContains(t, stdout, "message_id")
+}
+
+func TestHookInboxStatusZeroIsSilentAndFailureIsNotZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"count": 0, "unread": false})
+	}))
+	withTestSageEnv(t, srv.URL)
+	assert.Empty(t, captureStdout(t, func() { require.NoError(t, runHookInboxStatus()) }))
+	srv.Close()
+	err := runHookInboxStatus()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "count 0")
+}
+
 func writeHookTestSeed(t *testing.T, path string) []byte {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700))

--- a/cmd/sage-gui/hook_test.go
+++ b/cmd/sage-gui/hook_test.go
@@ -186,7 +186,7 @@ func TestHookInboxStatusZeroIsSilentAndFailureIsNotZero(t *testing.T) {
 }
 
 func TestHookInboxStatusRejectsIncompleteOrInconsistentProbe(t *testing.T) {
-	for _, body := range []string{`{"count":2}`, `{"unread":true}`, `{"count":2,"unread":false}`, `{"count":0,"unread":true}`} {
+	for _, body := range []string{`{"count":2}`, `{"unread":true}`, `{"count":2,"unread":false}`, `{"count":0,"unread":true}`, `{"count":-1,"unread":false}`} {
 		t.Run(body, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = io.WriteString(w, body) }))
 			defer srv.Close()

--- a/cmd/sage-gui/main.go
+++ b/cmd/sage-gui/main.go
@@ -302,6 +302,7 @@ MCP Subcommands:
 Hook Subcommands (invoked by .claude/hooks/*.sh or .codex/hooks/*.sh):
   hook session-start   Pre-fetch recent memories; emit context block on stdout
   hook session-end     Post a session-lifecycle observation
+  hook inbox-status    Emit an exact-agent, payload-free unread-work pointer
 
 Codex Subcommands:
   codex install     Install .codex/config.toml + hooks + AGENTS.md in the current project`)

--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -513,7 +513,7 @@ func installClaudeHooks(projectDir, sageHome string) error {
 		_ = json.Unmarshal(existing, &settings)
 	}
 
-	settings["hooks"] = sageHooksConfig("${CLAUDE_PROJECT_DIR}/.claude/hooks")
+	settings["hooks"] = mergeSageHooksConfig(settings["hooks"], "${CLAUDE_PROJECT_DIR}/.claude/hooks")
 	settings["permissions"] = sagePermissionsConfig(settings)
 
 	data, err := json.MarshalIndent(settings, "", "  ")
@@ -639,7 +639,7 @@ func syncClaudeSettings(projectDir string) error {
 	if readErr == nil {
 		_ = json.Unmarshal(existing, &settings)
 	}
-	settings["hooks"] = sageHooksConfig("${CLAUDE_PROJECT_DIR}/.claude/hooks")
+	settings["hooks"] = mergeSageHooksConfig(settings["hooks"], "${CLAUDE_PROJECT_DIR}/.claude/hooks")
 	settings["permissions"] = sagePermissionsConfig(settings)
 	data, marshalErr := json.MarshalIndent(settings, "", "  ")
 	if marshalErr != nil {
@@ -809,6 +809,33 @@ func sageHooksConfig(hookDirExpr string) map[string]any {
 			map[string]any{"hooks": stop},
 		},
 	}
+}
+
+// mergeSageHooksConfig replaces only installer-owned SAGE hook entries and
+// preserves unrelated user hooks under the same Claude lifecycle events.
+func mergeSageHooksConfig(existing any, hookDirExpr string) map[string]any {
+	merged := make(map[string]any)
+	if current, ok := existing.(map[string]any); ok {
+		for event, value := range current {
+			merged[event] = value
+		}
+	}
+	for event, desired := range sageHooksConfig(hookDirExpr) {
+		var kept []any
+		if entries, ok := merged[event].([]any); ok {
+			for _, entry := range entries {
+				raw, _ := json.Marshal(entry)
+				if !bytes.Contains(raw, []byte("/.claude/hooks/sage-")) {
+					kept = append(kept, entry)
+				}
+			}
+		}
+		if entries, ok := desired.([]any); ok {
+			kept = append(kept, entries...)
+		}
+		merged[event] = kept
+	}
+	return merged
 }
 
 // sagePermissionsConfig returns permissions with SAGE MCP tools allowed,

--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -866,6 +866,11 @@ func isInstalledSageHookCommand(command, hookDirExpr string) bool {
 			return true
 		}
 	}
+	for _, name := range []string{legacyBootScriptName, legacyTurnScriptName} {
+		if command == `bash "`+hookDirExpr+`/`+name+`"` {
+			return true
+		}
+	}
 	return false
 }
 

--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -96,10 +96,23 @@ echo "MANDATORY before compaction: Call sage_reflect with a concise summary of (
 
 const sageUserPromptScript = `#!/bin/bash
 # SAGE UserPromptSubmit hook — fires when the user submits a new prompt.
-# Soft nudge so the agent calls sage_turn early in its response.
+# Always surface payload-free coordination in automated modes. Memory cadence
+# remains mode-specific, but bookend must not hide newly delivered work.
 SAGE_HOME="${SAGE_HOME:-$HOME/.sage}"
 MODE=$(cat "$SAGE_HOME/memory_mode" 2>/dev/null || echo "full")
-if [ "$MODE" = "on-demand" ] || [ "$MODE" = "bookend" ]; then
+SAGE_GUI_BIN="${SAGE_GUI_BIN:-__SAGE_GUI_BIN__}"
+SAGE_PROVIDER="__SAGE_PROVIDER__"
+SAGE_IDENTITY_PATH="__SAGE_IDENTITY_PATH__"
+export SAGE_PROVIDER SAGE_IDENTITY_PATH
+if [ "$MODE" = "on-demand" ]; then
+    exit 0
+fi
+if [ -x "$SAGE_GUI_BIN" ]; then
+    if ! "$SAGE_GUI_BIN" hook inbox-status 2>/dev/null; then
+        echo "SAGE inbox check unavailable — do not treat this as zero messages. Call sage_inbox directly."
+    fi
+fi
+if [ "$MODE" = "bookend" ]; then
     exit 0
 fi
 echo "Reminder: call sage_turn early in your response with the topic + an observation of what just happened. Memories you don't store don't survive."
@@ -545,10 +558,8 @@ func shellDoubleQuote(value string) string {
 // the current installer's 5-script direct-write set.
 //
 // Decision matrix:
-//   - Any expected script missing OR every existing script lacks the current
-//     binary path → re-write the full set and re-wire settings.json.
-//   - All expected scripts present AND at least one references the right
-//     binary path → leave alone.
+//   - Any expected script missing or differing from the current rendered bytes
+//     rewrites the installer-owned set and re-wires settings.json.
 //
 // We compare against the *current* binary path because users upgrade
 // sage-gui by replacing it in place, but also by installing a new version
@@ -564,9 +575,8 @@ func healHooks(projectDir, hookDir, identityPath string) error {
 	}
 	expected := hookScriptSet()
 	needsRewrite := false
-	hasBinRef := false
 	anyScriptExisted := false
-	for name := range expected {
+	for name, tpl := range expected {
 		path := filepath.Join(hookDir, name)
 		data, readErr := os.ReadFile(path) //nolint:gosec // path is inside project's .claude/hooks
 		if readErr != nil {
@@ -574,10 +584,8 @@ func healHooks(projectDir, hookDir, identityPath string) error {
 			continue
 		}
 		anyScriptExisted = true
-		if strings.Contains(string(data), binPath) {
-			hasBinRef = true
-		}
-		if hookUsesDirectWriteIdentity(name) && (!strings.Contains(string(data), `SAGE_PROVIDER="claude-code"`) || !strings.Contains(string(data), identityPath)) {
+		want := renderHookScript(tpl, binPath, "claude-code", identityPath)
+		if string(data) != want {
 			needsRewrite = true
 		}
 	}
@@ -591,7 +599,7 @@ func healHooks(projectDir, hookDir, identityPath string) error {
 		}
 	}
 
-	if !needsRewrite && hasBinRef && !legacyDetected {
+	if !needsRewrite && !legacyDetected {
 		// Hook bytes can already be current while the generated permissions
 		// still advertise a retired/hidden tool from an older installer. Keep
 		// settings synchronized independently of whether scripts need repair.
@@ -821,6 +829,11 @@ func sagePermissionsConfig(settings map[string]any) map[string]any {
 		"mcp__sage__sage_register",
 		"mcp__sage__sage_rename",
 		"mcp__sage__sage_timeline",
+		"mcp__sage__sage_inbox",
+		"mcp__sage__sage_messages_receive",
+		"mcp__sage__sage_message_history",
+		"mcp__sage__sage_message_replies",
+		"mcp__sage__sage_message_status",
 	}
 
 	perms := make(map[string]any)

--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -824,9 +824,31 @@ func mergeSageHooksConfig(existing any, hookDirExpr string) map[string]any {
 		var kept []any
 		if entries, ok := merged[event].([]any); ok {
 			for _, entry := range entries {
-				raw, _ := json.Marshal(entry)
-				if !bytes.Contains(raw, []byte("/.claude/hooks/sage-")) {
+				entryMap, ok := entry.(map[string]any)
+				if !ok {
 					kept = append(kept, entry)
+					continue
+				}
+				hooks, ok := entryMap["hooks"].([]any)
+				if !ok {
+					kept = append(kept, entry)
+					continue
+				}
+				filtered := make([]any, 0, len(hooks))
+				for _, hook := range hooks {
+					hookMap, ok := hook.(map[string]any)
+					command, _ := hookMap["command"].(string)
+					if !ok || !isInstalledSageHookCommand(command, hookDirExpr) {
+						filtered = append(filtered, hook)
+					}
+				}
+				if len(filtered) > 0 {
+					copyEntry := make(map[string]any, len(entryMap))
+					for key, value := range entryMap {
+						copyEntry[key] = value
+					}
+					copyEntry["hooks"] = filtered
+					kept = append(kept, copyEntry)
 				}
 			}
 		}
@@ -836,6 +858,15 @@ func mergeSageHooksConfig(existing any, hookDirExpr string) map[string]any {
 		merged[event] = kept
 	}
 	return merged
+}
+
+func isInstalledSageHookCommand(command, hookDirExpr string) bool {
+	for name := range hookScriptSet() {
+		if command == `bash "`+hookDirExpr+`/`+name+`"` {
+			return true
+		}
+	}
+	return false
 }
 
 // sagePermissionsConfig returns permissions with SAGE MCP tools allowed,

--- a/cmd/sage-gui/mcp_test.go
+++ b/cmd/sage-gui/mcp_test.go
@@ -247,7 +247,11 @@ func TestSelfHeal_RewritesStaleUserPromptBytes(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(hookDir, name), []byte(content), 0755))
 	}
 	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
-	require.NoError(t, os.WriteFile(settingsPath, []byte(`{"custom":"preserve-me","permissions":{"allow":["mcp__other__tool"]}}`), 0600))
+	require.NoError(t, os.WriteFile(settingsPath, []byte(`{
+  "custom":"preserve-me",
+  "permissions":{"allow":["mcp__other__tool"]},
+  "hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"bash custom-user-hook.sh"}]}],"Notification":[{"hooks":[{"type":"command","command":"bash custom-notify.sh"}]}]}
+}`), 0600))
 
 	selfHealProject(projectDir, sageHome)
 	got, err := os.ReadFile(filepath.Join(hookDir, "sage-user-prompt.sh"))
@@ -257,6 +261,8 @@ func TestSelfHeal_RewritesStaleUserPromptBytes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(settings), "preserve-me")
 	assert.Contains(t, string(settings), "mcp__sage__sage_inbox")
+	assert.Contains(t, string(settings), "custom-user-hook.sh")
+	assert.Contains(t, string(settings), "custom-notify.sh")
 }
 
 // ─── Self-Heal Tests ───

--- a/cmd/sage-gui/mcp_test.go
+++ b/cmd/sage-gui/mcp_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -113,6 +114,52 @@ func TestHookScripts_BookendModeCheck(t *testing.T) {
 	assert.Contains(t, sageSessionStartTemplate, "bookend")
 	assert.Contains(t, sageUserPromptScript, "memory_mode")
 	assert.Contains(t, sageUserPromptScript, "bookend")
+	assert.Contains(t, sageUserPromptScript, "hook inbox-status")
+	assert.True(t, strings.Index(sageUserPromptScript, "hook inbox-status") < strings.LastIndex(sageUserPromptScript, `MODE" = "bookend`),
+		"bookend must check coordination before suppressing the memory nudge")
+	assert.Contains(t, sageUserPromptScript, "inbox check unavailable")
+}
+
+func TestUserPromptHookModeBehavior(t *testing.T) {
+	for _, tc := range []struct {
+		name, mode            string
+		wantPointer, wantTurn bool
+	}{
+		{name: "full", mode: "full", wantPointer: true, wantTurn: true},
+		{name: "bookend", mode: "bookend", wantPointer: true, wantTurn: false},
+		{name: "on-demand", mode: "on-demand", wantPointer: false, wantTurn: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(home, "memory_mode"), []byte(tc.mode), 0600))
+			fake := filepath.Join(home, "sage-gui")
+			require.NoError(t, os.WriteFile(fake, []byte("#!/bin/bash\n[ \"$1 $2\" = \"hook inbox-status\" ] || exit 9\necho INBOX-POINTER\n"), 0755))
+			script := filepath.Join(home, "user-prompt.sh")
+			rendered := renderHookScript(sageUserPromptScript, fake, "claude-code", filepath.Join(home, "agent.key"))
+			require.NoError(t, os.WriteFile(script, []byte(rendered), 0755))
+			cmd := exec.Command("bash", script) //nolint:gosec // test executes its own fixed script
+			cmd.Env = append(os.Environ(), "SAGE_HOME="+home, "SAGE_GUI_BIN="+fake)
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPointer, strings.Contains(string(out), "INBOX-POINTER"))
+			assert.Equal(t, tc.wantTurn, strings.Contains(string(out), "call sage_turn"))
+		})
+	}
+}
+
+func TestUserPromptHookReportsInboxProbeFailure(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(home, "memory_mode"), []byte("bookend"), 0600))
+	fake := filepath.Join(home, "sage-gui")
+	require.NoError(t, os.WriteFile(fake, []byte("#!/bin/bash\nexit 1\n"), 0755))
+	script := filepath.Join(home, "user-prompt.sh")
+	require.NoError(t, os.WriteFile(script, []byte(renderHookScript(sageUserPromptScript, fake, "claude-code", filepath.Join(home, "agent.key"))), 0755))
+	cmd := exec.Command("bash", script) //nolint:gosec // test executes its own fixed script
+	cmd.Env = append(os.Environ(), "SAGE_HOME="+home, "SAGE_GUI_BIN="+fake)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "inbox check unavailable")
+	assert.NotContains(t, string(out), "0 unread")
 }
 
 func TestHookScripts_OnDemandModeCheck(t *testing.T) {
@@ -170,8 +217,46 @@ func TestSagePermissionsConfigRemovesRetiredAliases(t *testing.T) {
 	allow, ok := permissions["allow"].([]string)
 	require.True(t, ok)
 	assert.Contains(t, allow, "mcp__sage__sage_inception")
+	for _, tool := range []string{
+		"mcp__sage__sage_inbox", "mcp__sage__sage_messages_receive",
+		"mcp__sage__sage_message_history", "mcp__sage__sage_message_replies",
+		"mcp__sage__sage_message_status",
+	} {
+		assert.Contains(t, allow, tool)
+	}
 	assert.NotContains(t, allow, "mcp__sage__sage_red_pill")
 	assert.Contains(t, allow, "mcp__other__tool", "non-SAGE permissions must be preserved")
+}
+
+func TestSelfHeal_RewritesStaleUserPromptBytes(t *testing.T) {
+	projectDir := t.TempDir()
+	sageHome := t.TempDir()
+	hookDir := filepath.Join(projectDir, ".claude", "hooks")
+	require.NoError(t, os.MkdirAll(hookDir, 0755))
+	binPath, err := os.Executable()
+	require.NoError(t, err)
+	if resolved, symErr := filepath.EvalSymlinks(binPath); symErr == nil {
+		binPath = resolved
+	}
+	identityPath := mcpIdentityPath(filepath.Join(projectDir, ".mcp.json"), sageHome, "claude-code")
+	for name, tpl := range hookScriptSet() {
+		content := renderHookScript(tpl, binPath, "claude-code", identityPath)
+		if name == "sage-user-prompt.sh" {
+			content = strings.ReplaceAll(content, "hook inbox-status", "hook old-silent-version")
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(hookDir, name), []byte(content), 0755))
+	}
+	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
+	require.NoError(t, os.WriteFile(settingsPath, []byte(`{"custom":"preserve-me","permissions":{"allow":["mcp__other__tool"]}}`), 0600))
+
+	selfHealProject(projectDir, sageHome)
+	got, err := os.ReadFile(filepath.Join(hookDir, "sage-user-prompt.sh"))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "hook inbox-status")
+	settings, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(settings), "preserve-me")
+	assert.Contains(t, string(settings), "mcp__sage__sage_inbox")
 }
 
 // ─── Self-Heal Tests ───

--- a/cmd/sage-gui/mcp_test.go
+++ b/cmd/sage-gui/mcp_test.go
@@ -254,6 +254,7 @@ func TestSelfHeal_RewritesStaleUserPromptBytes(t *testing.T) {
 }`), 0600))
 
 	selfHealProject(projectDir, sageHome)
+	selfHealProject(projectDir, sageHome)
 	got, err := os.ReadFile(filepath.Join(hookDir, "sage-user-prompt.sh"))
 	require.NoError(t, err)
 	assert.Contains(t, string(got), "hook inbox-status")
@@ -264,6 +265,7 @@ func TestSelfHeal_RewritesStaleUserPromptBytes(t *testing.T) {
 	assert.Contains(t, string(settings), "custom-user-hook.sh")
 	assert.Contains(t, string(settings), "sage-custom.sh")
 	assert.Contains(t, string(settings), "custom-notify.sh")
+	assert.Equal(t, 1, strings.Count(string(settings), "sage-user-prompt.sh"), "self-heal must replace, not duplicate, its exact installed hook")
 }
 
 // ─── Self-Heal Tests ───
@@ -277,6 +279,9 @@ func TestSelfHeal_MigratesLegacyTwoScriptInstall(t *testing.T) {
 	require.NoError(t, os.MkdirAll(hookDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(hookDir, "sage-boot.sh"), []byte("#!/bin/bash\necho boot\n"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(hookDir, "sage-turn.sh"), []byte("#!/bin/bash\necho turn\n"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, ".claude", "settings.json"), []byte(`{
+  "hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/sage-boot.sh\""}]}],"UserPromptSubmit":[{"hooks":[{"type":"command","command":"bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/sage-turn.sh\""}]}]}
+}`), 0600))
 
 	selfHealProject(projectDir, sageHome)
 
@@ -299,6 +304,7 @@ func TestSelfHeal_MigratesLegacyTwoScriptInstall(t *testing.T) {
 	assert.Contains(t, settings, "sage-session-start.sh")
 	assert.Contains(t, settings, "SessionEnd")
 	assert.NotContains(t, settings, "sage-boot.sh", "legacy hook should not be referenced in new config")
+	assert.NotContains(t, settings, "sage-turn.sh", "legacy hook should not be referenced in new config")
 }
 
 func TestSelfHeal_DoesNotRewriteCurrentHooks(t *testing.T) {

--- a/cmd/sage-gui/mcp_test.go
+++ b/cmd/sage-gui/mcp_test.go
@@ -250,7 +250,7 @@ func TestSelfHeal_RewritesStaleUserPromptBytes(t *testing.T) {
 	require.NoError(t, os.WriteFile(settingsPath, []byte(`{
   "custom":"preserve-me",
   "permissions":{"allow":["mcp__other__tool"]},
-  "hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"bash custom-user-hook.sh"}]}],"Notification":[{"hooks":[{"type":"command","command":"bash custom-notify.sh"}]}]}
+  "hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/sage-user-prompt.sh\""},{"type":"command","command":"bash custom-user-hook.sh"},{"type":"command","command":"bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/sage-custom.sh\""}]}],"Notification":[{"hooks":[{"type":"command","command":"bash custom-notify.sh"}]}]}
 }`), 0600))
 
 	selfHealProject(projectDir, sageHome)
@@ -262,6 +262,7 @@ func TestSelfHeal_RewritesStaleUserPromptBytes(t *testing.T) {
 	assert.Contains(t, string(settings), "preserve-me")
 	assert.Contains(t, string(settings), "mcp__sage__sage_inbox")
 	assert.Contains(t, string(settings), "custom-user-hook.sh")
+	assert.Contains(t, string(settings), "sage-custom.sh")
 	assert.Contains(t, string(settings), "custom-notify.sh")
 }
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -17,7 +17,7 @@ The hooks under `.claude/` here are what the SAGE maintainers use day-to-day. Yo
 | `SessionStart` (startup, resume, compact) | `sage-session-start.sh` | **direct-write** | Calls `sage-gui hook session-start`, which pre-fetches recent committed memories and emits them as a context block the agent reads on boot. Falls back to the soft-nudge boot-check if the SAGE node isn't reachable or the agent key isn't readable. |
 | `SessionEnd` | `sage-session-end.sh` | **direct-write** | Calls `sage-gui hook session-end`, which submits a `session-lifecycle` observation memory through full BFT consensus so the timeline shows session bookends. Soft-fails silently if SAGE isn't reachable — never blocks the agent's exit path. |
 | `PreCompact` | `sage-pre-compact.sh` | nudge | Fires right before Claude Code compresses the context. Turn-level detail is about to be discarded — this nudge prompts the agent to call `sage_reflect` (and any `sage_remember` for durable facts) while context is still fresh. |
-| `UserPromptSubmit` | `sage-user-prompt.sh` | nudge | Light reminder to call `sage_turn` early in the response, capturing the new conversational state. |
+| `UserPromptSubmit` | `sage-user-prompt.sh` | passive pointer + nudge | In `full` and `bookend`, calls `sage-gui hook inbox-status` to surface a payload-free exact-agent unread count without claiming work. `full` also reminds the agent to call `sage_turn`; `bookend` suppresses only that memory nudge. Probe failures are reported as unavailable, never as zero. |
 | `Stop` / `SubagentStop` | `sage-stop.sh` | reserved | No-op placeholder. Fires per-turn (and per-subagent), too high-frequency for direct-write without batching. |
 
 ### How the direct-write hooks work
@@ -27,7 +27,7 @@ Both direct-write scripts shell out to the `sage-gui hook` subcommand. The scrip
 1. Resolves the same ordinary-agent Ed25519 key as the paired MCP process (`SAGE_IDENTITY_PATH`, `SAGE_AGENT_KEY`, or the per-workspace identity). A missing or malformed project key fails closed; hooks never fall back to the CEREBRUM Root/operator key.
 2. Builds the canonical signed-request headers SAGE's REST middleware expects (`X-Agent-ID`, `X-Signature`, `X-Timestamp`).
 3. POSTs / GETs against `http://localhost:8080` (override with `SAGE_URL`) with a tight timeout.
-4. Soft-fails silently if any of those steps fail — the agent never sees an error from a missing SAGE node.
+4. Session boundary operations soft-fail through their safe wrapper behavior. The inbox-status wrapper is deliberately fail-visible: it says the check is unavailable and never manufactures a zero count.
 
 Earlier releases shelled out to a bundled `lib/sage_direct.py`. As of **v8.0** the logic ships inside the `sage-gui` binary itself, so the hooks no longer depend on a Python interpreter or `pynacl`.
 
@@ -36,7 +36,7 @@ Earlier releases shelled out to a bundled `lib/sage_direct.py`. As of **v8.0** t
 Every script reads `~/.sage/memory_mode` and adapts:
 
 - **`full`** (default) — all hooks fire; nudges encourage `sage_turn` on every turn.
-- **`bookend`** — SessionStart still prefetches, but the per-turn `sage_turn` nudges are suppressed; the agent only reflects at the end of significant tasks. SessionStart appends a `SAGE MODE: bookend` notice so the agent knows.
+- **`bookend`** — SessionStart still prefetches and UserPromptSubmit still checks the exact-agent inbox, but the per-turn `sage_turn` nudges are suppressed; the agent only reflects at the end of significant tasks. SessionStart appends a `SAGE MODE: bookend` notice so the agent knows.
 - **`on-demand`** — automatic memory calls are skipped entirely; the agent drives `sage_recall` / `sage_reflect` explicitly.
 
 ### Read scope on multi-agent nodes
@@ -65,7 +65,7 @@ Comment out or remove the matching event entry in `.claude/settings.json`. Hooks
 
 ## Mixed model
 
-SAGE ships **two SessionStart/SessionEnd direct-write hooks** plus **nudge hooks** for the events where direct-write would be too noisy (`UserPromptSubmit`, `PreCompact`) or too high-frequency without batching (`Stop` / `SubagentStop`). The mix lets capture happen automatically at the session boundary, while the conversation-level memory remains the agent's job (via `sage_turn`, `sage_reflect`) since only the LLM has enough context to distill what's actually worth remembering. The `memory_mode` flag (above) tunes how aggressively the nudges fire.
+SAGE ships **two SessionStart/SessionEnd direct-write hooks**, a payload-free exact-agent inbox pointer on `UserPromptSubmit`, and **nudge hooks** where direct-write would be too noisy (`UserPromptSubmit`, `PreCompact`) or too high-frequency without batching (`Stop` / `SubagentStop`). The inbox pointer never claims or exposes messages. Conversation-level memory remains the agent's job (via `sage_turn`, `sage_reflect`) since only the LLM has enough context to distill what's worth remembering. The `memory_mode` flag tunes memory nudges independently from coordination visibility.
 
 ## Forward direction
 


### PR DESCRIPTION
## Summary
- add a signed, payload-free exact-agent inbox-status hook
- run coordination visibility in full and bookend modes without claiming messages
- expose safe message visibility tools in generated Claude permissions
- self-heal stale installer-owned hook bytes across upgrades

## Verification
- focused hook/inbox/installer regressions
- full go test ./cmd/sage-gui
- go vet ./cmd/sage-gui
- git diff --check

Target: v11.18.11. Draft pending independent review and exact-head hosted gates.