### PR TITLE
chore(release): prepare v11.18.11 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,36 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.11
+
+**The CEREBRUM connectome now fires live without widening its operator-only
+boundary.** Successful local message sends emit a contentless invalidation tick;
+the browser then refetches the existing caller-filtered snapshot and pulses only
+newly observed synapses. Monotonic generations preserve later ticks across
+in-flight requests, ordinary reloads, failures, and retries, while initial loads
+and unrelated refreshes never create false activity.
+
+**Dashboard retrieval activity no longer duplicates authorized memory plaintext
+into the global operator stream.** Recall, search, and hybrid events now expose
+only their event type and result count. The obsolete expandable plaintext panel
+is gone, and serialized-frame regressions pin the contentless contract and live,
+non-replayed delivery.
+
+**Claude bookend sessions can discover waiting SAGE messages without claiming or
+revealing them.** A signed, payload-free inbox-status hook reports only the
+current identity and unread count, makes failures visible, preserves unrelated
+user hooks during self-heal, and exposes the read-only message tools needed to
+perform the explicit inbox fetch.
+
+This patch also keys local connectome locality by chain identity, removes a stale
+app-v7 validator warning after app-v14, dims the connectome skull for legibility,
+requires patched Go 1.25.13 throughout current builders and CI, and publishes
+checksum sidecars for Windows executables. It introduces no new consensus
+application version or state migration. The ceiling remains app-v26;
+**v11.18.11 introduces no app-v27**.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.11`. SDK 11.18.11.
+
 ## What's New in v11.18.10
 
 **Multiple MCP runtimes sharing one agent identity can no longer silently lose
@@ -257,8 +287,8 @@ with an exact composite-cursor catch-up action and forbid advancing the
 watermark until the window is drained.
 
 **Release builders now enforce the patched Go floor.** Root and `natter`
-modules require Go 1.25.13, CI and release jobs resolve that exact `go.mod`
-toolchain, every Go container builder uses 1.25.13, and pinned
+modules require Go 1.25.12, CI and release jobs resolve that exact `go.mod`
+toolchain, every Go container builder uses 1.25.12, and pinned
 `govulncheck v1.6.0` scans both modules before either CI fan-in or release
 publication can pass.
 
@@ -1735,7 +1765,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.10`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.11`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.10
+  version: 11.18.11
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.10-acceptance
+ARG VERSION=v11.18.11-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.10 federation Docker acceptance
+# v11.18.11 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.10-acceptance
+        VERSION: v11.18.11-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.10"
+version = "11.18.11"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.10"
+version = "11.18.11"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.10",
+  "version": "11.18.11",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.10/app-v26. -->
+<!-- Reconciled through SAGE v11.18.11/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,7 +45,7 @@ No tokens. No gas fees. No cryptocurrency. Just consensus-validated knowledge.
 | Layer | Technology |
 |-------|-----------|
 | Consensus | CometBFT v0.38.23 (ABCI 2.0, raw -- not Cosmos SDK) |
-| State Machine | Go 1.25.7+ ABCI application |
+| State Machine | Go 1.25.13+ ABCI application |
 | On-chain State | BadgerDB v4.5.0 (content hash, status, classification, votes, grants, appHash) |
 | Off-chain Storage | SQLite (personal / single-binary) or PostgreSQL 16 + pgvector / HNSW (cluster) -- write-behind projection |
 | Tx Format | Protobuf (deterministic serialization) |
@@ -69,7 +69,7 @@ No tokens. No gas fees. No cryptocurrency. Just consensus-validated knowledge.
 |------------|---------|-------|
 | Docker | 20.10+ | Required for the containerized network |
 | Docker Compose | v2+ | Uses `docker compose` (v2 syntax, not `docker-compose`) |
-| Go | 1.25.7+ | Only needed for local builds and running tests |
+| Go | 1.25.13+ | Only needed for local builds and running tests |
 | Python | 3.10+ | Only needed for the SDK and experiments |
 | make | any | Build automation |
 | curl | any | Used by `make status` and health checks |
@@ -1284,7 +1284,7 @@ sage/
 ├── papers/                           # Research papers (PDFs, CC BY 4.0)
 ├── .github/workflows/ci.yml          # CI: lint, test, build, docker, sdk-test
 ├── Makefile                          # Build/test/deploy targets
-├── go.mod                            # Go 1.25.7, CometBFT v0.38.23 (library)
+├── go.mod                            # Go 1.25.13, CometBFT v0.38.23 (library)
 └── .golangci.yml                     # Linter configuration
 ```
 

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.10 federation behavior. -->
+<!-- Verified against SAGE v11.18.11 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -14,7 +14,7 @@ And because SAGE uses real consensus infrastructure (not just a JSON file), your
 
 ## Quick Install
 
-### From Source (Go 1.25.7+)
+### From Source (Go 1.25.13+)
 
 ```bash
 git clone https://github.com/l33tdawg/sage.git
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.10
+# sage-gui v11.18.11
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.10 advertises 32 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.11 advertises 32 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.10 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.11 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -39,13 +39,38 @@ v11.18.10 message control plane attributes every claim to an opaque MCP session,
 supports compare-and-swap ownership handoff, rejects replies from a stale former
 owner, and preserves passive recovery after a lost response. CEREBRUM also
 projects its RBAC-filtered agent channels as a traffic-weighted 3D connectome.
-The supported consensus ceiling remains app-v26; **v11.18.10 does not introduce
-app-v27**.
+v11.18.11 adds operator-only live connectome firing driven by contentless ticks
+and caller-filtered snapshot refetches, strips memory plaintext from retrieval
+activity events, makes bookend inbox visibility payload-free and self-healing,
+and raises every current Go build floor to patched 1.25.13. The supported
+consensus ceiling remains app-v26; **v11.18.11 does not introduce app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.11 patch
+
+CEREBRUM now turns successful local message sends into contentless connectome
+invalidation ticks. The existing operator-only snapshot remains the source of
+truth: the browser refetches it under the current caller's authorization and
+pulses only new synapses. Monotonic generations retain ticks across concurrent
+loads and retry interleavings; initial and ordinary refreshes never produce
+false firing.
+
+Recall, search, and hybrid SSE activity is contentless apart from event type and
+result count, so authorized memory plaintext is no longer duplicated into the
+identity-free broadcaster. Claude bookend hooks now expose a signed,
+payload-free unread pointer that neither claims messages nor reveals IDs or
+content, while preserving unrelated user hooks during upgrade self-heal.
+
+Local connectome locality now follows chain identity rather than provider label,
+the obsolete app-v7 validator warning is suppressed after app-v14, the visual
+skull is dimmer, and Windows executable assets receive checksum sidecars. All
+current builders, CI, and release contracts require patched Go 1.25.13. This
+patch introduces no new consensus application version or state migration:
+app-v26 remains the ceiling and v11.18.11 does not introduce app-v27.
 
 ## v11.18.10 patch
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -101,6 +101,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.8 | Non-reusing HTTP/1.1 seam across fenced Comet submissions, signer-fence-first restart diagnostics, unsafe MCP reply-watermark recovery, and post-send passive inbox snapshots; no new app version; app-v26 remains the ceiling |
 | v11.18.9 | Typed indeterminate Comet commit/sync outcomes, fail-closed federation nil-result fencing, and cross-package commit-decoder drift contracts; no new app version; app-v26 remains the ceiling |
 | v11.18.10 | Same-agent MCP claimant-session ownership and atomic handoff, stale-session reply rejection, passive recovery, the CEREBRUM agent-connectome view, and bounded upgrade-watchdog broadcasts that retain indeterminate signer fencing; no new app version; app-v26 remains the ceiling |
+| v11.18.11 | Operator-only live connectome firing via contentless ticks and authorized snapshot refetch, contentless retrieval activity, payload-free Claude inbox visibility with hook self-heal, chain-ID locality, Windows executable checksums, and patched Go 1.25.13; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.10. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.11. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -33,7 +33,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.10 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.11 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -203,7 +203,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.10)
+## Related docs (reconciled through v11.18.11)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.10.
+Status: implementation contract through SAGE v11.18.11.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.10 authorization layer is off-consensus and does not require
+The current v11.18.11 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.10 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.11 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.10/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.11/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.10. Legacy organization/federation sections retain
+Verified against SAGE v11.18.11. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.10. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.11. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.10**.
+and is **not in v11.18.11**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.10. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.11. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.10 code (2026-08-12). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.11 code (2026-08-14). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.10.
+Reconciled against internal/mcp for SAGE v11.18.11.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.10. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.11. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.10
+**Package:** `sage-agent-sdk` **Version:** 11.18.11
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.10. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.11. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.10 lineage implementation (2026-08-12). -->
+<!-- Verified against SAGE v11.18.11 lineage implementation (2026-08-14). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -193,7 +193,26 @@ test('release and CI vulnerability gates scan the exact mandated Go floor', () =
     assert.match(source, /govulncheck \.\/\.\.\./);
     assert.match(source, /cd natter\n\s+govulncheck \.\/\.\.\./);
   }
-  assert.match(rootDockerfile, /^FROM golang:1\.25\.13-alpine AS builder$/m);
+  for (const path of [
+    '../go.mod',
+    '../natter/go.mod',
+  ]) {
+    assert.match(readFileSync(new URL(path, import.meta.url), 'utf8'), /^go 1\.25\.13$/m);
+  }
+  for (const [path, stage] of [
+    ['../Dockerfile', 'builder'],
+    ['../deploy/Dockerfile.node', 'builder'],
+    ['../deploy/Dockerfile.abci', 'source'],
+    ['../deploy/federation-acceptance/Dockerfile.node', 'builder'],
+    ['../deploy/federation-acceptance/Dockerfile.natter', 'build'],
+  ]) {
+    const source = readFileSync(new URL(path, import.meta.url), 'utf8');
+    assert.match(source, new RegExp(`^FROM golang:1\\.25\\.13-alpine AS ${stage}$`, 'm'));
+  }
+  assert.match(
+    readFileSync(new URL('../deploy/init-testnet.sh', import.meta.url), 'utf8'),
+    /golang:1\.25\.13-alpine/,
+  );
 });
 
 test('superseded checks stop spending runner minutes without weakening the newest commit', () => {

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -32,6 +32,7 @@ test('release-facing version metadata stays aligned', () => {
     ['scripts/stage-native-shell-daemon.sh', 'through v11.18.x semver'],
     ['web/static/js/app.js', `const SAGE_VERSION = 'v${version}';`],
     ['README.md', `## What's New in v${version}`],
+    ['README.md', '## What\'s New in v11.18.10'],
     ['README.md', 'App-v23 replaced capability-bit administration'],
     ['README.md', 'App-v24 closes the canonical terminal-hash lifecycle defect'],
     ['README.md', `SDK ${version}.`],
@@ -49,8 +50,18 @@ test('release-facing version metadata stays aligned', () => {
     ['docs/reference/app-v23-access-control-design.md', `SAGE v${version}`],
     ['docs/reference/upgrade-lineage-repair.md', `SAGE v${version}`],
     ['docs/ADMIN_BOOTSTRAP.md', `Reconciled through SAGE v${version}/app-v26`],
+	['docs/GETTING_STARTED.md', 'From Source (Go 1.25.13+)'],
 	['docs/GETTING_STARTED.md', `# sage-gui v${version}`],
 	['docs/GETTING_STARTED.md', `SAGE v${version} advertises 32 MCP tools`],
+    ['docs/ARCHITECTURE.md', 'Go 1.25.13+ ABCI application'],
+    ['docs/ARCHITECTURE.md', '| Go | 1.25.13+ |'],
+    ['docs/reference/concepts/signer-nonce-fence.md', `Status: v${version}.`],
+    ['docs/reference/concepts/signer-nonce-fence.md', `not in v${version}`],
+    ['deploy/federation-acceptance/README.md', `# v${version} federation Docker acceptance`],
+    ['docs/FEDERATION.md', `Verified against SAGE v${version} federation behavior`],
+    ['docs/reference/concepts/message-reply-lifecycle.md', `SAGE v${version} code`],
+    ['docs/UPGRADING.md', `| v${version} | Operator-only live connectome firing`],
+    ['docs/ROADMAP.md', `## v${version} patch`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],
     ['docs/UPGRADING.md', '`upgrade lineage status|doctor|verify`'],
@@ -86,6 +97,26 @@ test('upgrade release table stays in ascending semantic-version order', () => {
         || (current[0] === previous[0] && current[1] === previous[1] && current[2] > previous[2]),
       `docs/UPGRADING.md release table is out of order: v${previous.join('.')} before v${current.join('.')}`,
     );
+  }
+});
+
+test('historical v11.18.4 Go floor stays 1.25.12', () => {
+  const section = (path, start, end) => {
+    const body = read(path);
+    const from = body.indexOf(start);
+    assert.notEqual(from, -1, `${path} is missing ${start}`);
+    const to = body.indexOf(end, from + start.length);
+    assert.notEqual(to, -1, `${path} is missing ${end}`);
+    return body.slice(from, to);
+  };
+  for (const [path, start, end] of [
+    ['README.md', "## What's New in v11.18.4", "## What's New in v11.18.3"],
+    ['docs/ROADMAP.md', '## v11.18.4 patch', '## v11.18.3 patch'],
+  ]) {
+    const historical = section(path, start, end);
+    assert.match(historical, /Go floor to 1\.25\.12|modules require Go 1\.25\.12/);
+    assert.match(historical, /container builders (?:to |uses )?1\.25\.12|every Go container builder uses 1\.25\.12/);
+    assert.doesNotMatch(historical, /1\.25\.13/);
   }
 });
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.10 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.11 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.10"
+version = "11.18.11"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.10"
+__version__ = "11.18.11"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.10",
+  "version": "11.18.11",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.10",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.11",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.10';
+const SAGE_VERSION = 'v11.18.11';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
## Summary
- align server, SDK, OpenAPI, desktop, dashboard, container, federation-acceptance, and current reference metadata to v11.18.11 while preserving prior release history
- document operator-only live connectome firing, contentless retrieval activity, payload-free Claude inbox visibility, chain-ID locality, Windows checksum sidecars, and Go 1.25.13
- keep the consensus ceiling at app-v26 with no state migration

## Verification
- npm test (296/296)
- focused release/version tests (43/43)
- npm run check:js
- git diff --check

Exact base: a27633250f9a514d0cfd8eeab5e5ae82df3a3258
Exact head: 1850c13606e9ccd846282d0b01dd4eee2b3c1955