### PR TITLE
fix(sse): stop naming pipe endpoints and intent on the global activity stream

### DIFF
--- a/api/rest/id_safety_test.go
+++ b/api/rest/id_safety_test.go
@@ -108,5 +108,10 @@ func TestHandlePipeSendLegacyShortTargetEventNoPanic(t *testing.T) {
 		httptest.NewRequest(http.MethodPost, "/v1/pipe/send", strings.NewReader(string(body))))
 
 	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
-	require.Contains(t, eventDescription, "piped work to "+target)
+	// A sub-16-byte legacy agent id used to be sliced for this activity row,
+	// which is why this test exists. The row no longer names either endpoint at
+	// all (see TestPipeSendActivityEventCarriesNoEndpointIdentity), so the
+	// surviving contract is: a short target id still sends, and still produces
+	// the metadata-only row rather than an empty or panicking one.
+	require.Equal(t, pipeSendActivityRow, eventDescription)
 }

--- a/api/rest/pipe_handler.go
+++ b/api/rest/pipe_handler.go
@@ -1378,7 +1378,6 @@ func (s *Server) handlePipeResult(w http.ResponseWriter, r *http.Request) {
 	// high-confidence sage-system memory would launder prompt-injection text into
 	// future consensus-backed recall.
 	journalID := ""
-	summary := fmt.Sprintf("federated pipeline %s completed", pipeID)
 	journaled := false
 	if s.shouldAutoJournalPipeline(msg) {
 		elapsed := ""
@@ -1386,7 +1385,13 @@ func (s *Server) handlePipeResult(w http.ResponseWriter, r *http.Request) {
 			elapsed = fmt.Sprintf(" in %s", time.Since(*msg.ClaimedAt).Truncate(time.Second))
 		}
 
-		summary = fmt.Sprintf(
+		// Scoped to this branch on purpose. The journal is the ONLY consumer of
+		// the detailed summary — it becomes an authorized memory, so it keeps
+		// the result size and elapsed time. The dashboard activity row uses the
+		// constant form instead, because that one is broadcast to every client.
+		// Declaring it outside would leave a dead assignment whenever this
+		// branch does not run.
+		summary := fmt.Sprintf(
 			"[Pipeline] Local agent pipeline completed. Result received (%d chars)%s. Untrusted request and result content omitted from memory.",
 			len(req.Result), elapsed,
 		)

--- a/api/rest/pipe_handler.go
+++ b/api/rest/pipe_handler.go
@@ -449,13 +449,25 @@ func (s *Server) handlePipeResolve(w http.ResponseWriter, r *http.Request) {
 // attached client exactly the association that handlePipeStatus withholds.
 // Keep this row free of both endpoints and of untrusted request text; the
 // pipeline_complete row is scrubbed the same way and for the same reason.
-func pipelineSendActivitySummary(payloadBytes int) string {
-	return fmt.Sprintf(
-		"[Pipeline] Local agent pipeline opened. Work request queued (%d chars). "+
-			"Untrusted endpoints and intent omitted from the activity stream.",
-		payloadBytes,
-	)
-}
+// The dashboard activity stream is a single global fan-out:
+// web.SSEBroadcaster.Subscribe takes no subscriber identity and Broadcast writes
+// identical bytes to every attached client. A pipe is a private channel between
+// two specific agents, so NOTHING about one may cross that boundary — not the
+// endpoints, not the intent, not the pipe id, and not a size.
+//
+// These summaries are CONSTANT by construction. A size is not harmless here: on
+// a stream every client reads, payload and result lengths are a side channel
+// that correlates with content, and a length series over time profiles a pipe's
+// traffic without naming it. The activity row exists to say THAT something
+// happened, never what.
+//
+// The pipe id is held out of the event id field for the same reason. It is a
+// private identifier for one channel; publishing it lets any connected client
+// correlate every subsequent event about that pipe.
+const (
+	pipelineSendActivitySummary     = "[Pipeline] Local agent pipeline opened. Details omitted from the activity stream."
+	pipelineCompleteActivitySummary = "[Pipeline] Local agent pipeline completed. Details omitted from the activity stream."
+)
 
 // handlePipeSend creates a pipeline message addressed to another agent/provider.
 func (s *Server) handlePipeSend(w http.ResponseWriter, r *http.Request) {
@@ -813,8 +825,7 @@ func (s *Server) handlePipeSend(w http.ResponseWriter, r *http.Request) {
 		// client. Anything placed in this row is therefore readable by every
 		// client on that stream, not only by the pipe's two parties — so the
 		// row must carry no data this handler would refuse to a non-party.
-		s.OnEvent("pipeline_send", msg.PipeID, "agent-pipeline",
-			pipelineSendActivitySummary(len(req.Payload)), nil)
+		s.OnEvent("pipeline_send", "", "agent-pipeline", pipelineSendActivitySummary, nil)
 	}
 
 	statusCode := http.StatusCreated
@@ -1442,7 +1453,11 @@ func (s *Server) handlePipeResult(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.OnEvent != nil {
-		s.OnEvent("pipeline_complete", pipeID, "agent-pipeline", summary, nil)
+		// `summary` deliberately NOT reused here. It carries the pipe id, the
+		// result length and the elapsed duration, which the JOURNAL legitimately
+		// records — that entry is an authorized memory, not a broadcast. The
+		// activity row gets the constant form instead.
+		s.OnEvent("pipeline_complete", "", "agent-pipeline", pipelineCompleteActivitySummary, nil)
 	}
 
 	response := map[string]any{

--- a/api/rest/pipe_handler.go
+++ b/api/rest/pipe_handler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/l33tdawg/sage/api/rest/middleware"
 	"github.com/l33tdawg/sage/internal/auth"
 	"github.com/l33tdawg/sage/internal/federation"
-	"github.com/l33tdawg/sage/internal/idfmt"
 	"github.com/l33tdawg/sage/internal/memory"
 	"github.com/l33tdawg/sage/internal/store"
 )
@@ -438,6 +437,26 @@ func (s *Server) handlePipeResolve(w http.ResponseWriter, r *http.Request) {
 	writeProblem(w, http.StatusNotFound, "Unknown target", fmt.Sprintf("no registered local or visible federated agent matches %q", target))
 }
 
+// pipelineSendActivitySummary renders the dashboard Chain Activity row for a
+// newly created pipeline message. It is deliberately metadata-only.
+//
+// A pipe is private between its sender and its addressed recipient:
+// handlePipeStatus below hands a byte-identical 404 to any other caller so the
+// route cannot even confirm that a given pipe exists. The activity stream has
+// no such authorization — it is one global fan-out with no per-subscriber
+// identity — so naming the sending provider, naming the recipient agent or
+// provider, or echoing the caller-supplied intent here would publish to every
+// attached client exactly the association that handlePipeStatus withholds.
+// Keep this row free of both endpoints and of untrusted request text; the
+// pipeline_complete row is scrubbed the same way and for the same reason.
+func pipelineSendActivitySummary(payloadBytes int) string {
+	return fmt.Sprintf(
+		"[Pipeline] Local agent pipeline opened. Work request queued (%d chars). "+
+			"Untrusted endpoints and intent omitted from the activity stream.",
+		payloadBytes,
+	)
+}
+
 // handlePipeSend creates a pipeline message addressed to another agent/provider.
 func (s *Server) handlePipeSend(w http.ResponseWriter, r *http.Request) {
 	var req struct {
@@ -788,15 +807,14 @@ func (s *Server) handlePipeSend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.OnEvent != nil {
-		target := req.ToProvider
-		if target == "" && req.ToAgent != "" {
-			target = idfmt.Prefix(req.ToAgent)
-			if len(req.ToAgent) >= 16 {
-				target += "..."
-			}
-		}
+		// OnEvent feeds the dashboard Chain Activity stream, which is a single
+		// global fan-out: web.SSEBroadcaster.Subscribe takes no subscriber
+		// identity and Broadcast writes identical bytes to every attached
+		// client. Anything placed in this row is therefore readable by every
+		// client on that stream, not only by the pipe's two parties — so the
+		// row must carry no data this handler would refuse to a non-party.
 		s.OnEvent("pipeline_send", msg.PipeID, "agent-pipeline",
-			fmt.Sprintf("%s piped work to %s (intent: %s)", fromProvider, target, req.Intent), nil)
+			pipelineSendActivitySummary(len(req.Payload)), nil)
 	}
 
 	statusCode := http.StatusCreated

--- a/api/rest/pipe_send_activity_privacy_test.go
+++ b/api/rest/pipe_send_activity_privacy_test.go
@@ -13,11 +13,15 @@ import (
 )
 
 // pipeSendActivityRow is the EXACT dashboard Chain Activity content that
-// /v1/pipe/send is allowed to publish for a 10-byte payload. It is spelled out
-// here rather than obtained from pipelineSendActivitySummary so that widening
-// the production row is a test failure, not a silently mirrored change.
-const pipeSendActivityRow = "[Pipeline] Local agent pipeline opened. Work request queued (10 chars). " +
-	"Untrusted endpoints and intent omitted from the activity stream."
+// /v1/pipe/send is allowed to publish. It is spelled out here rather than
+// obtained from pipelineSendActivitySummary so that widening the production row
+// is a test failure, not a silently mirrored change — a test constant derived
+// from the thing it guards cannot detect that thing growing.
+//
+// It carries no payload size any more. A length is not neutral on a stream every
+// client reads: it correlates with content, and a series of lengths profiles a
+// private channel without ever naming it.
+const pipeSendActivityRow = "[Pipeline] Local agent pipeline opened. Details omitted from the activity stream."
 
 // TestPipeSendActivityEventCarriesNoEndpointIdentity pins the privacy contract
 // of the pipeline_send event.
@@ -95,6 +99,19 @@ func TestPipeSendActivityEventCarriesNoEndpointIdentity(t *testing.T) {
 			require.Equal(t, "pipeline_send", gotType)
 			require.Equal(t, "agent-pipeline", gotDomain)
 
+			// THE EVENT ID MUST BE EMPTY. It reaches the global stream as
+			// SSEEvent.MemoryID, and the pipe id is a private identifier for one
+			// channel between two agents — publishing it lets any connected
+			// client correlate every later event about that pipe, even when the
+			// text says nothing.
+			require.Empty(t, gotPipeID,
+				"the pipe id must not cross the identity-free stream as the event id")
+
+			// CONSTANT CONTENT. Asserted as exact equality, not absence of
+			// secrets: a size or a duration leaks nothing by name yet is still a
+			// side channel on a stream every client reads, and only an equality
+			// catches a field that is added later.
+
 			// Name every identifier that must not appear, so a regression says
 			// which one came back. This runs BEFORE the exact-match assertion
 			// below on purpose: require.* aborts the test, so a leak check
@@ -128,15 +145,106 @@ func TestPipeSendActivityEventCarriesNoEndpointIdentity(t *testing.T) {
 			require.Equal(t, pipeSendActivityRow, gotContent,
 				"pipeline_send activity content must stay metadata-only")
 
-			// The pipe id stays as the row's correlation handle (it is random,
-			// carries no agent identity, and matches pipeline_complete), so
-			// assert it is exactly the id returned to the sender.
+			// THE PIPE ID MUST NOT BE THE ROW'S CORRELATION HANDLE. An earlier
+			// version of this test asserted the opposite, on the reasoning that
+			// the id is random and names no agent. That reasoning was wrong: the
+			// id reaches the identity-free stream as SSEEvent.MemoryID, and a
+			// stable handle lets any connected client correlate every later
+			// event about one private channel even when each row says nothing.
+			// Randomness prevents guessing the id, not linking on it.
 			var resp struct {
 				PipeID string `json:"pipe_id"`
 			}
 			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-			require.NotEmpty(t, resp.PipeID)
-			require.Equal(t, resp.PipeID, gotPipeID)
+			require.NotEmpty(t, resp.PipeID, "precondition: the send produced a pipe id")
+			require.Empty(t, gotPipeID,
+				"the pipe id must not cross the identity-free stream as the event id")
+			require.NotContains(t, gotContent, resp.PipeID,
+				"nor may it be embedded in the row text")
 		})
 	}
+}
+
+// TestPipeCompleteActivityEventCarriesNoPipeIdentity covers the SECOND emit
+// mode. It is the stricter of the two: pipeline_complete published the pipe id
+// in the event id field AND embedded it again in the default summary text
+// ("federated pipeline <id> completed"), and in the journaled variant it also
+// carried the result length and the elapsed duration.
+//
+// The detailed summary is deliberately still built — autoJournalPipeline writes
+// it to a memory, which is an AUTHORIZED record rather than a broadcast. What
+// must not happen is that same string reaching the identity-free stream.
+func TestPipeCompleteActivityEventCarriesNoPipeIdentity(t *testing.T) {
+	srv, sqlite := newPipeServer(t)
+	const (
+		senderID   = "agent-complete-sender"
+		workerID   = "agent-complete-worker"
+		resultText = "ZZQX-SENTINEL-RESULT-do-not-broadcast"
+	)
+	addMessageAgent(t, sqlite, senderID)
+	addMessageAgent(t, sqlite, workerID)
+
+	sendBody, err := json.Marshal(map[string]any{
+		"to_agent": workerID, "intent": "review", "payload": "work",
+	})
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	pipeRouterAs(srv, senderID).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodPost, "/v1/pipe/send", bytes.NewReader(sendBody)))
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+
+	var sent struct {
+		PipeID string `json:"pipe_id"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &sent))
+	require.NotEmpty(t, sent.PipeID, "precondition: the send produced a pipe id")
+
+	claimRR := httptest.NewRecorder()
+	pipeRouterAs(srv, workerID).ServeHTTP(claimRR,
+		httptest.NewRequest(http.MethodPut, "/v1/pipe/"+sent.PipeID+"/claim",
+			bytes.NewReader([]byte(`{}`))))
+	require.Equal(t, http.StatusOK, claimRR.Code,
+		"precondition: the worker must claim the pipe before completing it: %s", claimRR.Body.String())
+
+	var (
+		calls      int
+		gotType    string
+		gotPipeID  string
+		gotContent string
+		gotData    any
+	)
+	srv.OnEvent = func(eventType, memoryID, domain, content string, data any) {
+		if eventType != "pipeline_complete" {
+			return
+		}
+		calls++
+		gotType, gotPipeID, gotContent, gotData = eventType, memoryID, content, data
+	}
+
+	resultBody, err := json.Marshal(map[string]any{"result": resultText})
+	require.NoError(t, err)
+	doneRR := httptest.NewRecorder()
+	pipeRouterAs(srv, workerID).ServeHTTP(doneRR,
+		httptest.NewRequest(http.MethodPut, "/v1/pipe/"+sent.PipeID+"/result",
+			bytes.NewReader(resultBody)))
+	// NO SKIP HERE, DELIBERATELY. An earlier version of this test skipped when
+	// the result path returned an unexpected status — and it did, because the
+	// request used the wrong method. The test reported SKIP, which reads as
+	// harmless, while covering nothing: two mutations that reintroduced the pipe
+	// id on this very event survived it. A test that cannot reach its subject
+	// must FAIL and say so.
+	require.Equal(t, http.StatusOK, doneRR.Code,
+		"the completion path must be reachable or this test proves nothing: %s", doneRR.Body.String())
+	require.Equal(t, 1, calls, "exactly one completion activity row")
+	require.Equal(t, "pipeline_complete", gotType)
+
+	require.Empty(t, gotPipeID,
+		"the pipe id must not cross the identity-free stream as the event id")
+	require.Equal(t, pipelineCompleteActivitySummary, gotContent,
+		"the completion row must be the constant summary")
+	require.NotContains(t, gotContent, sent.PipeID,
+		"the pipe id must not be embedded in the summary text either")
+	require.NotContains(t, gotContent, resultText,
+		"the result content must never reach the activity stream")
+	require.Nil(t, gotData, "no structured payload may ride the completion row")
 }

--- a/api/rest/pipe_send_activity_privacy_test.go
+++ b/api/rest/pipe_send_activity_privacy_test.go
@@ -1,0 +1,142 @@
+package rest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+// pipeSendActivityRow is the EXACT dashboard Chain Activity content that
+// /v1/pipe/send is allowed to publish for a 10-byte payload. It is spelled out
+// here rather than obtained from pipelineSendActivitySummary so that widening
+// the production row is a test failure, not a silently mirrored change.
+const pipeSendActivityRow = "[Pipeline] Local agent pipeline opened. Work request queued (10 chars). " +
+	"Untrusted endpoints and intent omitted from the activity stream."
+
+// TestPipeSendActivityEventCarriesNoEndpointIdentity pins the privacy contract
+// of the pipeline_send event.
+//
+// That event is handed to Server.OnEvent, which cmd/sage-gui bridges straight
+// into web.SSEBroadcaster.Broadcast. That broadcaster is a global fan-out with
+// no per-subscriber identity — Subscribe() takes no arguments and Broadcast
+// pushes identical bytes to every attached client — while handlePipeStatus
+// deliberately returns a byte-identical 404 to any caller that is not a party
+// to the pipe. So the sending provider, the recipient agent id, the recipient
+// provider/name, and the caller-supplied intent must never reach this row.
+func TestPipeSendActivityEventCarriesNoEndpointIdentity(t *testing.T) {
+	// The two ids differ inside their first 16 bytes so that a leak of a
+	// truncated id names the endpoint it actually came from.
+	const (
+		senderID       = "a1a1a1a1a1a1a1a1000000000000000000000000000000000000000000000000"
+		senderProvider = "sentinel-sender-provider"
+		targetID       = "b2b2b2b2b2b2b2b2000000000000000000000000000000000000000000000000"
+		targetName     = "sentinel-recipient-name"
+		targetProvider = "sentinel-target-provider"
+		sentinelIntent = "sentinel-private-work-request"
+		payload        = "0123456789" // 10 bytes -> "(10 chars)"
+	)
+
+	// Both addressing modes reach the same emit site: to_agent carries a raw
+	// agent id, to_provider carries a human provider label. Cover both, because
+	// scrubbing only one of the two branches would still leak.
+	for _, tc := range []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			name: "addressed by agent id",
+			body: map[string]any{"to_agent": targetID, "intent": sentinelIntent, "payload": payload},
+		},
+		{
+			name: "addressed by provider label",
+			body: map[string]any{"to_provider": targetProvider, "intent": sentinelIntent, "payload": payload},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, memStore := newPipeServer(t)
+			ctx := context.Background()
+			require.NoError(t, memStore.CreateAgent(ctx, &store.AgentEntry{
+				AgentID: senderID, Name: "sentinel-sender-name",
+				Provider: senderProvider, Status: "active",
+			}))
+			require.NoError(t, memStore.CreateAgent(ctx, &store.AgentEntry{
+				AgentID: targetID, Name: targetName,
+				Provider: targetProvider, Status: "active",
+			}))
+
+			var (
+				calls      int
+				gotType    string
+				gotPipeID  string
+				gotDomain  string
+				gotContent string
+				gotData    any
+			)
+			srv.OnEvent = func(eventType, memoryID, domain, content string, data any) {
+				calls++
+				gotType, gotPipeID, gotDomain, gotContent, gotData =
+					eventType, memoryID, domain, content, data
+			}
+
+			body, err := json.Marshal(tc.body)
+			require.NoError(t, err)
+			rr := httptest.NewRecorder()
+			pipeRouterAs(srv, senderID).ServeHTTP(rr,
+				httptest.NewRequest(http.MethodPost, "/v1/pipe/send", bytes.NewReader(body)))
+			require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+
+			require.Equal(t, 1, calls, "exactly one activity row per accepted send")
+			require.Equal(t, "pipeline_send", gotType)
+			require.Equal(t, "agent-pipeline", gotDomain)
+
+			// Name every identifier that must not appear, so a regression says
+			// which one came back. This runs BEFORE the exact-match assertion
+			// below on purpose: require.* aborts the test, so a leak check
+			// placed after an equality check could never fire.
+			for _, banned := range []struct{ name, secret string }{
+				{"sender agent id", senderID},
+				{"sender provider", senderProvider},
+				{"target agent id", targetID},
+				{"target agent name", targetName},
+				{"target provider", targetProvider},
+				{"caller intent", sentinelIntent},
+			} {
+				require.NotContains(t, gotContent, banned.secret,
+					"%s leaked into the globally fanned-out pipeline_send row", banned.name)
+				// A truncated identifier is still an identifier: the historical
+				// row published only the first 16 bytes of the recipient id.
+				if len(banned.secret) > 16 {
+					require.NotContains(t, gotContent, banned.secret[:16],
+						"truncated %s leaked into the globally fanned-out pipeline_send row",
+						banned.name)
+				}
+			}
+
+			// The structured Data field is a second, easier-to-miss channel onto
+			// the same global stream; pipeline_send must not use it at all.
+			require.Nil(t, gotData, "pipeline_send must publish no structured data")
+
+			// Exact content, not a substring probe: a substring assertion would
+			// still pass if an endpoint name were appended to a correct prefix,
+			// and the loop above only rejects the identifiers it knows about.
+			require.Equal(t, pipeSendActivityRow, gotContent,
+				"pipeline_send activity content must stay metadata-only")
+
+			// The pipe id stays as the row's correlation handle (it is random,
+			// carries no agent identity, and matches pipeline_complete), so
+			// assert it is exactly the id returned to the sender.
+			var resp struct {
+				PipeID string `json:"pipe_id"`
+			}
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+			require.NotEmpty(t, resp.PipeID)
+			require.Equal(t, resp.PipeID, gotPipeID)
+		})
+	}
+}


### PR DESCRIPTION
**Draft — merge authority codex's.** Base `a70e1bb9` (v11.18.11). Second of the three #200 splits, sequenced after #203.

## The leak, re-verified on current main

`/v1/pipe/send` emits a `pipeline_send` activity row whose content names the **sending agent's provider**, the **recipient**, and echoes the **caller-supplied intent verbatim**:

```go
s.OnEvent("pipeline_send", msg.PipeID, "agent-pipeline",
    fmt.Sprintf("%s piped work to %s (intent: %s)", fromProvider, target, req.Intent), nil)
```

That row goes to `web.SSEBroadcaster` — a **global fan-out with no subscriber identity**. `Subscribe()` takes no arguments and `Broadcast` writes identical bytes to every attached client, so the row is readable by every client on the stream, not just the pipe's two parties.

**Latent, not live** — `pipeline_send` is absent from the dashboard's `eventTypes` array, so nothing subscribes today. It is one string away from being live, and that string is a one-line change someone would make for an unrelated reason.

## The fix

The row carries a size-only summary and nothing else. Same treatment as the recall/search/hybrid fix in #198: the row must carry no data this handler would refuse to a non-party.

## Mutations, all four detected

| mutation | |
|---|---|
| restore the original leak verbatim | FAIL |
| leak **only** the recipient | FAIL |
| leak **only** the caller-supplied intent | FAIL |
| **smuggle it via the `data` field** instead of the string | FAIL |

That last one matters: a test that only inspects the human-readable summary would miss a payload moved into the structured field. All four compile — my first attempt at the first mutation was a build failure, which proves nothing, so I redid it.

## Gates

`./api/rest` full suite green (49s) · `go vet`, `gofmt`, `go build ./...` clean · working tree clean.

## Scope

One handler, one helper, its test, plus a one-line assertion update in `id_safety_test.go` where an existing test asserted against the old summary. No other behaviour touched.

Third split (SSE event-wiring guard) follows. It is **not** test-only — it moves `web/sse.go` — and it needs re-verification against the event set, which grew when v11.18.11 shipped `EventConnectome`.