### PR TITLE
test(app-v26): bound fixture peer recovery

### DIFF
--- a/.github/workflows/v11.9-fault-gates.yml
+++ b/.github/workflows/v11.9-fault-gates.yml
@@ -64,7 +64,7 @@ jobs:
   real-comet-chaos:
     name: App-v26 real Comet/ABCI crash, partition, and state-sync gate
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     # Independent of app-multiprocess: no needs.app-multiprocess.* reference
     # exists, so this edge only serialized two separate suites.
     steps:

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -699,8 +699,8 @@ func runServe(startupProof string) (rerr error) {
 		cometCfg.P2P.AddrBookStrict = false  // Allow LAN addresses
 		cometCfg.P2P.AllowDuplicateIP = true // Multiple nodes on same network
 		cometCfg.P2P.PexReactor = false      // Use persistent peers only
-		if err := applyV119FixturePersistentPeerDialCeiling(cometCfg.P2P); err != nil {
-			return fmt.Errorf("configure fixture persistent-peer retry ceiling: %w", err)
+		if fixtureErr := applyV119FixturePersistentPeerDialCeiling(cometCfg.P2P); fixtureErr != nil {
+			return fmt.Errorf("configure fixture persistent-peer retry ceiling: %w", fixtureErr)
 		}
 		logger.Info().
 			Str("p2p_addr", p2pAddr).

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -699,6 +699,9 @@ func runServe(startupProof string) (rerr error) {
 		cometCfg.P2P.AddrBookStrict = false  // Allow LAN addresses
 		cometCfg.P2P.AllowDuplicateIP = true // Multiple nodes on same network
 		cometCfg.P2P.PexReactor = false      // Use persistent peers only
+		if err := applyV119FixturePersistentPeerDialCeiling(cometCfg.P2P); err != nil {
+			return fmt.Errorf("configure fixture persistent-peer retry ceiling: %w", err)
+		}
 		logger.Info().
 			Str("p2p_addr", p2pAddr).
 			Int("peers", len(cfg.Quorum.Peers)).

--- a/cmd/sage-gui/v119_p2p_retry_ceiling_default.go
+++ b/cmd/sage-gui/v119_p2p_retry_ceiling_default.go
@@ -1,0 +1,9 @@
+//go:build !v119testfixture
+
+package main
+
+import "github.com/cometbft/cometbft/config"
+
+func applyV119FixturePersistentPeerDialCeiling(_ *config.P2PConfig) error {
+	return nil
+}

--- a/cmd/sage-gui/v119_p2p_retry_ceiling_default_test.go
+++ b/cmd/sage-gui/v119_p2p_retry_ceiling_default_test.go
@@ -1,0 +1,20 @@
+//go:build !v119testfixture
+
+package main
+
+import (
+	"testing"
+
+	"github.com/cometbft/cometbft/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyV119FixturePersistentPeerDialCeilingIsNoopInNormalBuild(t *testing.T) {
+	t.Setenv("SAGE_V119_PERSISTENT_PEER_MAX_DIAL_PERIOD", "5s")
+	cfg := config.DefaultP2PConfig()
+	want := *cfg
+
+	require.NoError(t, applyV119FixturePersistentPeerDialCeiling(cfg))
+	require.Equal(t, want, *cfg, "fixture environment must not change normal-build P2P configuration")
+	require.Equal(t, want.PersistentPeersMaxDialPeriod, cfg.PersistentPeersMaxDialPeriod)
+}

--- a/cmd/sage-gui/v119_p2p_retry_ceiling_v119testfixture.go
+++ b/cmd/sage-gui/v119_p2p_retry_ceiling_v119testfixture.go
@@ -1,0 +1,29 @@
+//go:build v119testfixture
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cometbft/cometbft/config"
+)
+
+const v119PersistentPeerMaxDialPeriodEnv = "SAGE_V119_PERSISTENT_PEER_MAX_DIAL_PERIOD"
+
+func applyV119FixturePersistentPeerDialCeiling(cfg *config.P2PConfig) error {
+	raw := os.Getenv(v119PersistentPeerMaxDialPeriodEnv)
+	if raw == "" {
+		return nil
+	}
+	period, err := time.ParseDuration(raw)
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", v119PersistentPeerMaxDialPeriodEnv, err)
+	}
+	if period <= 0 {
+		return fmt.Errorf("%s must be positive", v119PersistentPeerMaxDialPeriodEnv)
+	}
+	cfg.PersistentPeersMaxDialPeriod = period
+	return nil
+}

--- a/cmd/sage-gui/v119_p2p_retry_ceiling_v119testfixture_test.go
+++ b/cmd/sage-gui/v119_p2p_retry_ceiling_v119testfixture_test.go
@@ -1,0 +1,28 @@
+//go:build v119testfixture
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cometbft/cometbft/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyV119FixturePersistentPeerDialCeiling(t *testing.T) {
+	t.Setenv(v119PersistentPeerMaxDialPeriodEnv, "5s")
+	cfg := config.DefaultP2PConfig()
+	require.NoError(t, applyV119FixturePersistentPeerDialCeiling(cfg))
+	require.Equal(t, 5*time.Second, cfg.PersistentPeersMaxDialPeriod)
+}
+
+func TestApplyV119FixturePersistentPeerDialCeilingRejectsInvalidValues(t *testing.T) {
+	for _, value := range []string{"0s", "-1s", "not-a-duration"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv(v119PersistentPeerMaxDialPeriodEnv, value)
+			cfg := config.DefaultP2PConfig()
+			require.Error(t, applyV119FixturePersistentPeerDialCeiling(cfg))
+		})
+	}
+}

--- a/deploy/scripts/run-v11.9-chaos.sh
+++ b/deploy/scripts/run-v11.9-chaos.sh
@@ -34,6 +34,9 @@ NETWORK=${PROJECT}_sagenet
 FIREWALL_CHAIN=SAGE_V119
 P2P_PORT=26656
 P2P_TCP_RETRIES2=3
+PERSISTENT_PEER_MAX_DIAL_SECONDS=5
+PERSISTENT_PEER_MAX_DIAL_PERIOD="${PERSISTENT_PEER_MAX_DIAL_SECONDS}s"
+FULL_MESH_RECOVERY_TIMEOUT=90
 APP_V20_MEMPOOL_MAX_TX_BYTES=1048576
 COMETBFT_SOURCE_COMMIT=feb2aea4dc271d612129afc958cb844713ec792b
 COMETBFT_RUNTIME_VERSION="0.38.22+${COMETBFT_SOURCE_COMMIT}"
@@ -74,6 +77,11 @@ V119_VALIDATOR_PROBE_KEY=
 export V119_GOVERNANCE_OPERATOR_ID=
 export V119_GOVERNANCE_HEARTBEAT_ID=
 export V119_VALIDATOR_PROBE_ID=
+
+if [ "${FULL_MESH_RECOVERY_TIMEOUT}" -lt "$((PERSISTENT_PEER_MAX_DIAL_SECONDS * 6))" ]; then
+  echo "ERROR: full-mesh recovery timeout must cover at least six bounded persistent-peer retries" >&2
+  exit 1
+fi
 
 dump_diagnostics() {
   "${COMPOSE[@]}" ps -a || true
@@ -1052,6 +1060,7 @@ wait_full_peer_mesh() {
   local required_rounds=${2:-2}
   local deadline=$((SECONDS + timeout))
   local consecutive=0
+  local service id
   local expected0 expected1 expected2 expected3
   local actual0=ERROR actual1=ERROR actual2=ERROR actual3=ERROR
   expected0=$(expected_peer_ids "${NODE_IDS[1]}" "${NODE_IDS[2]}" "${NODE_IDS[3]}")
@@ -1080,7 +1089,17 @@ wait_full_peer_mesh() {
   done
 
   echo "ERROR: full peer mesh did not remain exact for ${required_rounds} consecutive rounds within ${timeout}s" >&2
+  echo "ERROR: configured persistent-peer max dial is ${PERSISTENT_PEER_MAX_DIAL_PERIOD}; recovery budget is ${timeout}s" >&2
   echo "ERROR: RPC peer snapshots: 0=${actual0} 1=${actual1} 2=${actual2} 3=${actual3}" >&2
+  for service in cometbft0 cometbft1 cometbft2 cometbft3; do
+    id=$(service_container "${service}" 2>/dev/null || true)
+    echo "ERROR: ${service} firewall diagnostics:" >&2
+    if [ -n "${id}" ]; then
+      docker exec "${id}" iptables -w 5 -S "${FIREWALL_CHAIN}" >&2 || true
+    else
+      echo "ERROR: ${service} has no container" >&2
+    fi
+  done
   return 1
 }
 
@@ -1347,7 +1366,7 @@ SAGE_TESTNET_ABCI_HOST_SUFFIX="-local" \
 COMETBFT_DOCKER_IMAGE="sage-v119-chaos-node:local" \
   bash deploy/init-testnet.sh
 
-python3 - "${APP_V20_MEMPOOL_MAX_TX_BYTES}" \
+python3 - "${APP_V20_MEMPOOL_MAX_TX_BYTES}" "${PERSISTENT_PEER_MAX_DIAL_PERIOD}" \
   "${V119_CHAOS_GENESIS_DIR}/node0/config/config.toml" \
   "${V119_CHAOS_GENESIS_DIR}/node1/config/config.toml" \
   "${V119_CHAOS_GENESIS_DIR}/node2/config/config.toml" \
@@ -1357,7 +1376,8 @@ import re
 import sys
 
 max_tx_bytes = int(sys.argv[1])
-for raw_path in sys.argv[2:]:
+max_dial_period = sys.argv[2]
+for raw_path in sys.argv[3:]:
     path = pathlib.Path(raw_path)
     text = path.read_text()
 
@@ -1369,8 +1389,20 @@ for raw_path in sys.argv[2:]:
     one(r"^recheck\s*=\s*(\S+)\s*$", "true")
     one(r"^max_tx_bytes\s*=\s*(\d+)\s*$", str(max_tx_bytes))
     one(r'^wal_dir\s*=\s*("[^"]*")\s*$', '""')
+    values = re.findall(r'^persistent_peers_max_dial_period\s*=\s*"([^"]*)"\s*$', text, flags=re.MULTILINE)
+    if len(values) != 1:
+        raise SystemExit(f"{path}: wanted one persistent_peers_max_dial_period, got {values!r}")
+    text = re.sub(
+        r'^(persistent_peers_max_dial_period\s*=\s*)"[^"]*"\s*$',
+        rf'\1"{max_dial_period}"',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    path.write_text(text)
+    one(r'^persistent_peers_max_dial_period\s*=\s*"([^"]*)"\s*$', max_dial_period)
 PY
-echo "validated external Comet mempool transition profile (recheck=true, max_tx_bytes=${APP_V20_MEMPOOL_MAX_TX_BYTES}, wal_dir empty)"
+echo "validated external Comet profile (recheck=true, max_tx_bytes=${APP_V20_MEMPOOL_MAX_TX_BYTES}, wal_dir empty, persistent-peer max dial ${PERSISTENT_PEER_MAX_DIAL_PERIOD})"
 
 NODE_PUBKEYS=()
 NODE_PUBKEYS_B64=()
@@ -1742,7 +1774,7 @@ for service in cometbft0 cometbft1 cometbft2 cometbft3; do
 done
 assert_matched_apphash "post-one-validator partition" 180
 wait_all_app_version 23 180
-wait_full_peer_mesh 90 2
+wait_full_peer_mesh "${FULL_MESH_RECOVERY_TIMEOUT}" 2
 echo "proved the full peer mesh recovered before the next partition"
 
 echo "--- fault 2: post-removal stable-IP 2+2 split must halt both live halves ---"

--- a/deploy/scripts/run-v11.9-state-sync.sh
+++ b/deploy/scripts/run-v11.9-state-sync.sh
@@ -28,6 +28,14 @@ REBUILD=${V119_STATE_SYNC_REBUILD:-${V119_CHAOS_REBUILD:-1}}
 KEEP=${V119_STATE_SYNC_KEEP:-0}
 TIMEOUT=${V119_STATE_SYNC_TIMEOUT:-240}
 TARGET_APP_VERSION=26
+PERSISTENT_PEER_MAX_DIAL_SECONDS=5
+PERSISTENT_PEER_MAX_DIAL_PERIOD="${PERSISTENT_PEER_MAX_DIAL_SECONDS}s"
+AUTHORIZED_PEER_ASSERT_TIMEOUT=30
+
+if [ "${AUTHORIZED_PEER_ASSERT_TIMEOUT}" -lt "$((PERSISTENT_PEER_MAX_DIAL_SECONDS * 4))" ]; then
+  echo "ERROR: authorized peer assertion must cover at least four bounded persistent-peer retries" >&2
+  exit 1
+fi
 
 for setting in "REBUILD=${REBUILD}" "KEEP=${KEEP}"; do
   case "${setting#*=}" in
@@ -420,6 +428,7 @@ create_sage() {
     -e SAGE_CMT_RPC_ADDR=tcp://0.0.0.0:26657 \
     -e SAGE_CMT_P2P_ADDR=tcp://0.0.0.0:26656 \
     -e SAGE_NO_BROWSER=1 \
+    -e "SAGE_V119_PERSISTENT_PEER_MAX_DIAL_PERIOD=${PERSISTENT_PEER_MAX_DIAL_PERIOD}" \
     -e "SAGE_V119_STATE_SYNC_PRE_PUBLISH_PAUSE_FILE=${pre_publish_pause_file}" \
     -v "${home}:/sage" \
     "${ABCI_IMAGE}" ./sage-gui-v119-fixture serve >/dev/null
@@ -565,7 +574,6 @@ start_readiness_probe() {
   fi
   docker exec "${RECEIVER}" sh -ec '
     violation=$1
-    rm -f "${violation}"
     while :; do
       if wget -qO- http://127.0.0.1:8080/ready >/dev/null 2>&1; then
         printf "%s\n" "REST /ready opened before the durable pre-publication boundary" >"${violation}"
@@ -721,6 +729,34 @@ strip_ansi() {
 
 rpc_peer_ids() {
   rpc_json "$1" /net_info | python3 -c 'import json,sys; print(" ".join(sorted(p["node_info"]["id"] for p in json.load(sys.stdin)["result"]["peers"])))'
+}
+
+wait_mutual_authorized_peers() {
+  local deadline=$((SECONDS + AUTHORIZED_PEER_ASSERT_TIMEOUT))
+  local provider_peers=unavailable receiver_peers=unavailable
+  local provider_has_receiver=0 receiver_has_provider=0
+  while [ "${SECONDS}" -lt "${deadline}" ]; do
+    provider_peers=$(rpc_peer_ids "${PROVIDER}" 2>/dev/null || printf unavailable)
+    receiver_peers=$(rpc_peer_ids "${RECEIVER}" 2>/dev/null || printf unavailable)
+    case " ${provider_peers} " in
+      *" ${receiver_id} "*) provider_has_receiver=1 ;;
+      *) provider_has_receiver=0 ;;
+    esac
+    case " ${receiver_peers} " in
+      *" ${provider_id} "*) receiver_has_provider=1 ;;
+      *) receiver_has_provider=0 ;;
+    esac
+    if [ "${provider_has_receiver}" = 1 ] && [ "${receiver_has_provider}" = 1 ]; then
+      echo "authorized provider and receiver reported reciprocal peer IDs"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: authorized peer IDs were not reciprocal within ${AUTHORIZED_PEER_ASSERT_TIMEOUT}s" >&2
+  echo "ERROR: persistent-peer max dial=${PERSISTENT_PEER_MAX_DIAL_PERIOD} provider=${provider_peers} receiver=${receiver_peers}" >&2
+  echo "ERROR: provider/receiver network attachments:" >&2
+  docker inspect --format '{{json .NetworkSettings.Networks}}' "${PROVIDER}" "${RECEIVER}" >&2 || true
+  return 1
 }
 
 rpc_p2p_filter_code() {
@@ -1287,6 +1323,7 @@ docker network connect --alias unauthorized-p2p "${P2P_NETWORK}" "${ATTACKER}"
 docker start "${RECEIVER}" "${ATTACKER}" >/dev/null
 wait_rpc "${RECEIVER}"
 wait_rpc "${ATTACKER}"
+docker exec "${RECEIVER}" rm -f "${READINESS_VIOLATION}"
 start_readiness_probe
 for candidate in "${RECEIVER}" "${ATTACKER}"; do
   assert_remote_rpc_origins "${candidate}" "${snapshot_height}"
@@ -1305,6 +1342,8 @@ fi
 # An outbound switch may transiently list its locally approved provider before
 # that remote admission rejection and EOF arrive.
 docker network disconnect "${P2P_NETWORK}" "${RECEIVER}" >/dev/null
+stop_readiness_probe
+stop_sage "${RECEIVER}"
 docker rm -f "${P2P_PLACEHOLDER}" >/dev/null
 authenticated_eofs_before=$(authenticated_outbound_eofs "${ATTACKER}" "${provider_id}")
 docker network connect --alias provider-p2p "${P2P_NETWORK}" "${PROVIDER}"
@@ -1409,6 +1448,10 @@ if [ "${provider_serving_height}" != "${latest_height}" ] ||
   exit 1
 fi
 docker network connect --alias receiver-p2p "${P2P_NETWORK}" "${RECEIVER}"
+docker start "${RECEIVER}" >/dev/null
+start_readiness_probe
+wait_rpc "${RECEIVER}"
+wait_mutual_authorized_peers
 wait_pre_publish_marker
 if rest_ready "${RECEIVER}"; then
   echo "ERROR: receiver exposed REST while its durable activation was still unpublished" >&2

--- a/deploy/scripts/run-v11.9-state-sync.sh
+++ b/deploy/scripts/run-v11.9-state-sync.sh
@@ -734,20 +734,12 @@ rpc_peer_ids() {
 wait_mutual_authorized_peers() {
   local deadline=$((SECONDS + AUTHORIZED_PEER_ASSERT_TIMEOUT))
   local provider_peers=unavailable receiver_peers=unavailable
-  local provider_has_receiver=0 receiver_has_provider=0
   while [ "${SECONDS}" -lt "${deadline}" ]; do
     provider_peers=$(rpc_peer_ids "${PROVIDER}" 2>/dev/null || printf unavailable)
     receiver_peers=$(rpc_peer_ids "${RECEIVER}" 2>/dev/null || printf unavailable)
-    case " ${provider_peers} " in
-      *" ${receiver_id} "*) provider_has_receiver=1 ;;
-      *) provider_has_receiver=0 ;;
-    esac
-    case " ${receiver_peers} " in
-      *" ${provider_id} "*) receiver_has_provider=1 ;;
-      *) receiver_has_provider=0 ;;
-    esac
-    if [ "${provider_has_receiver}" = 1 ] && [ "${receiver_has_provider}" = 1 ]; then
-      echo "authorized provider and receiver reported reciprocal peer IDs"
+    if [ "${provider_peers}" = "${receiver_id}" ] &&
+       [ "${receiver_peers}" = "${provider_id}" ]; then
+      echo "authorized provider and receiver reported the exact reciprocal peer set"
       return 0
     fi
     sleep 1

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1069,7 +1069,7 @@ test('App-v26 fixtures bound persistent-peer retries below their recovery assert
   assert.match(v119RetryCeiling, /cfg\.PersistentPeersMaxDialPeriod = period/);
   assert.match(
     vendoredNode,
-    /cometCfg\.P2P\.PersistentPeers = joinPeers\(cfg\.Quorum\.Peers\)[\s\S]*?applyV119FixturePersistentPeerDialCeiling\(cometCfg\.P2P\)[\s\S]*?return fmt\.Errorf\("configure fixture persistent-peer retry ceiling: %w", err\)/,
+    /cometCfg\.P2P\.PersistentPeers = joinPeers\(cfg\.Quorum\.Peers\)[\s\S]*?fixtureErr := applyV119FixturePersistentPeerDialCeiling\(cometCfg\.P2P\); fixtureErr != nil[\s\S]*?return fmt\.Errorf\("configure fixture persistent-peer retry ceiling: %w", fixtureErr\)/,
   );
   assert.match(mutualPeers, /provider_peers=.*rpc_peer_ids "\$\{PROVIDER\}"/);
   assert.match(mutualPeers, /receiver_peers=.*rpc_peer_ids "\$\{RECEIVER\}"/);

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1073,6 +1073,13 @@ test('App-v26 fixtures bound persistent-peer retries below their recovery assert
   );
   assert.match(mutualPeers, /provider_peers=.*rpc_peer_ids "\$\{PROVIDER\}"/);
   assert.match(mutualPeers, /receiver_peers=.*rpc_peer_ids "\$\{RECEIVER\}"/);
+  const exactReciprocalPeerSet = `if [ "\${provider_peers}" = "\${receiver_id}" ] &&
+       [ "\${receiver_peers}" = "\${provider_id}" ]; then`;
+  assert.ok(
+    mutualPeers.includes(exactReciprocalPeerSet),
+    'authorized provider and receiver must both report exactly the reciprocal peer ID',
+  );
+  assert.doesNotMatch(mutualPeers, /\]\s*\|\|\s*\[/);
   assert.match(mutualPeers, /persistent-peer max dial=\$\{PERSISTENT_PEER_MAX_DIAL_PERIOD\}/);
 });
 

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -80,6 +80,15 @@ function ciJob(id) {
   return next === -1 ? remainder : remainder.slice(0, next);
 }
 
+function faultJob(id) {
+  const marker = `  ${id}:\n`;
+  const start = faultWorkflow.indexOf(marker);
+  assert.notEqual(start, -1, `missing consensus fault job: ${id}`);
+  const remainder = faultWorkflow.slice(start + marker.length);
+  const next = remainder.search(/^  [a-z0-9][a-z0-9-]*:\n/m);
+  return next === -1 ? remainder : remainder.slice(0, next);
+}
+
 function shellFunction(source, name) {
   const marker = `${name}() {\n`;
   const start = source.indexOf(marker);
@@ -459,9 +468,15 @@ test('the Linux cold gate proves the closed placeholder through the real Comet d
 });
 
 test('the mandatory cold gate transfers one exact app-v26 session', () => {
+  const realCometChaos = faultJob('real-comet-chaos');
   assert.match(
-    faultWorkflow,
+    realCometChaos,
     /name: App-v26 real Comet\/ABCI crash, partition, and state-sync gate/,
+  );
+  assert.equal(
+    (realCometChaos.match(/^    timeout-minutes: 40$/gm) || []).length,
+    1,
+    'the bounded job ceiling must cover pinned image builds, the real-process gate, and cleanup',
   );
   assert.match(v119StateSync, /^TARGET_APP_VERSION=26$/m);
   assert.match(v119StateSync, /"app_version": \$\{TARGET_APP_VERSION\}/);

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -56,6 +56,11 @@ const v119StateSyncFixture = readFileSync(
   new URL('../cmd/sage-gui/v119_state_sync_fixture_command_v119testfixture.go', import.meta.url),
   'utf8',
 );
+const v119RetryCeiling = readFileSync(
+  new URL('../cmd/sage-gui/v119_p2p_retry_ceiling_v119testfixture.go', import.meta.url),
+  'utf8',
+);
+const vendoredNode = readFileSync(new URL('../cmd/sage-gui/node.go', import.meta.url), 'utf8');
 
 function job(id) {
   const marker = `  ${id}:\n`;
@@ -956,7 +961,10 @@ test('the real-Comet fixture proves full mesh recovery before the 2+2 split', ()
     'assert_matched_apphash "post-one-validator partition" 180',
   );
   const healedAppVersion = v119Chaos.indexOf('wait_all_app_version 23 180', healedAppHash);
-  const recoveryCall = v119Chaos.indexOf('wait_full_peer_mesh 90 2', healedAppVersion);
+  const recoveryCall = v119Chaos.indexOf(
+    'wait_full_peer_mesh "${FULL_MESH_RECOVERY_TIMEOUT}" 2',
+    healedAppVersion,
+  );
   const recoveredMesh = v119Chaos.indexOf(
     'proved the full peer mesh recovered before the next partition',
     healedAppVersion,
@@ -988,7 +996,8 @@ test('the real-Comet fixture proves full mesh recovery before the 2+2 split', ()
   );
   const recoveryWindow = v119Chaos.slice(healedAppVersion, recoveredMesh);
   assert.equal(
-    (recoveryWindow.match(/wait_full_peer_mesh 90 2/g) || []).length,
+    (recoveryWindow.match(/wait_full_peer_mesh "\$\{FULL_MESH_RECOVERY_TIMEOUT\}" 2/g) || [])
+      .length,
     1,
     'fault 2 must have one bounded two-round full-mesh precondition',
   );
@@ -1034,6 +1043,59 @@ test('the real-Comet fixture proves full mesh recovery before the 2+2 split', ()
     /consecutive=\$\(\(consecutive \+ 1\)\)[\s\S]*?\[ "\$\{consecutive\}" -ge "\$\{required_rounds\}" \][\s\S]*?else[\s\S]*?consecutive=0/,
     'one bounded sampling loop must observe every exact peer set in two consecutive rounds',
   );
+});
+
+test('App-v26 fixtures bound persistent-peer retries below their recovery assertions', () => {
+  const chaosConfig = v119Chaos.slice(
+    v119Chaos.indexOf('python3 - "${APP_V20_MEMPOOL_MAX_TX_BYTES}"'),
+    v119Chaos.indexOf("echo \"validated external Comet profile", v119Chaos.indexOf('python3 - "${APP_V20_MEMPOOL_MAX_TX_BYTES}"')),
+  );
+  const mutualPeers = shellFunction(v119StateSync, 'wait_mutual_authorized_peers');
+
+  for (const script of [v119Chaos, v119StateSync]) {
+    assert.match(script, /^PERSISTENT_PEER_MAX_DIAL_SECONDS=5$/m);
+    assert.match(script, /^PERSISTENT_PEER_MAX_DIAL_PERIOD="\$\{PERSISTENT_PEER_MAX_DIAL_SECONDS\}s"$/m);
+  }
+  assert.match(v119Chaos, /^FULL_MESH_RECOVERY_TIMEOUT=90$/m);
+  assert.match(v119Chaos, /FULL_MESH_RECOVERY_TIMEOUT.*PERSISTENT_PEER_MAX_DIAL_SECONDS \* 6/s);
+  assert.match(chaosConfig, /persistent_peers_max_dial_period/);
+  assert.match(chaosConfig, /path\.write_text\(text\)/);
+  assert.match(
+    v119StateSync,
+    /-e "SAGE_V119_PERSISTENT_PEER_MAX_DIAL_PERIOD=\$\{PERSISTENT_PEER_MAX_DIAL_PERIOD\}"/,
+  );
+  assert.match(v119RetryCeiling, /time\.ParseDuration\(raw\)/);
+  assert.match(v119RetryCeiling, /period <= 0/);
+  assert.match(v119RetryCeiling, /cfg\.PersistentPeersMaxDialPeriod = period/);
+  assert.match(
+    vendoredNode,
+    /cometCfg\.P2P\.PersistentPeers = joinPeers\(cfg\.Quorum\.Peers\)[\s\S]*?applyV119FixturePersistentPeerDialCeiling\(cometCfg\.P2P\)[\s\S]*?return fmt\.Errorf\("configure fixture persistent-peer retry ceiling: %w", err\)/,
+  );
+  assert.match(mutualPeers, /provider_peers=.*rpc_peer_ids "\$\{PROVIDER\}"/);
+  assert.match(mutualPeers, /receiver_peers=.*rpc_peer_ids "\$\{RECEIVER\}"/);
+  assert.match(mutualPeers, /persistent-peer max dial=\$\{PERSISTENT_PEER_MAX_DIAL_PERIOD\}/);
+});
+
+test('the authorized receiver restart preserves the pre-publication readiness sentinel', () => {
+  const placeholderSwap = v119StateSync.indexOf(
+    'docker network disconnect "${P2P_NETWORK}" "${RECEIVER}"',
+  );
+  const receiverReconnect = v119StateSync.indexOf(
+    'docker network connect --alias receiver-p2p "${P2P_NETWORK}" "${RECEIVER}"',
+    placeholderSwap + 1,
+  );
+  const sealWait = v119StateSync.indexOf('wait_pre_publish_marker', receiverReconnect);
+  const swap = v119StateSync.slice(placeholderSwap, sealWait);
+  const probe = shellFunction(v119StateSync, 'start_readiness_probe');
+
+  assert.ok(
+    placeholderSwap >= 0 && receiverReconnect > placeholderSwap && sealWait > receiverReconnect,
+  );
+  assert.match(swap, /stop_readiness_probe[\s\S]*?stop_sage "\$\{RECEIVER\}"/);
+  assert.match(swap, /docker start "\$\{RECEIVER\}"[\s\S]*?start_readiness_probe[\s\S]*?wait_rpc "\$\{RECEIVER\}"/);
+  assert.match(swap, /wait_mutual_authorized_peers\s*$/m);
+  assert.doesNotMatch(probe, /rm -f/);
+  assert.equal((v119StateSync.match(/rm -f "\$\{READINESS_VIOLATION\}"/g) || []).length, 1);
 });
 
 test('all private artifacts converge at one publication gate', () => {


### PR DESCRIPTION
## Summary
- cap fixture-only persistent-peer retry backoff at five seconds and tie recovery deadlines to that ceiling
- restart the authorized state-sync receiver after replacing the closed placeholder while preserving the readiness sentinel
- require reciprocal provider/receiver peer IDs before waiting on the durable seal and emit retry/firewall diagnostics
- mutation-pin the retry, restart, readiness, and reciprocal-peer contracts

## Verification
- npm test (345/345)
- go test -tags v119testfixture ./cmd/sage-gui
- go vet ./...
- bash -n deploy/scripts/run-v11.9-chaos.sh deploy/scripts/run-v11.9-state-sync.sh
- mutation checks: runtime hook removal, receiver restart/probe removal, reciprocal-peer proof removal all fail the contract suite

## Scope
Gate and fixture hardening only. No production authorization or access-surface changes. PR #208 remains separate and blocked pending this gate fix.