### PR TITLE
fix(cerebrum): move connectome caption into guide

### DIFF
--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -6,6 +6,8 @@ import { createGraphLoadCoordinator, mapConnectome, diffConnectomeActivity, crea
 
 const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
 const appSource = await readFile(new URL('../web/static/js/app.js', import.meta.url), 'utf8');
+const cssSource = await readFile(new URL('../web/static/css/sage.css', import.meta.url), 'utf8');
+const mriPageSource = await readFile(new URL('../web/static/mri.html', import.meta.url), 'utf8');
 
 // The CEREBRUM connectome view renders the agent message-bus in the brain hull.
 // mapConnectome() is the pure projection from the /network/synapses payload onto
@@ -144,11 +146,39 @@ test('renderer wires mode invalidation into both initial acquisition and reloads
     'a toggle must invalidate old work and refetch even before Graph exists');
 });
 
-test('connectome explanation stays in the existing guide instead of covering the graph', () => {
-  assert.doesNotMatch(mriSource, /\bmodeCap\b|mode-cap/,
+test('connectome guidance is reachable without adding another floating panel', () => {
+  const templateStart = mriSource.indexOf('root.innerHTML = `');
+  const templateEnd = mriSource.indexOf('`;\n  container.appendChild(root);', templateStart);
+  assert.ok(templateStart >= 0 && templateEnd > templateStart, 'renderer root template must remain inspectable');
+  const rootTemplate = mriSource.slice(templateStart, templateEnd);
+
+  const panelClasses = [...rootTemplate.matchAll(/class="panel ([^"]+)"/g)].map(match => match[1]).sort();
+  assert.deepEqual(panelClasses, ['hud', 'legend', 'scan'],
+    'the renderer must retain only its established scan, legend, and HUD panels');
+  assert.doesNotMatch(rootTemplate, /\bmodeCap\b|mode-cap/,
     'connectome mode must not create a free-floating explanatory panel');
-  assert.match(appSource, /<b>Connectome mode:<\/b> agents are neurons/,
-    'the existing How to read guide must retain the connectome explanation');
+
+  assert.match(rootTemplate, /class="lg-detail guide-connectome" hidden>[\s\S]*Agents are neurons[\s\S]*Click one to bloom its memories/i,
+    'standalone MRI must keep connectome guidance inside its existing reading legend');
+  assert.match(mriPageSource, /mountMriBrain\([\s\S]*showScan: true/,
+    'standalone MRI must continue mounting the renderer with its default reading legend');
+  assert.match(rootTemplate, /<button type="button" class="lg-toggle" aria-expanded="false">/,
+    'the standalone reading guide must be keyboard reachable');
+  assert.match(rootTemplate, /<button type="button" class="btn b-mode" aria-pressed="false">/,
+    'the mode toggle must be a keyboard-reachable button');
+  assert.match(mriSource, /connectomeGuide\.hidden = !connectome/,
+    'mode changes must associate the standalone guide with the active view');
+  assert.match(mriSource, /class="sr-status" role="status" aria-live="polite"/,
+    'mode changes must have a non-visual screen-reader announcement target');
+
+  assert.match(appSource, /<section class="brain-domain-guide" aria-label="How to read the brain">[\s\S]*<b>Connectome mode:<\/b> agents are neurons/,
+    'the dashboard How to read guide must retain the connectome explanation');
+  assert.match(appSource, /class="brain-domain-reset"/,
+    'the mobile-only action hiding rule needs an explicit Reset target');
+  assert.match(cssSource, /\.brain-domain-head-actions \.brain-domain-reset\s*\{\s*display:\s*none;/,
+    'mobile may hide Reset, not the How to read button');
+  assert.doesNotMatch(cssSource, /\.brain-domain-head-actions button:first-child\s*\{\s*display:\s*none;/,
+    'mobile must not hide whichever action happens to be first');
 });
 
 // Live firing pulses only the synapses that actually carried a message. The

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -157,6 +157,12 @@ test('connectome guidance is reachable without adding another floating panel', (
     'the renderer must retain only its established scan, legend, and HUD panels');
   assert.doesNotMatch(rootTemplate, /\bmodeCap\b|mode-cap/,
     'connectome mode must not create a free-floating explanatory panel');
+  const dynamicRootAppends = [...mriSource.matchAll(/\broot\.appendChild\(([^)]+)\)/g)]
+    .map(match => match[1].trim());
+  assert.deepEqual(dynamicRootAppends, ['p'],
+    'the only dynamic root child may be the established click-to-explore panel');
+  assert.match(mriSource, /p\.className = 'panel explore'; root\.appendChild\(p\)/,
+    'the dynamic-root allow-list must stay bound to the click-to-explore panel');
 
   assert.match(rootTemplate, /class="lg-detail guide-connectome" hidden>[\s\S]*Agents are neurons[\s\S]*Click one to bloom its memories/i,
     'standalone MRI must keep connectome guidance inside its existing reading legend');

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -9,6 +9,43 @@ const appSource = await readFile(new URL('../web/static/js/app.js', import.meta.
 const cssSource = await readFile(new URL('../web/static/css/sage.css', import.meta.url), 'utf8');
 const mriPageSource = await readFile(new URL('../web/static/mri.html', import.meta.url), 'utf8');
 
+function bracedBlock(source, marker, from = 0) {
+  const start = source.indexOf(marker, from);
+  assert.notEqual(start, -1, `${marker} not found`);
+  const open = source.indexOf('{', start + marker.length);
+  assert.notEqual(open, -1, `${marker} block did not open`);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}' && --depth === 0) {
+      return { body: source.slice(open + 1, i), start, end: i + 1 };
+    }
+  }
+  assert.fail(`${marker} block did not close`);
+}
+
+function cssDeclarations(source, exactSelector) {
+  const executable = source.replace(/\/\*[\s\S]*?\*\//g, '');
+  let cursor = 0;
+  let found = null;
+  while (cursor < executable.length) {
+    const open = executable.indexOf('{', cursor);
+    if (open === -1) break;
+    const close = executable.indexOf('}', open + 1);
+    if (close === -1) break;
+    const boundary = Math.max(executable.lastIndexOf('}', open - 1), executable.lastIndexOf('{', open - 1));
+    const selector = executable.slice(boundary + 1, open).trim();
+    if (selector === exactSelector) found = executable.slice(open + 1, close);
+    cursor = close + 1;
+  }
+  assert.notEqual(found, null, `${exactSelector} rule not found`);
+  return Object.fromEntries(found.split(';').map(part => part.trim()).filter(Boolean).map(part => {
+    const colon = part.indexOf(':');
+    assert.ok(colon > 0, `invalid declaration in ${exactSelector}: ${part}`);
+    return [part.slice(0, colon).trim(), part.slice(colon + 1).trim()];
+  }));
+}
+
 // The CEREBRUM connectome view renders the agent message-bus in the brain hull.
 // mapConnectome() is the pure projection from the /network/synapses payload onto
 // the MRI render contract; these tests pin the invariants the renderer relies on:
@@ -193,10 +230,34 @@ test('connectome guidance is reachable without adding another floating panel', (
     'the dashboard How to read guide must retain the connectome explanation');
   assert.match(appSource, /class="brain-domain-reset"/,
     'the mobile-only action hiding rule needs an explicit Reset target');
-  assert.match(cssSource, /\.brain-domain-head-actions \.brain-domain-reset\s*\{\s*display:\s*none;/,
+  const executableCss = cssSource.replace(/\/\*[\s\S]*?\*\//g, '');
+  const mobileBlocks = [];
+  let mobileCursor = 0;
+  while ((mobileCursor = executableCss.indexOf('@media (max-width: 760px)', mobileCursor)) !== -1) {
+    const block = bracedBlock(executableCss, '@media (max-width: 760px)', mobileCursor);
+    mobileBlocks.push(block.body);
+    mobileCursor = block.end;
+  }
+  const inventoryMobile = mobileBlocks.find(block => block.includes('.brain-domain-head-actions .brain-domain-reset'));
+  assert.ok(inventoryMobile, 'the executable 760px mobile block must target Reset explicitly');
+  assert.equal(cssDeclarations(inventoryMobile, '.brain-domain-head-actions .brain-domain-reset').display, 'none',
     'mobile may hide Reset, not the How to read button');
-  assert.doesNotMatch(cssSource, /\.brain-domain-head-actions button:first-child\s*\{\s*display:\s*none;/,
+  assert.doesNotMatch(executableCss, /\.brain-domain-head-actions button:first-child\s*\{\s*display:\s*none;/,
     'mobile must not hide whichever action happens to be first');
+});
+
+test('mode controls retain visible pressed and keyboard-focus styling in both themes', () => {
+  const styleStart = mriSource.indexOf('const STYLE = `');
+  const styleEnd = mriSource.indexOf('`;\n\nfunction injectStyleOnce', styleStart);
+  assert.ok(styleStart >= 0 && styleEnd > styleStart, 'the executable MRI stylesheet must remain inspectable');
+  const style = mriSource.slice(styleStart, styleEnd);
+  const darkPressed = cssDeclarations(style, '.mrib .hud .b-mode[aria-pressed="true"]');
+  const lightPressed = cssDeclarations(style, ':root[data-theme="light"] .mrib .hud .b-mode[aria-pressed="true"]');
+  const focus = cssDeclarations(style, '.mrib .hud .btn:focus-visible,.mrib .lg-toggle:focus-visible');
+
+  assert.deepEqual(darkPressed, { background: '#0e2943', 'border-color': '#39d0ff' });
+  assert.deepEqual(lightPressed, { background: '#dff5fb', 'border-color': '#0e7490' });
+  assert.deepEqual(focus, { outline: '2px solid #39d0ff', 'outline-offset': '2px' });
 });
 
 test('mode chrome exposes coherent toggle state, active guidance, and live status', () => {
@@ -249,8 +310,23 @@ test('mode chrome exposes coherent toggle state, active guidance, and live statu
   const executableSetMode = functionBody('setMode')
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/\/\/.*$/gm, '');
-  assert.match(executableSetMode, /updateModeChrome\(true\);/,
-    'a real mode transition must invoke the announcing path');
+  const modeAnnouncements = [];
+  const runSetMode = new Function(
+    'next', 'mode', 'allowConnectome', 'graphLoads', 'bloomLoads', 'connectomeActivity',
+    'connectomeReloadIntent', 'neuronBirths', 'currentDomain', 'focusId', 'focusSet',
+    'hideExplorePanel', 'clearFocusMarker', 'updateModeChrome', 'hullState', '$',
+    'sliderUnits', 'setHullOpacity', 'Graph', 'load', 'zoomOut', 'acquireInitialGraph',
+    executableSetMode,
+  );
+  const resettable = () => ({ reset() {} });
+  runSetMode(
+    'connectome', 'memory', true, { invalidate() {} }, { invalidate() {} }, resettable(),
+    resettable(), resettable(), null, null, null, () => {}, () => {},
+    announce => modeAnnouncements.push(announce), { valueFor: () => 0.03 }, () => null,
+    value => value, () => {}, null, () => {}, () => {}, () => {},
+  );
+  assert.deepEqual(modeAnnouncements, [true],
+    'the executable mode transition must invoke the announcing chrome path exactly once');
 });
 
 // Live firing pulses only the synapses that actually carried a message. The

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -5,6 +5,7 @@ import test from 'node:test';
 import { createGraphLoadCoordinator, mapConnectome, diffConnectomeActivity, createConnectomeActivityTracker, createConnectomeReloadIntent } from '../web/static/js/connectome-map.js';
 
 const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
+const appSource = await readFile(new URL('../web/static/js/app.js', import.meta.url), 'utf8');
 
 // The CEREBRUM connectome view renders the agent message-bus in the brain hull.
 // mapConnectome() is the pure projection from the /network/synapses payload onto
@@ -141,6 +142,13 @@ test('renderer wires mode invalidation into both initial acquisition and reloads
     'a stale initial response must fail closed after a mode change');
   assert.match(mriSource, /function setMode\(next\)\{[\s\S]*graphLoads\.invalidate\(\);[\s\S]*else acquireInitialGraph\(\);/,
     'a toggle must invalidate old work and refetch even before Graph exists');
+});
+
+test('connectome explanation stays in the existing guide instead of covering the graph', () => {
+  assert.doesNotMatch(mriSource, /\bmodeCap\b|mode-cap/,
+    'connectome mode must not create a free-floating explanatory panel');
+  assert.match(appSource, /<b>Connectome mode:<\/b> agents are neurons/,
+    'the existing How to read guide must retain the connectome explanation');
 });
 
 // Live firing pulses only the synapses that actually carried a message. The

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -226,15 +226,20 @@ test('mode chrome exposes coherent toggle state, active guidance, and live statu
   const $ = selector => elements[selector];
 
   runChrome($, root, 'connectome', true);
+  assert.equal(elements['.b-mode'].textContent, '◉ connectome',
+    'a toggle button keeps one visible label; aria-pressed carries its state');
   assert.equal(elements['.b-mode'].attrs['aria-label'], 'Connectome view',
     'aria-pressed needs a stable toggle name, not a changing action label');
   assert.equal(elements['.b-mode'].attrs['aria-pressed'], 'true');
+  assert.match(mriSource, /\.b-mode\[aria-pressed="true"\]\{[^}]*background:/,
+    'pressed state must remain visible without changing the toggle label');
   assert.equal(elements['.guide-memory'].hidden, true);
   assert.equal(elements['.guide-connectome'].hidden, false);
   assert.match(elements['.sr-status'].textContent, /Connectome view/);
   assert.deepEqual(labels.map(label => label.textContent), ['neurons', 'synapses', 'hubs']);
 
   runChrome($, root, 'memory', true);
+  assert.equal(elements['.b-mode'].textContent, '◉ connectome');
   assert.equal(elements['.b-mode'].attrs['aria-label'], 'Connectome view');
   assert.equal(elements['.b-mode'].attrs['aria-pressed'], 'false');
   assert.equal(elements['.guide-memory'].hidden, false);

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -157,27 +157,39 @@ test('connectome guidance is reachable without adding another floating panel', (
     'the renderer must retain only its established scan, legend, and HUD panels');
   assert.doesNotMatch(rootTemplate, /\bmodeCap\b|mode-cap/,
     'connectome mode must not create a free-floating explanatory panel');
-  const dynamicRootAppends = [...mriSource.matchAll(/\broot\.appendChild\(([^)]+)\)/g)]
-    .map(match => match[1].trim());
-  assert.deepEqual(dynamicRootAppends, ['p'],
-    'the only dynamic root child may be the established click-to-explore panel');
+  const executableMri = mriSource
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  const childMutations = [...executableMri.matchAll(
+    /\b(root|container)\.(appendChild|append|prepend|insertBefore|replaceChildren|insertAdjacentElement|insertAdjacentHTML|before|after|replaceWith)\s*\(([^;\n]*)\)/g,
+  )].map(match => `${match[1]}.${match[2]}(${match[3].trim()})`);
+  assert.deepEqual(childMutations, ['container.appendChild(root)', 'root.appendChild(p)'],
+    'the mount root and established Explore panel are the only root-level insertions, through any DOM insertion API');
   assert.match(mriSource, /p\.className = 'panel explore'; root\.appendChild\(p\)/,
     'the dynamic-root allow-list must stay bound to the click-to-explore panel');
 
   assert.match(rootTemplate, /class="lg-detail guide-connectome" hidden>[\s\S]*Agents are neurons[\s\S]*Click one to bloom its memories/i,
     'standalone MRI must keep connectome guidance inside its existing reading legend');
-  assert.match(mriPageSource, /mountMriBrain\([\s\S]*showScan: true/,
-    'standalone MRI must continue mounting the renderer with its default reading legend');
+  const standaloneMountStart = mriPageSource.indexOf("mountMriBrain(document.getElementById('mount')");
+  const standaloneMountEnd = mriPageSource.indexOf('});', standaloneMountStart);
+  assert.ok(standaloneMountStart >= 0 && standaloneMountEnd > standaloneMountStart,
+    'standalone MRI mount options must remain inspectable');
+  const standaloneMount = mriPageSource.slice(standaloneMountStart, standaloneMountEnd);
+  assert.match(standaloneMount, /showScan:\s*true/);
+  assert.doesNotMatch(standaloneMount, /showDomainLegend:\s*false|allowConnectome:\s*false/,
+    'standalone MRI must keep both the connectome toggle and its reading guide enabled');
   assert.match(rootTemplate, /<button type="button" class="lg-toggle" aria-expanded="false">/,
     'the standalone reading guide must be keyboard reachable');
-  assert.match(rootTemplate, /<button type="button" class="btn b-mode" aria-pressed="false">/,
+  assert.match(rootTemplate, /<button type="button" class="btn b-mode" aria-label="Connectome view" aria-pressed="false">/,
     'the mode toggle must be a keyboard-reachable button');
-  assert.match(mriSource, /connectomeGuide\.hidden = !connectome/,
-    'mode changes must associate the standalone guide with the active view');
   assert.match(mriSource, /class="sr-status" role="status" aria-live="polite"/,
     'mode changes must have a non-visual screen-reader announcement target');
 
-  assert.match(appSource, /<section class="brain-domain-guide" aria-label="How to read the brain">[\s\S]*<b>Connectome mode:<\/b> agents are neurons/,
+  const guideStart = appSource.indexOf('showGuide && html`<section class="brain-domain-guide"');
+  const guideEnd = appSource.indexOf('</section>`}', guideStart);
+  assert.ok(guideStart >= 0 && guideEnd > guideStart, 'dashboard guide template must remain inspectable');
+  const dashboardGuide = appSource.slice(guideStart, guideEnd);
+  assert.match(dashboardGuide, /<b>Connectome mode:<\/b> agents are neurons/,
     'the dashboard How to read guide must retain the connectome explanation');
   assert.match(appSource, /class="brain-domain-reset"/,
     'the mobile-only action hiding rule needs an explicit Reset target');
@@ -185,6 +197,55 @@ test('connectome guidance is reachable without adding another floating panel', (
     'mobile may hide Reset, not the How to read button');
   assert.doesNotMatch(cssSource, /\.brain-domain-head-actions button:first-child\s*\{\s*display:\s*none;/,
     'mobile must not hide whichever action happens to be first');
+});
+
+test('mode chrome exposes coherent toggle state, active guidance, and live status', () => {
+  const functionBody = name => {
+    const start = mriSource.indexOf(`function ${name}(`);
+    assert.notEqual(start, -1, `${name}() not found`);
+    const open = mriSource.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < mriSource.length; i++) {
+      if (mriSource[i] === '{') depth++;
+      else if (mriSource[i] === '}' && --depth === 0) return mriSource.slice(open + 1, i);
+    }
+    assert.fail(`${name}() body did not close`);
+  };
+
+  const body = functionBody('updateModeChrome');
+  const runChrome = new Function('$', 'root', 'mode', 'announce', body);
+  const elements = {
+    '.b-mode': { textContent: '', attrs: {}, setAttribute(k, v) { this.attrs[k] = v; } },
+    '.lg-title': { textContent: '' },
+    '.guide-memory': { hidden: false },
+    '.guide-connectome': { hidden: true },
+    '.sr-status': { textContent: '' },
+  };
+  const labels = [{ textContent: '' }, { textContent: '' }, { textContent: '' }];
+  const root = { querySelectorAll: () => labels };
+  const $ = selector => elements[selector];
+
+  runChrome($, root, 'connectome', true);
+  assert.equal(elements['.b-mode'].attrs['aria-label'], 'Connectome view',
+    'aria-pressed needs a stable toggle name, not a changing action label');
+  assert.equal(elements['.b-mode'].attrs['aria-pressed'], 'true');
+  assert.equal(elements['.guide-memory'].hidden, true);
+  assert.equal(elements['.guide-connectome'].hidden, false);
+  assert.match(elements['.sr-status'].textContent, /Connectome view/);
+  assert.deepEqual(labels.map(label => label.textContent), ['neurons', 'synapses', 'hubs']);
+
+  runChrome($, root, 'memory', true);
+  assert.equal(elements['.b-mode'].attrs['aria-label'], 'Connectome view');
+  assert.equal(elements['.b-mode'].attrs['aria-pressed'], 'false');
+  assert.equal(elements['.guide-memory'].hidden, false);
+  assert.equal(elements['.guide-connectome'].hidden, true);
+  assert.match(elements['.sr-status'].textContent, /Memory view/);
+
+  const executableSetMode = functionBody('setMode')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  assert.match(executableSetMode, /updateModeChrome\(true\);/,
+    'a real mode transition must invoke the announcing path');
 });
 
 // Live firing pulses only the synapses that actually carried a message. The

--- a/web/static/css/sage.css
+++ b/web/static/css/sage.css
@@ -6160,7 +6160,7 @@ input[type="range"]::-moz-range-thumb {
         min-width: 240px;
     }
     .brain-domain-guide-grid { grid-template-columns: 1fr; }
-    .brain-domain-head-actions button:first-child { display: none; }
+    .brain-domain-head-actions .brain-domain-reset { display: none; }
 }
 
 /* Tasks board first-run empty state (v11 UX uplift) */

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1020,7 +1020,7 @@ function BrainDomainInventory({ onInventory, onAvailability, selectedDomain, onS
             </div>
         `}
         ${!collapsed && html`<div class="brain-domain-body">
-            ${showGuide && html`<section class="brain-domain-guide" aria-label="How to read the memory brain">
+            ${showGuide && html`<section class="brain-domain-guide" aria-label="How to read the brain">
                 <p>SAGE captures episodic memories; corroboration and decay shape what consolidates.</p>
                 <div class="brain-domain-guide-grid">
                     <span><b>◍ Size + glow</b> corroboration</span>
@@ -1031,6 +1031,7 @@ function BrainDomainInventory({ onInventory, onAvailability, selectedDomain, onS
                     <span><b>◈ Angle</b> domain</span>
                 </div>
                 <p>Click a local domain below to isolate its lobe. Click a memory to follow its train of thought.</p>
+                <p><b>Connectome mode:</b> agents are neurons, domains set their hue, and message traffic drives synapse thickness and pulses. Active hubs sit near the core; click a neuron to bloom its memories.</p>
             </section>`}
             <section aria-labelledby="brain-local-domains">
                 <div class="brain-domain-section-head">

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -999,7 +999,7 @@ function BrainDomainInventory({ onInventory, onAvailability, selectedDomain, onS
             <div class="brain-domain-head-actions">
                 ${!collapsed && html`<button type="button" onClick=${toggleGuide}
                     aria-expanded=${showGuide}>${showGuide ? 'Less' : 'How to read'}</button>`}
-                <button type="button" onClick=${resetLayout} title="Reset panel position and size">Reset</button>
+                <button type="button" class="brain-domain-reset" onClick=${resetLayout} title="Reset panel position and size">Reset</button>
                 <button type="button" onClick=${toggle}
                     aria-expanded=${!collapsed}
                     aria-label=${collapsed ? 'Show domain sources' : 'Hide domain sources'}>

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -161,6 +161,7 @@ const STYLE = `
 .mrib .hud .l{color:#5d7395;font-size:10px;letter-spacing:1px;text-transform:uppercase}
 .mrib .hud .btn{cursor:pointer;color:#39d0ff;background:transparent;font:inherit;border:1px solid #15233b;border-radius:8px;padding:6px 11px;user-select:none}
 .mrib .hud .btn:hover{background:#0e1b30}
+.mrib .hud .b-mode[aria-pressed="true"]{background:#0e2943;border-color:#39d0ff}
 .mrib .hud .btn:focus-visible,.mrib .lg-toggle:focus-visible{outline:2px solid #39d0ff;outline-offset:2px}
 .mrib .hud .sld{display:flex;align-items:center;gap:7px;color:#5d7395;font-size:10px;letter-spacing:1px;text-transform:uppercase}
 .mrib .hud .sld input{width:84px;accent-color:#39d0ff;cursor:pointer}
@@ -224,6 +225,7 @@ const STYLE = `
 :root[data-theme="light"] .mrib .hud .btn:hover,
 :root[data-theme="light"] .mrib .explore .ex-back:hover,
 :root[data-theme="light"] .mrib .explore .ex-font button:hover:not(:disabled){background:#e9eef4;color:#0e7490}
+:root[data-theme="light"] .mrib .hud .b-mode[aria-pressed="true"]{background:#dff5fb;border-color:#0e7490}
 :root[data-theme="light"] .mrib .legend .cls,
 :root[data-theme="light"] .mrib .legend .row .t span,
 :root[data-theme="light"] .mrib .lobes .more,
@@ -1439,7 +1441,7 @@ export function mountMriBrain(container, opts = {}) {
     const connectome = mode === 'connectome';
     const btn=$('.b-mode');
     if(btn) {
-      btn.textContent = connectome ? '◈ memory' : '◉ connectome';
+      btn.textContent = '◉ connectome';
       btn.setAttribute('aria-label', 'Connectome view');
       btn.setAttribute('aria-pressed', connectome ? 'true' : 'false');
     }

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -361,7 +361,7 @@ export function mountMriBrain(container, opts = {}) {
       <div><div class="n nc">0</div><div class="l">consolidated</div></div>
       <button type="button" class="btn b-rot">⏸ pause</button>
       <button type="button" class="btn b-flow">⚡ flow: on</button>
-      ${allowConnectome ? '<button type="button" class="btn b-mode" aria-pressed="false">◉ connectome</button>' : ''}
+      ${allowConnectome ? '<button type="button" class="btn b-mode" aria-label="Connectome view" aria-pressed="false">◉ connectome</button>' : ''}
       <label class="sld">skull <input class="b-op" type="range" min="0" max="60" value="8"></label>
     </div>
     <div class="tip"></div>
@@ -1440,7 +1440,7 @@ export function mountMriBrain(container, opts = {}) {
     const btn=$('.b-mode');
     if(btn) {
       btn.textContent = connectome ? '◈ memory' : '◉ connectome';
-      btn.setAttribute('aria-label', connectome ? 'Show memory view' : 'Show connectome view');
+      btn.setAttribute('aria-label', 'Connectome view');
       btn.setAttribute('aria-pressed', connectome ? 'true' : 'false');
     }
     const title = $('.lg-title'); if (title) title.textContent = connectome ? 'Connectome' : 'Domain tags';

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -1419,19 +1419,13 @@ export function mountMriBrain(container, opts = {}) {
   root.addEventListener('mousemove', onMove);
   root.addEventListener('pointerdown', onGraphPointerDown);
   root.addEventListener('click', onGraphClick);
-  // Connectome legend caption — appended once, shown only in connectome mode.
-  const modeCap = document.createElement('div');
-  modeCap.className = 'panel mode-cap';
-  modeCap.style.cssText = 'position:absolute;left:auto;bottom:44px;top:auto;right:12px;display:none;max-width:236px;font-size:11px;line-height:1.55';
-  modeCap.innerHTML = '<b>Connectome</b> · the agent message-bus<br>◉ neuron = agent · hue = domain<br>synapse thickness + pulse = traffic (Hebbian)<br>idle synapses thin & fade · use it or lose it<br>new agents grow in · dormant ones grey out<br>hubs sink to the core · click a neuron → its memories bloom';
-  root.appendChild(modeCap);
-
-  // Relabel the stat panel + button and toggle the caption for the active mode.
+  // Relabel the stat panel and button for the active mode. The explanatory
+  // copy lives in CEREBRUM's existing "How to read" guide instead of covering
+  // the graph with a second floating panel.
   function updateModeChrome(){
     const btn=$('.b-mode'); if(btn) btn.textContent = mode==='connectome' ? '◈ memory' : '◉ connectome';
     const set = mode==='connectome' ? ['neurons','synapses','hubs'] : ['memories','synapses','consolidated'];
     root.querySelectorAll('.hud .l').forEach((el,i)=>{ if(set[i]) el.textContent=set[i]; });
-    modeCap.style.display = mode==='connectome' ? '' : 'none';
   }
   updateModeChrome();
 

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -144,7 +144,7 @@ const STYLE = `
 .mrib .legend.collapsed .lg-detail{display:none}
 .mrib .legend.collapsed{max-height:70%}
 .mrib .lg-head{display:flex;align-items:center;justify-content:space-between;gap:8px}
-.mrib .lg-toggle{cursor:pointer;color:#39d0ff;font-size:10px;letter-spacing:1px;text-transform:uppercase;border:1px solid #15233b;border-radius:7px;padding:3px 8px;user-select:none;white-space:nowrap}
+.mrib .lg-toggle{cursor:pointer;color:#39d0ff;background:transparent;font:inherit;font-size:10px;letter-spacing:1px;text-transform:uppercase;border:1px solid #15233b;border-radius:7px;padding:3px 8px;user-select:none;white-space:nowrap}
 .mrib .lg-toggle:hover{background:#0e1b30}
 .mrib .lobes .more{color:#5d7395;font-size:11px;margin-top:7px}
 .mrib .legend h4{margin:0 0 4px;font-size:11px;letter-spacing:1.5px;color:#39d0ff;text-transform:uppercase}
@@ -159,8 +159,9 @@ const STYLE = `
 .mrib .hud{bottom:16px;left:16px;padding:10px 14px;display:flex;gap:16px;align-items:center}
 .mrib .hud .n{color:#eaf4ff;font-size:17px;font-weight:700}
 .mrib .hud .l{color:#5d7395;font-size:10px;letter-spacing:1px;text-transform:uppercase}
-.mrib .hud .btn{cursor:pointer;color:#39d0ff;border:1px solid #15233b;border-radius:8px;padding:6px 11px;user-select:none}
+.mrib .hud .btn{cursor:pointer;color:#39d0ff;background:transparent;font:inherit;border:1px solid #15233b;border-radius:8px;padding:6px 11px;user-select:none}
 .mrib .hud .btn:hover{background:#0e1b30}
+.mrib .hud .btn:focus-visible,.mrib .lg-toggle:focus-visible{outline:2px solid #39d0ff;outline-offset:2px}
 .mrib .hud .sld{display:flex;align-items:center;gap:7px;color:#5d7395;font-size:10px;letter-spacing:1px;text-transform:uppercase}
 .mrib .hud .sld input{width:84px;accent-color:#39d0ff;cursor:pointer}
 .mrib .scan{position:absolute;top:16px;left:16px;padding:10px 14px}
@@ -171,6 +172,7 @@ const STYLE = `
 .mrib .tip .m{color:#5d7395;font-size:11px}
 .mrib .tip .chip{font-size:10px;padding:1px 6px;border-radius:6px;background:#0e1b30;color:#aecbf0;margin-right:4px}
 .mrib .flag{position:absolute;bottom:16px;right:16px;color:#3a4a66;font-size:10px;letter-spacing:1px}
+.mrib .sr-status{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .mrib .boot{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#5d7395;letter-spacing:2px;font-size:12px}
 .mrib .explore{--ex-font:12px;display:none;left:16px;right:306px;bottom:14px;height:47%;min-height:210px;max-height:72%;flex-direction:column;padding:0;overflow:hidden}
 .mrib .explore .ex-resize{position:absolute;top:0;left:12px;right:12px;height:10px;cursor:ns-resize;z-index:2}
@@ -329,8 +331,8 @@ export function mountMriBrain(container, opts = {}) {
     <div class="boot">◉ ACQUIRING HIPPOCAMPAL FIELD…</div>
     ${showScan ? '<div class="panel scan"><b>CEREBRUM · MRI</b><div class="s">◉ SCANNING</div></div>' : ''}
     ${showDomainLegend ? `<div class="panel legend">
-      <div class="lg-head"><h4>Domain tags</h4><span class="lg-toggle"></span></div>
-      <div class="lg-detail">
+      <div class="lg-head"><h4 class="lg-title">Domain tags</h4><button type="button" class="lg-toggle" aria-expanded="false"></button></div>
+      <div class="lg-detail guide-memory">
         <div class="cls">A complementary-learning-systems view: SAGE is the <b>hippocampus</b>
           (episodic capture); corroboration + decay is the <b>sleep/consolidation</b> cycle.</div>
         <div class="seg">Nodes — memories</div>
@@ -343,6 +345,13 @@ export function mountMriBrain(container, opts = {}) {
         <div class="row"><span class="k">◈</span><div class="t"><b>Angle = domain</b><br><span>each topic is a radial stream</span></div></div>
         <div class="row"><span class="k">◉</span><div class="t"><b>Click a memory</b><br><span>see its train of thought</span></div></div>
       </div>
+      <div class="lg-detail guide-connectome" hidden>
+        <div class="cls">Agents are neurons, domains set their hue, and message traffic drives synapse thickness and pulses.</div>
+        <div class="seg">Connectome</div>
+        <div class="row"><span class="k">◉</span><div class="t"><b>Neuron = agent</b><br><span>click one to bloom its memories</span></div></div>
+        <div class="row"><span class="k">↝</span><div class="t"><b>Thickness + pulse = traffic</b><br><span>active channels strengthen</span></div></div>
+        <div class="row"><span class="k">⊙</span><div class="t"><b>Depth = activity</b><br><span>active hubs sit near the core</span></div></div>
+      </div>
       <div class="seg">Lobes — domains</div><div class="lobes"></div>
       <div class="lg-detail"><div class="seg">Connectome — typed links</div><div class="linktypes"></div></div>
     </div>` : ''}
@@ -350,13 +359,14 @@ export function mountMriBrain(container, opts = {}) {
       <div><div class="n nn">0</div><div class="l">memories</div></div>
       <div><div class="n ne">0</div><div class="l">synapses</div></div>
       <div><div class="n nc">0</div><div class="l">consolidated</div></div>
-      <div class="btn b-rot">⏸ pause</div>
-      <div class="btn b-flow">⚡ flow: on</div>
-      ${allowConnectome ? '<div class="btn b-mode">◉ connectome</div>' : ''}
+      <button type="button" class="btn b-rot">⏸ pause</button>
+      <button type="button" class="btn b-flow">⚡ flow: on</button>
+      ${allowConnectome ? '<button type="button" class="btn b-mode" aria-pressed="false">◉ connectome</button>' : ''}
       <label class="sld">skull <input class="b-op" type="range" min="0" max="60" value="8"></label>
     </div>
     <div class="tip"></div>
-    <div class="flag"></div>`;
+    <div class="flag"></div>
+    <div class="sr-status" role="status" aria-live="polite"></div>`;
   container.appendChild(root);
   // Reflect the active view's skull opacity on the slider from the start.
   { const _op = root.querySelector('.b-op'); if (_op) _op.value = sliderUnits(hullState.valueFor(mode)); }
@@ -372,7 +382,10 @@ export function mountMriBrain(container, opts = {}) {
     const lg = $('.legend'); if (!lg) return;
     lg.classList.toggle('collapsed', legendMode !== 'full');
     const t = $('.lg-toggle');
-    if (t) t.textContent = legendMode === 'full' ? '▴ less' : '▾ how to read';
+    if (t) {
+      t.textContent = legendMode === 'full' ? '▴ less' : '▾ how to read';
+      t.setAttribute('aria-expanded', legendMode === 'full' ? 'true' : 'false');
+    }
   }
   applyLegendMode();
   const lgToggle = $('.lg-toggle');
@@ -1419,13 +1432,28 @@ export function mountMriBrain(container, opts = {}) {
   root.addEventListener('mousemove', onMove);
   root.addEventListener('pointerdown', onGraphPointerDown);
   root.addEventListener('click', onGraphClick);
-  // Relabel the stat panel and button for the active mode. The explanatory
-  // copy lives in CEREBRUM's existing "How to read" guide instead of covering
-  // the graph with a second floating panel.
-  function updateModeChrome(){
-    const btn=$('.b-mode'); if(btn) btn.textContent = mode==='connectome' ? '◈ memory' : '◉ connectome';
+  // Relabel the stat panel and expose mode-specific guidance through the
+  // existing reading panel. Mode changes are announced without placing another
+  // visible panel over the graph.
+  function updateModeChrome(announce=false){
+    const connectome = mode === 'connectome';
+    const btn=$('.b-mode');
+    if(btn) {
+      btn.textContent = connectome ? '◈ memory' : '◉ connectome';
+      btn.setAttribute('aria-label', connectome ? 'Show memory view' : 'Show connectome view');
+      btn.setAttribute('aria-pressed', connectome ? 'true' : 'false');
+    }
+    const title = $('.lg-title'); if (title) title.textContent = connectome ? 'Connectome' : 'Domain tags';
+    const memoryGuide = $('.guide-memory'); if (memoryGuide) memoryGuide.hidden = connectome;
+    const connectomeGuide = $('.guide-connectome'); if (connectomeGuide) connectomeGuide.hidden = !connectome;
     const set = mode==='connectome' ? ['neurons','synapses','hubs'] : ['memories','synapses','consolidated'];
     root.querySelectorAll('.hud .l').forEach((el,i)=>{ if(set[i]) el.textContent=set[i]; });
+    if (announce) {
+      const status = $('.sr-status');
+      if (status) status.textContent = connectome
+        ? 'Connectome view. Agents are neurons and message traffic drives synapses.'
+        : 'Memory view. Memories are grouped by domain and consolidation.';
+    }
   }
   updateModeChrome();
 
@@ -1441,7 +1469,7 @@ export function mountMriBrain(container, opts = {}) {
     neuronBirths.reset();
     currentDomain = null;
     focusId=null; focusSet=null; hideExplorePanel(); clearFocusMarker();
-    updateModeChrome();
+    updateModeChrome(true);
     // Recall this view's remembered skull opacity (its default, or the operator's
     // last manual choice for this view) and reflect it on the slider, so a round
     // trip preserves each view's setting independently.


### PR DESCRIPTION
Removes the free-floating Connectome explanation panel from the MRI canvas. Guidance now lives in the existing dashboard and standalone How to read panels, with mode-specific content, keyboard-reachable controls, and a screen-reader mode announcement.

Review follow-up:
- standalone MRI retains Connectome guidance in its existing legend
- mobile keeps How to read reachable and hides only Reset
- renderer mode/guide controls are real buttons with focus treatment
- the mode toggle keeps one stable visible/accessibility label, exposes state through `aria-pressed`, and styles the pressed state in both themes
- regression coverage behavior-tests the actual mode transition, parses effective dark/light/focus/mobile CSS rules, and allow-lists root-level insertions across DOM APIs
- adversarial dark/light transparent, focus-none, mobile comment/decoy, and dead-wiring mutations all fail the intended tests
- the standalone mount contract keeps both the Connectome toggle and its guide enabled

Local verification at exact head `3ebff9aa8659fd51ae86518b50ea5a6b0bbbd958`:
- `npm test` — 367/367
- Connectome mapping — 25/25
- static JS parse — 29 files
- browser QA on the unchanged runtime: collapsed Connectome canvas has no floating caption; existing guide expands with mode-specific content

Base: `ba006fa0e8ed3e3cb1f1ae9fea8c588baaf7a4a6` (v11.18.12)

Target: v11.18.13. Keep draft until two independent exact-head CODE GO reviews and all replacement-head hosted gates are complete.
