### PR TITLE
feat(mcp): connect the Claude wake adapter to the signed wake route

### DIFF
--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -205,7 +205,29 @@ func runMCP() error {
 	if projectDir, cwdErr := os.Getwd(); cwdErr == nil {
 		selfHealProject(projectDir, home, os.Getenv("SAGE_PROVIDER"), keyPath)
 	}
+	// The Claude channel stays opt-in, and a failure to arm it is deliberately
+	// not fatal: the wake channel is an accelerator over polling, so a host
+	// that cannot open the stream must still get an ordinary working MCP
+	// session rather than no session at all.
+	if claudeChannelEnabled() {
+		if err := server.EnableRESTClaudeChannel(); err != nil {
+			fmt.Fprintf(os.Stderr, "SAGE MCP: claude channel disabled: %v\n", err)
+		}
+	}
 	return server.Run(context.Background())
+}
+
+// claudeChannelEnabled reports whether the operator explicitly armed the
+// experimental Claude wake channel. Default-off is the shipped contract of the
+// adapter itself, so absence means off and an unparseable value means off —
+// envBool already warns on the latter rather than guessing.
+func claudeChannelEnabled() bool {
+	raw := os.Getenv("SAGE_CLAUDE_CHANNEL")
+	if strings.TrimSpace(raw) == "" {
+		return false
+	}
+	enabled, ok := envBool("SAGE_CLAUDE_CHANNEL", raw)
+	return ok && enabled
 }
 
 // configuredMCPIdentityEnv separates an explicitly pinned MCP registration

--- a/docs/reference/concepts/message-wake-bus.md
+++ b/docs/reference/concepts/message-wake-bus.md
@@ -79,3 +79,29 @@ pipeline-agent boundary. It does not use the dashboard `OnEvent` broadcaster.
 The older HTTP-MCP `notifications/sage_message` bridge remains a separate,
 best-effort compatibility notification for already-open MCP SSE sessions and
 does not define this durable sequence contract.
+
+## Claude wake channel enablement
+
+The Claude host adapter is the one shipped consumer of this route. It is
+**off by default** and is armed only by setting `SAGE_CLAUDE_CHANNEL` for
+`sage-gui mcp`, the stdio MCP server a Claude host launches
+(`cmd/sage-gui/mcp.go:224`). Constructing an MCP `Server` never advertises or
+emits the experimental protocol on its own; enabling is an explicit call
+(`internal/mcp/claude_wake_source.go:84`, `internal/mcp/claude_channel.go:50`).
+
+When armed, the adapter subscribes to this agent's own signed wake stream and
+turns a new durable cursor into a `notifications/claude/channel` JSON-RPC
+notification, so the host can stop polling its inbox on a timer.
+
+The channel is **only a poll accelerator, and it is payload-free**. A wake
+carries `version`, `seq`, and `pending` and nothing else, so the host learns
+that unclaimed work exists and never learns its content, its sender, or how
+many messages are waiting. The host still calls the canonical inbox operation
+to see or claim anything, and that operation remains the only thing that
+affects message lifecycle state.
+
+Two consequences follow from the lease described above. A second runtime for
+the same agent is rejected with 409 rather than silently sharing the wake, so
+the wake accelerates exactly one runtime at a time. And because the channel
+only accelerates polling, failing to arm it is not fatal: a host that cannot
+open the stream still gets an ordinary MCP session and ordinary polling.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -154,6 +154,7 @@ legacy Ollama vector space over a requested custom one (`cmd/amid/main.go`).
 |----------|--------------|---------|---------|--------|
 | `SAGE_SNAPSHOT_KEEP` | Snapshots to retain (newest N + per-version anchors, which are never pruned). Integer ≥ 1. | `5` | sage-gui | `cmd/sage-gui/node.go:262`, `cmd/sage-gui/snapshot.go:56` |
 | `SAGE_BRANCH_TAG` | Set `0`/`false`/`no` to disable branch tagging of memories. | on | MCP | `internal/mcp/branch.go:27` |
+| `SAGE_CLAUDE_CHANNEL` | Opt-in for the experimental Claude wake channel. When on, `sage-gui mcp` subscribes to this agent's signed `/v1/messages/wake` stream and emits a `notifications/claude/channel` JSON-RPC notification so the host can stop polling. Payload-free: the host learns only a durable wake cursor, never message content or sender. Accepts the usual boolean spellings; an unrecognized value warns and stays off. Failure to arm is non-fatal and leaves an ordinary MCP session. | off | sage-gui MCP (stdio) | `cmd/sage-gui/mcp.go:224`, `internal/mcp/claude_wake_source.go:84` |
 
 ---
 

--- a/internal/mcp/claude_wake_source.go
+++ b/internal/mcp/claude_wake_source.go
@@ -165,7 +165,9 @@ func (s *restClaudeWakeSubscription) Close() error {
 // reconnect; it never reconnects on its own.
 func (s *restClaudeWakeSubscription) read() {
 	defer close(s.events)
-	defer s.Close()
+	// Close is idempotent and always reports nil; the deferred call exists to
+	// release the connection when the stream ends on its own.
+	defer func() { _ = s.Close() }()
 
 	scanner := bufio.NewScanner(s.body)
 	scanner.Buffer(make([]byte, 0, 4096), claudeWakeMaxFrameBytes)

--- a/internal/mcp/claude_wake_source.go
+++ b/internal/mcp/claude_wake_source.go
@@ -28,9 +28,10 @@ const (
 	// small fields by design; anything larger is a malformed or hostile stream
 	// rather than a wake this adapter should try to parse.
 	claudeWakeMaxFrameBytes = 8 * 1024
-	// claudeWakeEventBuffer keeps a slow adapter from blocking the reader
-	// goroutine. Wakes coalesce by sequence downstream, so a dropped duplicate
-	// costs nothing; only the highest sequence matters.
+	// claudeWakeEventBuffer absorbs a burst while the adapter is mid-write.
+	// It is a smoothing buffer, not a drop threshold: delivery past it blocks
+	// rather than discarding, because the event that would be discarded is the
+	// newest one and therefore the one that matters.
 	claudeWakeEventBuffer = 8
 )
 
@@ -132,6 +133,7 @@ func (w *restClaudeWakeSource) Subscribe(ctx context.Context, afterSeq uint64) (
 		events: make(chan ClaudeWakeEvent, claudeWakeEventBuffer),
 		body:   resp.Body,
 		cancel: cancel,
+		done:   make(chan struct{}),
 	}
 	go subscription.read()
 	return subscription, nil
@@ -144,6 +146,10 @@ type restClaudeWakeSubscription struct {
 	events chan ClaudeWakeEvent
 	body   io.ReadCloser
 	cancel context.CancelFunc
+	// done is closed exactly once by Close. The reader selects on it while
+	// sending so that backpressure from a busy adapter can never strand the
+	// reader goroutine past shutdown.
+	done chan struct{}
 
 	closeOnce sync.Once
 }
@@ -152,8 +158,10 @@ func (s *restClaudeWakeSubscription) Events() <-chan ClaudeWakeEvent { return s.
 
 func (s *restClaudeWakeSubscription) Close() error {
 	s.closeOnce.Do(func() {
-		// Cancel first: it unblocks a read parked on a quiet stream so the
-		// reader goroutine cannot outlive Close.
+		// Close done first: it releases a reader parked on a full events
+		// buffer. Cancel then unblocks a read parked on a quiet stream. Between
+		// them the reader goroutine cannot outlive Close.
+		close(s.done)
 		s.cancel()
 		_ = s.body.Close()
 	})
@@ -203,12 +211,19 @@ func (s *restClaudeWakeSubscription) read() {
 				Seq:     payload.Seq,
 				Pending: payload.Pending,
 			}
+			// Delivery is lossless. An earlier revision dropped the event
+			// when the buffer was full, reasoning that only the highest
+			// sequence matters — but the event being dropped IS the highest
+			// sequence, and the stream stays open, so nothing later forces a
+			// catch-up. A burst of pending:false frames arriving while the
+			// adapter is blocked on stdout could therefore swallow the
+			// pending:true that follows them and suppress a real wake until
+			// unrelated traffic happened along. Blocking applies backpressure
+			// instead; done releases the reader if Close wins the race.
 			select {
 			case s.events <- event:
-			default:
-				// Buffer full: the adapter is mid-write and already owes a
-				// notification for a sequence at least this recent. Dropping is
-				// safe precisely because wakes carry no content to lose.
+			case <-s.done:
+				return
 			}
 		}
 	}

--- a/internal/mcp/claude_wake_source.go
+++ b/internal/mcp/claude_wake_source.go
@@ -1,0 +1,213 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// The Claude channel adapter shipped in v11.18.9 with no production
+// ClaudeWakeSource behind it: every implementation lived in a test file, so
+// ConfigureClaudeChannel had no caller outside the package and the adapter was
+// unreachable from any shipped binary. The node half — the signed
+// /v1/messages/wake SSE route — shipped separately and is live. This file is
+// the seam between them, and nothing here widens either contract.
+
+const (
+	// claudeWakeConsumerPrefix labels this runtime's lease so an operator
+	// reading node logs can tell which host holds the wake.
+	claudeWakeConsumerPrefix = "claude-code"
+	// claudeWakeMaxFrameBytes bounds one SSE frame. The wake payload is three
+	// small fields by design; anything larger is a malformed or hostile stream
+	// rather than a wake this adapter should try to parse.
+	claudeWakeMaxFrameBytes = 8 * 1024
+	// claudeWakeEventBuffer keeps a slow adapter from blocking the reader
+	// goroutine. Wakes coalesce by sequence downstream, so a dropped duplicate
+	// costs nothing; only the highest sequence matters.
+	claudeWakeEventBuffer = 8
+)
+
+// restClaudeWakeSource subscribes to this node's signed exact-recipient wake
+// route on behalf of the server's own agent identity. It is deliberately the
+// narrowest possible node dependency: it can observe a durable cursor and
+// nothing else. It holds no ability to receive, claim, read, or acknowledge a
+// message, and it never sees sender or content.
+type restClaudeWakeSource struct {
+	server     *Server
+	consumerID string
+
+	// stream is separate from server.httpClient on purpose. That client sets
+	// Timeout (75s by default), which bounds the WHOLE request including body
+	// reads — it would sever a healthy long-lived SSE stream on a fixed timer
+	// and mask the break as a reconnect. The transport, and therefore the TLS
+	// configuration and CA resolution, is shared exactly.
+	stream *http.Client
+}
+
+// newRESTClaudeWakeSource binds a wake source to this server's exact identity.
+//
+// The consumer ID is random per process rather than derived from the project or
+// provider, and that is a correctness requirement rather than a detail. The
+// node supersedes an existing stream when the SAME consumer reconnects, and
+// rejects a DIFFERENT consumer with 409 until the lease expires. A stable ID
+// would therefore let a second Claude runtime silently steal the wake from a
+// live one, which is exactly what the lease exists to prevent.
+func newRESTClaudeWakeSource(server *Server) (*restClaudeWakeSource, error) {
+	if server == nil {
+		return nil, fmt.Errorf("claude wake source requires a server")
+	}
+	if server.httpClient == nil {
+		return nil, fmt.Errorf("claude wake source requires an http client")
+	}
+	suffix := make([]byte, 8)
+	if _, err := rand.Read(suffix); err != nil {
+		return nil, fmt.Errorf("generate wake consumer id: %w", err)
+	}
+	return &restClaudeWakeSource{
+		server:     server,
+		consumerID: claudeWakeConsumerPrefix + "-" + hex.EncodeToString(suffix),
+		stream:     &http.Client{Transport: server.httpClient.Transport},
+	}, nil
+}
+
+// EnableRESTClaudeChannel binds the shipped Claude channel adapter to this
+// node's signed wake route. It stays an explicit call rather than something
+// NewServer does, because the adapter's own contract is that merely
+// constructing a Server never advertises or emits the experimental protocol.
+func (s *Server) EnableRESTClaudeChannel() error {
+	source, err := newRESTClaudeWakeSource(s)
+	if err != nil {
+		return err
+	}
+	return s.ConfigureClaudeChannel(source)
+}
+
+// Subscribe opens one signed wake stream positioned after afterSeq. It returns
+// promptly on ctx cancellation because the request carries ctx, and it reports
+// a non-200 as an error so the adapter's bounded backoff — not this code — owns
+// the retry policy.
+func (w *restClaudeWakeSource) Subscribe(ctx context.Context, afterSeq uint64) (ClaudeWakeSubscription, error) {
+	path := fmt.Sprintf("/v1/messages/wake?after_seq=%d&consumer_id=%s", afterSeq, w.consumerID)
+	prepared, err := w.server.prepareSignedRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("sign wake subscribe: %w", err)
+	}
+
+	streamCtx, cancel := context.WithCancel(ctx)
+	req, err := http.NewRequestWithContext(streamCtx, prepared.method, w.server.baseURL+prepared.path, nil)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("create wake request: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("X-Agent-ID", prepared.agentID)
+	req.Header.Set("X-Signature", prepared.signature)
+	req.Header.Set("X-Timestamp", prepared.timestamp)
+	req.Header.Set("X-Nonce", prepared.nonce)
+
+	resp, err := w.stream.Do(req)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("open wake stream: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Drain a bounded prefix so the connection can be reused, then discard.
+		// The body is a problem+json document; it is diagnostic only and must
+		// not reach the host, which is entitled to a cursor and nothing else.
+		_, _ = io.CopyN(io.Discard, resp.Body, claudeWakeMaxFrameBytes)
+		_ = resp.Body.Close()
+		cancel()
+		return nil, fmt.Errorf("wake stream rejected: %s", resp.Status)
+	}
+
+	subscription := &restClaudeWakeSubscription{
+		events: make(chan ClaudeWakeEvent, claudeWakeEventBuffer),
+		body:   resp.Body,
+		cancel: cancel,
+	}
+	go subscription.read()
+	return subscription, nil
+}
+
+// restClaudeWakeSubscription owns exactly one live stream. Close is idempotent
+// and Events is closed exactly once when the stream ends, both of which the
+// ClaudeWakeSubscription contract requires.
+type restClaudeWakeSubscription struct {
+	events chan ClaudeWakeEvent
+	body   io.ReadCloser
+	cancel context.CancelFunc
+
+	closeOnce sync.Once
+}
+
+func (s *restClaudeWakeSubscription) Events() <-chan ClaudeWakeEvent { return s.events }
+
+func (s *restClaudeWakeSubscription) Close() error {
+	s.closeOnce.Do(func() {
+		// Cancel first: it unblocks a read parked on a quiet stream so the
+		// reader goroutine cannot outlive Close.
+		s.cancel()
+		_ = s.body.Close()
+	})
+	return nil
+}
+
+// read translates SSE frames into wake events until the stream ends. It closes
+// events on exit so the adapter observes the break and schedules its own
+// reconnect; it never reconnects on its own.
+func (s *restClaudeWakeSubscription) read() {
+	defer close(s.events)
+	defer s.Close()
+
+	scanner := bufio.NewScanner(s.body)
+	scanner.Buffer(make([]byte, 0, 4096), claudeWakeMaxFrameBytes)
+
+	var isWake bool
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == "":
+			// Frame boundary. Reset so a data line can never be attributed to
+			// a previous frame's event type.
+			isWake = false
+		case strings.HasPrefix(line, ":"):
+			// Heartbeat comment. Proves liveness, carries nothing.
+		case strings.HasPrefix(line, "event:"):
+			isWake = strings.TrimSpace(strings.TrimPrefix(line, "event:")) == "wake"
+		case strings.HasPrefix(line, "data:"):
+			if !isWake {
+				continue
+			}
+			var payload struct {
+				Version int    `json:"version"`
+				Seq     uint64 `json:"seq"`
+				Pending bool   `json:"pending"`
+			}
+			raw := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+				// A frame we cannot parse is not a frame we may guess at.
+				continue
+			}
+			event := ClaudeWakeEvent{
+				Version: payload.Version,
+				Seq:     payload.Seq,
+				Pending: payload.Pending,
+			}
+			select {
+			case s.events <- event:
+			default:
+				// Buffer full: the adapter is mid-write and already owes a
+				// notification for a sequence at least this recent. Dropping is
+				// safe precisely because wakes carry no content to lose.
+			}
+		}
+	}
+}

--- a/internal/mcp/claude_wake_source_test.go
+++ b/internal/mcp/claude_wake_source_test.go
@@ -1,0 +1,239 @@
+package mcp
+
+import (
+	"context"
+	"crypto/ed25519"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testWakeServer(t *testing.T, handler http.HandlerFunc) (*Server, *httptest.Server) {
+	t.Helper()
+	node := httptest.NewServer(handler)
+	t.Cleanup(node.Close)
+	_, key, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	return NewServer(node.URL, key), node
+}
+
+func flushWrite(t *testing.T, w http.ResponseWriter, format string, args ...any) {
+	t.Helper()
+	_, err := fmt.Fprintf(w, format, args...)
+	require.NoError(t, err)
+	w.(http.Flusher).Flush()
+}
+
+// The wake source must not reuse the server's request client. That client sets
+// Timeout, which bounds the entire request including body reads, so a healthy
+// SSE stream would be severed on a fixed timer and the break would masquerade
+// as a reconnect. This pins the separation.
+func TestClaudeWakeSourceStreamClientHasNoRequestTimeout(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	require.Zero(t, source.stream.Timeout, "SSE client must not carry a whole-request timeout")
+	require.NotZero(t, server.httpClient.Timeout, "the ordinary request client should still be bounded")
+	require.Same(t, server.httpClient.Transport, source.stream.Transport,
+		"the stream client must share the server transport so TLS and CA resolution match")
+}
+
+// Two runtimes for the same agent must not both believe they own the wake. The
+// node supersedes a reconnect from the same consumer and rejects a different
+// one, so the consumer ID has to be unique per process.
+func TestClaudeWakeSourceConsumerIDIsUniquePerSource(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {})
+	first, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+	second, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	require.NotEqual(t, first.consumerID, second.consumerID)
+	require.True(t, strings.HasPrefix(first.consumerID, claudeWakeConsumerPrefix))
+}
+
+func TestClaudeWakeSourceSignsAndPositionsSubscribe(t *testing.T) {
+	type observed struct {
+		agentID, signature, timestamp, nonce, accept, query string
+	}
+	seen := make(chan observed, 1)
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		seen <- observed{
+			agentID:   r.Header.Get("X-Agent-ID"),
+			signature: r.Header.Get("X-Signature"),
+			timestamp: r.Header.Get("X-Timestamp"),
+			nonce:     r.Header.Get("X-Nonce"),
+			accept:    r.Header.Get("Accept"),
+			query:     r.URL.RawQuery,
+		}
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	subscription, err := source.Subscribe(ctx, 42)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, subscription.Close()) }()
+
+	got := <-seen
+	require.NotEmpty(t, got.agentID)
+	require.NotEmpty(t, got.signature)
+	require.NotEmpty(t, got.timestamp)
+	require.NotEmpty(t, got.nonce)
+	require.Equal(t, "text/event-stream", got.accept)
+	require.Contains(t, got.query, "after_seq=42")
+	require.Contains(t, got.query, "consumer_id="+source.consumerID)
+}
+
+// A rejected subscribe must surface as an error so the adapter's bounded
+// backoff owns retry. A 409 is the lease conflict and must not be swallowed.
+func TestClaudeWakeSourceReportsRejectedSubscribe(t *testing.T) {
+	for _, status := range []int{http.StatusConflict, http.StatusUnauthorized, http.StatusNotImplemented} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"title":"nope"}`))
+			})
+			source, err := newRESTClaudeWakeSource(server)
+			require.NoError(t, err)
+
+			subscription, err := source.Subscribe(context.Background(), 0)
+			require.Error(t, err)
+			require.Nil(t, subscription)
+		})
+	}
+}
+
+func TestClaudeWakeSourceTranslatesEventsAndIgnoresHeartbeats(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		flushWrite(t, w, ": heartbeat\n\n")
+		flushWrite(t, w, "id: 7\nevent: wake\ndata: {\"version\":1,\"seq\":7,\"pending\":true}\n\n")
+		flushWrite(t, w, ": heartbeat\n\n")
+		flushWrite(t, w, "id: 9\nevent: wake\ndata: {\"version\":1,\"seq\":9,\"pending\":false}\n\n")
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	subscription, err := source.Subscribe(ctx, 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, subscription.Close()) }()
+
+	first := requireWakeEvent(t, subscription)
+	require.Equal(t, ClaudeWakeEvent{Version: 1, Seq: 7, Pending: true}, first)
+	second := requireWakeEvent(t, subscription)
+	require.Equal(t, ClaudeWakeEvent{Version: 1, Seq: 9, Pending: false}, second)
+}
+
+// The host is entitled to a cursor and nothing else. If the node ever grows
+// extra fields, they must not reach the adapter — the event type is the whole
+// contract and this fails if that stops being true.
+func TestClaudeWakeSourceNeverSurfacesSenderOrContent(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":3,\"pending\":true,"+
+			"\"from_agent\":\"mallory\",\"payload\":\"secret\",\"intent\":\"leak\"}\n\n")
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	subscription, err := source.Subscribe(ctx, 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, subscription.Close()) }()
+
+	event := requireWakeEvent(t, subscription)
+	require.Equal(t, ClaudeWakeEvent{Version: 1, Seq: 3, Pending: true}, event)
+
+	// The notification the host actually receives must not carry the extras
+	// either, whatever the node sent.
+	rendered := fmt.Sprintf("%v", claudeChannelNotification(event.Seq))
+	require.NotContains(t, rendered, "mallory")
+	require.NotContains(t, rendered, "secret")
+	require.NotContains(t, rendered, "leak")
+}
+
+// A data line must never be attributed to a previous frame's event type.
+func TestClaudeWakeSourceIgnoresDataOutsideAWakeFrame(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		flushWrite(t, w, "event: other\ndata: {\"version\":1,\"seq\":5,\"pending\":true}\n\n")
+		flushWrite(t, w, "data: {\"version\":1,\"seq\":6,\"pending\":true}\n\n")
+		flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":8,\"pending\":true}\n\n")
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	subscription, err := source.Subscribe(ctx, 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, subscription.Close()) }()
+
+	// The first event delivered must be seq 8: the non-wake frame and the
+	// orphaned data line are both dropped.
+	require.Equal(t, uint64(8), requireWakeEvent(t, subscription).Seq)
+}
+
+func TestClaudeWakeSourceClosesEventsWhenStreamEndsAndCloseIsIdempotent(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":2,\"pending\":true}\n\n")
+		// Handler returns: the stream ends.
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	subscription, err := source.Subscribe(context.Background(), 0)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(2), requireWakeEvent(t, subscription).Seq)
+
+	require.Eventually(t, func() bool {
+		select {
+		case _, ok := <-subscription.Events():
+			return !ok
+		default:
+			return false
+		}
+	}, 5*time.Second, 10*time.Millisecond, "Events must close when the stream ends")
+
+	require.NoError(t, subscription.Close())
+	require.NoError(t, subscription.Close())
+}
+
+func requireWakeEvent(t *testing.T, subscription ClaudeWakeSubscription) ClaudeWakeEvent {
+	t.Helper()
+	select {
+	case event, ok := <-subscription.Events():
+		require.True(t, ok, "stream closed before an event arrived")
+		return event
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a wake event")
+		return ClaudeWakeEvent{}
+	}
+}

--- a/internal/mcp/claude_wake_source_test.go
+++ b/internal/mcp/claude_wake_source_test.go
@@ -237,3 +237,110 @@ func requireWakeEvent(t *testing.T, subscription ClaudeWakeSubscription) ClaudeW
 		return ClaudeWakeEvent{}
 	}
 }
+
+// Losslessness under saturation. An earlier revision dropped the event when the
+// buffer was full, on the reasoning that only the highest sequence matters —
+// but the dropped event IS the highest sequence, and the stream stays open so
+// nothing forces a catch-up.
+//
+// The test must not begin draining until the buffer has actually saturated,
+// otherwise the consumer keeps pace, the buffer never fills, and the assertion
+// passes against the very drop it exists to forbid. Waiting on the handler to
+// finish writing cannot be the synchronisation either: correct backpressure
+// blocks the handler, so that would deadlock the fixed implementation. Waiting
+// on the buffer to reach capacity is the condition that works for both.
+func TestClaudeWakeSourceDeliversNewestEventUnderBufferSaturation(t *testing.T) {
+	const total = claudeWakeEventBuffer * 4
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		// A burst of non-pending frames first, exactly the shape that used to
+		// fill the buffer and swallow the pending wake that follows.
+		for seq := 1; seq < total; seq++ {
+			flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":%d,\"pending\":false}\n\n", seq)
+		}
+		flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":%d,\"pending\":true}\n\n", total)
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	subscription, err := source.Subscribe(ctx, 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, subscription.Close()) }()
+
+	// Saturate first, draining nothing. Only now is a drop observable.
+	require.Eventually(t, func() bool {
+		return len(subscription.(*restClaudeWakeSubscription).events) == claudeWakeEventBuffer
+	}, 10*time.Second, 10*time.Millisecond, "buffer should saturate while nothing drains")
+
+	deadline := time.After(10 * time.Second)
+	var highest uint64
+	var sawPending bool
+	for highest < total {
+		select {
+		case event, ok := <-subscription.Events():
+			require.True(t, ok, "stream closed before the newest wake arrived")
+			require.GreaterOrEqual(t, event.Seq, highest, "sequences must not go backwards")
+			highest = event.Seq
+			if event.Seq == total {
+				sawPending = event.Pending
+			}
+		case <-deadline:
+			t.Fatalf("newest wake was dropped; highest seen was %d of %d", highest, total)
+		}
+	}
+	require.Equal(t, uint64(total), highest, "the newest cursor must survive a saturated buffer")
+	require.True(t, sawPending, "the surviving newest event must retain pending=true")
+}
+
+// Close must release a reader parked on a full buffer rather than stranding the
+// goroutine, and must stay idempotent while doing it.
+func TestClaudeWakeSourceCloseReleasesReaderBlockedOnFullBuffer(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		for seq := 1; seq <= claudeWakeEventBuffer*4; seq++ {
+			flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":%d,\"pending\":true}\n\n", seq)
+		}
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	subscription, err := source.Subscribe(context.Background(), 0)
+	require.NoError(t, err)
+
+	// Let the reader fill the buffer and park on the send. Never drain.
+	require.Eventually(t, func() bool {
+		return len(subscription.(*restClaudeWakeSubscription).events) == claudeWakeEventBuffer
+	}, 5*time.Second, 10*time.Millisecond, "buffer should saturate while nothing drains")
+
+	closed := make(chan error, 1)
+	go func() { closed <- subscription.Close() }()
+	select {
+	case closeErr := <-closed:
+		require.NoError(t, closeErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close blocked behind a parked reader")
+	}
+
+	// The reader must finish and close Events even though it was mid-send.
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for range subscription.Events() {
+		}
+	}()
+	select {
+	case <-drained:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reader goroutine was stranded; Events never closed")
+	}
+
+	require.NoError(t, subscription.Close())
+}


### PR DESCRIPTION
## The gap

The Claude channel adapter shipped in #209 with **no production `ClaudeWakeSource` behind it**. Every implementation of the interface lives in a test file, so `ConfigureClaudeChannel` has no caller outside the package:

```
$ git grep -ln ConfigureClaudeChannel origin/main | grep -v _test.go
internal/mcp/claude_channel.go      # the file that defines it
```

The node half shipped separately in #210 and is fully live — `GET /v1/messages/wake` registered at `api/rest/server.go:837`, fed by `api/rest/messages_handler.go:140` via `publishMessageWake(msg.ToAgent, msg.WakeSeq)`. An unauthenticated probe of the running node returns 401 with the exact signed-header contract, so the route works.

Neither PR is defective. The seam between them was simply never built, which made the adapter opt-in with no way to opt in.

## What this adds

`restClaudeWakeSource` — the seam, and nothing more. It subscribes to the signed exact-recipient wake route as the server's own identity and translates SSE frames into `ClaudeWakeEvent`. It gains no ability to receive, claim, read, or acknowledge a message, preserving #209's deliberate narrowing where the host learns a cursor and never content or sender.

## Two load-bearing properties, both pinned by tests

**The stream client cannot be the server's request client.** `s.httpClient` sets `Timeout` (75s default), which bounds the *entire* request including body reads — it would sever a healthy SSE stream on a fixed timer and the break would masquerade as a reconnect. The transport is shared so TLS and CA resolution stay byte-identical.

**The consumer ID is random per process**, not derived from project or provider. The node supersedes a reconnect from the *same* consumer and rejects a *different* one with 409. A stable ID would therefore let a second Claude runtime silently steal the wake from a live one — exactly what the lease exists to prevent.

Retry policy deliberately stays with the adapter: a rejected subscribe returns an error rather than retrying here, so the shipped bounded backoff owns it.

## Verified live against a running node

Driven through the real code path, not a mock:

```
HARNESS baseURL=http://127.0.0.1:8080 consumer=claude-code-70f7d480ad373c3e
HARNESS subscribed OK — streaming wake events
HARNESS WAKE #1 version=1 seq=2 pending=true
```

Signed subscribe accepted, and a real wake delivered end to end after a message landed for that agent. The harness was temporary and is not part of this branch.

## Tests

8 new tests, green under `-race`. The timeout guard is mutation-checked: reusing the server's client makes it fail with `Should be zero, but was 1m15s`.

- stream client carries no whole-request timeout, shares the server transport
- consumer ID unique per source
- subscribe is signed and positioned (`after_seq`, `consumer_id`, `Accept`)
- rejected subscribe surfaces as an error (409 / 401 / 501)
- SSE translation, heartbeats ignored
- **never surfaces sender or content**, even when the node sends extra fields
- data outside a wake frame is dropped, no cross-frame attribution
- `Events` closes when the stream ends; `Close` idempotent

## Scope

Adapter/protocol-facing only, per the lane split. Does not touch wake-bus core, the Codex adapter, or control-plane reliability files. Enabling stays explicit via `SAGE_CLAUDE_CHANNEL`, default off, and failure to arm is non-fatal — the channel accelerates polling, so a host that cannot open the stream still gets an ordinary MCP session.

Base `ba006fa0e8ed3e3cb1f1ae9fea8c588baaf7a4a6` (= v11.18.12). Draft; not for merge without codex review.