### PR TITLE
fix(mcp): preserve claimant session across reply fallback

### DIFF
--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1041,6 +1041,12 @@ state; no original request workflow/read state or result content is exposed.
 
 **REST:** `POST /v1/messages/{message_id}/reply`.
 
+MCP falls back to the deprecated pipe-result route only when an older node
+returns a non-Problem-Details 404 for the missing Messages route. A current
+typed `https://sage.dev/errors/404` response is an authoritative
+non-enumerating denial, including after a claimant-session handoff, and is
+never retried through the compatibility endpoint.
+
 ---
 
 ### sage_message_status
@@ -1892,6 +1898,12 @@ labels, result bytes, or pipe identifiers; foreign completion returns
 says the result was **queued for delivery**, not delivered; if retry later
 becomes terminal, the completing agent receives a `message_delivery_updates`
 notice on `sage_turn`.
+
+For local canonical messages, this compatibility alias supplies the current
+MCP runtime's claimant session and obeys the same typed-404 fence as
+`sage_message_reply`; it cannot be used by a sibling runtime to complete work
+after that claim was handed away. Responses report the actual `scope` as
+`local` or `federated`, and expose `reply_event_id` only for a federated result.
 
 **REST:** `PUT /v1/pipe/{pipe_id}/result`
 

--- a/internal/mcp/messages_tools_test.go
+++ b/internal/mcp/messages_tools_test.go
@@ -266,6 +266,7 @@ func TestMessageReplyRetainsPlain404LegacyFallbackAndLocalScope(t *testing.T) {
 		legacyResultCalls++
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"status": "completed", "journal_id": "journal-legacy", "journaled": true,
+			"reply_event_id": "must-not-be-local", "reply_status": "forged",
 		})
 	})
 	ts := httptest.NewServer(mux)
@@ -281,6 +282,7 @@ func TestMessageReplyRetainsPlain404LegacyFallbackAndLocalScope(t *testing.T) {
 	response := result.(map[string]any)
 	require.Equal(t, "local", response["scope"])
 	require.NotContains(t, response, "reply_event_id")
+	require.NotContains(t, response, "reply_status")
 	require.Contains(t, response["message"], "legacy local pipeline")
 	require.Equal(t, 2, canonicalCalls,
 		"the compatibility helper rechecks canonical Messages before using the old endpoint")

--- a/internal/mcp/messages_tools_test.go
+++ b/internal/mcp/messages_tools_test.go
@@ -131,6 +131,165 @@ func TestCanonicalMessageToolsSendReceiveReplyAndStatus(t *testing.T) {
 	require.Contains(t, status.(map[string]any)["message"], "does not prove comprehension")
 }
 
+func writeCanonical404ForMCPTest(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(http.StatusNotFound)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"type": canonicalNotFoundProblemType, "title": "Message not found",
+		"status": http.StatusNotFound, "detail": "The message is unavailable to this claimant session.",
+	})
+}
+
+func TestMessageReplyCannotFallbackAcrossSameAgentClaimantSessions(t *testing.T) {
+	var claimA string
+	canonicalCalls := 0
+	pipePreflightCalls := 0
+	legacyResultCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/messages/msg-session/reply", func(w http.ResponseWriter, r *http.Request) {
+		canonicalCalls++
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		if body["claimant_session_id"] != claimA {
+			writeCanonical404ForMCPTest(w)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"message_id": "msg-session", "status": "completed"})
+	})
+	mux.HandleFunc("/v1/pipe/msg-session", func(w http.ResponseWriter, _ *http.Request) {
+		pipePreflightCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"pipe_id": "msg-session", "status": "claimed"})
+	})
+	mux.HandleFunc("/v1/pipe/msg-session/result", func(w http.ResponseWriter, _ *http.Request) {
+		legacyResultCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "completed"})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	sessionA := NewServer(ts.URL, privateKey)
+	sessionB := NewServer(ts.URL, privateKey)
+	claimA, err = sessionA.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	claimB, err := sessionB.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	require.NotEqual(t, claimA, claimB)
+
+	_, err = sessionB.toolMessageReply(context.Background(), map[string]any{
+		"message_id": "msg-session", "result": "stale",
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, canonicalCalls, "a typed denial must be the only attempt")
+	require.Zero(t, pipePreflightCalls, "a typed denial must not enter the compatibility path")
+	require.Zero(t, legacyResultCalls, "a sibling session must not bypass through pipe result")
+
+	result, err := sessionA.toolMessageReply(context.Background(), map[string]any{
+		"message_id": "msg-session", "result": "done",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "local", result.(map[string]any)["scope"])
+	require.Equal(t, 2, canonicalCalls)
+	require.Zero(t, pipePreflightCalls)
+	require.Zero(t, legacyResultCalls)
+}
+
+func TestPipeResultAliasCannotOmitOrBypassClaimantSession(t *testing.T) {
+	var claimA, seenSession string
+	canonicalCalls := 0
+	legacyResultCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/pipe/msg-hidden", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"pipe_id": "msg-hidden", "status": "claimed"})
+	})
+	mux.HandleFunc("/v1/messages/msg-hidden/reply", func(w http.ResponseWriter, r *http.Request) {
+		canonicalCalls++
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		seenSession, _ = body["claimant_session_id"].(string)
+		if seenSession != claimA {
+			writeCanonical404ForMCPTest(w)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"message_id": "msg-hidden", "status": "completed"})
+	})
+	mux.HandleFunc("/v1/pipe/msg-hidden/result", func(w http.ResponseWriter, _ *http.Request) {
+		legacyResultCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "completed"})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	sessionA := NewServer(ts.URL, privateKey)
+	sessionB := NewServer(ts.URL, privateKey)
+	claimA, err = sessionA.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	claimB, err := sessionB.claimantSessionID(context.Background())
+	require.NoError(t, err)
+
+	_, err = sessionB.toolPipeResult(context.Background(), map[string]any{
+		"pipe_id": "msg-hidden", "result": "stale",
+	})
+	require.Error(t, err)
+	require.Equal(t, claimB, seenSession, "the hidden alias must send its runtime claimant session")
+	require.Equal(t, 1, canonicalCalls)
+	require.Zero(t, legacyResultCalls, "a canonical typed denial must not fall through")
+
+	result, err := sessionA.toolPipeResult(context.Background(), map[string]any{
+		"pipe_id": "msg-hidden", "result": "done",
+	})
+	require.NoError(t, err)
+	require.Equal(t, claimA, seenSession)
+	require.Equal(t, "local", result.(map[string]any)["scope"])
+	require.Equal(t, 2, canonicalCalls)
+	require.Zero(t, legacyResultCalls)
+}
+
+func TestMessageReplyRetainsPlain404LegacyFallbackAndLocalScope(t *testing.T) {
+	canonicalCalls := 0
+	legacyResultCalls := 0
+	var claimantSessions []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/messages/msg-legacy/reply", func(w http.ResponseWriter, r *http.Request) {
+		canonicalCalls++
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		claimantSession, _ := body["claimant_session_id"].(string)
+		claimantSessions = append(claimantSessions, claimantSession)
+		http.Error(w, "route not found", http.StatusNotFound)
+	})
+	mux.HandleFunc("/v1/pipe/msg-legacy", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"pipe_id": "msg-legacy", "status": "claimed"})
+	})
+	mux.HandleFunc("/v1/pipe/msg-legacy/result", func(w http.ResponseWriter, r *http.Request) {
+		legacyResultCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "completed", "journal_id": "journal-legacy", "journaled": true,
+		})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	s := NewServer(ts.URL, privateKey)
+
+	result, err := s.toolMessageReply(context.Background(), map[string]any{
+		"message_id": "msg-legacy", "result": "done",
+	})
+	require.NoError(t, err)
+	response := result.(map[string]any)
+	require.Equal(t, "local", response["scope"])
+	require.NotContains(t, response, "reply_event_id")
+	require.Contains(t, response["message"], "legacy local pipeline")
+	require.Equal(t, 2, canonicalCalls,
+		"the compatibility helper rechecks canonical Messages before using the old endpoint")
+	require.Equal(t, 1, legacyResultCalls)
+	require.Len(t, claimantSessions, 2)
+	require.NotEmpty(t, claimantSessions[0])
+	require.Equal(t, claimantSessions[0], claimantSessions[1])
+}
+
 func TestMessageSendSurfacesInboundThatArrivedAfterPriorEmptyPoll(t *testing.T) {
 	var inboxChecks int
 	var sendSucceeded bool

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -6462,7 +6462,7 @@ func (s *Server) toolPipeResult(ctx context.Context, params map[string]any) (any
 		"scope":      scope,
 		"message":    message,
 	}
-	if resp.ReplyEventID != "" {
+	if federated && resp.ReplyEventID != "" {
 		response["reply_event_id"] = resp.ReplyEventID
 		response["reply_status"] = resp.ReplyStatus
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -675,6 +675,20 @@ func isLegacySelfPolicyRouteNotFound(err error) bool {
 		!strings.HasPrefix(problem.ContentType, "application/problem+json")
 }
 
+const canonicalNotFoundProblemType = "https://sage.dev/errors/404"
+
+// isLegacyMessagesRouteNotFound recognizes only an older node that lacks the
+// canonical Messages route. A current node intentionally uses the same
+// non-enumerating typed 404 for missing, unauthorized, and stale-session
+// replies; treating that denial as a route miss would let the compatibility
+// pipe endpoint bypass the claimant-session fence.
+func isLegacyMessagesRouteNotFound(err error) bool {
+	if !isAPIStatus(err, http.StatusNotFound) {
+		return false
+	}
+	return !isCanonicalAPIProblem(err, canonicalNotFoundProblemType, http.StatusNotFound)
+}
+
 // resolveWriteDomain preserves an explicitly requested domain exactly. Only an
 // omitted/empty domain is eligible for the app-v23 convenience default: the
 // signed caller's approved owned home domain from its self-scoped profile.
@@ -4836,19 +4850,23 @@ func (s *Server) toolMessageReply(ctx context.Context, params map[string]any) (a
 	body, _ := json.Marshal(map[string]any{"result": result, "claimant_session_id": claimantSessionID})
 	var response map[string]any
 	if err := s.doSignedJSON(ctx, http.MethodPost, "/v1/messages/"+url.PathEscape(messageID)+"/reply", body, &response); err != nil {
-		if !isAPIStatus(err, http.StatusNotFound) {
+		if !isLegacyMessagesRouteNotFound(err) {
 			return nil, fmt.Errorf("message reply: %w", err)
 		}
 		legacy, legacyErr := s.toolPipeResult(ctx, map[string]any{"pipe_id": messageID, "result": result})
 		if legacyErr != nil {
-			return nil, fmt.Errorf("federated message reply: %w", legacyErr)
+			return nil, fmt.Errorf("legacy message reply: %w", legacyErr)
 		}
 		response = legacy.(map[string]any)
 		response["message_id"] = messageID
-		response["scope"] = "federated"
-		response["message"] = "Reply queued over the trusted connection. reply_event_id is the immutable outbound reply receipt; pass it to sage_message_status to inspect delivery without creating another inbox request. Repeating the same federated event is deduplicated by the receiving SAGE."
+		if response["scope"] == "federated" {
+			response["message"] = "Reply queued over the trusted connection. reply_event_id is the immutable outbound reply receipt; pass it to sage_message_status to inspect delivery without creating another inbox request. Repeating the same federated event is deduplicated by the receiving SAGE."
+		} else {
+			response["message"] = "Reply recorded through the legacy local pipeline service."
+		}
 		return response, nil
 	}
+	response["scope"] = "local"
 	response["message"] = "Reply recorded. Repeating this exact reply is safe; a different second reply is rejected."
 	return response, nil
 }
@@ -6394,15 +6412,23 @@ func (s *Server) toolPipeResult(ctx context.Context, params map[string]any) (any
 	}
 	body, _ := json.Marshal(bodyFields)
 	if !federated {
+		claimantSessionID, err := s.claimantSessionID(ctx)
+		if err != nil {
+			return nil, err
+		}
+		canonicalBody, _ := json.Marshal(map[string]any{
+			"result": result, "claimant_session_id": claimantSessionID,
+		})
 		var canonical map[string]any
-		err := s.doSignedJSON(ctx, http.MethodPost, "/v1/messages/"+url.PathEscape(pipeID)+"/reply", body, &canonical)
+		err = s.doSignedJSON(ctx, http.MethodPost, "/v1/messages/"+url.PathEscape(pipeID)+"/reply", canonicalBody, &canonical)
 		if err == nil {
 			return map[string]any{
 				"status": canonical["status"], "journal_id": "", "journaled": false,
+				"scope":   "local",
 				"message": "Result delivered through the idempotent local Messages service. The requesting agent can query exact workflow and read status.",
 			}, nil
 		}
-		if !isAPIStatus(err, http.StatusNotFound) {
+		if !isLegacyMessagesRouteNotFound(err) {
 			return nil, fmt.Errorf("pipeline result: %w", err)
 		}
 		// Definite route miss on an older node: use the compatibility endpoint.
@@ -6425,10 +6451,15 @@ func (s *Server) toolPipeResult(ctx context.Context, params map[string]any) (any
 	} else if resp.Journaled {
 		message += " A local journal entry was created summarizing the exchange."
 	}
+	scope := "local"
+	if federated {
+		scope = "federated"
+	}
 	response := map[string]any{
 		"status":     resp.Status,
 		"journal_id": resp.JournalID,
 		"journaled":  resp.Journaled,
+		"scope":      scope,
 		"message":    message,
 	}
 	if resp.ReplyEventID != "" {


### PR DESCRIPTION
Closes the claimant-session compatibility bypass found during the v11.18.13 SAGE backlog audit.\n\nA current canonical typed 404 is now authoritative and never falls through to the legacy pipe-result mutation. The hidden sage_pipe_result alias sends the active runtime claimant session on its canonical local attempt. Truly old plain-404 nodes retain compatibility, and responses report truthful local/federated scope.\n\nVerified locally:\n- full internal/mcp package\n- targeted internal/store claimant-session tests\n- canonical REST message tests\n- targeted race suite and go vet\n- documentation citation guard\n- independent mutations for both fallback guards, omitted claimant session, and false scope all fail\n\nDraft only pending two exact-head reviews and hosted gates.