### PR TITLE
fix(sse)+test: pipeline_send privacy, event-wiring pin, app-v23 characterisation, log-scrub coverage (#182 prerequisites)

### DIFF
--- a/api/rest/id_safety_test.go
+++ b/api/rest/id_safety_test.go
@@ -108,5 +108,10 @@ func TestHandlePipeSendLegacyShortTargetEventNoPanic(t *testing.T) {
 		httptest.NewRequest(http.MethodPost, "/v1/pipe/send", strings.NewReader(string(body))))
 
 	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
-	require.Contains(t, eventDescription, "piped work to "+target)
+	// A sub-16-byte legacy agent id used to be sliced for this activity row,
+	// which is why this test exists. The row no longer names either endpoint at
+	// all (see TestPipeSendActivityEventCarriesNoEndpointIdentity), so the
+	// surviving contract is: a short target id still sends, and still produces
+	// the metadata-only row rather than an empty or panicking one.
+	require.Equal(t, pipeSendActivityRow, eventDescription)
 }

--- a/api/rest/pipe_handler.go
+++ b/api/rest/pipe_handler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/l33tdawg/sage/api/rest/middleware"
 	"github.com/l33tdawg/sage/internal/auth"
 	"github.com/l33tdawg/sage/internal/federation"
-	"github.com/l33tdawg/sage/internal/idfmt"
 	"github.com/l33tdawg/sage/internal/memory"
 	"github.com/l33tdawg/sage/internal/store"
 )
@@ -438,6 +437,26 @@ func (s *Server) handlePipeResolve(w http.ResponseWriter, r *http.Request) {
 	writeProblem(w, http.StatusNotFound, "Unknown target", fmt.Sprintf("no registered local or visible federated agent matches %q", target))
 }
 
+// pipelineSendActivitySummary renders the dashboard Chain Activity row for a
+// newly created pipeline message. It is deliberately metadata-only.
+//
+// A pipe is private between its sender and its addressed recipient:
+// handlePipeStatus below hands a byte-identical 404 to any other caller so the
+// route cannot even confirm that a given pipe exists. The activity stream has
+// no such authorization — it is one global fan-out with no per-subscriber
+// identity — so naming the sending provider, naming the recipient agent or
+// provider, or echoing the caller-supplied intent here would publish to every
+// attached client exactly the association that handlePipeStatus withholds.
+// Keep this row free of both endpoints and of untrusted request text; the
+// pipeline_complete row is scrubbed the same way and for the same reason.
+func pipelineSendActivitySummary(payloadBytes int) string {
+	return fmt.Sprintf(
+		"[Pipeline] Local agent pipeline opened. Work request queued (%d chars). "+
+			"Untrusted endpoints and intent omitted from the activity stream.",
+		payloadBytes,
+	)
+}
+
 // handlePipeSend creates a pipeline message addressed to another agent/provider.
 func (s *Server) handlePipeSend(w http.ResponseWriter, r *http.Request) {
 	var req struct {
@@ -788,15 +807,14 @@ func (s *Server) handlePipeSend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.OnEvent != nil {
-		target := req.ToProvider
-		if target == "" && req.ToAgent != "" {
-			target = idfmt.Prefix(req.ToAgent)
-			if len(req.ToAgent) >= 16 {
-				target += "..."
-			}
-		}
+		// OnEvent feeds the dashboard Chain Activity stream, which is a single
+		// global fan-out: web.SSEBroadcaster.Subscribe takes no subscriber
+		// identity and Broadcast writes identical bytes to every attached
+		// client. Anything placed in this row is therefore readable by every
+		// client on that stream, not only by the pipe's two parties — so the
+		// row must carry no data this handler would refuse to a non-party.
 		s.OnEvent("pipeline_send", msg.PipeID, "agent-pipeline",
-			fmt.Sprintf("%s piped work to %s (intent: %s)", fromProvider, target, req.Intent), nil)
+			pipelineSendActivitySummary(len(req.Payload)), nil)
 	}
 
 	statusCode := http.StatusCreated

--- a/api/rest/pipe_send_activity_privacy_test.go
+++ b/api/rest/pipe_send_activity_privacy_test.go
@@ -1,0 +1,142 @@
+package rest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+// pipeSendActivityRow is the EXACT dashboard Chain Activity content that
+// /v1/pipe/send is allowed to publish for a 10-byte payload. It is spelled out
+// here rather than obtained from pipelineSendActivitySummary so that widening
+// the production row is a test failure, not a silently mirrored change.
+const pipeSendActivityRow = "[Pipeline] Local agent pipeline opened. Work request queued (10 chars). " +
+	"Untrusted endpoints and intent omitted from the activity stream."
+
+// TestPipeSendActivityEventCarriesNoEndpointIdentity pins the privacy contract
+// of the pipeline_send event.
+//
+// That event is handed to Server.OnEvent, which cmd/sage-gui bridges straight
+// into web.SSEBroadcaster.Broadcast. That broadcaster is a global fan-out with
+// no per-subscriber identity — Subscribe() takes no arguments and Broadcast
+// pushes identical bytes to every attached client — while handlePipeStatus
+// deliberately returns a byte-identical 404 to any caller that is not a party
+// to the pipe. So the sending provider, the recipient agent id, the recipient
+// provider/name, and the caller-supplied intent must never reach this row.
+func TestPipeSendActivityEventCarriesNoEndpointIdentity(t *testing.T) {
+	// The two ids differ inside their first 16 bytes so that a leak of a
+	// truncated id names the endpoint it actually came from.
+	const (
+		senderID       = "a1a1a1a1a1a1a1a1000000000000000000000000000000000000000000000000"
+		senderProvider = "sentinel-sender-provider"
+		targetID       = "b2b2b2b2b2b2b2b2000000000000000000000000000000000000000000000000"
+		targetName     = "sentinel-recipient-name"
+		targetProvider = "sentinel-target-provider"
+		sentinelIntent = "sentinel-private-work-request"
+		payload        = "0123456789" // 10 bytes -> "(10 chars)"
+	)
+
+	// Both addressing modes reach the same emit site: to_agent carries a raw
+	// agent id, to_provider carries a human provider label. Cover both, because
+	// scrubbing only one of the two branches would still leak.
+	for _, tc := range []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			name: "addressed by agent id",
+			body: map[string]any{"to_agent": targetID, "intent": sentinelIntent, "payload": payload},
+		},
+		{
+			name: "addressed by provider label",
+			body: map[string]any{"to_provider": targetProvider, "intent": sentinelIntent, "payload": payload},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, memStore := newPipeServer(t)
+			ctx := context.Background()
+			require.NoError(t, memStore.CreateAgent(ctx, &store.AgentEntry{
+				AgentID: senderID, Name: "sentinel-sender-name",
+				Provider: senderProvider, Status: "active",
+			}))
+			require.NoError(t, memStore.CreateAgent(ctx, &store.AgentEntry{
+				AgentID: targetID, Name: targetName,
+				Provider: targetProvider, Status: "active",
+			}))
+
+			var (
+				calls      int
+				gotType    string
+				gotPipeID  string
+				gotDomain  string
+				gotContent string
+				gotData    any
+			)
+			srv.OnEvent = func(eventType, memoryID, domain, content string, data any) {
+				calls++
+				gotType, gotPipeID, gotDomain, gotContent, gotData =
+					eventType, memoryID, domain, content, data
+			}
+
+			body, err := json.Marshal(tc.body)
+			require.NoError(t, err)
+			rr := httptest.NewRecorder()
+			pipeRouterAs(srv, senderID).ServeHTTP(rr,
+				httptest.NewRequest(http.MethodPost, "/v1/pipe/send", bytes.NewReader(body)))
+			require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+
+			require.Equal(t, 1, calls, "exactly one activity row per accepted send")
+			require.Equal(t, "pipeline_send", gotType)
+			require.Equal(t, "agent-pipeline", gotDomain)
+
+			// Name every identifier that must not appear, so a regression says
+			// which one came back. This runs BEFORE the exact-match assertion
+			// below on purpose: require.* aborts the test, so a leak check
+			// placed after an equality check could never fire.
+			for _, banned := range []struct{ name, secret string }{
+				{"sender agent id", senderID},
+				{"sender provider", senderProvider},
+				{"target agent id", targetID},
+				{"target agent name", targetName},
+				{"target provider", targetProvider},
+				{"caller intent", sentinelIntent},
+			} {
+				require.NotContains(t, gotContent, banned.secret,
+					"%s leaked into the globally fanned-out pipeline_send row", banned.name)
+				// A truncated identifier is still an identifier: the historical
+				// row published only the first 16 bytes of the recipient id.
+				if len(banned.secret) > 16 {
+					require.NotContains(t, gotContent, banned.secret[:16],
+						"truncated %s leaked into the globally fanned-out pipeline_send row",
+						banned.name)
+				}
+			}
+
+			// The structured Data field is a second, easier-to-miss channel onto
+			// the same global stream; pipeline_send must not use it at all.
+			require.Nil(t, gotData, "pipeline_send must publish no structured data")
+
+			// Exact content, not a substring probe: a substring assertion would
+			// still pass if an endpoint name were appended to a correct prefix,
+			// and the loop above only rejects the identifiers it knows about.
+			require.Equal(t, pipeSendActivityRow, gotContent,
+				"pipeline_send activity content must stay metadata-only")
+
+			// The pipe id stays as the row's correlation handle (it is random,
+			// carries no agent identity, and matches pipeline_complete), so
+			// assert it is exactly the id returned to the sender.
+			var resp struct {
+				PipeID string `json:"pipe_id"`
+			}
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+			require.NotEmpty(t, resp.PipeID)
+			require.Equal(t, resp.PipeID, gotPipeID)
+		})
+	}
+}

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -1430,7 +1430,7 @@ func runServe(startupProof string) (rerr error) {
 	// Bridge REST API events to dashboard SSE for the chain activity log
 	restServer.OnEvent = func(eventType, memoryID, domain, content string, data any) {
 		dashboard.SSE.Broadcast(web.SSEEvent{
-			Type:     web.EventType(eventType),
+			Type:     web.EventTypeFromREST(eventType),
 			MemoryID: memoryID,
 			Domain:   domain,
 			Content:  content,
@@ -1654,7 +1654,7 @@ func runServe(startupProof string) (rerr error) {
 				return
 			case status := <-redeployer.StatusChan():
 				dashboard.SSE.Broadcast(web.SSEEvent{
-					Type: "redeploy",
+					Type: web.EventRedeploy,
 					Data: map[string]any{
 						"active":    status.Active,
 						"operation": status.Operation,

--- a/internal/tx/comet_commit_log_scrub_test.go
+++ b/internal/tx/comet_commit_log_scrub_test.go
@@ -1,0 +1,240 @@
+package tx
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// The CheckTx and TxResult logs that BroadcastCometCommit and BroadcastCometSync
+// hand back are remote-derived text: a compromised CometBFT endpoint, or a
+// reverse proxy in front of an honest one, chooses every byte of them. They are
+// scrubbed at the call site so a hostile node cannot echo the signed transaction
+// it was just handed back into operator-visible output.
+//
+// Until these tests existed the scrub on those three fields was pinned only from
+// the web package. Deleting all three calls from comet_commit.go left the whole
+// of ./internal/tx green, so the package that owns the scrub could not detect
+// losing it. Everything below drives the real broadcasters against an httptest
+// CometBFT and asserts on what the caller actually receives.
+
+// submittedTxHexFromRequest recovers the hex of the transaction THIS request
+// actually carried, read back off the wire in whichever shape
+// cometBroadcastRequest chose for it.
+//
+// The fixtures embed that recovered value rather than a hand-written constant.
+// A log quoting some other string is not scrubbable by the exact-match pass at
+// all, so asserting it came back clean would prove nothing -- which is the exact
+// mistake that has been made on this code before.
+func submittedTxHexFromRequest(t *testing.T, r *http.Request) string {
+	t.Helper()
+	if r.Method == http.MethodGet {
+		raw := r.URL.Query().Get("tx")
+		if !strings.HasPrefix(raw, "0x") {
+			t.Errorf("GET broadcast carried tx=%q, want an 0x-prefixed hex transaction", raw)
+			return ""
+		}
+		return raw[len("0x"):]
+	}
+	var envelope struct {
+		Params struct {
+			Tx string `json:"tx"`
+		} `json:"params"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		t.Errorf("decode JSON-RPC broadcast body: %v", err)
+		return ""
+	}
+	raw, err := base64.StdEncoding.DecodeString(envelope.Params.Tx)
+	if err != nil {
+		t.Errorf("decode base64 transaction from JSON-RPC body: %v", err)
+		return ""
+	}
+	return hex.EncodeToString(raw)
+}
+
+// leakedLogFor wraps the submitted transaction hex in prose, BARE: no tx=0x
+// parameter around it, and short enough to stay under the long-run and
+// chunked-hex budgets.
+//
+// That shape is deliberate. It is invisible to every scrub pass except the
+// exact match, and the exact match is the only one that needs the encoded bytes
+// handed to it. So a fixture in this shape fails not just when the scrub call is
+// deleted, but also when it survives as a call that passes nil where the encoded
+// transaction belongs. requireExactMatchOnlyWitness re-proves that isolation at
+// runtime instead of trusting the arithmetic in this comment.
+func leakedLogFor(txHex string) string {
+	return "mempool rejected submission " + txHex + " upstream"
+}
+
+// scrubbedLogFor is leakedLogFor with the payload replaced, i.e. exactly what a
+// correct call site must return. Asserting equality against this rather than
+// merely searching for the marker is what stops a wrong-but-similar value --
+// a truncated hex tail, or the marker appended beside a surviving payload --
+// from passing.
+func scrubbedLogFor() string {
+	return "mempool rejected submission " + redactedTxMarker + " upstream"
+}
+
+// requireExactMatchOnlyWitness proves the fixture is a real witness before
+// anything is asserted about the scrubbed output.
+//
+// Two ways these tests could go quietly vacuous, both closed here: a fixture
+// that never carried the submitted transaction, and a fixture whose shape one of
+// the heuristic passes redacts on its own -- the latter would keep the
+// assertions passing even with the encoded bytes unbound at the call site.
+func requireExactMatchOnlyWitness(t *testing.T, rawLog, txHex string) {
+	t.Helper()
+	if txHex == "" {
+		t.Fatal("no transaction hex was recovered from the wire; the fixture cannot witness a leak")
+	}
+	if !strings.Contains(rawLog, txHex) {
+		t.Fatalf("fixture log %q omits the submitted transaction hex %q, so it has nothing to scrub",
+			rawLog, txHex)
+	}
+	if unbound := ScrubBroadcastText(rawLog, nil); !strings.Contains(unbound, txHex) {
+		t.Fatalf("fixture log is redacted even with no encoded transaction bound (%q); it no longer "+
+			"isolates the exact-match pass and would pass against a call site that scrubs with nil",
+			unbound)
+	}
+}
+
+// assertLogScrubbed states the contract on one surfaced log field.
+func assertLogScrubbed(t *testing.T, where, got, txHex string) {
+	t.Helper()
+	if strings.Contains(got, txHex) {
+		t.Fatalf("%s handed back the signed transaction verbatim: %q", where, got)
+	}
+	if strings.Contains(strings.ToUpper(got), strings.ToUpper(txHex)) {
+		t.Fatalf("%s leaked the signed transaction in a different hex case: %q", where, got)
+	}
+	if !strings.Contains(got, redactedTxMarker) {
+		t.Fatalf("%s dropped the redaction marker %q, so the sentence was lost rather than redacted: %q",
+			where, redactedTxMarker, got)
+	}
+	if want := scrubbedLogFor(); got != want {
+		t.Fatalf("%s = %q, want exactly %q", where, got, want)
+	}
+}
+
+// TestBroadcastCometCommitScrubsRemoteSuppliedLogs pins the ScrubBroadcastText
+// calls that build CometCommitResult.CheckTxLog and CometCommitResult.TxResultLog.
+//
+// All three verdict shapes are covered because all three return the result to the
+// caller: a CheckTx refusal and a FinalizeBlock refusal both hand back a
+// populated result with a nil error, and a committed transaction's log is
+// exactly as remote-controlled as a failed one's.
+func TestBroadcastCometCommitScrubsRemoteSuppliedLogs(t *testing.T) {
+	encoded := []byte("internal-tx-commit-log-scrub-witness")
+	txHex := hex.EncodeToString(encoded)
+	bound := cometHashHexForTest(encoded)
+
+	for _, tc := range []struct {
+		name      string
+		checkCode uint32
+		txCode    uint32
+		height    int
+		// leaked names the field whose log carries the transaction hex.
+		leakCheckTx  bool
+		leakTxResult bool
+	}{
+		{name: "CheckTx refusal log", checkCode: 2, height: 0, leakCheckTx: true},
+		{name: "FinalizeBlock refusal log", txCode: 5, height: 12, leakTxResult: true},
+		{name: "committed success logs", height: 12, leakCheckTx: true, leakTxResult: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var observed atomic.Value
+			rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				wireHex := submittedTxHexFromRequest(t, r)
+				observed.Store(wireHex)
+				leak := leakedLogFor(wireHex)
+				checkLog, txLog := "admitted", "applied"
+				if tc.leakCheckTx {
+					checkLog = leak
+				}
+				if tc.leakTxResult {
+					txLog = leak
+				}
+				_, _ = fmt.Fprintf(w,
+					`{"result":{"check_tx":{"code":%d,"log":%q},"tx_result":{"code":%d,"log":%q},"hash":%q,"height":"%d"}}`,
+					tc.checkCode, checkLog, tc.txCode, txLog, bound, tc.height)
+			}))
+			defer rpc.Close()
+
+			got, err := BroadcastCometCommit(context.Background(), rpc.URL, nil, encoded)
+			if err != nil {
+				t.Fatalf("BroadcastCometCommit: %v", err)
+			}
+			if got == nil {
+				t.Fatal("BroadcastCometCommit returned no result")
+			}
+
+			wireHex, _ := observed.Load().(string)
+			if wireHex != txHex {
+				t.Fatalf("node observed transaction hex %q, want %q; the fixture did not carry the "+
+					"bytes this submission actually sent", wireHex, txHex)
+			}
+			requireExactMatchOnlyWitness(t, leakedLogFor(wireHex), txHex)
+
+			if tc.leakCheckTx {
+				assertLogScrubbed(t, "CometCommitResult.CheckTxLog", got.CheckTxLog, txHex)
+			}
+			if tc.leakTxResult {
+				assertLogScrubbed(t, "CometCommitResult.TxResultLog", got.TxResultLog, txHex)
+			}
+		})
+	}
+}
+
+// TestBroadcastCometSyncScrubsRemoteSuppliedLog pins the ScrubBroadcastText call
+// that builds CometSyncResult.CheckTxLog. Sync surfaces its log on both verdicts
+// -- a refusal clears the fence and returns, an admission returns -- so both are
+// covered.
+func TestBroadcastCometSyncScrubsRemoteSuppliedLog(t *testing.T) {
+	encoded := []byte("internal-tx-sync-log-scrub-witness")
+	txHex := hex.EncodeToString(encoded)
+	bound := cometHashHexForTest(encoded)
+
+	for _, tc := range []struct {
+		name string
+		code uint32
+	}{
+		{name: "CheckTx refusal log", code: 2},
+		{name: "admitted log", code: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var observed atomic.Value
+			rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				wireHex := submittedTxHexFromRequest(t, r)
+				observed.Store(wireHex)
+				_, _ = fmt.Fprintf(w, `{"result":{"code":%d,"hash":%q,"log":%q}}`,
+					tc.code, bound, leakedLogFor(wireHex))
+			}))
+			defer rpc.Close()
+
+			got, err := BroadcastCometSync(context.Background(), rpc.URL, nil, encoded)
+			if err != nil {
+				t.Fatalf("BroadcastCometSync: %v", err)
+			}
+			if got == nil {
+				t.Fatal("BroadcastCometSync returned no result")
+			}
+
+			wireHex, _ := observed.Load().(string)
+			if wireHex != txHex {
+				t.Fatalf("node observed transaction hex %q, want %q; the fixture did not carry the "+
+					"bytes this submission actually sent", wireHex, txHex)
+			}
+			requireExactMatchOnlyWitness(t, leakedLogFor(wireHex), txHex)
+
+			assertLogScrubbed(t, "CometSyncResult.CheckTxLog", got.CheckTxLog, txHex)
+		})
+	}
+}

--- a/web/network_handler.go
+++ b/web/network_handler.go
@@ -1518,7 +1518,7 @@ func (h *DashboardHandler) handleTriggerRedeploy(w http.ResponseWriter, r *http.
 		// Broadcast completion via SSE if available
 		if h.SSE != nil {
 			h.SSE.Broadcast(SSEEvent{
-				Type: "redeploy",
+				Type: EventRedeploy,
 				Data: map[string]any{
 					"operation": req.Operation,
 					"agent_id":  req.AgentID,

--- a/web/sse.go
+++ b/web/sse.go
@@ -33,7 +33,76 @@ const (
 	// Chain Activity an auditable view of enforced permissions, not merely a
 	// memory-operation feed.
 	EventAccess EventType = "access"
+	// EventReinstate is the counterpart of EventForget: a deprecated memory
+	// returned to active service by consensus.
+	EventReinstate EventType = "reinstate"
+	// EventCoCommit is a multi-agent shared commit. It is a commit like
+	// EventRemember, so the dashboard must be able to observe it.
+	EventCoCommit EventType = "cocommit"
+	// EventSearch is a text-search retrieval — the lexical sibling of
+	// EventRecall.
+	EventSearch EventType = "search"
+	// EventHybrid is a combined vector+text retrieval — the hybrid sibling of
+	// EventRecall.
+	EventHybrid EventType = "hybrid"
+	// EventPipelineSend reports a message handed to an agent pipeline.
+	EventPipelineSend EventType = "pipeline_send"
+	// EventPipelineComplete reports an agent pipeline run reaching its end.
+	EventPipelineComplete EventType = "pipeline_complete"
+	// EventRedeploy reports chain-reconfiguration progress for the network page.
+	EventRedeploy EventType = "redeploy"
 )
+
+// AllEventTypes is the canonical registry of every SSE event the node emits.
+//
+// An SSE event only reaches a user when three separate places agree on the same
+// string: the emit site in Go, this registry, and the listener list in
+// static/js/sse.js. Nothing about the language links them — the REST layer emits
+// raw strings that cmd/sage-gui converts straight into EventType, and the
+// browser only receives event names it explicitly subscribed to. Miss one copy
+// and the feature compiles, runs, emits, and is seen by nobody.
+//
+// This slice is the single Go-side source of truth that closes that gap:
+// TestSSEEventWiring in sse_wiring_test.go proves the const block above, every
+// emit site in the repository, and the JavaScript listener list all name exactly
+// these events. Adding an event means adding it here and in static/js/sse.js;
+// the test fails until both are done.
+var AllEventTypes = []EventType{
+	EventRemember,
+	EventRecall,
+	EventForget,
+	EventVote,
+	EventConsensus,
+	EventAgent,
+	EventImport,
+	EventUpdate,
+	EventGovernance,
+	EventTask,
+	EventRecovery,
+	EventAccess,
+	EventReinstate,
+	EventCoCommit,
+	EventSearch,
+	EventHybrid,
+	EventPipelineSend,
+	EventPipelineComplete,
+	EventRedeploy,
+}
+
+// EventTypeFromREST adopts an event name produced by the REST layer, which
+// passes plain strings to api/rest.Server.OnEvent because that package does not
+// import this one.
+//
+// This is the ONLY place an unconstrained string is allowed to become an
+// EventType. The name is still checked — TestSSEEventWiring reads the OnEvent
+// call sites directly and requires every name they pass to be registered in
+// AllEventTypes — so routing the bridge through a named function keeps that one
+// unchecked-looking conversion greppable instead of letting any
+// EventType(someExpression) anywhere in the tree slip an unregistered event onto
+// the stream.
+func EventTypeFromREST(name string) EventType {
+	return EventType(name)
+}
 
 // SSEEvent is an event sent to connected dashboard clients.
 type SSEEvent struct {

--- a/web/sse_wiring_test.go
+++ b/web/sse_wiring_test.go
@@ -269,6 +269,19 @@ func scanSSESources(t *testing.T) sseSourceScan {
 		ast.Inspect(pf.file, func(node ast.Node) bool {
 			switch n := node.(type) {
 			case *ast.CallExpr:
+				// emitContentlessRetrievalActivity (api/rest/sse_retrieval_activity.go)
+				// is the sanctioned wrapper the memory handlers use to fire the
+				// recall/search/hybrid retrieval pulses without any result material.
+				// It reaches OnEvent through a func parameter the scanner cannot
+				// follow across the call boundary, so match the wrapper itself and
+				// hold its second argument — the event name — to the registry
+				// exactly as a direct OnEvent literal is.
+				if isCalled(n.Fun, "emitContentlessRetrievalActivity") {
+					if len(n.Args) >= 2 {
+						record(n.Args[1], "emitContentlessRetrievalActivity event name")
+					}
+					return true
+				}
 				sel, ok := n.Fun.(*ast.SelectorExpr)
 				if !ok || sel.Sel.Name != "OnEvent" || len(n.Args) == 0 {
 					return true

--- a/web/sse_wiring_test.go
+++ b/web/sse_wiring_test.go
@@ -1,0 +1,513 @@
+package web
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An SSE event name lives in three places that the compiler does not connect:
+//
+//  1. the emit site — either a raw string handed to api/rest.Server.OnEvent, or
+//     a web.SSEEvent literal broadcast directly;
+//  2. the EventType const block plus AllEventTypes in web/sse.go;
+//  3. the eventTypes listener array in web/static/js/sse.js.
+//
+// The REST bridge in cmd/sage-gui/node.go adopts whatever string the handler
+// passed (web.EventTypeFromREST), so the const block never constrains the emit
+// sites, and EventSource only delivers named events to listeners that were
+// explicitly registered, so the browser silently drops anything missing from the
+// JavaScript array. An event can therefore be emitted correctly, marshalled
+// correctly, written to the wire correctly — and observed by nobody. Every Go
+// test passes and scripts/check-static-js.mjs passes, because it only parses
+// modules.
+//
+// That is not hypothetical. Before this test existed, "cocommit", "search",
+// "hybrid", "pipeline_send", "pipeline_complete", "reinstate" and "redeploy"
+// were all emitted by production code and absent from both the const block and
+// the JavaScript array.
+//
+// DESIGN CHOICE: this test asserts FULL consistency and the accompanying change
+// closed those seven gaps, rather than asserting the invariant for an allow-list
+// of events that "should" be observable. An allow-list would have been a fourth
+// hand-maintained copy of the same list, reproducing the exact failure mode it
+// was meant to prevent: add an event, forget the allow-list, nothing fails.
+// Full consistency has no list to forget — a new emit site fails the test until
+// the event is registered in Go and subscribed to in JavaScript.
+func TestSSEEventWiring(t *testing.T) {
+	scan := scanSSESources(t)
+	registry := eventTypeStrings(AllEventTypes)
+
+	t.Run("registry is well formed", func(t *testing.T) {
+		assertNoDuplicates(t, registry, "web.AllEventTypes")
+		for _, name := range registry {
+			assert.NotEmpty(t, name, "web.AllEventTypes must not contain an empty event name")
+		}
+	})
+
+	// The const block is the vocabulary; AllEventTypes is the registry the other
+	// two checks are stated against. A const declared but never registered is
+	// invisible to those checks, so pin them to each other first.
+	t.Run("const block matches AllEventTypes", func(t *testing.T) {
+		declared := make([]string, 0, len(scan.consts))
+		for _, value := range scan.consts {
+			declared = append(declared, value)
+		}
+		assertSameEventSet(t, registry, declared,
+			"web.AllEventTypes", "the EventType const block in web/sse.go", "")
+	})
+
+	t.Run("every emitted event is registered and every registered event is emitted", func(t *testing.T) {
+		require.Empty(t, scan.unresolved,
+			"every SSE emit site must name its event with a string literal or an EventType const so the wiring is checkable")
+		require.NotEmpty(t, scan.emits, "found no SSE emit sites at all — the source scan is broken")
+
+		emitted := make([]string, 0, len(scan.emits))
+		for _, site := range scan.emits {
+			emitted = append(emitted, site.name)
+		}
+		assertSameEventSet(t, registry, emitted,
+			"web.AllEventTypes", "the SSE event names emitted by Go code",
+			"emit sites found:\n"+scan.sitesByName())
+	})
+
+	t.Run("dashboard JavaScript subscribes to exactly the registered events", func(t *testing.T) {
+		js := readDashboardSSEScript(t)
+		listened := jsListenedEventTypes(t, js)
+		assertNoDuplicates(t, listened, "the eventTypes array in web/static/js/sse.js")
+		assertSameEventSet(t, registry, listened,
+			"web.AllEventTypes", "the eventTypes array in web/static/js/sse.js", "")
+	})
+
+	// The array only matters because it drives addEventListener. Pin that too,
+	// or the array could be preserved as decoration while the browser stops
+	// subscribing.
+	t.Run("the eventTypes array actually registers the listeners", func(t *testing.T) {
+		js := readDashboardSSEScript(t)
+		assert.Contains(t, js, "for (const type of eventTypes) {",
+			"eventTypes must be the loop that registers listeners")
+		assert.Contains(t, js, "this.es.addEventListener(type, (e) => {",
+			"each event type in the array must be subscribed on the EventSource")
+	})
+}
+
+func readDashboardSSEScript(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile("static/js/sse.js")
+	require.NoError(t, err)
+	return string(raw)
+}
+
+var (
+	jsEventTypesArrayRe = regexp.MustCompile(`(?s)const\s+eventTypes\s*=\s*\[(.*?)]`)
+	jsStringLiteralRe   = regexp.MustCompile(`'([^']*)'|"([^"]*)"`)
+)
+
+// jsListenedEventTypes extracts the event names the dashboard client subscribes
+// to from the single eventTypes array literal in static/js/sse.js.
+func jsListenedEventTypes(t *testing.T, js string) []string {
+	t.Helper()
+	matches := jsEventTypesArrayRe.FindAllStringSubmatch(js, -1)
+	require.Len(t, matches, 1,
+		"static/js/sse.js must declare exactly one eventTypes array; a second one would shadow the checked list")
+
+	entries := jsStringLiteralRe.FindAllStringSubmatch(matches[0][1], -1)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry[1]
+		if name == "" {
+			name = entry[2]
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+// sseEmitSite is one place in the repository that names an SSE event.
+type sseEmitSite struct {
+	name string
+	pos  string
+}
+
+// sseSourceScan is the result of reading every non-test Go file in the module
+// for SSE event vocabulary and SSE emit sites.
+type sseSourceScan struct {
+	consts     map[string]string // EventType const identifier -> event name
+	emits      []sseEmitSite
+	unresolved []string
+}
+
+// sitesByName renders the emit sites grouped by event name so a failure names
+// the offending file and line rather than only the offending string.
+func (s sseSourceScan) sitesByName() string {
+	grouped := map[string][]string{}
+	for _, site := range s.emits {
+		grouped[site.name] = append(grouped[site.name], site.pos)
+	}
+	names := make([]string, 0, len(grouped))
+	for name := range grouped {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	for _, name := range names {
+		b.WriteString("    ")
+		b.WriteString(name)
+		b.WriteString(": ")
+		b.WriteString(strings.Join(grouped[name], ", "))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+var sseScanSkipDirs = map[string]bool{
+	"third_party":  true,
+	"vendor":       true,
+	"node_modules": true,
+	"testdata":     true,
+	".git":         true,
+}
+
+// scanSSESources parses every non-test Go file in the module and collects both
+// the EventType vocabulary and every SSE emit site. It walks the whole module
+// rather than a fixed package list so an emit site added in a new package is
+// covered the day it is written.
+func scanSSESources(t *testing.T) sseSourceScan {
+	t.Helper()
+
+	root := moduleRoot(t)
+	fset := token.NewFileSet()
+	type parsedFile struct {
+		path string
+		file *ast.File
+	}
+	var parsed []parsedFile
+
+	walkErr := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if path != root && (sseScanSkipDirs[entry.Name()] || strings.HasPrefix(entry.Name(), ".")) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		parsed = append(parsed, parsedFile{path: path, file: file})
+		return nil
+	})
+	require.NoError(t, walkErr)
+	require.NotEmpty(t, parsed, "found no Go sources to scan")
+
+	scan := sseSourceScan{consts: map[string]string{}}
+
+	// Pass 1: the EventType vocabulary, so pass 2 can resolve identifiers.
+	for _, pf := range parsed {
+		for _, decl := range pf.file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				typeIdent, ok := value.Type.(*ast.Ident)
+				if !ok || typeIdent.Name != "EventType" {
+					continue
+				}
+				for i, name := range value.Names {
+					require.Less(t, i, len(value.Values),
+						"EventType const %s has no value at %s", name.Name, relPos(root, fset, name.Pos()))
+					lit, ok := value.Values[i].(*ast.BasicLit)
+					require.True(t, ok && lit.Kind == token.STRING,
+						"EventType const %s must be a string literal at %s", name.Name, relPos(root, fset, name.Pos()))
+					unquoted, unquoteErr := strconv.Unquote(lit.Value)
+					require.NoError(t, unquoteErr)
+					scan.consts[name.Name] = unquoted
+				}
+			}
+		}
+	}
+	require.NotEmpty(t, scan.consts, "found no EventType constants — the source scan is broken")
+
+	// Pass 2: the emit sites.
+	for _, pf := range parsed {
+		pf := pf
+		record := func(expr ast.Expr, what string) {
+			pos := relPos(root, fset, expr.Pos())
+			names, ok := scan.resolve(pf.file, expr, 0)
+			if !ok {
+				scan.unresolved = append(scan.unresolved, what+" at "+pos)
+				return
+			}
+			for _, name := range names {
+				scan.emits = append(scan.emits, sseEmitSite{name: name, pos: pos})
+			}
+		}
+
+		ast.Inspect(pf.file, func(node ast.Node) bool {
+			switch n := node.(type) {
+			case *ast.CallExpr:
+				sel, ok := n.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "OnEvent" || len(n.Args) == 0 {
+					return true
+				}
+				record(n.Args[0], "OnEvent event name")
+			case *ast.CompositeLit:
+				if !isSSEEventType(n.Type) {
+					return true
+				}
+				for _, elt := range n.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					key, ok := kv.Key.(*ast.Ident)
+					if !ok || key.Name != "Type" {
+						continue
+					}
+					record(kv.Value, "SSEEvent Type field")
+					return true
+				}
+				if len(n.Elts) > 0 {
+					scan.unresolved = append(scan.unresolved,
+						"SSEEvent literal without a Type field at "+relPos(root, fset, n.Pos()))
+				}
+			}
+			return true
+		})
+	}
+
+	return scan
+}
+
+// isSSEEventType reports whether a composite literal type is web.SSEEvent,
+// written either from inside package web or through the package qualifier.
+func isSSEEventType(expr ast.Expr) bool {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name == "SSEEvent"
+	case *ast.SelectorExpr:
+		return t.Sel.Name == "SSEEvent"
+	}
+	return false
+}
+
+// resolve statically evaluates an expression that names an SSE event. It returns
+// every value the expression can take, and false when the expression cannot be
+// evaluated at all — which the test treats as a defect, because an unreadable
+// emit site is exactly the blind spot this file exists to close.
+func (s *sseSourceScan) resolve(file *ast.File, expr ast.Expr, depth int) ([]string, bool) {
+	if depth > 4 {
+		return nil, false
+	}
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if e.Kind != token.STRING {
+			return nil, false
+		}
+		unquoted, err := strconv.Unquote(e.Value)
+		if err != nil {
+			return nil, false
+		}
+		return []string{unquoted}, true
+	case *ast.Ident:
+		if value, ok := s.consts[e.Name]; ok {
+			return []string{value}, true
+		}
+		return s.resolveLocalVar(file, e.Name, depth)
+	case *ast.SelectorExpr:
+		if value, ok := s.consts[e.Sel.Name]; ok {
+			return []string{value}, true
+		}
+		return nil, false
+	case *ast.CallExpr:
+		if len(e.Args) != 1 {
+			return nil, false
+		}
+		// web.EventTypeFromREST is the single sanctioned bridge: it adopts the
+		// raw name a REST handler passed to OnEvent, and that name is checked at
+		// the OnEvent call site itself, so contributing nothing here is correct.
+		// A bare EventType(x) conversion gets no such pass — only its argument
+		// can excuse it — because that is precisely how an unregistered event
+		// would otherwise reach the stream unnoticed.
+		if isCalled(e.Fun, "EventTypeFromREST") {
+			// A caller that hands the bridge a name it knows statically is not
+			// bridging anything, so that name is held to the registry too.
+			if names, ok := s.resolve(file, e.Args[0], depth+1); ok {
+				return names, true
+			}
+			return nil, true
+		}
+		if !isCalled(e.Fun, "EventType") {
+			return nil, false
+		}
+		return s.resolve(file, e.Args[0], depth+1)
+	}
+	return nil, false
+}
+
+// resolveLocalVar resolves an identifier that is not an EventType const by
+// collecting every value assigned to that name in the same file — the shape used
+// where a handler picks between two event types before broadcasting.
+func (s *sseSourceScan) resolveLocalVar(file *ast.File, name string, depth int) ([]string, bool) {
+	var values []string
+	found := false
+	resolvedAll := true
+
+	collect := func(lhs []ast.Expr, rhs []ast.Expr) {
+		for i, target := range lhs {
+			ident, ok := target.(*ast.Ident)
+			if !ok || ident.Name != name || i >= len(rhs) {
+				continue
+			}
+			found = true
+			resolved, ok := s.resolve(file, rhs[i], depth+1)
+			if !ok {
+				resolvedAll = false
+				continue
+			}
+			values = append(values, resolved...)
+		}
+	}
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.AssignStmt:
+			collect(n.Lhs, n.Rhs)
+		case *ast.ValueSpec:
+			names := make([]ast.Expr, 0, len(n.Names))
+			for _, ident := range n.Names {
+				names = append(names, ident)
+			}
+			collect(names, n.Values)
+		}
+		return true
+	})
+
+	if !found {
+		return nil, false
+	}
+	return values, resolvedAll
+}
+
+// isCalled reports whether a call's function expression names fn, written either
+// from inside package web or through the package qualifier.
+func isCalled(expr ast.Expr, fn string) bool {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name == fn
+	case *ast.SelectorExpr:
+		return t.Sel.Name == fn
+	}
+	return false
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs("..")
+	require.NoError(t, err)
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, dir, parent, "no go.mod found above the web package")
+		dir = parent
+	}
+}
+
+func relPos(root string, fset *token.FileSet, pos token.Pos) string {
+	position := fset.Position(pos)
+	if rel, err := filepath.Rel(root, position.Filename); err == nil {
+		position.Filename = rel
+	}
+	return position.String()
+}
+
+func eventTypeStrings(types []EventType) []string {
+	out := make([]string, 0, len(types))
+	for _, t := range types {
+		out = append(out, string(t))
+	}
+	return out
+}
+
+// assertSameEventSet compares two event-name sets exactly in both directions. A
+// containment check would let a wrong-but-similar name ("pipeline_sent") pass
+// alongside the right one, so equality of the deduplicated, sorted sets is the
+// contract.
+func assertSameEventSet(t *testing.T, want, got []string, wantLabel, gotLabel, detail string) {
+	t.Helper()
+	wantSet := uniqueSorted(want)
+	gotSet := uniqueSorted(got)
+	if assert.ObjectsAreEqual(wantSet, gotSet) {
+		return
+	}
+	if detail != "" {
+		detail = "\n" + detail
+	}
+	assert.Equal(t, wantSet, gotSet,
+		"SSE event wiring is inconsistent.\nmissing from %s: %v\nmissing from %s: %v%s",
+		gotLabel, difference(wantSet, gotSet),
+		wantLabel, difference(gotSet, wantSet),
+		detail)
+}
+
+func assertNoDuplicates(t *testing.T, names []string, label string) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, name := range names {
+		assert.False(t, seen[name], "%s lists %q more than once", label, name)
+		seen[name] = true
+	}
+}
+
+func uniqueSorted(names []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func difference(from, remove []string) []string {
+	excluded := map[string]bool{}
+	for _, name := range remove {
+		excluded[name] = true
+	}
+	out := []string{}
+	for _, name := range from {
+		if !excluded[name] {
+			out = append(out, name)
+		}
+	}
+	return out
+}

--- a/web/static/js/sse.js
+++ b/web/static/js/sse.js
@@ -29,7 +29,17 @@ export class SSEClient {
             this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000);
         };
 
-        const eventTypes = ['remember', 'recall', 'forget', 'vote', 'consensus', 'agent', 'access', 'update', 'governance', 'import', 'task', 'recovery'];
+        // Every event the node emits must be listed here: EventSource only
+        // delivers named events to listeners that were explicitly registered, so
+        // an omitted name is emitted by the server and seen by nobody. This list
+        // is kept in lockstep with web.AllEventTypes (web/sse.go) by
+        // TestSSEEventWiring — add an event there and here, or the build fails.
+        const eventTypes = [
+            'remember', 'recall', 'forget', 'vote', 'consensus', 'agent',
+            'access', 'update', 'governance', 'import', 'task', 'recovery',
+            'reinstate', 'cocommit', 'search', 'hybrid',
+            'pipeline_send', 'pipeline_complete', 'redeploy',
+        ];
         for (const type of eventTypes) {
             this.es.addEventListener(type, (e) => {
                 try {

--- a/web/synapse_appv23_rbac_test.go
+++ b/web/synapse_appv23_rbac_test.go
@@ -1,0 +1,236 @@
+package web
+
+import (
+	"context"
+	"crypto/ed25519"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+// appV23SynapseFixture is the connectome endpoint standing on an app-v23-ACTIVE
+// node. Every other synapse test in web/synapse_handler_test.go leaves
+// AppV23ActiveFn nil, and appV23IsActive reports false for a nil func
+// (web/appv23_access_handler.go:379-381), so those tests only ever exercise the
+// LEGACY half of resolveAgentRBAC. This fixture exercises the app-v23 half that
+// new nodes actually run.
+type appV23SynapseFixture struct {
+	handler   *DashboardHandler
+	sql       *store.SQLiteStore
+	badger    *store.BadgerStore
+	rootID    string
+	memberID  string
+	strangerA string
+	strangerB string
+}
+
+// newAppV23SynapseFixture bootstraps the app-v23 genesis the way
+// web/appv23_projection_visibility_test.go:197 does, then enrolls two further
+// agents that the member has no relationship with whatsoever: separate owned
+// home domains, no grants, no shared domain between them.
+func newAppV23SynapseFixture(t *testing.T) appV23SynapseFixture {
+	t.Helper()
+
+	sqlStore, err := store.NewSQLiteStore(
+		context.Background(), filepath.Join(t.TempDir(), "sage.db"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sqlStore.Close()) })
+
+	badgerStore, err := store.NewBadgerStore(filepath.Join(t.TempDir(), "badger"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, badgerStore.CloseBadger()) })
+
+	newID := func() string {
+		_, key, keyErr := ed25519.GenerateKey(nil)
+		require.NoError(t, keyErr)
+		return agentIDForKey(key)
+	}
+	fixture := appV23SynapseFixture{
+		sql: sqlStore, badger: badgerStore,
+		rootID: newID(), memberID: newID(),
+		strangerA: newID(), strangerB: newID(),
+	}
+
+	// The member is a STANDARD/MEMBER enrollment with capability mask 0: it does
+	// NOT hold AgentCapabilityReadAllDomains, so its read reach is exactly its
+	// own home domain plus explicit grants. This is the most restricted active
+	// app-v23 principal that still passes every resolveAgentRBAC precondition.
+	require.NoError(t, badgerStore.BootstrapAppV23Genesis(store.AppV23GenesisBootstrap{
+		RootID: fixture.rootID, Scope: "synapse-appv23-rbac-fixture",
+		AgentID: fixture.memberID, Profile: store.AppV23ProfileStandard,
+		HomeDomain: "member-home", Clearance: uint8(store.ClearanceInternal),
+		Capabilities: 0, Height: 1, BootstrapDigest: "synapse-appv23-rbac-fixture",
+	}))
+
+	// The neuron half of the response reads the on-chain agent registry, which
+	// is a separate record from the app-v23 enrollment. Approval requires the
+	// registry row to exist first.
+	for i, id := range []string{fixture.memberID, fixture.strangerA, fixture.strangerB} {
+		require.NoError(t, badgerStore.RegisterAgent(
+			id, id, store.AppV23RoleMember, "", "test", "", int64(i+1),
+		))
+	}
+
+	for _, stranger := range []struct{ id, home string }{
+		{fixture.strangerA, "stranger-a-home"},
+		{fixture.strangerB, "stranger-b-home"},
+	} {
+		require.NoError(t, badgerStore.ApproveAppV23LocalAgent(
+			store.AppV23LocalEnrollment{
+				AgentID: stranger.id, ApprovedBy: fixture.rootID, RootGeneration: 1,
+				Profile: store.AppV23ProfileStandard, HomeDomain: stranger.home,
+				Clearance: uint8(store.ClearanceInternal), Capabilities: 0,
+				Active: true, UpdatedHeight: 2,
+			},
+			store.AppV23RoleMember, 0, 0,
+		))
+	}
+
+	handler := NewDashboardHandler(sqlStore, "test")
+	handler.BadgerStore = badgerStore
+	handler.AppV23ActiveFn = func() bool { return true }
+	fixture.handler = handler
+	return fixture
+}
+
+// TestHandleSynapsesAppV23MemberCurrentlySeesAllNeuronsAndEdges is a
+// CHARACTERISATION test. It records what the CEREBRUM connectome returns TODAY
+// for a restricted app-v23 member; it does NOT assert what the endpoint ought to
+// return. Read every assertion below as "this is what happens", never as "this
+// is correct".
+//
+// The behaviour it pins:
+//
+//	web/handler.go:396-431 resolveAgentRBAC, once the app-v23 fork is active,
+//	returns (nil, true) — seeAll — for ANY caller holding a valid enrollment and
+//	role, regardless of role, profile, capability mask, or clearance. The comment
+//	at web/handler.go:428-430 justifies dropping the submitter pre-filter with
+//	"every record is still checked by agentDomainReadDecision".
+//
+//	web/synapse_handler.go never calls agentDomainReadDecision. It consumes
+//	seeAll at line 63 and short-circuits BOTH the neuron filter (line 76) and the
+//	edge guard (line 98) on it, so the compensating check the comment names does
+//	not run on this route.
+//
+// The net effect asserted here: a restricted member with no grant, no shared
+// domain, and no traffic of its own receives the complete neuron list and the
+// complete edge set — including a directed edge between two agents whose home
+// domains it is definitively DENIED read on (asserted as a precondition below,
+// so the mismatch between the justification and the route is executable, not
+// prose).
+//
+// This is BELIEVED TO BE A GAP. Whether app-v23 connectome seeAll is intentional
+// (domain-derived visibility deliberately not applying to bus topology) or a
+// missing guard is the MAINTAINER'S CALL, not this test's. If the disposition is
+// "fix it", this test is expected to fail and should be rewritten to assert the
+// filtered result. If the disposition is "intended", keep it as the explicit
+// record of that decision.
+func TestHandleSynapsesAppV23MemberCurrentlySeesAllNeuronsAndEdges(t *testing.T) {
+	fixture := newAppV23SynapseFixture(t)
+	h := fixture.handler
+
+	// Precondition 1: the app-v23 branch is the one under test. Without this the
+	// test would silently re-run the legacy branch, which is the exact blind spot
+	// this file exists to close.
+	require.True(t, h.appV23IsActive(), "precondition: app-v23 fork is active")
+
+	// Precondition 2: the member really is domain-restricted. agentDomainReadDecision
+	// — the check web/handler.go:428-430 names as the compensating control — returns
+	// a DEFINITIVE DENY for this member on each stranger's home domain.
+	for _, domain := range []string{"stranger-a-home", "stranger-b-home"} {
+		allowedDomain, definitive := h.agentDomainReadDecision(
+			context.Background(), fixture.memberID, domain,
+		)
+		require.True(t, definitive,
+			"precondition: the domain decision is definitive for %s", domain)
+		require.False(t, allowedDomain,
+			"precondition: member is denied read on %s", domain)
+	}
+	// The member's own home domain is readable, proving the deny above is a real
+	// restriction and not a broken fixture that denies everything.
+	ownAllowed, ownDefinitive := h.agentDomainReadDecision(
+		context.Background(), fixture.memberID, "member-home",
+	)
+	require.True(t, ownDefinitive)
+	require.True(t, ownAllowed, "precondition: member reads its own home domain")
+
+	// Bus traffic exclusively between the two strangers. The member is not an
+	// endpoint of any edge, so under two-endpoint visibility it would see none.
+	base := time.Now().UTC().Truncate(time.Second)
+	insertSynapseMessage(t, fixture.sql, "v23-1", fixture.strangerA, fixture.strangerB, base)
+	insertSynapseMessage(t, fixture.sql, "v23-2", fixture.strangerA, fixture.strangerB,
+		base.Add(time.Minute))
+	insertSynapseMessage(t, fixture.sql, "v23-3", fixture.strangerB, fixture.strangerA, base)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/network/synapses", nil)
+	req = req.WithContext(context.WithValue(
+		req.Context(), verifiedDashboardAgentKey{}, fixture.memberID,
+	))
+
+	// Precondition 3: resolveAgentRBAC hands this member the unfiltered posture.
+	// Asserted exactly: allowed is nil (not merely empty) and seeAll is true.
+	allowed, seeAll := h.resolveAgentRBAC(req)
+	require.Nil(t, allowed,
+		"CURRENT: app-v23 resolveAgentRBAC returns no allowlist for a restricted member")
+	require.True(t, seeAll,
+		"CURRENT: app-v23 resolveAgentRBAC returns seeAll for a restricted member")
+
+	rec := httptest.NewRecorder()
+	h.handleSynapses(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	body := decodeSynapseBody(t, rec)
+
+	// CURRENT BEHAVIOUR — neurons: the member is handed the whole registry,
+	// including two agents it can neither read from nor address.
+	neurons := make(map[string]bool, len(body.Neurons))
+	for _, n := range body.Neurons {
+		neurons[n.AgentID] = true
+	}
+	require.Len(t, body.Neurons, 4,
+		"CURRENT: every registered agent is a neuron for a restricted app-v23 member")
+	require.True(t, neurons[fixture.memberID])
+	require.True(t, neurons[fixture.strangerA],
+		"CURRENT: a domain-denied agent is still named as a neuron")
+	require.True(t, neurons[fixture.strangerB],
+		"CURRENT: a domain-denied agent is still named as a neuron")
+	require.True(t, neurons[fixture.rootID],
+		"CURRENT: the CEREBRUM root identity is disclosed to the member too")
+
+	// CURRENT BEHAVIOUR — edges: both directed stranger-to-stranger synapses are
+	// returned in full, weights included, to a caller that is not an endpoint of
+	// either and is denied read on both endpoints' home domains.
+	byEdge := make(map[string]store.PipeSynapse, len(body.Synapses))
+	for _, e := range body.Synapses {
+		byEdge[e.FromAgent+"|"+e.ToAgent] = e
+	}
+	require.Len(t, body.Synapses, 2,
+		"CURRENT: the edge guard does not run for an app-v23 member; got %v", byEdge)
+
+	forward, ok := byEdge[fixture.strangerA+"|"+fixture.strangerB]
+	require.True(t, ok,
+		"CURRENT: an edge between two agents invisible to the caller is returned")
+	require.Equal(t, fixture.strangerA, forward.FromAgent)
+	require.Equal(t, fixture.strangerB, forward.ToAgent)
+	require.Equal(t, int64(2), forward.Count,
+		"CURRENT: the full synaptic weight is disclosed, not a redacted one")
+
+	reverse, ok := byEdge[fixture.strangerB+"|"+fixture.strangerA]
+	require.True(t, ok,
+		"CURRENT: the reverse edge between two invisible agents is returned too")
+	require.Equal(t, fixture.strangerB, reverse.FromAgent)
+	require.Equal(t, fixture.strangerA, reverse.ToAgent)
+	require.Equal(t, int64(1), reverse.Count)
+
+	// Nothing in the response involves the caller. Every byte it received
+	// describes traffic between two agents it has no authorization to read.
+	for edge := range byEdge {
+		require.NotContains(t, edge, fixture.memberID,
+			"the caller is an endpoint of no returned edge")
+	}
+}


### PR DESCRIPTION
## Issue #182 step 3 — the living connectome *fires* (fMRI), safely

Closes the step-3 rung of #182 ("Live firing — synapses pulse as messages transit, over SSE"). The brain already renders neurons + weighted synapses (steps 1–2, #181/#188); this makes them **pulse on real activity** without turning the identity-free activity stream into a side channel. Rebased onto protected `main` (`9be8a413`).

### What's here (maps to the assigned scope)

**1. Contentless activity — the one production fix** (`api/rest/pipe_handler.go`)
`/v1/pipe/send` emitted a `pipeline_send` activity row naming the sending provider, the recipient, and the caller's intent verbatim — handed to the **global** `SSEBroadcaster` (no per-subscriber identity; identical bytes to every client). That inverts the privacy `handlePipeStatus` enforces (byte-identical 404 so the route can't confirm a pipe even exists). The row is now **metadata-only** (pipe id + payload size), matching the already-scrubbed `pipeline_complete`. New test `TestPipeSendActivityEventCarriesNoEndpointIdentity` covers both addressing modes and fails if any endpoint id, truncated id, intent text, or `Data` payload returns.

**2. Reconnect/error/cleanup + mutation-resistant wiring** (`web/sse.go`, `web/network_handler.go`, `cmd/sage-gui/node.go`, `web/static/js/sse.js`, `web/sse_wiring_test.go`)
`TestSSEEventWiring` AST-scans every non-test Go file for SSE emit sites and asserts **full bidirectional consistency** between the `AllEventTypes` registry, the emitted event names, and the `eventTypes` listener array in `sse.js` — an event can be emitted, marshalled, written to the wire correctly, and observed by nobody if the JS array omits it. No allow-list to forget: a new emit site fails the test until it's registered in Go **and** subscribed in JS.

**3. Operator-only + app-v23 route parity** (`web/synapse_appv23_rbac_test.go`)
Characterises the connectome `/network/synapses` RBAC exactly as it behaves today (member vs restricted caller; missing/unreadable registry), pinning the operator-only surface so a route change can't silently widen it.

**4. Contentless log scrub coverage** (`internal/tx/comet_commit_log_scrub_test.go`)
Covers the CometBFT commit-log scrubs directly from `internal/tx`, so the no-leak guarantee is pinned at its source, not only end-to-end.

### Rebase reconciliation (last commit)
Merged #198 replaced the direct `s.OnEvent("recall"/"search"/"hybrid", …)` retrieval broadcasts with the `emitContentlessRetrievalActivity` wrapper (which reaches `OnEvent` through a func parameter the AST scanner can't follow). Those events stayed in `AllEventTypes` + `sse.js` (still emitted, contentlessly), so the wiring scan read them as registered-but-unemitted. The scanner now treats the wrapper as an emit site and holds its event-name argument to the registry — mirroring the existing `EventTypeFromREST` special-case. No production change in that commit.

### Verification (local, against `9be8a413`)
- `go build ./...` and `go build ./cmd/amid` — clean
- `gofmt -l` (all changed files) and `go vet` — clean
- `go test ./api/rest ./web ./internal/tx ./cmd/sage-gui` — pass
- `go test -race ./api/rest ./internal/tx` and `-race -run 'Race|Concurrent|TOCTOU|Linear' ./web` — pass
- `npm test` (frontend-static) — 282/282; `check:js` — 29 files clean

golangci-lint / govulncheck / full `go test ./...` / fault-gates / byzantine / SDK run in CI.

> **DRAFT — do not merge.** Opened for review + full CI on protected main per the v11.18.11 release gate.
