### PR TITLE
chore: release v11.18.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,37 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.12
+
+**CEREBRUM can now open an agent as a memory lobe.** Selecting a connectome
+neuron lazily blooms that agent's highest-confidence visible memories as
+engrams, while retaining the operator-only route and app-v23 per-record
+projection checks. The indexed, bounded query avoids whole-brain scans; stale,
+failed, and disposed frontend requests cannot leave another agent's lobe on
+screen.
+
+**Dashboard live activity is now guarded as one exact 20-event registry.** The
+seven previously unwired operator events now reach the existing dashboard SSE
+stream, while message wake, MCP, and wizard protocols stay route-local. A
+fail-closed typed control-flow audit and executable browser contract reject
+dead, aliased, escaped, build-tagged, or decoy event sinks.
+
+**Signed task creation and message attribution now agree end to end.** Every
+official task constructor explicitly signs the required initial `planned`
+status, and REST fails fast instead of mutating an omitted signed field into a
+transaction that app-v23 through app-v26 must reject. Authorized message and
+pipe responses retain exact immutable agent IDs alongside mutable presentation
+labels, use one bounded metadata query, suppress foreign-chain label
+collisions, and keep count-only responses identity-free.
+
+This patch also repairs release-facing documentation drift, pins the current
+33-tool MCP inventory, and adds fail-closed symbol/citation coverage for the
+references it can verify. It introduces no new consensus application version
+or state migration. The ceiling remains app-v26; **v11.18.12 introduces no
+app-v27**.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.12`. SDK 11.18.12.
+
 ## What's New in v11.18.11
 
 **The CEREBRUM connectome now fires live without widening its operator-only
@@ -1765,7 +1796,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.11`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.12`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ official task constructor explicitly signs the required initial `planned`
 status, and REST fails fast instead of mutating an omitted signed field into a
 transaction that app-v23 through app-v26 must reject. Authorized message and
 pipe responses retain exact immutable agent IDs alongside mutable presentation
-labels, use one bounded metadata query, suppress foreign-chain label
-collisions, and keep count-only responses identity-free.
+labels, use one bounded batch metadata query on healthy production stores with
+a bounded exact-ID fallback, suppress foreign-chain label collisions, and keep
+count-only responses identity-free.
 
 This patch also repairs release-facing documentation drift, pins the current
 33-tool MCP inventory, and adds fail-closed symbol/citation coverage for the

--- a/SECURITY_FAQ.md
+++ b/SECURITY_FAQ.md
@@ -11,7 +11,7 @@ SAGE has two distinct deployment models with fundamentally different threat mode
 | **Who** | One user, one local operator | Multiple agents, teams, organizations |
 | **Trust model** | User IS the only validator | Byzantine fault tolerance across validators |
 | **Database** | Local BadgerDB/SQLite stores in `~/.sage/data/` | BadgerDB consensus state plus off-chain mirror |
-| **Release** | v11.18.11 personal-node surface | v11.18.11 quorum/federation surface |
+| **Release** | v11.18.12 personal-node surface | v11.18.12 quorum/federation surface |
 
 Many concerns raised about the enterprise codebase do not apply to SAGE Personal, and vice versa. Each item below is tagged with which deployment it affects.
 
@@ -108,7 +108,7 @@ The `make byzantine` target and GitHub Actions CI job spin up a 4-validator Dock
 
 The following boundaries describe the current v11 codebase:
 
-**SAGE Personal (sage-gui v11.18.11):**
+**SAGE Personal (sage-gui v11.18.12):**
 - Designed for one operator. The management dashboard/API remains a local surface; anyone with access to the operator session or machine should be treated as trusted.
 - Federation is an explicit network-facing feature, off by default. When enabled it uses a separate pinned-mTLS listener, active on-chain treaty checks, chain-qualified signed requests, and replay protection. That authenticated protocol now runs over libp2p NAT traversal and Circuit Relay v2; the relay sees encrypted traffic and connection metadata, not plaintext memories or federation keys.
 - SQLite database supports optional AES-256-GCM encryption at rest (Synaptic Ledger). Enable from CEREBRUM Settings → Security.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.11
+  version: 11.18.12
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.11-acceptance
+ARG VERSION=v11.18.12-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.11 federation Docker acceptance
+# v11.18.12 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.11-acceptance
+        VERSION: v11.18.12-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.11"
+version = "11.18.12"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.11"
+version = "11.18.12"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.11",
+  "version": "11.18.12",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.11/app-v26. -->
+<!-- Reconciled through SAGE v11.18.12/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.11 federation behavior. -->
+<!-- Verified against SAGE v11.18.12 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.11
+# sage-gui v11.18.12
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.11 advertises 33 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.12 advertises 33 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.11 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.12 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -42,13 +42,45 @@ projects its RBAC-filtered agent channels as a traffic-weighted 3D connectome.
 v11.18.11 adds operator-only live connectome firing driven by contentless ticks
 and caller-filtered snapshot refetches, strips memory plaintext from retrieval
 activity events, makes bookend inbox visibility payload-free and self-healing,
-and raises every current Go build floor to patched 1.25.13. The supported
-consensus ceiling remains app-v26; **v11.18.11 does not introduce app-v27**.
+and raises every current Go build floor to patched 1.25.13. v11.18.12 adds the
+projection-safe agent-as-lobe engram view, hardens the exact 20-event operator
+dashboard SSE registry, restores signed task creation across official clients,
+adds exact-agent message presentation without changing claim/read/delivery
+semantics, and repairs release-facing documentation drift with fail-closed
+citation coverage. The supported consensus ceiling remains app-v26;
+**v11.18.12 does not introduce app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.12 patch
+
+CEREBRUM can lazily bloom one selected agent's highest-confidence visible
+memories around its connectome neuron. The bounded indexed lookup retains the
+operator-only and app-v23 per-record projection gates, and the browser clears,
+fences, and disposes stale lobe requests safely.
+
+The dashboard SSE contract now audits one exact 20-event operator registry,
+wires the seven previously missing events, and keeps message wake, MCP, and
+wizard protocols route-local. Typed control-flow analysis and executable client
+tests fail closed on dead, aliased, escaped, build-tagged, or decoy sinks.
+
+Official signed task constructors now include the required initial `planned`
+status; REST rejects an omitted signed task status before broadcast rather than
+constructing a deterministic app-v23-through-app-v26 proof mismatch. Message
+and pipe responses expose exact immutable sender/counterparty IDs beside mutable
+friendly labels through one bounded metadata query, suppress foreign-chain
+collisions, preserve authorized rows on lookup failure, and keep count-only
+responses identity-free.
+
+Release-facing documentation now matches the 33-tool MCP inventory and current
+dependency/route contracts. Symbol-anchored code citations are repaired and
+their verified coverage fails closed if a checked citation silently becomes
+unresolved. This patch introduces no new consensus application version or state
+migration: app-v26 remains the ceiling and v11.18.12 does not introduce
+app-v27.
 
 ## v11.18.11 patch
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -71,9 +71,10 @@ Official signed task constructors now include the required initial `planned`
 status; REST rejects an omitted signed task status before broadcast rather than
 constructing a deterministic app-v23-through-app-v26 proof mismatch. Message
 and pipe responses expose exact immutable sender/counterparty IDs beside mutable
-friendly labels through one bounded metadata query, suppress foreign-chain
-collisions, preserve authorized rows on lookup failure, and keep count-only
-responses identity-free.
+friendly labels through one bounded batch metadata query on healthy production
+stores with a bounded exact-ID fallback, suppress foreign-chain collisions,
+preserve authorized rows on lookup failure, and keep count-only responses
+identity-free.
 
 Release-facing documentation now matches the 33-tool MCP inventory and current
 dependency/route contracts. Symbol-anchored code citations are repaired and

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -102,6 +102,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.9 | Typed indeterminate Comet commit/sync outcomes, fail-closed federation nil-result fencing, and cross-package commit-decoder drift contracts; no new app version; app-v26 remains the ceiling |
 | v11.18.10 | Same-agent MCP claimant-session ownership and atomic handoff, stale-session reply rejection, passive recovery, the CEREBRUM agent-connectome view, and bounded upgrade-watchdog broadcasts that retain indeterminate signer fencing; no new app version; app-v26 remains the ceiling |
 | v11.18.11 | Operator-only live connectome firing via contentless ticks and authorized snapshot refetch, contentless retrieval activity, payload-free Claude inbox visibility with hook self-heal, chain-ID locality, Windows executable checksums, and patched Go 1.25.13; no new app version; app-v26 remains the ceiling |
+| v11.18.12 | Projection-safe agent-as-lobe engrams, exact dashboard SSE registry coverage, signed task-status repair across official clients, exact-agent message presentation, and fail-closed documentation citation coverage; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.11. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.12. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -34,7 +34,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.11 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.12 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -205,7 +205,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.11)
+## Related docs (reconciled through v11.18.12)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.11.
+Status: implementation contract through SAGE v11.18.12.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.11 authorization layer is off-consensus and does not require
+The current v11.18.12 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.11 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.12 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.11/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.12/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.11. Legacy organization/federation sections retain
+Verified against SAGE v11.18.12. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.11. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.12. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.11**.
+and is **not in v11.18.12**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.11. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.12. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.11 code (2026-08-14). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.12 code (2026-08-14). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.11.
+Reconciled against internal/mcp for SAGE v11.18.12.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.11. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.12. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.11
+**Package:** `sage-agent-sdk` **Version:** 11.18.12
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.11. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.12. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.11 lineage implementation (2026-08-14). -->
+<!-- Verified against SAGE v11.18.12 lineage implementation (2026-08-14). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -60,7 +60,7 @@ test('release-facing version metadata stays aligned', () => {
     ['deploy/federation-acceptance/README.md', `# v${version} federation Docker acceptance`],
     ['docs/FEDERATION.md', `Verified against SAGE v${version} federation behavior`],
     ['docs/reference/concepts/message-reply-lifecycle.md', `SAGE v${version} code`],
-    ['docs/UPGRADING.md', `| v${version} | Operator-only live connectome firing`],
+    ['docs/UPGRADING.md', `| v${version} | Projection-safe agent-as-lobe engrams`],
     ['docs/ROADMAP.md', `## v${version} patch`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.11 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.12 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.11"
+version = "11.18.12"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.11"
+__version__ = "11.18.12"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.11",
+  "version": "11.18.12",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.11",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.12",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.11';
+const SAGE_VERSION = 'v11.18.12';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
## Summary\n- bump every current release marker to exactly v11.18.12\n- publish release notes for agent-as-lobe engrams, exact dashboard SSE coverage, signed task creation, exact message attribution, and documentation guards\n- preserve the app-v26 consensus ceiling, Go 1.25.13 floor, current 33-tool MCP count, and historical release markers\n\n## Included merged work\n- #212 agent-as-lobe engrams\n- #214 dashboard SSE registry hardening\n- #215 signed task-status repair\n- #216 exact sender attribution\n- #208 documentation drift and citation guards\n\n## Local verification\n- npm test: 364/364\n- Python SDK: 174/174\n- go test ./...: pass with loopback permissions\n- go vet ./...: pass\n- go mod tidy -diff: clean\n- citation fixer: 0 repairs\n- git diff --check: clean\n\nDraft pending independent exact-head review and every hosted release gate.