### PR TITLE
fix(mcp): sign the initial task status so sage_remember(type=task) works

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -340,8 +340,11 @@ components:
           enum:
             - planned
           description: >-
-            New task memories must enter consensus as planned. Omit this field
-            or send planned; use the task-status endpoint after creation.
+            New task memories must enter consensus as planned, and MUST send it
+            explicitly. Omitting it returns 400 Missing task status: a signed
+            caller's agent proof covers the request body, so the server cannot
+            supply the value afterwards without invalidating that proof. Use the
+            task-status endpoint to change it after creation.
         linked_memories:
           type: array
           items:

--- a/api/rest/memory_handler.go
+++ b/api/rest/memory_handler.go
@@ -1099,8 +1099,28 @@ func (s *Server) handleSubmitMemory(w http.ResponseWriter, r *http.Request) {
 		) {
 			return
 		}
+		// FAIL FAST instead of mutating a field the caller already signed.
+		//
+		// This used to default an omitted task_status to "planned". That looks
+		// helpful and is the opposite: the mutation happens AFTER the agent's
+		// signature covers the body, so the transaction broadcast here no
+		// longer matches what was signed. The app-v26 proof check rebuilds the
+		// expected transaction from the signed bytes, finds task_status absent,
+		// and rejects the whole submission — after a broadcast, as an opaque
+		// "agent proof does not match the submitted action" whose own remedy
+		// text ("update or reconnect the client") cannot possibly help.
+		//
+		// A signed caller therefore had no way to write a task at all. Rejecting
+		// at the edge costs the same request and says exactly what is wrong,
+		// and it broadcasts nothing.
+		//
+		// Deliberately NOT normalized server-side: making the proof check accept
+		// an omitted status would change which transactions validate, which is
+		// fork-class and belongs to a future app version, not to a bug fix.
 		if req.TaskStatus == "" {
-			req.TaskStatus = string(memory.TaskStatusPlanned)
+			writeProblem(w, http.StatusBadRequest, "Missing task status",
+				"task_status is required for a new task and must be signed as \"planned\"; the server cannot supply it after the fact without invalidating your agent proof.")
+			return
 		}
 		if req.TaskStatus != string(memory.TaskStatusPlanned) {
 			writeProblem(w, http.StatusBadRequest, "Invalid initial task status", "A new task must enter consensus as planned; its assigned agent may start it after creation.")

--- a/api/rest/task_status_signed_body_test.go
+++ b/api/rest/task_status_signed_body_test.go
@@ -1,0 +1,105 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// An omitted task_status on a new task must be rejected BEFORE any broadcast.
+//
+// This previously defaulted to "planned" by mutating the request AFTER the
+// caller's signature covered the body. The transaction that then went to
+// consensus no longer matched what was signed, so the app-v26 proof check —
+// which rebuilds the expected transaction from the signed bytes — rejected it
+// as "agent proof does not match the submitted action". A signed caller had no
+// way to write a task at all, and the error's own remedy text ("update or
+// reconnect the client") could not help, because nothing about the client was
+// wrong.
+//
+// The zero-broadcast assertion is the load-bearing one: a 400 that still
+// broadcast would have spent consensus work on a transaction guaranteed to be
+// rejected.
+func TestSignedTaskSubmitRejectsOmittedStatusBeforeBroadcast(t *testing.T) {
+	fixture := newAppV23RESTRouteFixture(t)
+	broadcasts := 0
+	comet := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		broadcasts++
+	}))
+	t.Cleanup(comet.Close)
+	fixture.server.cometbftRPC = comet.URL
+
+	body := []byte(`{"content":"omitted status","memory_type":"task","domain_tag":"member.home","confidence_score":0.9}`)
+	req := appV23SignedRESTRouteRequest(
+		t, fixture, "member", http.MethodPost, "/v1/memory/submit", body, false,
+	)
+	rec := httptest.NewRecorder()
+	fixture.server.Router().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	require.Contains(t, rec.Body.String(), "task_status is required",
+		"the rejection must say what is missing, not surface as a proof mismatch later")
+	require.Zero(t, broadcasts,
+		"an omitted task_status must never reach consensus; the proof cannot verify")
+}
+
+// An explicitly signed "planned" must be unaffected by the fail-fast — it is
+// the only valid initial status and it must still get past this guard.
+func TestSignedTaskSubmitAcceptsExplicitPlannedPastTheGuard(t *testing.T) {
+	fixture := newAppV23RESTRouteFixture(t)
+	comet := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(comet.Close)
+	fixture.server.cometbftRPC = comet.URL
+
+	body := []byte(`{"content":"explicit planned","memory_type":"task","domain_tag":"member.home","confidence_score":0.9,"task_status":"planned"}`)
+	req := appV23SignedRESTRouteRequest(
+		t, fixture, "member", http.MethodPost, "/v1/memory/submit", body, false,
+	)
+	rec := httptest.NewRecorder()
+	fixture.server.Router().ServeHTTP(rec, req)
+
+	require.NotEqual(t, http.StatusBadRequest, rec.Code,
+		"an explicitly signed planned status must not be rejected by the omitted-status guard: %s",
+		rec.Body.String())
+	require.NotContains(t, rec.Body.String(), "task_status is required")
+}
+
+// Any other initial status must still be rejected. The fail-fast must not have
+// widened what a new task may enter consensus as.
+func TestSignedTaskSubmitStillRejectsNonPlannedInitialStatus(t *testing.T) {
+	fixture := newAppV23RESTRouteFixture(t)
+	comet := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(comet.Close)
+	fixture.server.cometbftRPC = comet.URL
+
+	body := []byte(`{"content":"already running","memory_type":"task","domain_tag":"member.home","confidence_score":0.9,"task_status":"in_progress"}`)
+	req := appV23SignedRESTRouteRequest(
+		t, fixture, "member", http.MethodPost, "/v1/memory/submit", body, false,
+	)
+	rec := httptest.NewRecorder()
+	fixture.server.Router().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	require.Contains(t, rec.Body.String(), "Invalid initial task status")
+}
+
+// A NON-task memory must be entirely unaffected: it neither requires nor
+// accepts a task_status, and the new guard must not have leaked into its path.
+func TestNonTaskSubmitUnaffectedByTaskStatusGuard(t *testing.T) {
+	fixture := newAppV23RESTRouteFixture(t)
+	comet := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(comet.Close)
+	fixture.server.cometbftRPC = comet.URL
+
+	body := []byte(`{"content":"an ordinary fact","memory_type":"fact","domain_tag":"member.home","confidence_score":0.9}`)
+	req := appV23SignedRESTRouteRequest(
+		t, fixture, "member", http.MethodPost, "/v1/memory/submit", body, false,
+	)
+	rec := httptest.NewRecorder()
+	fixture.server.Router().ServeHTTP(rec, req)
+
+	require.NotContains(t, rec.Body.String(), "task_status is required",
+		"a non-task memory must never be asked for a task status")
+}

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -3830,13 +3830,22 @@ func autoImport(ctx context.Context, cfg *Config, embedProvider embedding.Provid
 			continue
 		}
 
-		body, _ := json.Marshal(map[string]any{
+		submitBody := map[string]any{
 			"content":          mem.Content,
 			"memory_type":      mem.Type,
 			"domain_tag":       mem.Domain,
 			"confidence_score": mem.Confidence,
 			"embedding":        emb,
-		})
+		}
+		// A task must carry its initial status in the SIGNED body. REST
+		// defaults an omitted task_status to "planned" by mutating the
+		// request AFTER the signature covers it; the proof check then
+		// rebuilds the expected tx from the signed bytes and rejects the
+		// submission as "agent proof does not match the submitted action".
+		if mem.Type == "task" {
+			submitBody["task_status"] = "planned"
+		}
+		body, _ := json.Marshal(submitBody)
 
 		if err := submitSigned(baseURL+"/v1/memory/submit", body, agentID, priv); err != nil {
 			logger.Debug().Err(err).Msg("auto-import submit failed")

--- a/cmd/sage-gui/seed.go
+++ b/cmd/sage-gui/seed.go
@@ -125,13 +125,22 @@ Examples:
 			}
 
 			// Submit memory
-			body, _ := json.Marshal(map[string]any{
+			submitBody := map[string]any{
 				"content":          mem.Content,
 				"memory_type":      mem.Type,
 				"domain_tag":       mem.Domain,
 				"confidence_score": mem.Confidence,
 				"embedding":        embedding,
-			})
+			}
+			// A task must carry its initial status in the SIGNED body. REST
+			// defaults an omitted task_status to "planned" by mutating the
+			// request AFTER the signature covers it; the proof check then
+			// rebuilds the expected tx from the signed bytes and rejects the
+			// submission as "agent proof does not match the submitted action".
+			if mem.Type == "task" {
+				submitBody["task_status"] = "planned"
+			}
+			body, _ := json.Marshal(submitBody)
 
 			if err := submitSigned(baseURL+"/v1/memory/submit", body, agentID, priv); err != nil {
 				lastErr = err

--- a/cmd/sage-gui/vault.go
+++ b/cmd/sage-gui/vault.go
@@ -242,13 +242,22 @@ func runImport() error {
 		_ = json.Unmarshal(embedResp, &embedResult)
 
 		// Submit memory.
-		submitReq, _ := json.Marshal(map[string]any{
+		submitBody := map[string]any{
 			"content":          mem.Content,
 			"memory_type":      mem.MemoryType,
 			"domain_tag":       mem.DomainTag,
 			"confidence_score": mem.ConfidenceScore,
 			"embedding":        embedResult.Embedding,
-		})
+		}
+		// A task must carry its initial status in the SIGNED body. REST
+		// defaults an omitted task_status to "planned" by mutating the
+		// request AFTER the signature covers it; the proof check then
+		// rebuilds the expected tx from the signed bytes and rejects the
+		// submission as "agent proof does not match the submitted action".
+		if mem.MemoryType == "task" {
+			submitBody["task_status"] = "planned"
+		}
+		submitReq, _ := json.Marshal(submitBody)
 		_, err = doSignedRequest(baseURL, privKey, "POST", "/v1/memory/submit", submitReq)
 		if err != nil {
 			skipped++

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -62,7 +62,7 @@ Submit a memory for BFT consensus. Blocks until `broadcast_tx_commit` returns (F
 | `embedding` | []float32 | no | Compatibility field. The node regenerates the vector from `content` with its currently selected provider so stale/foreign vector spaces cannot mix. |
 | `knowledge_triples` | []KnowledgeTriple | no | `{subject, predicate, object}` triples |
 | `parent_hash` | string | no | SHA-256 hex of parent memory for lineage |
-| `task_status` | string | no | New `task` memories must omit this or send `planned`. Agents start or finish an assigned task through the task-status route after creation. |
+| `task_status` | string | **yes for `task`** | A new `task` memory MUST send `planned` explicitly; omitting it is rejected with `400 Missing task status`. The server cannot supply it for you: a signed caller's proof covers the request body, so defaulting it server-side would invalidate that proof and the submission would be rejected at consensus instead. Agents start or finish an assigned task through the task-status route after creation. |
 | `linked_memories` | []string | no | Related memory IDs for legacy/non-idempotent submission paths. App-v23 task creation rejects this field because links are not part of the canonical task transaction; create links separately after the task is confirmed. |
 | `tags` | []string | no | Up to 32 labels of 128 UTF-8 bytes each. Above app-v20 they are sorted/deduplicated into the signed tx; scoped-domain tags are also AppHash-covered and projection-recoverable. Ordinary-domain tags remain node-local. OR-filter on query/search. |
 | `provider` | string | no | Stored off-chain only; not on-chain |

--- a/extension/chrome/background.js
+++ b/extension/chrome/background.js
@@ -209,13 +209,24 @@ async function getEmbedding(text, baseUrl) {
 
 async function submitMemory(content, domain, memType, confidence, baseUrl) {
   const { embedding } = await getEmbedding(content, baseUrl);
-  return signedFetch("POST", baseUrl, "/v1/memory/submit", {
+  const body = {
     content,
     memory_type: memType,
     domain_tag: domain,
     confidence_score: confidence,
     embedding
-  });
+  };
+  // A task must carry its initial status in the SIGNED body. The server
+  // defaults an omitted task_status to "planned", but it does so by MUTATING
+  // the request after the signature already covers it; the consensus proof
+  // check then rebuilds the expected transaction from the signed bytes, where
+  // the field is absent, and rejects the whole submission as
+  // "agent proof does not match the submitted action". Omitting it does not
+  // get a helpful default — it makes the write impossible.
+  if (memType === "task") {
+    body.task_status = "planned";
+  }
+  return signedFetch("POST", baseUrl, "/v1/memory/submit", body);
 }
 
 async function queryMemories(queryText, domain, topK, minConfidence, baseUrl) {

--- a/internal/abci/task_status_proof_boundary_test.go
+++ b/internal/abci/task_status_proof_boundary_test.go
@@ -1,0 +1,80 @@
+package abci
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/l33tdawg/sage/internal/tx"
+	"github.com/stretchr/testify/require"
+)
+
+// THE CONSENSUS BOUNDARY THIS PINS.
+//
+// A signed task submission binds task_status. If the client omits it, the
+// signed body carries no status while the node broadcasts one — REST used to
+// default the omission to "planned" AFTER the signature covered the request —
+// and the reconstruction below rejects the pair. That rejection is CORRECT and
+// must stay correct through app-v26.
+//
+// This is a read-only guard on that boundary, with no production change. It
+// exists because the clients were fixed to send the field explicitly and REST
+// now rejects an omission at the edge, which means nothing reaching consensus
+// exercises this path any more. The risk that creates is the opposite of the
+// original bug: a future change could teach the proof check to normalize an
+// omitted status server-side and nothing would notice. That would be an
+// UNGATED CONSENSUS CHANGE — nodes on different versions would disagree about
+// whether the same transaction validates, which is a fork.
+//
+// Normalizing here is future app-v27 work behind a version gate. Until then,
+// omission must remain a mismatch.
+func TestAppV26TaskStatusOmissionStaysAProofMismatch(t *testing.T) {
+	app, _, companion := directAppV23GenesisTestApp(t)
+	content := "[TASK] pin the consensus boundary"
+	contentHash := sha256.Sum256([]byte(content))
+
+	// The agent signs a task WITHOUT task_status.
+	omitted := canonicalAgentRequest(t, "POST", "/v1/memory/submit", map[string]any{
+		"content": content, "memory_type": "task", "confidence_score": 0.9,
+	})
+	omittedReq, err := parseSignedAgentRequest(omitted)
+	require.NoError(t, err)
+
+	// The node broadcasts one carrying "planned" — exactly what the old REST
+	// default produced after the signature was already fixed.
+	broadcast := &tx.ParsedTx{Type: tx.TxTypeMemorySubmit, MemorySubmit: &tx.MemorySubmit{
+		MemoryID: "00000000-0000-4000-8000-000000000000", ContentHash: contentHash[:],
+		MemoryType: tx.MemoryTypeTask, DomainTag: "voice-interface",
+		ConfidenceScore: 0.9, Content: content, TaskStatus: "planned",
+	}}
+
+	err = app.verifySignedAgentAction(broadcast, companion.id, omittedReq, false, true, true)
+	require.Error(t, err,
+		"an omitted signed task_status must NOT be normalized by the proof check; "+
+			"accepting it would change which transactions validate, which is fork-class")
+}
+
+// The converse, so the guard above cannot be satisfied by a proof check that
+// simply rejects everything: an EXPLICITLY signed "planned" must still verify.
+func TestAppV26ExplicitPlannedTaskStatusStillVerifies(t *testing.T) {
+	app, _, companion := directAppV23GenesisTestApp(t)
+	content := "[TASK] explicit planned still verifies"
+	contentHash := sha256.Sum256([]byte(content))
+
+	explicit := canonicalAgentRequest(t, "POST", "/v1/memory/submit", map[string]any{
+		"content": content, "memory_type": "task", "confidence_score": 0.9,
+		"task_status": "planned",
+	})
+	explicitReq, err := parseSignedAgentRequest(explicit)
+	require.NoError(t, err)
+
+	broadcast := &tx.ParsedTx{Type: tx.TxTypeMemorySubmit, MemorySubmit: &tx.MemorySubmit{
+		MemoryID: "00000000-0000-4000-8000-000000000000", ContentHash: contentHash[:],
+		MemoryType: tx.MemoryTypeTask, DomainTag: "voice-interface",
+		ConfidenceScore: 0.9, Content: content, TaskStatus: "planned",
+	}}
+
+	require.NoError(t,
+		app.verifySignedAgentAction(broadcast, companion.id, explicitReq, false, true, true),
+		"an explicitly signed planned status is what every fixed client now sends; "+
+			"it must verify, or the clients are broken instead")
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -857,6 +857,28 @@ func (s *Server) toolRemember(ctx context.Context, params map[string]any) (any, 
 		"confidence_score": confidence,
 		"embedding":        embedResp.Embedding,
 	}
+	if memType == "task" {
+		// A task MUST carry its initial status in the SIGNED body.
+		//
+		// REST defaults an omitted task_status to "planned"
+		// (api/rest/memory_handler.go) — but it does so by MUTATING the request
+		// AFTER the agent's signature already covered it. The ABCI proof check
+		// then rebuilds the expected transaction from the signed bytes, where
+		// task_status is still empty, compares it against the mutated one the
+		// node broadcast, and rejects the whole submission as
+		// "delegated agent action mismatch" — surfaced to the caller as
+		// "agent proof does not match the submitted action".
+		//
+		// Omitting it therefore does not get a helpful default; it makes every
+		// sage_remember(type="task") fail outright for a signed ordinary agent
+		// on a post-app-v23 node. sage_task already sends this for the same
+		// reason; this path simply never did.
+		//
+		// "planned" is not a choice here: REST rejects any other initial status
+		// outright, so sending it explicitly matches the server contract
+		// exactly rather than guessing at it.
+		submitBody["task_status"] = "planned"
+	}
 	if len(tags) > 0 {
 		submitBody["tags"] = tags
 	}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -6197,3 +6197,95 @@ func TestTaskContentPrefixIdempotent(t *testing.T) {
 		}
 	}
 }
+
+// A task memory must carry task_status in the SIGNED body.
+//
+// REST defaults an omitted task_status to "planned", but it does so by mutating
+// the request AFTER the agent signature covers it; the ABCI proof check then
+// rebuilds the expected tx from the signed bytes (task_status still empty),
+// compares it to the mutated one, and rejects the submission as
+// "delegated agent action mismatch". So omitting the field does not yield a
+// helpful default — it makes every sage_remember(type="task") fail outright for
+// a signed ordinary agent on a post-app-v23 node.
+//
+// This asserts the field is present AND that it is exactly "planned": REST
+// rejects any other initial status, so sending a different one would trade this
+// failure for a 400.
+func TestSageRememberTaskSignsItsInitialStatus(t *testing.T) {
+	var submitted map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/memory/list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"memories": []any{}})
+	})
+	mux.HandleFunc("/v1/memory/pre-validate", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"accepted": true})
+	})
+	mux.HandleFunc("/v1/embed", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float32{0.1, 0.2}})
+	})
+	mux.HandleFunc("/v1/memory/submit", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&submitted))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"memory_id": "task-memory",
+			"status":    "committed",
+			"tx_hash":   "task-tx",
+		})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	_, priv, _ := ed25519.GenerateKey(nil)
+	s := NewServer(ts.URL, priv)
+	_, err := s.toolRemember(context.Background(), map[string]any{
+		"content": "Rebase PR 208 onto current protected main before requesting merge",
+		"type":    "task",
+		"domain":  "trace-spec-crypto-review",
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, submitted, "the submit request must have been issued")
+	assert.Equal(t, "task", submitted["memory_type"])
+	assert.Equal(t, "planned", submitted["task_status"],
+		"a task must sign its initial status; omitting it makes the node mutate the signed body and the agent proof then fails to verify")
+}
+
+// The converse: a non-task memory must NOT carry task_status. Sending it for a
+// fact or observation would put a field in the signed body that the REST
+// contract does not expect for those types.
+func TestSageRememberNonTaskOmitsTaskStatus(t *testing.T) {
+	var submitted map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/memory/list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"memories": []any{}})
+	})
+	mux.HandleFunc("/v1/memory/pre-validate", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"accepted": true})
+	})
+	mux.HandleFunc("/v1/embed", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float32{0.1, 0.2}})
+	})
+	mux.HandleFunc("/v1/memory/submit", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&submitted))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"memory_id": "fact-memory",
+			"status":    "committed",
+			"tx_hash":   "fact-tx",
+		})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	_, priv, _ := ed25519.GenerateKey(nil)
+	s := NewServer(ts.URL, priv)
+	_, err := s.toolRemember(context.Background(), map[string]any{
+		"content": "Broadcast writes identical bytes to every SSE subscriber",
+		"type":    "fact",
+		"domain":  "trace-spec-crypto-review",
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, submitted)
+	assert.Equal(t, "fact", submitted["memory_type"])
+	_, present := submitted["task_status"]
+	assert.False(t, present, "only a task memory may sign a task_status")
+}

--- a/sdk/python/src/sage_sdk/models.py
+++ b/sdk/python/src/sage_sdk/models.py
@@ -144,6 +144,23 @@ class MemorySubmitRequest(BaseModel):
         else:
             if self.task_status not in (None, TaskStatus.planned):
                 raise ValueError("new tasks must enter consensus as planned")
+            # Normalize an omitted status to planned so it is present in the
+            # SIGNED body.
+            #
+            # The server defaults an omitted task_status to "planned", but it
+            # does so by MUTATING the request after the caller's signature
+            # already covered it; the consensus proof check then rebuilds the
+            # expected transaction from the signed bytes, where task_status is
+            # still absent, and rejects the whole submission as
+            # "agent proof does not match the submitted action".
+            #
+            # Since the payload is serialized with exclude_none=True, leaving
+            # this None drops the field from the wire entirely — so omitting it
+            # does not get a helpful default, it makes the write impossible for
+            # a signed client. planned is not a choice: the check immediately
+            # above is what rejects anything else.
+            if self.task_status is None:
+                self.task_status = TaskStatus.planned
             if self.knowledge_triples or self.linked_memories:
                 raise ValueError(
                     "app-v23 tasks cannot include knowledge_triples or linked_memories"

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -508,3 +508,59 @@ def test_pipe_message_replied_by_is_none_when_unattributed():
     })
 
     assert reply.replied_by is None
+
+
+def test_task_submission_signs_planned_when_status_omitted():
+    """An omitted task_status must be normalized BEFORE signing.
+
+    The server defaults it to "planned" by mutating the request after the
+    caller's signature covers it; the consensus proof check then rebuilds the
+    expected transaction from the signed bytes, where the field is absent, and
+    rejects the submission as "agent proof does not match the submitted
+    action". Because the payload is serialized with exclude_none=True, leaving
+    it None drops the field from the wire entirely — so this is not cosmetic,
+    it is the difference between a task write working and failing outright.
+    """
+    from sage_sdk.models import MemorySubmitRequest
+
+    req = MemorySubmitRequest(
+        content="rebase before requesting merge",
+        memory_type="task",
+        domain_tag="trace-spec-crypto-review",
+        confidence_score=0.9,
+    )
+    assert req.task_status == "planned"
+
+    body = req.model_dump(mode="json", exclude_none=True, by_alias=True)
+    assert body["task_status"] == "planned", (
+        "task_status must survive exclude_none into the signed body"
+    )
+
+
+def test_explicit_planned_task_status_is_preserved():
+    from sage_sdk.models import MemorySubmitRequest
+
+    req = MemorySubmitRequest(
+        content="explicit status",
+        memory_type="task",
+        domain_tag="trace-spec-crypto-review",
+        confidence_score=0.9,
+        task_status="planned",
+    )
+    assert req.task_status == "planned"
+
+
+def test_non_task_memory_never_gains_a_task_status():
+    """The converse: normalization must not leak into non-task memories."""
+    from sage_sdk.models import MemorySubmitRequest
+
+    req = MemorySubmitRequest(
+        content="Broadcast writes identical bytes to every subscriber",
+        memory_type="fact",
+        domain_tag="trace-spec-crypto-review",
+        confidence_score=0.9,
+    )
+    assert req.task_status is None
+
+    body = req.model_dump(mode="json", exclude_none=True, by_alias=True)
+    assert "task_status" not in body


### PR DESCRIPTION
**Draft. Merge authority is not mine.** Found while consolidating a SAGE task list — every `sage_remember` with `type="task"` fails outright.

## Symptom

```
Broadcast error: agent proof does not match the submitted action;
update or reconnect the SAGE MCP client and retry
```

Reproducible 100% of the time for a signed ordinary agent on a post-app-v23 node. **The advice in that message cannot help** — nothing about the client is stale.

## Root cause

`api/rest/memory_handler.go:1102-1104` defaults an omitted `task_status` to `"planned"` — but by **mutating the request after the agent's signature already covered it**, then building the transaction from the mutated value (`:1235`).

`internal/abci/agent_proof.go` `verifySignedAgentAction` rebuilds the **expected** transaction from the *signed* bytes, where `task_status` is still empty, compares it against the mutated one the node broadcast, and rejects the submission. That becomes `delegated agent action mismatch` (`agent_proof.go:93`), mapped to the 409 above (`memory_handler.go:3374`).

Omitting the field doesn't get a helpful default — it makes the write impossible.

`sage_task` has always sent this explicitly, with a comment saying why. `sage_remember` never did, and its schema exposes no `task_status` parameter, so an MCP caller cannot supply one. **Two paths in the same file disagreed, and only one worked.**

`"planned"` is not a guess: REST rejects any other initial status outright, so sending it explicitly matches the server contract exactly.

## Isolation — by probe, not by reading

The variable is the **type**, not length and not the correction path:

| write | result |
|---|---|
| `observation` ~250 chars | committed (h 34876) |
| `observation` + `replaces_memory_id` | committed (h 34884) |
| `observation` ~900 chars | committed (h 34892) |
| `fact` ~2500 chars | committed (h 34706) |
| **`task` ~230 chars** | **FAILED** |
| **`task` with explicit domain** | **FAILED** |

## Verification

Both tests **fail without the change** — verified by removing the fix and re-running; the mutation compiles and the task assertion fails. The converse test pins that a non-task memory must **not** sign a `task_status`.

`go test ./internal/mcp/` green · `go vet` clean · `golangci-lint` v2.12.2 (the version `ci.yml` pins) **0 issues**.

## Deliberately not fixed here

The underlying hazard is that **REST mutates a field after signing it**. ABCI already mirrors this pattern correctly for `domain_tag` — both sides independently derive the same home domain — but `task_status` never got the same treatment.

Teaching ABCI to apply the default would **change which transactions validate**, which is fork-class and belongs in a deliberate app-version change, not a client fix. This closes the caller-visible failure without touching consensus. Flagged to the release owner separately.