### PR TITLE
feat(cerebrum): connectome plasticity — idle synapses thin and fade (#182 step 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "check:js": "node scripts/check-static-js.mjs",
-    "test": "npm run check:js && node --test scripts/access-controls-ui.test.mjs scripts/appv23-linked-message-ui.test.mjs scripts/appv23-policy.test.mjs scripts/bulk-sequence.test.mjs scripts/cerebrum-shell.test.mjs scripts/chrome-extension-contract.test.mjs scripts/connectome-mapping.test.mjs scripts/mode-hull.test.mjs scripts/domain-inventory.test.mjs scripts/federation-acceptance-contract.test.mjs scripts/federation-flow.test.mjs scripts/federation-peer-capabilities.test.mjs scripts/federation-route-state.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/governance-retry.test.mjs scripts/release-recovery-workflow.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/task-reorder.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
+    "test": "npm run check:js && node --test scripts/access-controls-ui.test.mjs scripts/appv23-linked-message-ui.test.mjs scripts/appv23-policy.test.mjs scripts/bulk-sequence.test.mjs scripts/cerebrum-shell.test.mjs scripts/chrome-extension-contract.test.mjs scripts/connectome-mapping.test.mjs scripts/connectome-plasticity.test.mjs scripts/mode-hull.test.mjs scripts/domain-inventory.test.mjs scripts/federation-acceptance-contract.test.mjs scripts/federation-flow.test.mjs scripts/federation-peer-capabilities.test.mjs scripts/federation-route-state.test.mjs scripts/filter-codeql-sarif.test.mjs scripts/governance-retry.test.mjs scripts/release-recovery-workflow.test.mjs scripts/release-workflow.test.mjs scripts/restart-proof.test.mjs scripts/task-reorder.test.mjs scripts/update-banner.test.mjs scripts/version-alignment.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/connectome-plasticity.test.mjs
+++ b/scripts/connectome-plasticity.test.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import { synapsePlasticity } from '../web/static/js/connectome-map.js';
+
+// Resting-weight plasticity ("use it or lose it"): a synapse's retained strength
+// decays from its raw weight toward a floor the longer it sits idle, and snaps back
+// as it fires. These tests pin the decay curve (pure synapsePlasticity) and the
+// mri-brain wiring that renders it, scoped so reverting either fails.
+
+const HL = 1800000; // 30 min default half-life
+const FLOOR = 0.15;
+const T0 = Date.parse('2026-08-14T12:00:00Z');
+
+test('a just-fired synapse is at full strength (1.0)', () => {
+  assert.equal(synapsePlasticity('2026-08-14T12:00:00Z', T0), 1);
+});
+
+test('one half-life of idleness decays halfway from 1 toward the floor', () => {
+  const v = synapsePlasticity('2026-08-14T11:30:00Z', T0);      // 30 min idle
+  assert.ok(Math.abs(v - (FLOOR + (1 - FLOOR) * 0.5)) < 1e-9, `got ${v}`); // 0.575
+});
+
+test('two half-lives decay a quarter of the way up from the floor', () => {
+  const v = synapsePlasticity('2026-08-14T11:00:00Z', T0);      // 60 min idle
+  assert.ok(Math.abs(v - (FLOOR + (1 - FLOOR) * 0.25)) < 1e-9, `got ${v}`); // 0.3625
+});
+
+test('decay is monotonic and bounded in [floor, 1]', () => {
+  let prev = 1.0001;
+  for (let mins = 0; mins <= 600; mins += 15) {
+    const iso = new Date(T0 - mins * 60000).toISOString();
+    const v = synapsePlasticity(iso, T0);
+    assert.ok(v <= 1 && v >= FLOOR, `out of range at ${mins}m: ${v}`);
+    assert.ok(v <= prev, `not monotonic at ${mins}m: ${v} > ${prev}`);
+    prev = v;
+  }
+});
+
+test('a long-idle synapse asymptotes to the floor but never below it', () => {
+  const v = synapsePlasticity('2020-01-01T00:00:00Z', T0);      // years idle
+  assert.ok(v >= FLOOR && v < FLOOR + 0.001, `got ${v}`);
+});
+
+test('missing or unparseable last_fired is treated as fully idle (floor)', () => {
+  assert.equal(synapsePlasticity('', T0), FLOOR);
+  assert.equal(synapsePlasticity(null, T0), FLOOR);
+  assert.equal(synapsePlasticity(undefined, T0), FLOOR);
+  assert.equal(synapsePlasticity('not-a-date', T0), FLOOR);
+});
+
+test('a future last_fired (clock skew) clamps to full strength, not >1', () => {
+  assert.equal(synapsePlasticity('2026-08-14T12:05:00Z', T0), 1);
+});
+
+test('half-life and floor are configurable', () => {
+  // custom floor 0.3, custom half-life 10 min; at 10 min idle → 0.3 + 0.7*0.5 = 0.65
+  const v = synapsePlasticity('2026-08-14T11:50:00Z', T0, { halfLifeMs: 600000, floor: 0.3 });
+  assert.ok(Math.abs(v - 0.65) < 1e-9, `got ${v}`);
+});
+
+// --- Source wiring: mri-brain must RENDER the decayed weight, not raw _w ---
+const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
+
+function functionBody(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name}() not found`);
+  const open = src.indexOf('{', start);
+  let depth = 0, i = open;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) break;
+  }
+  return src.slice(open + 1, i);
+}
+
+test('restingWeight is the raw weight scaled by the plasticity factor', () => {
+  assert.match(mriSource, /restingWeight\s*=\s*l\s*=>\s*\(l\._w\|\|0\)\s*\*\s*plasticityOf\(l\)/,
+    'restingWeight must be _w * plasticityOf(l)');
+  assert.match(mriSource, /plasticityOf\s*=\s*l\s*=>\s*synapsePlasticity\(/,
+    'plasticityOf must call synapsePlasticity');
+});
+
+test('synapse width renders the DECAYED resting weight, not raw _w', () => {
+  const body = functionBody(mriSource, 'linkWidthFor');
+  assert.match(body, /link_type==='synapse'/);
+  assert.match(body, /restingWeight\(l\)\*2\.4/,
+    'the synapse width term must use restingWeight(l), so deleting plasticity fails');
+  assert.doesNotMatch(body, /\(l\._w\|\|0\)\*2\.4/,
+    'width must NOT fall back to the raw undecayed _w term');
+});
+
+test('synapse colour alpha rides the plasticity factor so idle edges dim', () => {
+  const body = functionBody(mriSource, 'linkColorFor');
+  assert.match(body, /link_type==='synapse'/);
+  assert.match(body, /plasticityOf\(l\)/,
+    'the synapse colour alpha must scale with plasticityOf(l)');
+});
+
+test('an idle connectome re-reads its accessors on a timer, cleaned up on dispose', () => {
+  const body = functionBody(mriSource, 'startPlasticityDecay');
+  assert.match(body, /setInterval/, 'plasticity decay must run on an interval');
+  assert.match(body, /mode\s*!==\s*'connectome'/, 'the timer must self-gate to connectome mode');
+  assert.match(body, /linkWidth\(linkWidthFor\)\.linkColor\(linkColorFor\)/,
+    'the refresh must re-apply the decayed width AND colour');
+  assert.match(mriSource, /clearInterval\(plasticityTimer\)/,
+    'the plasticity timer must be cleared on cleanup');
+});
+
+// Particle COUNT and SPEED both carry the Hebbian signal, so both must render the
+// decayed restingWeight with no raw-_w fallback — otherwise idle synapses keep
+// firing particles at full historical rate while only their width fades.
+test('synapse particle count renders restingWeight, not raw _w', () => {
+  const body = functionBody(mriSource, 'linkParticlesFor');
+  assert.match(body, /link_type==='synapse'/);
+  assert.match(body, /restingWeight\(l\)\*5/,
+    'particle count must scale on restingWeight(l), so reverting to _w fails');
+  assert.doesNotMatch(body, /\(l\._w\|\|0\)\*5/,
+    'particle count must NOT fall back to the raw undecayed _w term');
+});
+
+test('synapse particle speed renders restingWeight, not raw _w', () => {
+  const body = functionBody(mriSource, 'linkParticleSpeedFor');
+  assert.match(body, /link_type==='synapse'/);
+  assert.match(body, /restingWeight\(l\)\*0\.02/,
+    'particle speed must scale on restingWeight(l), so reverting to _w fails');
+  assert.doesNotMatch(body, /\(l\._w\|\|0\)\*0\.02/,
+    'particle speed must NOT fall back to the raw undecayed _w term');
+});
+
+test('the plasticity refresh re-applies the particle accessor, not just width/colour', () => {
+  const body = functionBody(mriSource, 'startPlasticityDecay');
+  assert.match(body, /linkDirectionalParticles\(linkParticlesFor\)/,
+    'dropping linkDirectionalParticles from the refresh must fail — particle count is decayed too');
+});

--- a/web/static/js/connectome-map.js
+++ b/web/static/js/connectome-map.js
@@ -152,3 +152,24 @@ export function createConnectomeReloadIntent() {
     reset() { requestedGeneration = 0; satisfiedGeneration = 0; },
   };
 }
+
+// Resting-weight plasticity ("use it or lose it"): a synapse's RETAINED strength
+// decays from its raw Hebbian weight toward a floor the longer it sits idle, and
+// climbs back as it fires. This is distinct from the transient firing pulse — the
+// pulse is a seconds-long flash on a live message, plasticity is the slow drift of
+// the resting weight over minutes/hours, keyed on how long ago the edge last fired.
+//
+// Returns a 0..1 multiplier to apply to the rendered weight: ~1 for an edge that
+// just fired, decaying with `halfLifeMs` toward `floor` (never below it, so an idle
+// channel dims but does not vanish). Pure — the caller passes `now` — so the decay
+// curve is unit-testable. A missing/invalid last_fired is treated as fully idle.
+export function synapsePlasticity(lastFiredISO, now, opts = {}) {
+  const halfLifeMs = opts.halfLifeMs > 0 ? opts.halfLifeMs : 1800000; // 30 min
+  const floor = opts.floor >= 0 && opts.floor <= 1 ? opts.floor : 0.15;
+  if (!lastFiredISO) return floor;
+  const t = Date.parse(lastFiredISO);
+  if (Number.isNaN(t)) return floor;
+  const age = now - t;
+  if (age <= 0) return 1;                       // fired now (or clock skew) → full strength
+  return floor + (1 - floor) * Math.pow(0.5, age / halfLifeMs);
+}

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -17,7 +17,7 @@
 
 import { THREE, ForceGraph3D, UnrealBloomPass } from '/ui/js/vendor/sage-graph.bundle.js';
 import { MRI_LAYOUT, mriDepthForAge, mriVerticalPosition } from '/ui/js/mri-layout.js';
-import { createGraphLoadCoordinator, mapConnectome, createConnectomeActivityTracker, createConnectomeReloadIntent } from '/ui/js/connectome-map.js';
+import { createGraphLoadCoordinator, mapConnectome, createConnectomeActivityTracker, createConnectomeReloadIntent, synapsePlasticity } from '/ui/js/connectome-map.js';
 import { createModeHull } from '/ui/js/mode-hull.js';
 
 const LINK_TYPES = {
@@ -467,17 +467,32 @@ export function mountMriBrain(container, opts = {}) {
     if (age < 0 || age > SYNAPSE_PULSE_MS) return 0;
     return 1 - (age / SYNAPSE_PULSE_MS);
   }
+  // Resting-weight plasticity ("use it or lose it"): the RETAINED weight decays
+  // toward a floor while a synapse sits idle and climbs back as it fires, keyed on
+  // last_fired. Distinct from synapsePulse (the seconds-long firing flash) — this is
+  // the slow drift of the resting weight, so idle channels thin and dim while busy
+  // ones stay bright. restingWeight() is what the accessors render instead of raw _w.
+  const PLASTICITY = opts.plasticity || { halfLifeMs: 1800000, floor: 0.15 };
+  const plasticityOf = l => synapsePlasticity(l && l.last_fired, Date.now(), PLASTICITY);
+  const restingWeight = l => (l._w||0) * plasticityOf(l);
   function linkWidthFor(l){
-    if(l.link_type==='synapse') return 0.25 + (l._w||0)*2.4 + synapsePulse(l)*2.0;
+    if(l.link_type==='synapse') return 0.25 + restingWeight(l)*2.4 + synapsePulse(l)*2.0;
     return l.link_type==='focus'?0.8 : l.link_type==='contradicts'?0.6 : (LINK_TYPES[l.link_type]||{}).typed?0.35:0.18;
   }
   function linkParticlesFor(l){
-    if(l.link_type==='synapse') return flow ? Math.min(8, 1+Math.round((l._w||0)*5)+Math.round(synapsePulse(l)*2)) : 0;
+    if(l.link_type==='synapse') return flow ? Math.min(8, 1+Math.round(restingWeight(l)*5)+Math.round(synapsePulse(l)*2)) : 0;
     return l.link_type==='focus'?3 : (flow&&(LINK_TYPES[l.link_type]||{}).typed?2:0);
   }
   function linkParticleSpeedFor(l){
-    if(l.link_type==='synapse') return 0.004 + (l._w||0)*0.02;
+    if(l.link_type==='synapse') return 0.004 + restingWeight(l)*0.02;
     return 0.006;
+  }
+  // Idle synapses also dim: alpha rides the plasticity factor so a cold channel
+  // recedes and a warm one stands out. Non-synapse links keep their typed colour.
+  const SYNAPSE_RGB = '57,208,255';
+  function linkColorFor(l){
+    if(l.link_type==='synapse') return `rgba(${SYNAPSE_RGB},${(0.40 + 0.60*plasticityOf(l)).toFixed(2)})`;
+    return (LINK_TYPES[l.link_type]||LINK_TYPES.related).color;
   }
 
   // Clicking a neuron lights its synaptic neighbourhood (the clicked cell + every
@@ -741,6 +756,21 @@ export function mountMriBrain(container, opts = {}) {
       Graph.linkWidth(linkWidthFor).linkDirectionalParticles(linkParticlesFor);
     }, SYNAPSE_PULSE_MS + 100);
   }
+
+  // Resting-weight plasticity is time-based, so an idle connectome must re-read its
+  // synapse accessors on a slow cadence to visibly settle (thin + dim) even when no
+  // message fires. Cheap — it re-applies the accessor functions; node positions are
+  // pinned — and self-gated to connectome mode, so the memory view never pays for it.
+  const PLASTICITY_REFRESH_MS = 30000;
+  let plasticityTimer = null;
+  function startPlasticityDecay(){
+    if (plasticityTimer) return;
+    plasticityTimer = setInterval(() => {
+      if (disposed || !Graph || mode !== 'connectome') return;
+      Graph.linkWidth(linkWidthFor).linkColor(linkColorFor).linkDirectionalParticles(linkParticlesFor);
+    }, PLASTICITY_REFRESH_MS);
+  }
+  startPlasticityDecay();
 
   const connectomeReloadIntent = createConnectomeReloadIntent();
   function load(fromConnectomeTick = false){
@@ -1031,7 +1061,7 @@ export function mountMriBrain(container, opts = {}) {
       .backgroundColor(mriBgColor())
       .graphData(data).nodeId('id').nodeLabel(()=>'' )
       .nodeVal(nodeVal).nodeColor(nodeColorRGBA).nodeRelSize(2.4).nodeResolution(10).nodeOpacity(0.9)
-      .linkColor(l=>(LINK_TYPES[l.link_type]||LINK_TYPES.related).color)
+      .linkColor(linkColorFor)
       .linkWidth(linkWidthFor)
       .linkOpacity(0.32)
       .linkDirectionalParticles(linkParticlesFor)
@@ -1269,7 +1299,7 @@ export function mountMriBrain(container, opts = {}) {
   const modeCap = document.createElement('div');
   modeCap.className = 'panel mode-cap';
   modeCap.style.cssText = 'position:absolute;left:auto;bottom:44px;top:auto;right:12px;display:none;max-width:236px;font-size:11px;line-height:1.55';
-  modeCap.innerHTML = '<b>Connectome</b> · the agent message-bus<br>◉ neuron = agent · hue = domain<br>synapse thickness + pulse = traffic (Hebbian)<br>hubs sink to the core · click a neuron to light its circle';
+  modeCap.innerHTML = '<b>Connectome</b> · the agent message-bus<br>◉ neuron = agent · hue = domain<br>synapse thickness + pulse = traffic (Hebbian)<br>idle synapses thin & fade · use it or lose it<br>hubs sink to the core · click a neuron to light its circle';
   root.appendChild(modeCap);
 
   // Relabel the stat panel + button and toggle the caption for the active mode.
@@ -1311,6 +1341,7 @@ export function mountMriBrain(container, opts = {}) {
   return function cleanup(){
     disposed = true;
     clearTimeout(graphRetryTimer);
+    clearInterval(plasticityTimer);
     subs.forEach(u => { try { u && u(); } catch(e){ /* noop */ } });
     root.removeEventListener('mousemove', onMove);
     root.removeEventListener('pointerdown', onGraphPointerDown);


### PR DESCRIPTION
## What

Adds **resting-weight plasticity** to the connectome (step 4 of #182): a synapse's *retained* strength now decays toward a floor the longer it sits idle and climbs back as it fires, keyed on `last_fired`. An idle connectome visibly settles — thinner, dimmer channels — while active circuits stay bright. "Use it or lose it."

## Why

Today every synapse renders at its raw Hebbian weight, so an edge that carried heavy traffic weeks ago reads exactly as strong as one busy this minute. The graph shows *who has ever talked to whom*, not *which circuits are alive now*. Plasticity is the missing half of the Hebbian metaphor and the thing that makes the brain look **alive at rest**.

This composes with — and is deliberately distinct from — the live firing pulse (#201): the pulse is a ~2.6s flash on a message in flight; plasticity is the slow drift of the resting weight over minutes/hours. Both ride the same synapse accessors.

## How

- `web/static/js/connectome-map.js` — new pure `synapsePlasticity(lastFiredISO, now, {halfLifeMs, floor})`: a 0..1 multiplier that halves from 1 toward `floor` every half-life (defaults 30 min / 0.15), clamped so an idle edge dims but never vanishes and clock skew never exceeds 1. The server already returns raw `count` + `last_fired` and explicitly defers time-decay to the client (`pipe_synapses.go`: *"Time-decay is left to the client"*) — this is the client honouring that contract.
- `web/static/js/mri-brain.js` — synapse width, particle count/speed, and colour alpha render `restingWeight(l) = _w * plasticity(last_fired)` instead of raw `_w`. A self-gated 30s refresh re-reads the accessors so an idle connectome keeps settling with no new events (cleared on dispose). Tunable via `opts.plasticity`.

## Determinism / safety

Frontend-only, connectome-scoped. No Go/consensus. The memory view is byte-for-byte unchanged; the pulse path (#201) is untouched — plasticity only replaces the resting `_w` term the accessors read.

## Tests

`scripts/connectome-plasticity.test.mjs`: decay-curve coverage (half-life math, monotonic + bounded `[floor,1]`, idle→floor asymptote, missing/future `last_fired`, configurable knobs) plus **scoped** mri-brain wiring assertions binding `restingWeight` through the width and colour accessors. Mutation-verified: reverting the width term to raw `_w` fails the suite. Full `npm test` green (308).

## Verification

Rendered headless (Chromium/SwiftShader) against a synthetic swarm spanning fresh→ancient `last_fired`: fresh channels read thick and bright, idle ones (hours/days) thin and dim toward the floor — a clear at-rest gradient, with the memory view unaffected.

## Context

Step 4 of the connectome arc in #182 (after #181 endpoint, #188 view, #201 live firing). Half-life/floor are tunable — happy to adjust to your eye.
