### PR TITLE
feat(cerebrum): distributed engrams — bridge a memory to the neurons that corroborate it

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -2253,7 +2253,7 @@ address resolved from a bounded legacy-status offline cache can be accepted
 locally while the peer is down. Delivery waits for that peer to return and pass
 the fresh live authorization preflight above.
 
-**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:513-515`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6333` payload, `:6336` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:527-529`) to 413.
+**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:513-515`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6338` payload, `:6341` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:527-529`) to 413.
 
 **Open-pipe quota → HTTP 429 + `Retry-After`.** A single verified agent identity may hold at most 256 non-terminal (pending or claimed) pipes open at once, and a node caps 10000 across all requesters (`MaxOpenPipesPerAgent`/`MaxOpenPipesGlobal`). An index-backed COUNT and its INSERT run under the same write critical section, so parallel sends cannot race past either cap. Over-quota inserts are rejected as **429 with `Retry-After`** (`ErrPipeQuotaPerAgent`/`ErrPipeQuotaGlobal`), keyed on the Ed25519-verified `from_agent`, not the spoofable rate-limit header. This mirrors the mempool-full recipe (see `GET /v1/chain/backpressure` below): treat it as backpressure and retry after the hinted interval, not as a per-agent rate-limit breach.
 
@@ -2475,7 +2475,7 @@ the result over the original agreement-bound return route
 | `source_pipe_id` | string | for foreign work | Stable source proof/event ID returned with the inbox item; prevents replying against stale foreign metadata |
 | `source_chain_id` | string | for foreign work | Exact local reply-source chain returned as `reply_source_chain_id` by the pipe status preflight; prevents another node relabeling the signed result |
 
-`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:513`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6597`, mapping `ErrPipeResultTooLarge`).
+`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:513`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6604`, mapping `ErrPipeResultTooLarge`).
 
 **Response** (HTTP 200):
 `{"status":"completed","journal_id":"<memory_id or empty>","journaled":true|false}`.

--- a/internal/store/engram_index_test.go
+++ b/internal/store/engram_index_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -26,6 +27,72 @@ func TestEngramIndexDeclaredOnBothBackends(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(pgSrc), "idx_memories_submitting_agent ON memories (submitting_agent, confidence_score)",
 		"postgres must declare the submitting_agent index too")
+}
+
+// TestCorroborationIndexDeclaredOnBothBackends mirrors the engram-index guard for
+// idx_corroborations_memory. The corroborations child FK column is not
+// auto-indexed by sqlite, so the CEREBRUM distributed-engram per-memory read
+// (and GetCorroborationCounts) would full-scan without it. It must be declared for
+// NEW databases (initSchema) AND EXISTING ones (the migration mirror) on sqlite,
+// and on postgres.
+func TestCorroborationIndexDeclaredOnBothBackends(t *testing.T) {
+	const idx = "idx_corroborations_memory ON corroborations(memory_id)"
+	sqlSrc, err := os.ReadFile("sqlite.go")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, strings.Count(string(sqlSrc), idx), 2,
+		"sqlite must declare the corroborations index in BOTH initSchema and the migration mirror")
+
+	pgSrc, err := os.ReadFile("postgres.go")
+	require.NoError(t, err)
+	require.Contains(t, string(pgSrc), "idx_corroborations_memory ON corroborations (memory_id)",
+		"postgres must declare the corroborations index too")
+}
+
+// TestCorroborationIndexServesPerMemoryRead pins the plan for GetCorroborations'
+// query (WHERE memory_id = ? ORDER BY created_at): idx_corroborations_memory must
+// turn the per-memory read into a SEARCH (a seek), not a full scan of every
+// corroboration on the node — which is what the CEREBRUM lobe issues per
+// corroborated engram.
+//
+// Like the engram-index test, this deliberately does NOT ANALYZE: SAGE never runs
+// ANALYZE, so a real node has no sqlite_stat1. A plain equality on a single-column
+// index is used without stats, but pinning it here catches a regression to a scan
+// (which would need an INDEXED BY hint, per PR #181).
+func TestCorroborationIndexServesPerMemoryRead(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	at := time.Unix(1_700_000_000, 0).UTC()
+	for i := 0; i < 20; i++ {
+		id := fmt.Sprintf("m%03d", i)
+		require.NoError(t, s.InsertMemory(ctx, testMemory(id, "author", "content-"+id, "dom")))
+	}
+	for i := 0; i < 200; i++ {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{
+			MemoryID:  fmt.Sprintf("m%03d", i%20),
+			AgentID:   fmt.Sprintf("agent-%d", i),
+			CreatedAt: at.Add(time.Duration(i) * time.Second),
+		}))
+	}
+
+	rows, err := s.conn.QueryContext(ctx,
+		"EXPLAIN QUERY PLAN SELECT id, memory_id, agent_id, evidence, created_at FROM corroborations WHERE memory_id = ? ORDER BY created_at",
+		"m003")
+	require.NoError(t, err)
+	defer rows.Close() //nolint:errcheck
+	var plan string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		plan += detail + "\n"
+	}
+	require.NoError(t, rows.Err())
+
+	require.Contains(t, plan, "idx_corroborations_memory",
+		"the per-memory corroborator read must SEARCH via the index, not a full scan; plan was:\n"+plan)
+	require.NotContains(t, plan, "SCAN corroborations",
+		"a full scan of corroborations per engram is exactly what the index must prevent; plan was:\n"+plan)
 }
 
 // The CEREBRUM agent-as-lobe read is `WHERE submitting_agent = ? [AND status = ?]

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -421,6 +421,9 @@ var postgresTaskAssignmentSchema = []string{
 	// CEREBRUM agent-as-lobe: each agent's top memories by confidence
 	// (WHERE submitting_agent = ? ORDER BY confidence_score DESC), index-satisfiable.
 	`CREATE INDEX IF NOT EXISTS idx_memories_submitting_agent ON memories (submitting_agent, confidence_score)`,
+	// CEREBRUM distributed engrams: per-memory corroborator set + count
+	// (WHERE memory_id = ?), so the read is a seek, not a full scan.
+	`CREATE INDEX IF NOT EXISTS idx_corroborations_memory ON corroborations (memory_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories (created_at)`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_projection_page ON memories (created_at, memory_id)`,
 	// FindByContentHash became a live query in v11.11 (it previously returned a

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -520,6 +520,10 @@ func (s *SQLiteStore) initSchema(ctx context.Context) error {
 		evidence   TEXT,
 		created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 	);
+	-- corroborations is read by memory_id (per-memory corroborator set + count for
+	-- the CEREBRUM distributed-engram view, and GetCorroborationCounts); without
+	-- this the child FK column is unindexed and every such read is a full scan.
+	CREATE INDEX IF NOT EXISTS idx_corroborations_memory ON corroborations(memory_id);
 
 	CREATE TABLE IF NOT EXISTS challenges (
 		id             INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1372,6 +1376,7 @@ func (s *SQLiteStore) migrateTaskSupport(ctx context.Context) {
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_provider ON memories(provider)`)
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_task_status ON memories(task_status) WHERE task_status != ''`)
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_submitting_agent ON memories(submitting_agent, confidence_score)`)
+	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_corroborations_memory ON corroborations(memory_id)`)
 }
 
 // --- Helper functions ---

--- a/scripts/connectome-engrams.test.mjs
+++ b/scripts/connectome-engrams.test.mjs
@@ -44,6 +44,37 @@ test('an engram is NOT a neuron (renders via the memory node path, not neuronTin
   assert.notEqual(n.isNeuron, true, 'no isNeuron flag → memory styling, not a neuron');
 });
 
+// --- distributed engram (Phase B): corroborator bridges ---
+
+test('mapEngrams carries the server-disclosed corroborators; defaults to []', () => {
+  const [withCorr, without, bad] = mapEngrams({
+    engrams: [
+      { id: 'm1', content: 'shared', corroborators: ['bob', 'carol'] },
+      { id: 'm2', content: 'solo' },
+      { id: 'm3', content: 'malformed', corroborators: 'nope' },
+    ],
+  });
+  assert.deepEqual(withCorr.corroborators, ['bob', 'carol'], 'the RBAC-filtered corroborators pass through');
+  assert.deepEqual(without.corroborators, [], 'a solitary memory defaults to no corroborators');
+  assert.deepEqual(bad.corroborators, [], 'a non-array corroborators field is coerced to []');
+});
+
+test('stripBloom removes engram-bridge links (transient), keeps real synapses', () => {
+  const gd = {
+    nodes: [{ id: 'author', isNeuron: true }, { id: 'peer', isNeuron: true }, { id: 'm1', _added: true }],
+    links: [
+      { source: 'a', target: 'b', link_type: 'synapse' },
+      { source: 'author', target: 'm1', link_type: 'focus' },
+      { source: 'm1', target: 'peer', link_type: 'engram-bridge' },
+    ],
+  };
+  const out = stripBloom(gd);
+  assert.deepEqual(out.links.map(l => l.link_type), ['synapse'],
+    'both focus tethers AND engram-bridges are stripped; the real synapse stays');
+  assert.deepEqual(out.nodes.map(n => n.id), ['author', 'peer'],
+    'permanent neurons kept, transient engram removed');
+});
+
 // --- scoped mri-brain wiring ---
 const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
 function functionBody(src, name) {
@@ -112,4 +143,17 @@ test('only a NEURON click blooms engrams — clicking a bloomed engram does not 
   // node. Guard: connectome click blooms only when n.isNeuron.
   assert.match(mriSource, /mode==='connectome'\)\s*\{\s*if \(n\.isNeuron\) bloomEngrams\(n\); \}\s*else exploreNode\(n\)/,
     'connectome click must bloom only neurons; memory-mode click keeps exploreNode');
+});
+
+test('bloomEngrams bridges an engram to its corroborating NEURONS using node objects', () => {
+  const body = functionBody(mriSource, 'bloomEngrams');
+  // gate: only bridge to a node that is present AND a neuron
+  assert.match(body, /cn && cn\.isNeuron/,
+    'a corroborator is bridged only when it resolves to a rendered NEURON node');
+  assert.match(body, /link_type:\s*'engram-bridge'/, 'the bridge carries the engram-bridge link_type');
+  // endpoints must be node OBJECTS (em and cn), not string ids (#188)
+  assert.match(body, /gd\.links\.push\(\{\s*source:\s*em,\s*target:\s*cn,\s*link_type:\s*'engram-bridge'\s*\}\)/,
+    'source/target must be the engram and neuron OBJECTS so the bridge renders under the pinned layout');
+  // never bridge back to the author neuron itself
+  assert.match(body, /if \(cid === n\.id\) return/, 'a self-bridge to the author neuron is skipped');
 });

--- a/web/engrams_corroborators_test.go
+++ b/web/engrams_corroborators_test.go
@@ -1,0 +1,178 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/l33tdawg/sage/internal/memory"
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+// seedCorroboration records that agentID corroborated memID, the off-chain
+// corroborations table the distributed-engram disclosure reads (the same table
+// GetCorroborationCounts already tallies for corroboration_count).
+func seedCorroboration(t *testing.T, s *store.SQLiteStore, memID, agentID string, at time.Time) {
+	t.Helper()
+	require.NoError(t, s.InsertCorroboration(context.Background(), &store.Corroboration{
+		MemoryID: memID, AgentID: agentID, CreatedAt: at,
+	}))
+}
+
+// TestHandleEngramsDisclosesVisibleCorroboratorsOnly is the headline security
+// property of the distributed engram: a memory's corroborators are bridged to
+// their neurons, but ONLY the corroborators the caller is cleared to see — under
+// exactly the both-endpoints rule the connectome synapse guard applies. A
+// corroborator the caller cannot see, and a corroborator that is not a registered
+// neuron, are never named; they survive only inside the true corroboration_count
+// as the anonymous remainder the view renders as "+N held elsewhere".
+//
+// Written to FAIL if either half of the guard is removed: dropping the RBAC
+// (!seeAll && !visible[id]) check leaks the hidden peer; dropping the neuronSet
+// intersection leaks the non-neuron corroborator.
+func TestHandleEngramsDisclosesVisibleCorroboratorsOnly(t *testing.T) {
+	h, s := newSynapseTestHandler(t) // wires the on-chain neuron registry
+
+	const (
+		author   = "alice"
+		cVisible = "bob"   // a neuron alice may see → bridged
+		cHidden  = "carol" // a neuron alice may NOT see → count-only
+		cExtern  = "ext-x" // corroborated but never a registered neuron → count-only
+	)
+	for i, id := range []string{author, cVisible, cHidden} {
+		require.NoError(t, h.BadgerStore.RegisterAgent(id, id, "member", "", "test", "", int64(i+1)))
+	}
+	// alice is a member whose visibility list names exactly bob. carol is hidden.
+	require.NoError(t, h.BadgerStore.SetAgentPermission(author, 1, "", `["`+cVisible+`"]`, "", ""))
+
+	base := time.Now().UTC().Truncate(time.Second)
+	seedEngramMemory(t, s, "m1", author, "a shared fact", "ops", 0.9, memory.StatusCommitted)
+	seedCorroboration(t, s, "m1", cVisible, base)
+	seedCorroboration(t, s, "m1", cHidden, base.Add(time.Second))
+	seedCorroboration(t, s, "m1", cExtern, base.Add(2*time.Second))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent="+author, nil)
+	req = req.WithContext(context.WithValue(req.Context(), verifiedDashboardAgentKey{}, author))
+	rec := httptest.NewRecorder()
+	h.handleEngrams(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Engrams, 1)
+	e := body.Engrams[0]
+
+	require.Equal(t, 3, e.CorroborationCount, "the true total counts every corroborator, seen or not")
+	require.Equal(t, []string{cVisible}, e.Corroborators,
+		"only a corroborator that is BOTH a neuron AND visible to the caller is disclosed")
+	require.NotContains(t, e.Corroborators, cHidden, "a corroborator the caller may not see must never be named")
+	require.NotContains(t, e.Corroborators, cExtern, "a non-neuron corroborator must never be named")
+}
+
+// TestHandleEngramsDisclosesAllNeuronCorroboratorsForHumanDashboard: a human
+// dashboard (no agent identity → seeAll) bridges every corroborating NEURON, so
+// the distributed engram renders in full — but a corroborator that is not a
+// registered neuron is STILL never named, because the neuron registry is the
+// connectome's disclosure boundary. seeAll relaxes RBAC, not the neuron gate.
+func TestHandleEngramsDisclosesAllNeuronCorroboratorsForHumanDashboard(t *testing.T) {
+	h, s := newSynapseTestHandler(t)
+
+	const author, cA, cB, cExtern = "alice", "bob", "carol", "ext-x"
+	for i, id := range []string{author, cA, cB} {
+		require.NoError(t, h.BadgerStore.RegisterAgent(id, id, "member", "", "test", "", int64(i+1)))
+	}
+	base := time.Now().UTC().Truncate(time.Second)
+	seedEngramMemory(t, s, "m1", author, "a widely shared fact", "ops", 0.9, memory.StatusCommitted)
+	seedCorroboration(t, s, "m1", cA, base)
+	seedCorroboration(t, s, "m1", cB, base.Add(time.Second))
+	seedCorroboration(t, s, "m1", cExtern, base.Add(2*time.Second))
+
+	// No verified agent → human dashboard, seeAll.
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent="+author, nil)
+	rec := httptest.NewRecorder()
+	h.handleEngrams(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Engrams, 1)
+	e := body.Engrams[0]
+
+	require.Equal(t, 3, e.CorroborationCount)
+	require.ElementsMatch(t, []string{cA, cB}, e.Corroborators,
+		"a human dashboard bridges every corroborating neuron")
+	require.NotContains(t, e.Corroborators, cExtern,
+		"even seeAll never names a non-neuron corroborator — the neuron registry is the boundary")
+}
+
+// TestHandleEngramsWithholdsCorroboratorsWithoutRegistry: with no neuron registry
+// we cannot confirm a corroborator is an already-visible neuron, so we disclose
+// NONE rather than risk naming an unconfirmed identity. The count is unaffected,
+// so the lobe still conveys that the memory is distributed — it just cannot draw
+// the bridges. This is the fail-closed degradation, not a functional path (a nil
+// Badger store is fatal at node startup).
+func TestHandleEngramsWithholdsCorroboratorsWithoutRegistry(t *testing.T) {
+	h, s := newTestHandler(t) // no BadgerStore
+	require.Nil(t, h.BadgerStore, "precondition: no registry attached")
+
+	base := time.Now().UTC().Truncate(time.Second)
+	seedEngramMemory(t, s, "m1", "alice", "a fact", "ops", 0.9, memory.StatusCommitted)
+	seedCorroboration(t, s, "m1", "bob", base)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent=alice", nil)
+	rec := httptest.NewRecorder()
+	h.handleEngrams(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Engrams, 1)
+	require.Equal(t, 1, body.Engrams[0].CorroborationCount, "the count still reflects the corroboration")
+	require.Empty(t, body.Engrams[0].Corroborators,
+		"without a registry to confirm neuron membership, no corroborator is named")
+}
+
+// TestHandleEngramsCapsCorroboratorBridges: a memory corroborated by more neurons
+// than the bridge cap discloses at most engramCorroboratorLimit — the bridges
+// illustrate distribution, they are not an exhaustive dump — while the count still
+// carries the true total.
+func TestHandleEngramsCapsCorroboratorBridges(t *testing.T) {
+	h, s := newSynapseTestHandler(t)
+
+	const author = "alice"
+	require.NoError(t, h.BadgerStore.RegisterAgent(author, author, "member", "", "test", "", 1))
+	base := time.Now().UTC().Truncate(time.Second)
+	seedEngramMemory(t, s, "m1", author, "a very widely held fact", "ops", 0.9, memory.StatusCommitted)
+
+	total := engramCorroboratorLimit + 5
+	for i := 0; i < total; i++ {
+		id := "corr-" + string(rune('a'+i))
+		require.NoError(t, h.BadgerStore.RegisterAgent(id, id, "member", "", "test", "", int64(i+2)))
+		seedCorroboration(t, s, "m1", id, base.Add(time.Duration(i)*time.Second))
+	}
+
+	// Human dashboard so every corroborator is RBAC-visible; the cap is the only bound.
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent="+author, nil)
+	rec := httptest.NewRecorder()
+	h.handleEngrams(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Engrams, 1)
+	require.Equal(t, total, body.Engrams[0].CorroborationCount, "count is the true total")
+	require.Len(t, body.Engrams[0].Corroborators, engramCorroboratorLimit,
+		"bridges are capped; the remainder survives only in the count")
+}

--- a/web/engrams_handler.go
+++ b/web/engrams_handler.go
@@ -22,6 +22,18 @@ type engramNode struct {
 	CreatedAt          string   `json:"created_at"`
 	CorroborationCount int      `json:"corroboration_count"`
 	Tags               []string `json:"tags,omitempty"`
+	// Corroborators is the subset of agents who corroborated this memory that the
+	// caller is cleared to see AND that exist as neurons — the endpoints the
+	// agent-as-lobe view bridges the engram to. A memory bridged to several neurons
+	// is a "distributed engram": one memory consolidated across multiple cells. It
+	// is RBAC-filtered exactly as the connectome synapse edge guard filters its
+	// endpoints — an author's own lobe is already visible, so a corroborator is
+	// disclosed only when it is itself a visible neuron. Corroborators the caller
+	// may NOT see are never named; they survive only inside CorroborationCount, so
+	// CorroborationCount - len(Corroborators) is the anonymous remainder the view
+	// renders as "+N held elsewhere". This is a pure off-chain read of the
+	// corroborations table — no consensus surface, nothing anchored.
+	Corroborators []string `json:"corroborators,omitempty"`
 }
 
 // engramPerAgentLimit caps how many memories one neuron blooms. Kept small: the
@@ -40,6 +52,12 @@ const engramFetchLimit = engramPerAgentLimit * 4
 // mostly canonically hidden can never turn the fetch into a full-table walk. Each
 // page is an index seek; this only caps how many pages the backfill will chase.
 const engramRawScanCap = engramFetchLimit * 8
+
+// engramCorroboratorLimit caps how many corroborator bridges one engram
+// discloses. A memory corroborated by hundreds of agents must not draw hundreds
+// of edges; the bridges illustrate that a memory is distributed across cells, and
+// CorroborationCount still carries the true total for the anonymous remainder.
+const engramCorroboratorLimit = 12
 
 // handleEngrams returns ONE agent's authored memories — the "engrams" that
 // re-anchor to their author neuron in the agent-as-lobe view. It is loaded on
@@ -66,23 +84,20 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 	}
 
 	allowed, seeAll := h.resolveAgentRBAC(r)
+	// The set of agents the caller may see, reused by both the neuron-visibility
+	// gate below and the corroborator (distributed-engram) disclosure further down.
+	visible := make(map[string]bool, len(allowed))
+	for _, a := range allowed {
+		visible[a] = true
+	}
 
 	// Neuron-visibility gate: if the caller cannot see this agent at all, do not
 	// disclose the shape of its lobe — return an empty engram set, the same as a
 	// neuron with no memories. Under appV23 seeAll is true and agent visibility is
 	// domain-derived per-record below, so this only bites legacy RBAC.
-	if !seeAll {
-		visible := false
-		for _, a := range allowed {
-			if a == agentID {
-				visible = true
-				break
-			}
-		}
-		if !visible {
-			_ = json.NewEncoder(w).Encode(map[string]any{"agent_id": agentID, "engrams": []engramNode{}})
-			return
-		}
+	if !seeAll && !visible[agentID] {
+		_ = json.NewEncoder(w).Encode(map[string]any{"agent_id": agentID, "engrams": []engramNode{}})
+		return
 	}
 
 	// The lobe is a TRUE highest-confidence top-N, not a representative spread. The
@@ -181,8 +196,61 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Neuron set for the distributed-engram bridges: a corroborator is only
+	// disclosed if it is itself a registered neuron, because the connectome renders
+	// no node for a non-registered corroborator and, more importantly, the neuron
+	// registry is the disclosure boundary the whole connectome uses — an identity
+	// absent from it must not be named here either. When the registry is
+	// unavailable (a store without a Badger registry, or an unreadable one), we
+	// disclose NO corroborators rather than risk naming an identity we cannot
+	// confirm is already a visible neuron; the count still conveys distribution.
+	var neuronSet map[string]bool
+	if h.BadgerStore != nil {
+		if regs, regErr := h.BadgerStore.ListRegisteredAgents(); regErr == nil {
+			neuronSet = make(map[string]bool, len(regs))
+			for _, a := range regs {
+				neuronSet[a.AgentID] = true
+			}
+		}
+	}
+
 	engrams := make([]engramNode, 0, len(records))
 	for _, rec := range records {
+		// Distributed-engram disclosure: the corroborators the caller is cleared to
+		// see. Fetched only for a memory that actually has corroborations (most have
+		// none), so a lobe of solitary memories costs no extra reads. Each disclosed
+		// corroborator must be (a) a registered neuron, (b) visible to the caller
+		// under the same rule the synapse edge guard applies, and (c) not the author
+		// itself; the rest survive only in CorroborationCount as the anonymous "+N".
+		var corroborators []string
+		if neuronSet != nil && corrCounts[rec.MemoryID] > 0 {
+			// A per-engram corroborator read failure degrades to "no bridges for this
+			// engram" rather than failing the whole lobe — the same fail-closed choice
+			// the missing-registry path makes above, applied per record because this
+			// read is in the loop. The engram still renders (it was read fine) and
+			// corroboration_count still conveys the memory is distributed; only the
+			// bridges are withheld. The count is a separate batch read that already
+			// succeeded, so the "held across N" total is unaffected.
+			corrs, cErr := h.store.GetCorroborations(ctx, rec.MemoryID)
+			if cErr != nil {
+				corrs = nil
+			}
+			seen := make(map[string]bool, len(corrs))
+			for _, c := range corrs {
+				id := c.AgentID
+				if id == "" || id == rec.SubmittingAgent || seen[id] {
+					continue
+				}
+				if !neuronSet[id] || (!seeAll && !visible[id]) {
+					continue
+				}
+				seen[id] = true
+				corroborators = append(corroborators, id)
+				if len(corroborators) >= engramCorroboratorLimit {
+					break
+				}
+			}
+		}
 		engrams = append(engrams, engramNode{
 			ID:                 rec.MemoryID,
 			Content:            truncate(rec.Content, 200),
@@ -193,6 +261,7 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 			CreatedAt:          rec.CreatedAt.Format(time.RFC3339),
 			CorroborationCount: corrCounts[rec.MemoryID],
 			Tags:               tagMap[rec.MemoryID],
+			Corroborators:      corroborators,
 		})
 	}
 

--- a/web/static/js/connectome-map.js
+++ b/web/static/js/connectome-map.js
@@ -227,7 +227,10 @@ export function stripBloom(graphData) {
   const links = (graphData && Array.isArray(graphData.links)) ? graphData.links : [];
   return {
     nodes: nodes.filter(n => !n._added),
-    links: links.filter(l => l.link_type !== 'focus'),
+    // Both bloom artifacts are transient: the 'focus' tethers from the neuron to
+    // its engrams, and the 'engram-bridge' links from an engram to the other
+    // neurons that corroborate it (the distributed engram). Real synapses stay.
+    links: links.filter(l => l.link_type !== 'focus' && l.link_type !== 'engram-bridge'),
   };
 }
 
@@ -246,6 +249,11 @@ export function mapEngrams(g) {
     status: e.status || 'committed',
     confidence: typeof e.confidence === 'number' ? e.confidence : 0.5,
     corroboration_count: e.corroboration_count || 0,
+    // The corroborating neurons the viewer is cleared to see — the endpoints the
+    // agent-as-lobe view bridges this engram to (the "distributed engram"). The
+    // server has already RBAC-filtered these; corroborators the viewer may not see
+    // survive only inside corroboration_count as the anonymous remainder.
+    corroborators: Array.isArray(e.corroborators) ? e.corroborators : [],
     memory_type: e.memory_type || '',
     created_at: e.created_at || '',
     _added: true,

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -34,6 +34,12 @@ const LINK_TYPES = {
   // scale with traffic (Hebbian weight), so this one entry is styled dynamically
   // by the link accessors rather than by a fixed width like the memory link types.
   synapse:     { color: '#39d0ff', label: 'synapse',     typed: true },
+  // Connectome mode: a "distributed engram" bridge — a memory (engram) that a
+  // second neuron has also corroborated, drawn from the engram to that
+  // corroborating neuron. One memory bridged to several neurons is the same
+  // knowledge consolidated across cells. Kept faint so the neuron synapses stay
+  // dominant; styled dynamically by the width accessor like the synapse.
+  'engram-bridge': { color: '#d98cff', label: 'distributed engram', typed: false },
 };
 const PALETTE = ['#ff6b9d','#ffd166','#5ee2a0','#5ab0ff','#c08bff','#ff9f5a','#4dd6c4','#f7748a','#9ad14b','#7aa0ff'];
 function hexToRgb(h){ const n = parseInt(h.slice(1), 16); return [n >> 16 & 255, n >> 8 & 255, n & 255]; }
@@ -498,6 +504,7 @@ export function mountMriBrain(container, opts = {}) {
   const restingWeight = l => (l._w||0) * plasticityOf(l);
   function linkWidthFor(l){
     if(l.link_type==='synapse') return 0.25 + restingWeight(l)*2.4 + synapsePulse(l)*2.0;
+    if(l.link_type==='engram-bridge') return 0.5;
     return l.link_type==='focus'?0.8 : l.link_type==='contradicts'?0.6 : (LINK_TYPES[l.link_type]||{}).typed?0.35:0.18;
   }
   function linkParticlesFor(l){
@@ -561,18 +568,30 @@ export function mountMriBrain(container, opts = {}) {
     if (disposed || !Graph || mode !== 'connectome' || focusId !== n.id) return;
     const engrams = mapEngrams(payload);
     const gd = stripBloom(Graph.graphData());
-    const present = new Set(gd.nodes.map(nn => nn.id));
+    const nodeById = new Map(gd.nodes.map(nn => [nn.id, nn]));
     const fs = new Set(focusSet || [n.id]);
     engrams.forEach((em, i) => {
-      if (!present.has(em.id)) {
+      if (!nodeById.has(em.id)) {
         placeNear(em, n, i);
         gd.nodes.push(em);
-        present.add(em.id);
+        nodeById.set(em.id, em);
       }
       // endpoints are node OBJECTS so the tether renders under the pinned layout
       // (string ids go unresolved once the link force is nulled — see #188).
       gd.links.push({ source: n, target: em, link_type: 'focus' });
       fs.add(em.id);
+      // Distributed-engram bridges: this memory is also held by other neurons the
+      // viewer is cleared to see (the server already RBAC-filtered em.corroborators).
+      // Bridge the engram to each such corroborating neuron ALREADY rendered in the
+      // connectome — a memory spanning several neurons is one engram distributed
+      // across cells. Endpoints are node OBJECTS (#188). A corroborator absent from
+      // the graph (not a rendered neuron) is never bridged; it stays in the
+      // anonymous corroboration_count.
+      (em.corroborators || []).forEach(cid => {
+        if (cid === n.id) return;
+        const cn = nodeById.get(cid);
+        if (cn && cn.isNeuron) gd.links.push({ source: em, target: cn, link_type: 'engram-bridge' });
+      });
     });
     focusId = n.id; focusSet = fs;
     Graph.graphData(gd);


### PR DESCRIPTION
## What

Phase B of #217, scoped to **off-chain** per your decision on the issue. Building on the agent-as-lobe view (#212), a bloomed engram is now bridged to the other neurons that have corroborated the same memory. Zoom into a neuron and its authored memories still bloom around it; a memory several agents also hold now renders as **one engram distributed across their cells** — the distributed engram #217 asked for.

The bridge is a faint `engram-bridge` link (styled below the neuron synapses so they stay dominant) from the engram to each corroborating neuron the viewer is cleared to see.

## Why off-chain, and why no commitment

#217 originally framed this as *cryptographic* distributed engrams. Walking that back to a pure read was the right call, and the reasoning is worth recording since it drove the whole design:

- The endpoint is a plain read of the **corroborations table** — the same source `/v1/dashboard/memory/engrams` already tallies for `corroboration_count`. Nothing new is anchored, nothing enters the AppHash, no app-version gate. It ships on an ordinary release.
- A Merkle/accumulator commitment's only value is proving the corroborator set *without trusting the serving node*. But that set is **already AppHash-covered by consensus**, so an off-chain root built by the same node is a weaker duplicate of a guarantee that already exists — and cross-peer it reconstructs exactly the read-time verifiability the #217 decision accepts not having (SAGE federation is 2-of-2 and treaty-bounded, so a peer only ever serves data the viewer already consented to). No threat model is left for it to serve. Raised and agreed on the issue before I built anything.

So the security here is **disclosure scope**, not cryptography.

## Safety — the connectome's existing both-endpoints guard, reused

A synapse edge in the connectome is disclosed only when **both** of its endpoints are visible to the caller (the guard `handleSynapses` applies, #181). A corroborator bridge is the same shape: the author's lobe is already visible to the viewer, so the corroborator is the **one** endpoint that must clear the check. A corroborator is bridged only when it is:

- **a registered neuron** — the neuron registry (`ListRegisteredAgents`) is the connectome's disclosure boundary; an identity absent from it is never named here either; and
- **visible to the caller** — under the same `(!seeAll && !visible[id])` RBAC filter, reusing the visibility set the neuron-visibility gate already builds.

A corroborator that fails either half is never named. It survives only inside `corroboration_count`, so `corroboration_count - len(corroborators)` is the anonymous remainder the view renders as "+N held elsewhere". `seeAll` (human dashboard) relaxes the RBAC half but **not** the neuron gate — the registry stays the boundary.

**Fail-closed:** with no neuron registry attached (or an unreadable one) the endpoint discloses **no** corroborators rather than risk naming an unconfirmed identity. The count is unaffected, so the lobe still conveys the memory is distributed; it just cannot draw the bridges.

**The count cannot silently truncate.** The "held across N" total is `GetCorroborationCounts` — a real `COUNT(DISTINCT agent_id)` — never the length of a bounded slice, so on the high-fan-out engrams the view exists to show it stays honest. The per-engram cap (`engramCorroboratorLimit = 12`) bounds the *drawn* edges, not the count. The author is excluded from the bridge set, so **N means one thing: distinct non-author agents who corroborated, of which the bridges are the visible-neuron subset.**

The corroboration read is skipped entirely for a memory with no corroborations (most have none), so a lobe of solitary memories costs no extra store reads.

## Index

`corroborations` had no index on its `memory_id` child FK (sqlite does not auto-index FK children), so the per-engram corroborator read — and the existing `GetCorroborationCounts` — was a full scan of every corroboration on the node. Adds `idx_corroborations_memory` on both backends (initSchema **and** the migration mirror on sqlite, and postgres), so the read is a seek. Pinned by a plan test run **WITHOUT ANALYZE** (SAGE never runs ANALYZE; a real node has no `sqlite_stat1`), matching `idx_memories_submitting_agent`.

## Client

- `mapEngrams` carries the server-disclosed `corroborators` through (defaults to `[]`, coerces a non-array to `[]`); the server has already RBAC-filtered them.
- `bloomEngrams` bridges the engram only to a corroborator that is **already rendered as a neuron** in the connectome, skipping a self-bridge to the author. Endpoints are node **objects**, not string ids, so the bridge resolves under the pinned layout with the link force nulled (#188).
- `stripBloom` clears `engram-bridge` links alongside the `focus` tethers on exit-focus; real synapses stay.

## ABCI determinism

Consensus path untouched. This is a dashboard-only read of the off-chain corroborations table and the agent registry — no `internal/abci`, no `internal/tx`, no FinalizeBlock code, no AppHash input, no app-version gate. The only `internal/store` change is an additive index (local storage, not consensus state). It cannot affect determinism.

## Tests

- `web/engrams_corroborators_test.go` — the headline disclosure property, written to **fail if either half of the guard is removed** (mutation-verified: dropping the RBAC check leaks the hidden peer; dropping the neuron intersection leaks the non-neuron corroborator). Covers: visible-only disclosure under scoped RBAC; `seeAll` human dashboard bridging every corroborating neuron while still withholding a non-neuron; fail-closed with no registry; and the per-engram bridge cap while `corroboration_count` keeps the true total (the truncation case, pinned).
- `internal/store/engram_index_test.go` — `idx_corroborations_memory` is declared on both backends (initSchema + migration + postgres), and the per-memory read SEARCHes via it (no full scan) WITHOUT ANALYZE.
- `scripts/connectome-engrams.test.mjs` — `mapEngrams` carries corroborators (and coerces malformed input to `[]`); `stripBloom` clears the transient `engram-bridge` links but keeps real synapses; `bloomEngrams` bridges only to a rendered neuron, using node objects (#188), and never self-bridges the author.

Part of the #217 line, following #212 (agent-as-lobe) and #188 (pinned-layout node objects).
