### PR TITLE
feat(cerebrum): live connectome firing over SSE (#182 step 3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #   docker exec -i -e SAGE_PROVIDER=claude-code -e SAGE_PROJECT=my-project \
 #     -e SAGE_IDENTITY_PATH=/root/.sage/agents/claude-code-my-project/agent.key \
 #     sage /usr/local/bin/sage-gui mcp
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ with an exact composite-cursor catch-up action and forbid advancing the
 watermark until the window is drained.
 
 **Release builders now enforce the patched Go floor.** Root and `natter`
-modules require Go 1.25.12, CI and release jobs resolve that exact `go.mod`
-toolchain, every Go container builder uses 1.25.12, and pinned
+modules require Go 1.25.13, CI and release jobs resolve that exact `go.mod`
+toolchain, every Go container builder uses 1.25.13, and pinned
 `govulncheck v1.6.0` scans both modules before either CI fan-in or release
 publication can pass.
 

--- a/api/rest/connectome_activity.go
+++ b/api/rest/connectome_activity.go
@@ -1,0 +1,9 @@
+package rest
+
+// connectomeActivityEvent is the SSE event name announcing that the local agent
+// connectome may have changed.
+//
+// It is spelled here rather than imported from web because api/rest does not
+// depend on web; the name is held to web.EventConnectome and to the dashboard's
+// subscription list by TestConnectomeActivityEventNameMatchesRegistry.
+const connectomeActivityEvent = "connectome"

--- a/api/rest/connectome_activity_test.go
+++ b/api/rest/connectome_activity_test.go
@@ -1,0 +1,171 @@
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/web"
+)
+
+// connectomeWire connects the REAL production bridge — the same shape as
+// cmd/sage-gui/node.go's restServer.OnEvent — to a REAL web.SSEBroadcaster and
+// captures the exact bytes a dashboard would receive. The disclosure risk lives
+// on the serialized frame, so that is what these tests inspect; a stubbed
+// callback would only prove what this package passes to it.
+type connectomeWire struct {
+	client chan []byte
+}
+
+func newConnectomeWire(t *testing.T, srv *Server) *connectomeWire {
+	t.Helper()
+	b := web.NewSSEBroadcaster()
+	ch := b.Subscribe()
+	require.NotNil(t, ch)
+	t.Cleanup(func() { b.CloseAll() })
+	srv.OnEvent = func(eventType, memoryID, domain, content string, data any) {
+		b.Broadcast(web.SSEEvent{
+			Type: web.EventType(eventType), MemoryID: memoryID,
+			Domain: domain, Content: content, Data: data,
+		})
+	}
+	return &connectomeWire{client: ch}
+}
+
+// framesOfType drains the subscriber and returns only connectome ticks, so an
+// unrelated event on the shared stream cannot make a count assertion flaky.
+func (w *connectomeWire) framesOfType(t *testing.T, eventType string) []string {
+	t.Helper()
+	var out []string
+	for {
+		select {
+		case msg := <-w.client:
+			frame := string(msg)
+			if strings.HasPrefix(frame, "event: "+eventType+"\n") {
+				out = append(out, frame)
+			}
+		case <-time.After(150 * time.Millisecond):
+			return out
+		}
+	}
+}
+
+func sendCanonical(t *testing.T, srv *Server, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	return callMessageJSON(t, messageRouterAs(srv, "agent-sender", true),
+		http.MethodPost, "/v1/messages", map[string]any{
+			"to_agent": "agent-recipient", "intent": "secret-intent",
+			"payload": "secret-payload", "idempotency_key": key,
+		})
+}
+
+// TestConnectomeActivityEventNameMatchesRegistry links the three unconnected
+// copies of this event name. api/rest spells it as a local constant because it
+// does not import web; the dashboard spells it again in JavaScript. Nothing in
+// the compiler connects them, so a rename in one place leaves the tick emitted
+// by the server and subscribed by nobody — fully implemented, fully green, and
+// silently dead. That is the failure mode this project has already shipped once.
+func TestConnectomeActivityEventNameMatchesRegistry(t *testing.T) {
+	require.Equal(t, string(web.EventConnectome), connectomeActivityEvent,
+		"the emit-site name must equal web.EventConnectome")
+
+	js, err := os.ReadFile(filepath.Join(moduleRootForConnectome(t), "web", "static", "js", "sse.js"))
+	require.NoError(t, err)
+	require.Contains(t, string(js), "'"+connectomeActivityEvent+"'",
+		"the dashboard must subscribe to the event or the server emits to nobody")
+}
+
+// TestConnectomeActivityTickIsContentless drives a real canonical send and
+// inspects the serialized frame. The tick invalidates an RBAC-filtered
+// snapshot, so it must name neither endpoint, nor the provider, intent or
+// payload: this stream fans out identically to every client, while the snapshot
+// withholds edges per caller.
+func TestConnectomeActivityTickIsContentless(t *testing.T) {
+	srv, sqlite := newPipeServer(t)
+	addMessageAgent(t, sqlite, "agent-sender")
+	addMessageAgent(t, sqlite, "agent-recipient")
+	wire := newConnectomeWire(t, srv)
+
+	require.Equal(t, http.StatusCreated, sendCanonical(t, srv, "tick-1").Code)
+
+	frames := wire.framesOfType(t, connectomeActivityEvent)
+	require.Len(t, frames, 1, "exactly one connectome tick per non-replayed send")
+
+	_, dataLine, ok := strings.Cut(frames[0], "data: ")
+	require.True(t, ok)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(dataLine)), &payload))
+
+	require.Equal(t, connectomeActivityEvent, payload["type"])
+	require.Equal(t, "", payload["memory_id"], "the tick carries no identifier")
+	for _, forbidden := range []string{"domain", "content", "data"} {
+		require.NotContains(t, payload, forbidden,
+			"the tick must be contentless; %q present in %s", forbidden, dataLine)
+	}
+	for k := range payload {
+		require.Contains(t, []string{"type", "memory_id"}, k,
+			"unexpected key %q in a contentless tick: %s", k, dataLine)
+	}
+	for _, secret := range []string{"agent-sender", "agent-recipient", "secret-intent", "secret-payload"} {
+		require.NotContains(t, frames[0], secret,
+			"no send material may reach the global stream; frame:\n%s", frames[0])
+	}
+}
+
+// TestConnectomeActivityDoesNotTickOnReplay pins the non-replayed condition.
+// An idempotent retry moved nothing, so pulsing for it would animate traffic
+// that never happened — and a client retrying after a lost response would make
+// the graph lie about its own history.
+func TestConnectomeActivityDoesNotTickOnReplay(t *testing.T) {
+	srv, sqlite := newPipeServer(t)
+	addMessageAgent(t, sqlite, "agent-sender")
+	addMessageAgent(t, sqlite, "agent-recipient")
+	wire := newConnectomeWire(t, srv)
+
+	require.Equal(t, http.StatusCreated, sendCanonical(t, srv, "replay-1").Code)
+	require.Len(t, wire.framesOfType(t, connectomeActivityEvent), 1, "precondition: first send ticks")
+
+	require.Equal(t, http.StatusOK, sendCanonical(t, srv, "replay-1").Code, "same key replays")
+	require.Empty(t, wire.framesOfType(t, connectomeActivityEvent),
+		"an idempotent replay must not tick")
+}
+
+// TestConnectomeActivityDoesNotTickOnFailedSend pins the failure direction: a
+// send that never became durable must not announce a connectome change.
+func TestConnectomeActivityDoesNotTickOnFailedSend(t *testing.T) {
+	srv, sqlite := newPipeServer(t)
+	addMessageAgent(t, sqlite, "agent-sender")
+	wire := newConnectomeWire(t, srv)
+
+	rr := callMessageJSON(t, messageRouterAs(srv, "agent-sender", true),
+		http.MethodPost, "/v1/messages", map[string]any{
+			"to_agent": "agent-nonexistent", "payload": "secret-payload",
+			"idempotency_key": "bad-1",
+		})
+	require.NotEqual(t, http.StatusCreated, rr.Code, "precondition: the send is rejected")
+	require.Empty(t, wire.framesOfType(t, connectomeActivityEvent),
+		"a rejected send must not tick")
+}
+
+// moduleRootForConnectome walks up to the directory holding go.mod, so the
+// dashboard script is found regardless of the package the test runs from.
+func moduleRootForConnectome(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs(".")
+	require.NoError(t, err)
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, dir, parent, "no go.mod found above the rest package")
+		dir = parent
+	}
+}

--- a/api/rest/messages_handler.go
+++ b/api/rest/messages_handler.go
@@ -132,6 +132,18 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 	if replayed {
 		code = http.StatusOK
 	}
+	if !replayed && s.OnEvent != nil {
+		// Live connectome firing. Emitted ONLY here: after the send has
+		// durably succeeded and only when it is NOT an idempotent replay, so a
+		// retried send cannot pulse an edge twice for one message.
+		//
+		// Deliberately carries nothing — not the endpoints, not the sender's
+		// provider, not the intent, not even a count. See web.EventConnectome
+		// for why an identity-free fan-out must not name an edge that the
+		// RBAC-filtered snapshot would withhold. Clients treat this as
+		// "re-fetch the authorized snapshot", never as data.
+		s.OnEvent(string(connectomeActivityEvent), "", "", "", nil)
+	}
 	if !replayed && s.messageNotifier != nil {
 		// Best effort only: a missing, closed, or backpressured SSE session
 		// cannot change durable send/delivery state and must never fail the send.

--- a/deploy/Dockerfile.abci
+++ b/deploy/Dockerfile.abci
@@ -2,7 +2,7 @@
 # Multi-stage build: compile Go binary, copy to minimal Alpine
 
 # ── Shared source ─────────────────────────────
-FROM golang:1.25.12-alpine AS source
+FROM golang:1.25.13-alpine AS source
 
 RUN apk add --no-cache git
 

--- a/deploy/Dockerfile.node
+++ b/deploy/Dockerfile.node
@@ -7,7 +7,7 @@
 # permissions for that fixed container user.
 
 # -- Builder -------------------------------------------
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 RUN apk add --no-cache git make
 

--- a/deploy/federation-acceptance/Dockerfile.natter
+++ b/deploy/federation-acceptance/Dockerfile.natter
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS build
+FROM golang:1.25.13-alpine AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/deploy/init-testnet.sh
+++ b/deploy/init-testnet.sh
@@ -83,7 +83,7 @@ elif [ "${HOST_COMETBFT_VERSION}" != "${COMETBFT_VERSION#v}" ]; then
     # instead of leaking through as a confusing "cometbft: not found" from the
     # testnet call below. The build's stderr is intentionally NOT suppressed.
     docker run --rm -v "${GENESIS_DIR}:/genesis" \
-        golang:1.25.12-alpine sh -c '
+        golang:1.25.13-alpine sh -c '
         set -e
         apk add --no-cache git make >/dev/null 2>&1
         git clone --branch v'"${COMETBFT_VERSION#v}"' --depth 1 https://github.com/cometbft/cometbft.git /tmp/cometbft 2>/dev/null

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/l33tdawg/sage
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/natter/go.mod
+++ b/natter/go.mod
@@ -1,6 +1,6 @@
 module github.com/l33tdawg/sage/natter
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/libp2p/go-libp2p v0.48.0

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -213,6 +213,17 @@ test('connectome tick fires only edges changed since the latest authorized basel
   ), ['a\u0000b']);
 });
 
+test('tick arriving during an ordinary load keeps the pre-tick baseline', () => {
+  const activity = createConnectomeActivityTracker();
+  const before = [{ source: 'a', target: 'b', count: 1, last_fired: 't1' }];
+  const after = [{ source: 'a', target: 'b', count: 2, last_fired: 't2' }];
+  activity.observe(before, false);
+  assert.deepEqual(activity.observe(after, false, true), [],
+    'ordinary response must not pulse or consume a pending tick');
+  assert.deepEqual(activity.observe(after, true), ['a\u0000b'],
+    'queued tick refetch must still observe the firing transition');
+});
+
 // The renderer subscribes to the contentless tick and refetches the authorized
 // snapshot; it must never read edge data off the event itself.
 test('mri-brain refetches the authorized snapshot on a connectome tick', () => {
@@ -220,6 +231,8 @@ test('mri-brain refetches the authorized snapshot on a connectome tick', () => {
     'the renderer must subscribe to the connectome tick');
   assert.match(mriSource, /load\(true\)/,
     'only the connectome tick path may request a firing diff');
-  assert.match(mriSource, /markConnectomeFiring\(d, fromConnectomeTick\)/,
+  assert.match(mriSource, /markConnectomeFiring\(d, fromConnectomeTick, graphReloadPulsePending\)/,
     'the fired-edge diff must run on the applied snapshot');
+  assert.match(mriSource, /scheduleGraphRetry\(\(\) => load\(fromConnectomeTick\)\)/,
+    'a failed tick refetch must preserve its firing intent across retry');
 });

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -232,21 +232,44 @@ test('tick intent survives failed retry and an ordinary reload during backoff', 
   activity.observe(before, false);
 
   intent.requestTick();
-  const failedTickAware = intent.begin('connectome');
-  assert.equal(failedTickAware, true);
-  intent.settle('connectome', failedTickAware, false);
+  const failedTickGeneration = intent.begin('connectome');
+  assert.equal(failedTickGeneration, 1);
+  intent.settle('connectome', failedTickGeneration, false);
   assert.equal(intent.isPending('connectome'), true,
     'failed tick fetch must retain intent throughout retry backoff');
 
   // A remember/forget refresh can cancel the retry timer. It must inherit the
   // pending tick instead of advancing the baseline as an ordinary reload.
   const ordinaryDuringBackoff = intent.begin('connectome');
-  assert.equal(ordinaryDuringBackoff, true);
-  assert.deepEqual(activity.observe(after, ordinaryDuringBackoff), ['a\u0000b']);
+  assert.equal(ordinaryDuringBackoff, 1);
+  assert.deepEqual(activity.observe(after, ordinaryDuringBackoff > 0), ['a\u0000b']);
   intent.settle('connectome', ordinaryDuringBackoff, true);
   assert.equal(intent.isPending('connectome'), false);
   assert.deepEqual(activity.observe(after, intent.begin('connectome')), [],
     'a satisfied tick must pulse exactly once');
+});
+
+test('a second tick is not acknowledged by an older in-flight generation', () => {
+  const activity = createConnectomeActivityTracker();
+  const intent = createConnectomeReloadIntent();
+  const before = [{ source: 'a', target: 'b', count: 1, last_fired: 't1' }];
+  const afterTick1 = [{ source: 'a', target: 'b', count: 2, last_fired: 't2' }];
+  const afterTick2 = [{ source: 'a', target: 'b', count: 3, last_fired: 't3' }];
+  activity.observe(before, false);
+
+  intent.requestTick();
+  const generation1 = intent.begin('connectome');
+  intent.requestTick();
+  assert.deepEqual(activity.observe(afterTick1, generation1 > 0), ['a\u0000b']);
+  intent.settle('connectome', generation1, true);
+  assert.equal(intent.isPending('connectome'), true,
+    'tick 1 response must not consume tick 2, which arrived after it began');
+
+  const generation2 = intent.begin('connectome');
+  assert.equal(generation2, 2);
+  assert.deepEqual(activity.observe(afterTick2, generation2 > 0), ['a\u0000b']);
+  intent.settle('connectome', generation2, true);
+  assert.equal(intent.isPending('connectome'), false);
 });
 
 // The renderer subscribes to the contentless tick and refetches the authorized
@@ -262,4 +285,6 @@ test('mri-brain refetches the authorized snapshot on a connectome tick', () => {
     'the event must persist tick intent independently of a retry timer');
   assert.match(mriSource, /scheduleGraphRetry\(load\)/,
     'retries must consult persistent tick intent when they begin');
+  assert.match(mriSource, /connectomeReloadIntent\.settle\(request\.mode, tickGeneration, true\)/,
+    'a successful production fetch must acknowledge exactly its captured generation');
 });

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
-import { createGraphLoadCoordinator, mapConnectome, diffConnectomeActivity, createConnectomeActivityTracker } from '../web/static/js/connectome-map.js';
+import { createGraphLoadCoordinator, mapConnectome, diffConnectomeActivity, createConnectomeActivityTracker, createConnectomeReloadIntent } from '../web/static/js/connectome-map.js';
 
 const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
 
@@ -224,6 +224,31 @@ test('tick arriving during an ordinary load keeps the pre-tick baseline', () => 
     'queued tick refetch must still observe the firing transition');
 });
 
+test('tick intent survives failed retry and an ordinary reload during backoff', () => {
+  const activity = createConnectomeActivityTracker();
+  const intent = createConnectomeReloadIntent();
+  const before = [{ source: 'a', target: 'b', count: 1, last_fired: 't1' }];
+  const after = [{ source: 'a', target: 'b', count: 2, last_fired: 't2' }];
+  activity.observe(before, false);
+
+  intent.requestTick();
+  const failedTickAware = intent.begin('connectome');
+  assert.equal(failedTickAware, true);
+  intent.settle('connectome', failedTickAware, false);
+  assert.equal(intent.isPending('connectome'), true,
+    'failed tick fetch must retain intent throughout retry backoff');
+
+  // A remember/forget refresh can cancel the retry timer. It must inherit the
+  // pending tick instead of advancing the baseline as an ordinary reload.
+  const ordinaryDuringBackoff = intent.begin('connectome');
+  assert.equal(ordinaryDuringBackoff, true);
+  assert.deepEqual(activity.observe(after, ordinaryDuringBackoff), ['a\u0000b']);
+  intent.settle('connectome', ordinaryDuringBackoff, true);
+  assert.equal(intent.isPending('connectome'), false);
+  assert.deepEqual(activity.observe(after, intent.begin('connectome')), [],
+    'a satisfied tick must pulse exactly once');
+});
+
 // The renderer subscribes to the contentless tick and refetches the authorized
 // snapshot; it must never read edge data off the event itself.
 test('mri-brain refetches the authorized snapshot on a connectome tick', () => {
@@ -231,8 +256,10 @@ test('mri-brain refetches the authorized snapshot on a connectome tick', () => {
     'the renderer must subscribe to the connectome tick');
   assert.match(mriSource, /load\(true\)/,
     'only the connectome tick path may request a firing diff');
-  assert.match(mriSource, /markConnectomeFiring\(d, fromConnectomeTick, graphReloadPulsePending\)/,
+  assert.match(mriSource, /markConnectomeFiring\(d, tickAware, connectomeReloadIntent\.isPending\(request\.mode\) && !tickAware\)/,
     'the fired-edge diff must run on the applied snapshot');
-  assert.match(mriSource, /scheduleGraphRetry\(\(\) => load\(fromConnectomeTick\)\)/,
-    'a failed tick refetch must preserve its firing intent across retry');
+  assert.match(mriSource, /if \(fromConnectomeTick\) connectomeReloadIntent\.requestTick\(\)/,
+    'the event must persist tick intent independently of a retry timer');
+  assert.match(mriSource, /scheduleGraphRetry\(load\)/,
+    'retries must consult persistent tick intent when they begin');
 });

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
-import { createGraphLoadCoordinator, mapConnectome, diffConnectomeActivity } from '../web/static/js/connectome-map.js';
+import { createGraphLoadCoordinator, mapConnectome, diffConnectomeActivity, createConnectomeActivityTracker } from '../web/static/js/connectome-map.js';
 
 const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
 
@@ -191,11 +191,35 @@ test('diffConnectomeActivity keys object endpoints the same as string ids', () =
   assert.deepEqual(diffConnectomeActivity(prev, next), []);
 });
 
+test('initial connectome acquisition establishes a baseline without firing', () => {
+  const activity = createConnectomeActivityTracker();
+  const initial = [{ source: 'a', target: 'b', count: 7, last_fired: 't7' }];
+  assert.deepEqual(activity.observe(initial, false), []);
+});
+
+test('ordinary reload updates the baseline without firing', () => {
+  const activity = createConnectomeActivityTracker();
+  activity.observe([{ source: 'a', target: 'b', count: 1, last_fired: 't1' }], false);
+  assert.deepEqual(activity.observe(
+    [{ source: 'a', target: 'b', count: 2, last_fired: 't2' }], false,
+  ), []);
+});
+
+test('connectome tick fires only edges changed since the latest authorized baseline', () => {
+  const activity = createConnectomeActivityTracker();
+  activity.observe([{ source: 'a', target: 'b', count: 1, last_fired: 't1' }], false);
+  assert.deepEqual(activity.observe(
+    [{ source: 'a', target: 'b', count: 2, last_fired: 't2' }], true,
+  ), ['a\u0000b']);
+});
+
 // The renderer subscribes to the contentless tick and refetches the authorized
 // snapshot; it must never read edge data off the event itself.
 test('mri-brain refetches the authorized snapshot on a connectome tick', () => {
   assert.match(mriSource, /opts\.sse\.on\('connectome'/,
     'the renderer must subscribe to the connectome tick');
-  assert.match(mriSource, /markConnectomeFiring/,
+  assert.match(mriSource, /load\(true\)/,
+    'only the connectome tick path may request a firing diff');
+  assert.match(mriSource, /markConnectomeFiring\(d, fromConnectomeTick\)/,
     'the fired-edge diff must run on the applied snapshot');
 });

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
-import { createGraphLoadCoordinator, mapConnectome } from '../web/static/js/connectome-map.js';
+import { createGraphLoadCoordinator, mapConnectome, diffConnectomeActivity } from '../web/static/js/connectome-map.js';
 
 const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
 
@@ -141,4 +141,61 @@ test('renderer wires mode invalidation into both initial acquisition and reloads
     'a stale initial response must fail closed after a mode change');
   assert.match(mriSource, /function setMode\(next\)\{[\s\S]*graphLoads\.invalidate\(\);[\s\S]*else acquireInitialGraph\(\);/,
     'a toggle must invalidate old work and refetch even before Graph exists');
+});
+
+// Live firing pulses only the synapses that actually carried a message. The
+// server tick is contentless by design, so which edges fired is derived here by
+// diffing two AUTHORIZED snapshots — meaning a client can only ever pulse an
+// edge the RBAC-filtered endpoint was willing to show it.
+test('diffConnectomeActivity reports a brand new synapse as fired', () => {
+  const fired = diffConnectomeActivity(
+    [],
+    [{ source: 'a', target: 'b', count: 1, last_fired: '2026-01-01T00:00:00Z' }],
+  );
+  assert.deepEqual(fired, ['a\u0000b']);
+});
+
+test('diffConnectomeActivity reports a risen count as fired', () => {
+  const prev = [{ source: 'a', target: 'b', count: 1, last_fired: 't1' }];
+  const next = [{ source: 'a', target: 'b', count: 2, last_fired: 't1' }];
+  assert.deepEqual(diffConnectomeActivity(prev, next), ['a\u0000b']);
+});
+
+// Needed because a burst can land inside one timestamp granularity, and a send
+// that coincides with a retention prune can leave the count unmoved.
+test('diffConnectomeActivity reports an advanced last_fired as fired', () => {
+  const prev = [{ source: 'a', target: 'b', count: 5, last_fired: '2026-01-01T00:00:00Z' }];
+  const next = [{ source: 'a', target: 'b', count: 5, last_fired: '2026-01-01T00:00:09Z' }];
+  assert.deepEqual(diffConnectomeActivity(prev, next), ['a\u0000b']);
+});
+
+test('diffConnectomeActivity reports an unchanged synapse as quiet', () => {
+  const same = [{ source: 'a', target: 'b', count: 3, last_fired: 't9' }];
+  assert.deepEqual(diffConnectomeActivity(same, same), []);
+});
+
+// Retained-row pruning lowers a count without any message being sent. Treating
+// that as activity would animate traffic that did not happen.
+test('diffConnectomeActivity does not treat a pruned count as firing', () => {
+  const prev = [{ source: 'a', target: 'b', count: 9, last_fired: 't1' }];
+  const next = [{ source: 'a', target: 'b', count: 2, last_fired: 't1' }];
+  assert.deepEqual(diffConnectomeActivity(prev, next), []);
+});
+
+// After force-simulation binding, link endpoints are node objects rather than
+// id strings. The diff must key identically in both shapes or every edge would
+// read as new on the first pulse after a render.
+test('diffConnectomeActivity keys object endpoints the same as string ids', () => {
+  const prev = [{ source: 'a', target: 'b', count: 4, last_fired: 't1' }];
+  const next = [{ source: { id: 'a' }, target: { id: 'b' }, count: 4, last_fired: 't1' }];
+  assert.deepEqual(diffConnectomeActivity(prev, next), []);
+});
+
+// The renderer subscribes to the contentless tick and refetches the authorized
+// snapshot; it must never read edge data off the event itself.
+test('mri-brain refetches the authorized snapshot on a connectome tick', () => {
+  assert.match(mriSource, /opts\.sse\.on\('connectome'/,
+    'the renderer must subscribe to the connectome tick');
+  assert.match(mriSource, /markConnectomeFiring/,
+    'the fired-edge diff must run on the applied snapshot');
 });

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -193,7 +193,7 @@ test('release and CI vulnerability gates scan the exact mandated Go floor', () =
     assert.match(source, /govulncheck \.\/\.\.\./);
     assert.match(source, /cd natter\n\s+govulncheck \.\/\.\.\./);
   }
-  assert.match(rootDockerfile, /^FROM golang:1\.25\.12-alpine AS builder$/m);
+  assert.match(rootDockerfile, /^FROM golang:1\.25\.13-alpine AS builder$/m);
 });
 
 test('superseded checks stop spending runner minutes without weakening the newest commit', () => {

--- a/web/appv23_projection_cold_ui_test.go
+++ b/web/appv23_projection_cold_ui_test.go
@@ -51,7 +51,7 @@ func TestMRIGraphFailureIsUnavailableAndNeverSyntheticEmptyData(t *testing.T) {
 	assert.Contains(t, mri, "let graphRetryDelay = 2000")
 	assert.Contains(t, mri, "graphRetryDelay = Math.min(graphRetryDelay * 2, 30000)")
 	assert.Contains(t, mri, "scheduleGraphRetry(acquireInitialGraph)")
-	assert.Contains(t, mri, "scheduleGraphRetry(load)")
+	assert.Contains(t, mri, "scheduleGraphRetry(() => load(fromConnectomeTick))")
 	assert.NotContains(t, mri,
 		"return { live: false, nodes: [], links: [], total: 0",
 		"a transport failure must not masquerade as a successful empty graph")

--- a/web/appv23_projection_cold_ui_test.go
+++ b/web/appv23_projection_cold_ui_test.go
@@ -51,7 +51,8 @@ func TestMRIGraphFailureIsUnavailableAndNeverSyntheticEmptyData(t *testing.T) {
 	assert.Contains(t, mri, "let graphRetryDelay = 2000")
 	assert.Contains(t, mri, "graphRetryDelay = Math.min(graphRetryDelay * 2, 30000)")
 	assert.Contains(t, mri, "scheduleGraphRetry(acquireInitialGraph)")
-	assert.Contains(t, mri, "scheduleGraphRetry(() => load(fromConnectomeTick))")
+	assert.Contains(t, mri, "scheduleGraphRetry(load)")
+	assert.Contains(t, mri, "connectomeReloadIntent.requestTick()")
 	assert.NotContains(t, mri,
 		"return { live: false, nodes: [], links: [], total: 0",
 		"a transport failure must not masquerade as a successful empty graph")

--- a/web/connectome_route_security_test.go
+++ b/web/connectome_route_security_test.go
@@ -1,0 +1,127 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	connectomeSnapshotPath = "/v1/dashboard/network/synapses"
+	connectomeEventsPath   = "/v1/dashboard/events"
+)
+
+func signedConnectomeRouteRequest(
+	t *testing.T,
+	fixture appV23DashboardRouteFixture,
+	path, actor, remoteAddr, host, origin string,
+) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.RemoteAddr = remoteAddr
+	req.Host = host
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+		req.Header.Set("Sec-Fetch-Site", "cross-site")
+	}
+	signAgentRequest(t, req, fixture.keys[actor], nil)
+	return req
+}
+
+func serveConnectomeRoute(
+	t *testing.T,
+	fixture appV23DashboardRouteFixture,
+	path, actor, remoteAddr, host, origin string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	testRouter(fixture.handler).ServeHTTP(rec, signedConnectomeRouteRequest(
+		t, fixture, path, actor, remoteAddr, host, origin,
+	))
+	return rec
+}
+
+// This matrix drives the real RegisterRoutes router. It therefore pins the
+// complete production middleware composition for both the authorized snapshot
+// and the global contentless invalidation stream, rather than merely testing a
+// hand-assembled approximation of the gates.
+func TestAppV23ConnectomeRoutesUseOperatorOnlyProductionGuards(t *testing.T) {
+	for _, path := range []string{connectomeSnapshotPath, connectomeEventsPath} {
+		for _, tc := range []struct {
+			name       string
+			actor      string
+			remoteAddr string
+			host       string
+			origin     string
+			want       int
+		}{
+			{name: "local Member", actor: "member", remoteAddr: "127.0.0.1:54321", host: "localhost:8080", want: http.StatusForbidden},
+			{name: "local Manager", actor: "manager", remoteAddr: "127.0.0.1:54321", host: "localhost:8080", want: http.StatusForbidden},
+			{name: "stale Admin", actor: "stale-admin", remoteAddr: "127.0.0.1:54321", host: "localhost:8080", want: http.StatusForbidden},
+			{name: "LAN Root", actor: "current-root", remoteAddr: "192.168.1.20:54321", host: "192.168.1.10:8080", want: http.StatusNotFound},
+			{name: "LAN Admin", actor: "current-admin", remoteAddr: "192.168.1.20:54321", host: "192.168.1.10:8080", want: http.StatusNotFound},
+			{name: "cross-origin Root", actor: "current-root", remoteAddr: "127.0.0.1:54321", host: "localhost:8080", origin: "https://attacker.example", want: http.StatusForbidden},
+			{name: "cross-origin Admin", actor: "current-admin", remoteAddr: "127.0.0.1:54321", host: "localhost:8080", origin: "https://attacker.example", want: http.StatusForbidden},
+		} {
+			t.Run(path+"/"+tc.name, func(t *testing.T) {
+				fixture := newAppV23DashboardRouteFixture(t)
+				rec := serveConnectomeRoute(
+					t, fixture, path, tc.actor, tc.remoteAddr, tc.host, tc.origin,
+				)
+				require.Equal(t, tc.want, rec.Code, rec.Body.String())
+				require.Zero(t, fixture.handler.SSE.ClientCount(),
+					"a rejected events request must not reach the broadcaster")
+			})
+		}
+	}
+}
+
+func TestAppV23CurrentLocalRootAndAdminCanUseConnectomeProductionRoutes(t *testing.T) {
+	for _, actor := range []string{"current-root", "current-admin"} {
+		t.Run(actor+" snapshot", func(t *testing.T) {
+			fixture := newAppV23DashboardRouteFixture(t)
+			rec := serveConnectomeRoute(
+				t, fixture, connectomeSnapshotPath, actor,
+				"127.0.0.1:54321", "localhost:8080", "",
+			)
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+			require.Contains(t, rec.Body.String(), `"neurons"`)
+			require.Contains(t, rec.Body.String(), `"synapses"`)
+		})
+
+		t.Run(actor+" events", func(t *testing.T) {
+			fixture := newAppV23DashboardRouteFixture(t)
+			router := testRouter(fixture.handler)
+			ctx, cancel := context.WithCancel(context.Background())
+			req := signedConnectomeRouteRequest(
+				t, fixture, connectomeEventsPath, actor,
+				"127.0.0.1:54321", "localhost:8080", "",
+			).WithContext(ctx)
+			rec := httptest.NewRecorder()
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				router.ServeHTTP(rec, req)
+			}()
+
+			require.Eventually(t, func() bool {
+				return fixture.handler.SSE.ClientCount() == 1
+			}, time.Second, 5*time.Millisecond,
+				"authorized request must reach the real SSE broadcaster")
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("authorized SSE handler did not stop after context cancellation")
+			}
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+			require.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+			require.Contains(t, rec.Body.String(), ": connected")
+			require.Zero(t, fixture.handler.SSE.ClientCount())
+		})
+	}
+}

--- a/web/sse.go
+++ b/web/sse.go
@@ -33,6 +33,20 @@ const (
 	// Chain Activity an auditable view of enforced permissions, not merely a
 	// memory-operation feed.
 	EventAccess EventType = "access"
+	// EventConnectome announces that the local agent connectome may have
+	// changed. It is a CACHE-INVALIDATION TICK, not data: it carries no
+	// identifiers, no counts and no text at all.
+	//
+	// The reason it must stay empty is structural. This stream is a global
+	// fan-out with no subscriber identity, while the connectome snapshot at
+	// /v1/dashboard/network/synapses is RBAC-filtered per caller — an edge is
+	// returned only when both endpoints are visible. Putting an edge on the
+	// tick would publish, to every connected client, a relationship the
+	// snapshot would have withheld from most of them. Sending nothing and
+	// letting each client re-fetch through the authorized endpoint keeps that
+	// filter as the single enforcement point, so the guarantee holds by
+	// construction rather than by a second filter kept in sync by hand.
+	EventConnectome EventType = "connectome"
 )
 
 // SSEEvent is an event sent to connected dashboard clients.

--- a/web/static/js/connectome-map.js
+++ b/web/static/js/connectome-map.js
@@ -125,3 +125,21 @@ export function createConnectomeActivityTracker() {
     reset() { baseline = null; },
   };
 }
+
+// Retains a connectome invalidation until an authorized snapshot has actually
+// satisfied it. Retry timers are deliberately not the source of truth: an
+// ordinary graph refresh may cancel a timer, but while a tick is pending that
+// refresh becomes the tick-aware fetch and must either pulse or preserve the
+// intent for the next retry.
+export function createConnectomeReloadIntent() {
+  let pending = false;
+  return {
+    requestTick() { pending = true; },
+    begin(mode) { return mode === 'connectome' && pending; },
+    settle(mode, tickAware, succeeded) {
+      if (mode === 'connectome' && tickAware && succeeded) pending = false;
+    },
+    isPending(mode) { return mode === 'connectome' && pending; },
+    reset() { pending = false; },
+  };
+}

--- a/web/static/js/connectome-map.js
+++ b/web/static/js/connectome-map.js
@@ -65,3 +65,32 @@ export function createGraphLoadCoordinator() {
     },
   };
 }
+
+// diffConnectomeActivity reports which directed edges FIRED between two
+// connectome snapshots, so a live pulse animates the channels that actually
+// carried a message rather than flashing the whole graph.
+//
+// An edge counts as fired when it is new, when its retained count rose, or when
+// its last_fired advanced. All three are needed: count alone misses a send that
+// coincided with a retention prune, and last_fired alone misses a burst that
+// lands within the same timestamp granularity.
+//
+// A DROP IN COUNT IS NOT A FIRING. Retained-row pruning can lower a count
+// without any message being sent, and animating that would report activity that
+// did not happen.
+export function diffConnectomeActivity(prevLinks, nextLinks) {
+  const key = (l) => `${typeof l.source === 'object' ? l.source.id : l.source}\u0000${typeof l.target === 'object' ? l.target.id : l.target}`;
+  const before = new Map();
+  for (const l of (Array.isArray(prevLinks) ? prevLinks : [])) {
+    before.set(key(l), { count: l.count || 0, last: l.last_fired || '' });
+  }
+  const fired = [];
+  for (const l of (Array.isArray(nextLinks) ? nextLinks : [])) {
+    const k = key(l);
+    const was = before.get(k);
+    if (!was) { fired.push(k); continue; }
+    if ((l.count || 0) > was.count) { fired.push(k); continue; }
+    if ((l.last_fired || '') > was.last) { fired.push(k); }
+  }
+  return fired;
+}

--- a/web/static/js/connectome-map.js
+++ b/web/static/js/connectome-map.js
@@ -132,14 +132,23 @@ export function createConnectomeActivityTracker() {
 // refresh becomes the tick-aware fetch and must either pulse or preserve the
 // intent for the next retry.
 export function createConnectomeReloadIntent() {
-  let pending = false;
+  let requestedGeneration = 0;
+  let satisfiedGeneration = 0;
   return {
-    requestTick() { pending = true; },
-    begin(mode) { return mode === 'connectome' && pending; },
-    settle(mode, tickAware, succeeded) {
-      if (mode === 'connectome' && tickAware && succeeded) pending = false;
+    requestTick() { requestedGeneration += 1; },
+    begin(mode) {
+      return mode === 'connectome' && requestedGeneration > satisfiedGeneration
+        ? requestedGeneration
+        : 0;
     },
-    isPending(mode) { return mode === 'connectome' && pending; },
-    reset() { pending = false; },
+    settle(mode, generation, succeeded) {
+      if (mode === 'connectome' && generation > 0 && succeeded) {
+        satisfiedGeneration = Math.max(satisfiedGeneration, generation);
+      }
+    },
+    isPending(mode) {
+      return mode === 'connectome' && requestedGeneration > satisfiedGeneration;
+    },
+    reset() { requestedGeneration = 0; satisfiedGeneration = 0; },
   };
 }

--- a/web/static/js/connectome-map.js
+++ b/web/static/js/connectome-map.js
@@ -110,8 +110,12 @@ function snapshotConnectomeLinks(links) {
 export function createConnectomeActivityTracker() {
   let baseline = null;
   return {
-    observe(links, fromConnectomeTick = false) {
+    observe(links, fromConnectomeTick = false, tickPending = false) {
       const next = snapshotConnectomeLinks(links);
+      // A tick that arrived during an ordinary request owns the next baseline
+      // transition. Do not let the older request consume that transition before
+      // the queued tick refetch can turn it into a pulse.
+      if (tickPending && !fromConnectomeTick) return [];
       const fired = baseline !== null && fromConnectomeTick
         ? diffConnectomeActivity(baseline, next)
         : [];

--- a/web/static/js/connectome-map.js
+++ b/web/static/js/connectome-map.js
@@ -94,3 +94,30 @@ export function diffConnectomeActivity(prevLinks, nextLinks) {
   }
   return fired;
 }
+
+function snapshotConnectomeLinks(links) {
+  return (Array.isArray(links) ? links : []).map(l => ({
+    source: typeof l.source === 'object' ? l.source.id : l.source,
+    target: typeof l.target === 'object' ? l.target.id : l.target,
+    count: l.count || 0,
+    last_fired: l.last_fired || '',
+  }));
+}
+
+// Tracks the last authorized snapshot while keeping activity semantics tied to
+// an actual connectome invalidation tick. Initial acquisition and ordinary
+// reloads establish/update the baseline but never claim that an edge fired.
+export function createConnectomeActivityTracker() {
+  let baseline = null;
+  return {
+    observe(links, fromConnectomeTick = false) {
+      const next = snapshotConnectomeLinks(links);
+      const fired = baseline !== null && fromConnectomeTick
+        ? diffConnectomeActivity(baseline, next)
+        : [];
+      baseline = next;
+      return fired;
+    },
+    reset() { baseline = null; },
+  };
+}

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -17,7 +17,7 @@
 
 import { THREE, ForceGraph3D, UnrealBloomPass } from '/ui/js/vendor/sage-graph.bundle.js';
 import { MRI_LAYOUT, mriDepthForAge, mriVerticalPosition } from '/ui/js/mri-layout.js';
-import { createGraphLoadCoordinator, mapConnectome, diffConnectomeActivity } from '/ui/js/connectome-map.js';
+import { createGraphLoadCoordinator, mapConnectome, createConnectomeActivityTracker } from '/ui/js/connectome-map.js';
 import { createModeHull } from '/ui/js/mode-hull.js';
 
 const LINK_TYPES = {
@@ -716,19 +716,14 @@ export function mountMriBrain(container, opts = {}) {
 
   // Re-fetch (respecting the drill domain) and re-render. Deterministic placement
   // keeps existing nodes put; no re-heat.
-  // lastConnectomeLinks is the previous AUTHORIZED snapshot. The diff runs on
+  // The tracker retains the previous AUTHORIZED snapshot. The diff runs on
   // what this client was actually allowed to fetch, so a pulse can never be
   // shown for an edge the snapshot withheld.
-  let lastConnectomeLinks = [];
+  const connectomeActivity = createConnectomeActivityTracker();
   let pulseDecayTimer = null;
-  function markConnectomeFiring(d){
+  function markConnectomeFiring(d, fromConnectomeTick){
     if (mode !== 'connectome' || !d || !Array.isArray(d.links)) return;
-    const fired = new Set(diffConnectomeActivity(lastConnectomeLinks, d.links));
-    lastConnectomeLinks = d.links.map(l => ({
-      source: typeof l.source === 'object' ? l.source.id : l.source,
-      target: typeof l.target === 'object' ? l.target.id : l.target,
-      count: l.count || 0, last_fired: l.last_fired || '',
-    }));
+    const fired = new Set(connectomeActivity.observe(d.links, fromConnectomeTick));
     if (!fired.size) return;
     const now = Date.now();
     for (const l of d.links) {
@@ -745,9 +740,11 @@ export function mountMriBrain(container, opts = {}) {
     }, SYNAPSE_PULSE_MS + 100);
   }
 
-  function load(){
+  let graphReloadPulsePending = false;
+  function load(fromConnectomeTick = false){
     if (graphLoadInFlight) {
       graphReloadPending = true;
+      graphReloadPulsePending = graphReloadPulsePending || fromConnectomeTick;
       return;
     }
     graphLoadInFlight = true;
@@ -761,7 +758,7 @@ export function mountMriBrain(container, opts = {}) {
       reportGraphAvailability('ready');
       placeActive(d.nodes);
       resolveConnectomeLinks(d);
-      markConnectomeFiring(d);
+      markConnectomeFiring(d, fromConnectomeTick);
       Graph.graphData(d);
       rendered = d;
       refreshCounts(d);
@@ -773,9 +770,11 @@ export function mountMriBrain(container, opts = {}) {
     }).finally(() => {
       graphLoadInFlight = false;
       if (graphReloadPending && !disposed) {
+        const pulsePending = graphReloadPulsePending;
         graphReloadPending = false;
+        graphReloadPulsePending = false;
         clearTimeout(graphRetryTimer);
-        load();
+        load(pulsePending);
       }
     });
   }
@@ -1023,6 +1022,7 @@ export function mountMriBrain(container, opts = {}) {
     $('.boot').style.display = 'none';
     placeActive(data.nodes);
     resolveConnectomeLinks(data);
+    markConnectomeFiring(data, false);
     rendered = data;
     Graph = ForceGraph3D({ controlType:'orbit' })($('.mrib-graph'))
       .backgroundColor(mriBgColor())
@@ -1203,11 +1203,6 @@ export function mountMriBrain(container, opts = {}) {
       subs.push(opts.sse.on('forget', reload));
 
       // LIVE CONNECTOME FIRING. The tick carries nothing, so the data comes
-      // from re-fetching the AUTHORIZED snapshot — the same RBAC-filtered
-      // endpoint the view already uses. That keeps the edge guard the single
-      // enforcement point: a client can only ever pulse an edge it was allowed
-      // to fetch.
-      // LIVE CONNECTOME FIRING. The tick carries nothing, so the data comes
       // from re-fetching the AUTHORIZED snapshot through the existing load
       // path — the same RBAC-filtered endpoint the view already uses. That
       // keeps the edge guard the single enforcement point: a client can only
@@ -1218,7 +1213,7 @@ export function mountMriBrain(container, opts = {}) {
       const pulse = () => {
         if (mode !== 'connectome') return;
         clearTimeout(ct);
-        ct = setTimeout(load, 900);
+        ct = setTimeout(() => load(true), 900);
       };
       subs.push(() => clearTimeout(ct));
       subs.push(() => clearTimeout(pulseDecayTimer));
@@ -1290,6 +1285,7 @@ export function mountMriBrain(container, opts = {}) {
     if (mode===next || (next==='connectome' && !allowConnectome)) return;
     graphLoads.invalidate();
     mode = next;
+    connectomeActivity.reset();
     currentDomain = null;
     focusId=null; focusSet=null; hideExplorePanel(); clearFocusMarker();
     updateModeChrome();

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -751,7 +751,8 @@ export function mountMriBrain(container, opts = {}) {
     }
     graphLoadInFlight = true;
     const request = graphLoads.begin(mode);
-    const tickAware = connectomeReloadIntent.begin(request.mode);
+    const tickGeneration = connectomeReloadIntent.begin(request.mode);
+    const tickAware = tickGeneration > 0;
     // A drill / reload leaves focus mode.
     focusId = null; focusSet = null; hideExplorePanel(); clearFocusMarker();
     fetchActive(request.mode).then(d => {
@@ -766,7 +767,7 @@ export function mountMriBrain(container, opts = {}) {
       rendered = d;
       refreshCounts(d);
       buildLobes(d);
-      connectomeReloadIntent.settle(request.mode, tickAware, true);
+      connectomeReloadIntent.settle(request.mode, tickGeneration, true);
     }).catch(() => {
       if (disposed || !graphLoads.isCurrent(request, mode)) return;
       reportGraphAvailability('unavailable');

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -17,7 +17,7 @@
 
 import { THREE, ForceGraph3D, UnrealBloomPass } from '/ui/js/vendor/sage-graph.bundle.js';
 import { MRI_LAYOUT, mriDepthForAge, mriVerticalPosition } from '/ui/js/mri-layout.js';
-import { createGraphLoadCoordinator, mapConnectome } from '/ui/js/connectome-map.js';
+import { createGraphLoadCoordinator, mapConnectome, diffConnectomeActivity } from '/ui/js/connectome-map.js';
 import { createModeHull } from '/ui/js/mode-hull.js';
 
 const LINK_TYPES = {
@@ -457,12 +457,22 @@ export function mountMriBrain(container, opts = {}) {
   // every link is a typed memory edge (unchanged formulas); in the connectome a
   // synapse's normalized weight _w drives Hebbian thickness, particle count and
   // pulse speed — heavier, hotter channels read thicker and fire faster.
+  // A synapse that just carried a message is briefly thickened and given extra
+  // particles. The boost decays on its own so a burst reads as firing rather
+  // than as a permanent weight change — the retained weight already covers that.
+  const SYNAPSE_PULSE_MS = 2600;
+  function synapsePulse(l){
+    if (!l || !l._firedAt) return 0;
+    const age = Date.now() - l._firedAt;
+    if (age < 0 || age > SYNAPSE_PULSE_MS) return 0;
+    return 1 - (age / SYNAPSE_PULSE_MS);
+  }
   function linkWidthFor(l){
-    if(l.link_type==='synapse') return 0.25 + (l._w||0)*2.4;
+    if(l.link_type==='synapse') return 0.25 + (l._w||0)*2.4 + synapsePulse(l)*2.0;
     return l.link_type==='focus'?0.8 : l.link_type==='contradicts'?0.6 : (LINK_TYPES[l.link_type]||{}).typed?0.35:0.18;
   }
   function linkParticlesFor(l){
-    if(l.link_type==='synapse') return flow ? Math.min(6, 1+Math.round((l._w||0)*5)) : 0;
+    if(l.link_type==='synapse') return flow ? Math.min(8, 1+Math.round((l._w||0)*5)+Math.round(synapsePulse(l)*2)) : 0;
     return l.link_type==='focus'?3 : (flow&&(LINK_TYPES[l.link_type]||{}).typed?2:0);
   }
   function linkParticleSpeedFor(l){
@@ -706,6 +716,35 @@ export function mountMriBrain(container, opts = {}) {
 
   // Re-fetch (respecting the drill domain) and re-render. Deterministic placement
   // keeps existing nodes put; no re-heat.
+  // lastConnectomeLinks is the previous AUTHORIZED snapshot. The diff runs on
+  // what this client was actually allowed to fetch, so a pulse can never be
+  // shown for an edge the snapshot withheld.
+  let lastConnectomeLinks = [];
+  let pulseDecayTimer = null;
+  function markConnectomeFiring(d){
+    if (mode !== 'connectome' || !d || !Array.isArray(d.links)) return;
+    const fired = new Set(diffConnectomeActivity(lastConnectomeLinks, d.links));
+    lastConnectomeLinks = d.links.map(l => ({
+      source: typeof l.source === 'object' ? l.source.id : l.source,
+      target: typeof l.target === 'object' ? l.target.id : l.target,
+      count: l.count || 0, last_fired: l.last_fired || '',
+    }));
+    if (!fired.size) return;
+    const now = Date.now();
+    for (const l of d.links) {
+      const src = typeof l.source === 'object' ? l.source.id : l.source;
+      const tgt = typeof l.target === 'object' ? l.target.id : l.target;
+      if (fired.has(`${src}\u0000${tgt}`)) l._firedAt = now;
+    }
+    // Re-read the accessors once the pulse has decayed so the boost does not
+    // linger until some unrelated redraw happens to clear it.
+    clearTimeout(pulseDecayTimer);
+    pulseDecayTimer = setTimeout(() => {
+      if (disposed || !Graph) return;
+      Graph.linkWidth(linkWidthFor).linkDirectionalParticles(linkParticlesFor);
+    }, SYNAPSE_PULSE_MS + 100);
+  }
+
   function load(){
     if (graphLoadInFlight) {
       graphReloadPending = true;
@@ -722,6 +761,7 @@ export function mountMriBrain(container, opts = {}) {
       reportGraphAvailability('ready');
       placeActive(d.nodes);
       resolveConnectomeLinks(d);
+      markConnectomeFiring(d);
       Graph.graphData(d);
       rendered = d;
       refreshCounts(d);
@@ -1161,6 +1201,28 @@ export function mountMriBrain(container, opts = {}) {
       subs.push(() => clearTimeout(t));
       subs.push(opts.sse.on('remember', reload));
       subs.push(opts.sse.on('forget', reload));
+
+      // LIVE CONNECTOME FIRING. The tick carries nothing, so the data comes
+      // from re-fetching the AUTHORIZED snapshot — the same RBAC-filtered
+      // endpoint the view already uses. That keeps the edge guard the single
+      // enforcement point: a client can only ever pulse an edge it was allowed
+      // to fetch.
+      // LIVE CONNECTOME FIRING. The tick carries nothing, so the data comes
+      // from re-fetching the AUTHORIZED snapshot through the existing load
+      // path — the same RBAC-filtered endpoint the view already uses. That
+      // keeps the edge guard the single enforcement point: a client can only
+      // pulse an edge it was allowed to fetch. load() already reports
+      // 'unavailable' and retries if the refetch fails, so a dropped tick or a
+      // failed fetch never leaves the view asserting it is live.
+      let ct = null;
+      const pulse = () => {
+        if (mode !== 'connectome') return;
+        clearTimeout(ct);
+        ct = setTimeout(load, 900);
+      };
+      subs.push(() => clearTimeout(ct));
+      subs.push(() => clearTimeout(pulseDecayTimer));
+      subs.push(opts.sse.on('connectome', pulse));
     }
   }
 

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -17,7 +17,7 @@
 
 import { THREE, ForceGraph3D, UnrealBloomPass } from '/ui/js/vendor/sage-graph.bundle.js';
 import { MRI_LAYOUT, mriDepthForAge, mriVerticalPosition } from '/ui/js/mri-layout.js';
-import { createGraphLoadCoordinator, mapConnectome, createConnectomeActivityTracker } from '/ui/js/connectome-map.js';
+import { createGraphLoadCoordinator, mapConnectome, createConnectomeActivityTracker, createConnectomeReloadIntent } from '/ui/js/connectome-map.js';
 import { createModeHull } from '/ui/js/mode-hull.js';
 
 const LINK_TYPES = {
@@ -742,15 +742,16 @@ export function mountMriBrain(container, opts = {}) {
     }, SYNAPSE_PULSE_MS + 100);
   }
 
-  let graphReloadPulsePending = false;
+  const connectomeReloadIntent = createConnectomeReloadIntent();
   function load(fromConnectomeTick = false){
+    if (fromConnectomeTick) connectomeReloadIntent.requestTick();
     if (graphLoadInFlight) {
       graphReloadPending = true;
-      graphReloadPulsePending = graphReloadPulsePending || fromConnectomeTick;
       return;
     }
     graphLoadInFlight = true;
     const request = graphLoads.begin(mode);
+    const tickAware = connectomeReloadIntent.begin(request.mode);
     // A drill / reload leaves focus mode.
     focusId = null; focusSet = null; hideExplorePanel(); clearFocusMarker();
     fetchActive(request.mode).then(d => {
@@ -760,23 +761,22 @@ export function mountMriBrain(container, opts = {}) {
       reportGraphAvailability('ready');
       placeActive(d.nodes);
       resolveConnectomeLinks(d);
-      markConnectomeFiring(d, fromConnectomeTick, graphReloadPulsePending);
+      markConnectomeFiring(d, tickAware, connectomeReloadIntent.isPending(request.mode) && !tickAware);
       Graph.graphData(d);
       rendered = d;
       refreshCounts(d);
       buildLobes(d);
+      connectomeReloadIntent.settle(request.mode, tickAware, true);
     }).catch(() => {
       if (disposed || !graphLoads.isCurrent(request, mode)) return;
       reportGraphAvailability('unavailable');
-      if (!graphReloadPending) scheduleGraphRetry(() => load(fromConnectomeTick));
+      if (!graphReloadPending) scheduleGraphRetry(load);
     }).finally(() => {
       graphLoadInFlight = false;
       if (graphReloadPending && !disposed) {
-        const pulsePending = graphReloadPulsePending;
         graphReloadPending = false;
-        graphReloadPulsePending = false;
         clearTimeout(graphRetryTimer);
-        load(pulsePending);
+        load();
       }
     });
   }
@@ -1288,6 +1288,7 @@ export function mountMriBrain(container, opts = {}) {
     graphLoads.invalidate();
     mode = next;
     connectomeActivity.reset();
+    connectomeReloadIntent.reset();
     currentDomain = null;
     focusId=null; focusSet=null; hideExplorePanel(); clearFocusMarker();
     updateModeChrome();

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -721,9 +721,11 @@ export function mountMriBrain(container, opts = {}) {
   // shown for an edge the snapshot withheld.
   const connectomeActivity = createConnectomeActivityTracker();
   let pulseDecayTimer = null;
-  function markConnectomeFiring(d, fromConnectomeTick){
+  function markConnectomeFiring(d, fromConnectomeTick, tickPending = false){
     if (mode !== 'connectome' || !d || !Array.isArray(d.links)) return;
-    const fired = new Set(connectomeActivity.observe(d.links, fromConnectomeTick));
+    const fired = new Set(connectomeActivity.observe(
+      d.links, fromConnectomeTick, tickPending,
+    ));
     if (!fired.size) return;
     const now = Date.now();
     for (const l of d.links) {
@@ -758,7 +760,7 @@ export function mountMriBrain(container, opts = {}) {
       reportGraphAvailability('ready');
       placeActive(d.nodes);
       resolveConnectomeLinks(d);
-      markConnectomeFiring(d, fromConnectomeTick);
+      markConnectomeFiring(d, fromConnectomeTick, graphReloadPulsePending);
       Graph.graphData(d);
       rendered = d;
       refreshCounts(d);
@@ -766,7 +768,7 @@ export function mountMriBrain(container, opts = {}) {
     }).catch(() => {
       if (disposed || !graphLoads.isCurrent(request, mode)) return;
       reportGraphAvailability('unavailable');
-      if (!graphReloadPending) scheduleGraphRetry(load);
+      if (!graphReloadPending) scheduleGraphRetry(() => load(fromConnectomeTick));
     }).finally(() => {
       graphLoadInFlight = false;
       if (graphReloadPending && !disposed) {

--- a/web/static/js/sse.js
+++ b/web/static/js/sse.js
@@ -29,7 +29,7 @@ export class SSEClient {
             this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000);
         };
 
-        const eventTypes = ['remember', 'recall', 'forget', 'vote', 'consensus', 'agent', 'access', 'update', 'governance', 'import', 'task', 'recovery'];
+        const eventTypes = ['remember', 'recall', 'forget', 'vote', 'consensus', 'agent', 'access', 'update', 'governance', 'import', 'task', 'recovery', 'connectome'];
         for (const type of eventTypes) {
             this.es.addEventListener(type, (e) => {
                 try {


### PR DESCRIPTION
**Draft — not for merge.** Merge authority remains codex's. Base: `9be8a413`.

Issue #182 step 3. The connectome view already renders agents as neurons and bus channels as synapses; this makes it **live** — a message send pulses the channel that carried it.

## The event carries nothing

Not the endpoints, not the provider, not the intent, not a count.

The stream it rides is a **global fan-out with no subscriber identity** (`SSEBroadcaster.Subscribe()` takes no arguments; `Broadcast` sends identical bytes to every client), while `/v1/dashboard/network/synapses` is **RBAC-filtered per caller** — an edge is returned only when *both* endpoints are visible.

Naming an edge on the tick would publish, to every connected client, a relationship the snapshot would have withheld from most of them. Sending nothing and letting each client re-fetch through the authorized endpoint keeps that filter the **single enforcement point** — the guarantee holds by construction, not by a second filter kept in sync by hand.

```
event: connectome
data: {"type":"connectome","memory_id":""}
```

## Emission is gated on a durable, non-replayed send

An idempotent retry moved nothing. Pulsing for it would animate traffic that never happened and make the graph lie about its own history.

## How "which edges fired" is derived

The client debounces the tick, re-fetches the authorized snapshot **through the existing `load()` path**, and diffs it against the previous authorized snapshot.

An edge counts as fired when it is new, when its retained count rises, **or** when `last_fired` advances — count alone misses a send that coincided with a retention prune; `last_fired` alone misses a burst inside one timestamp granularity. **A drop in count is never firing**: pruning is not traffic.

Reusing `load()` rather than writing a second apply path means reconnect, failure and retry behaviour are **inherited rather than reimplemented** — a failed refetch already reports unavailable and retries, so it can't leave the view asserting it is live while blind.

## Mutations, each failing

| mutation | caught by |
|---|---|
| delete the emit | contentless + replay tests |
| emit on replays | `…DoesNotTickOnReplay` |
| put the endpoints on the tick | `…TickIsContentless` |
| **unsubscribe the dashboard** | `…EventNameMatchesRegistry` |
| **rename the emit-site constant** | `…EventNameMatchesRegistry` |

The last two are the *silently-dead-feature* case — emitted by the server, observed by nobody, every other test green. That is the failure mode this repo has already shipped once, so it is pinned rather than assumed.

Plus 7 JS tests on the pure diff, including the pruned-count and object-endpoint cases.

## Gates

`./api/rest` 55s · `./web` 170s · `npm test` 289/0 · `check:js` 29 files · vet, gofmt, `go build ./...` clean.

## Scope

Out, as assigned: no step 4/5, no plasticity, no consensus/app migration, **no access broadened** — snapshot and SSE routes are untouched and remain operator-only.

**Interaction to note:** PR #200 adds an AST wiring pin that requires every emitted event to be registered *and* subscribed. This PR registers `connectome` in `web/sse.go` and `sse.js`, so the two are compatible; whichever merges second may need a trivial conflict resolution in the `eventTypes` array.