### PR TITLE
release: SAGE v11.18.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,36 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.13
+
+**Hubanov's distributed-engram contribution now connects memories to the
+neurons that corroborated them.** CEREBRUM keeps agent and memory identities in
+separate graph namespaces, rejects stale bloom generations, and removes every
+transient bridge on focus or graph replacement. The server uses a deterministic,
+indexed 96-row evidence prefix and exposes at most 12 authorized bridges without
+turning historical corroboration into a claim of current possession.
+
+**Claude's production wake source can now arm the payload-free message bus.**
+When explicitly enabled with `SAGE_CLAUDE_CHANNEL`, the MCP runtime consumes the
+existing signed SSE wake route with a random process lease and resumable cursor.
+Delivery applies backpressure instead of dropping the newest wake, and shutdown
+releases saturated readers without leaking goroutines or claiming message
+content.
+
+**The Connectome no longer floats an instructional card over the brain.** Its
+guidance lives in the existing reading panel, the mode toggle keeps one stable
+name and visible pressed state in both themes, keyboard focus remains clear,
+mobile Reset behavior stays intentional, and view changes are announced to
+assistive technology.
+
+This patch also closes a claimant-session compatibility bypass: a current typed
+404 is authoritative, the deprecated pipe-result alias carries the active MCP
+session, and only a genuine old-node route miss may fall back. It introduces no
+new consensus application version or state migration. The ceiling remains
+app-v26; **v11.18.13 introduces no app-v27**.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.13`. SDK 11.18.13.
+
 ## What's New in v11.18.12
 
 **CEREBRUM can now open an agent as a memory lobe.** Selecting a connectome
@@ -1797,7 +1827,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.12`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.13`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/SECURITY_FAQ.md
+++ b/SECURITY_FAQ.md
@@ -11,7 +11,7 @@ SAGE has two distinct deployment models with fundamentally different threat mode
 | **Who** | One user, one local operator | Multiple agents, teams, organizations |
 | **Trust model** | User IS the only validator | Byzantine fault tolerance across validators |
 | **Database** | Local BadgerDB/SQLite stores in `~/.sage/data/` | BadgerDB consensus state plus off-chain mirror |
-| **Release** | v11.18.12 personal-node surface | v11.18.12 quorum/federation surface |
+| **Release** | v11.18.13 personal-node surface | v11.18.13 quorum/federation surface |
 
 Many concerns raised about the enterprise codebase do not apply to SAGE Personal, and vice versa. Each item below is tagged with which deployment it affects.
 
@@ -108,7 +108,7 @@ The `make byzantine` target and GitHub Actions CI job spin up a 4-validator Dock
 
 The following boundaries describe the current v11 codebase:
 
-**SAGE Personal (sage-gui v11.18.12):**
+**SAGE Personal (sage-gui v11.18.13):**
 - Designed for one operator. The management dashboard/API remains a local surface; anyone with access to the operator session or machine should be treated as trusted.
 - Federation is an explicit network-facing feature, off by default. When enabled it uses a separate pinned-mTLS listener, active on-chain treaty checks, chain-qualified signed requests, and replay protection. That authenticated protocol now runs over libp2p NAT traversal and Circuit Relay v2; the relay sees encrypted traffic and connection metadata, not plaintext memories or federation keys.
 - SQLite database supports optional AES-256-GCM encryption at rest (Synaptic Ledger). Enable from CEREBRUM Settings → Security.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.12
+  version: 11.18.13
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -205,7 +205,29 @@ func runMCP() error {
 	if projectDir, cwdErr := os.Getwd(); cwdErr == nil {
 		selfHealProject(projectDir, home, os.Getenv("SAGE_PROVIDER"), keyPath)
 	}
+	// The Claude channel stays opt-in, and a failure to arm it is deliberately
+	// not fatal: the wake channel is an accelerator over polling, so a host
+	// that cannot open the stream must still get an ordinary working MCP
+	// session rather than no session at all.
+	if claudeChannelEnabled() {
+		if err := server.EnableRESTClaudeChannel(); err != nil {
+			fmt.Fprintf(os.Stderr, "SAGE MCP: claude channel disabled: %v\n", err)
+		}
+	}
 	return server.Run(context.Background())
+}
+
+// claudeChannelEnabled reports whether the operator explicitly armed the
+// experimental Claude wake channel. Default-off is the shipped contract of the
+// adapter itself, so absence means off and an unparseable value means off —
+// envBool already warns on the latter rather than guessing.
+func claudeChannelEnabled() bool {
+	raw := os.Getenv("SAGE_CLAUDE_CHANNEL")
+	if strings.TrimSpace(raw) == "" {
+		return false
+	}
+	enabled, ok := envBool("SAGE_CLAUDE_CHANNEL", raw)
+	return ok && enabled
 }
 
 // configuredMCPIdentityEnv separates an explicitly pinned MCP registration

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.12-acceptance
+ARG VERSION=v11.18.13-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.12 federation Docker acceptance
+# v11.18.13 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.12-acceptance
+        VERSION: v11.18.13-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.12"
+version = "11.18.13"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.12"
+version = "11.18.13"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.12",
+  "version": "11.18.13",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.12/app-v26. -->
+<!-- Reconciled through SAGE v11.18.13/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.12 federation behavior. -->
+<!-- Verified against SAGE v11.18.13 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.12
+# sage-gui v11.18.13
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.12 advertises 33 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.13 advertises 33 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.12 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.13 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -47,13 +47,45 @@ projection-safe agent-as-lobe engram view, hardens the exact 20-event operator
 dashboard SSE registry, restores signed task creation across official clients,
 adds exact-agent message presentation without changing claim/read/delivery
 semantics, and repairs release-facing documentation drift with fail-closed
-citation coverage. The supported consensus ceiling remains app-v26;
-**v11.18.12 does not introduce app-v27**.
+citation coverage. v11.18.13 ships Hubanov's distributed-engram bridges with
+deterministic bounded corroborator evidence and lifecycle hardening, removes
+the floating Connectome caption while strengthening mode accessibility, adds
+Claude's explicitly enabled signed production wake source with lossless
+backpressure, and closes the MCP claimant-session compatibility fallback
+bypass. The supported consensus ceiling remains app-v26;
+**v11.18.13 does not introduce app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.13 patch
+
+Hubanov's distributed-engram contribution now blooms a selected agent's visible
+memories with transient links to rendered corroborating neurons. Agent and
+memory graph identities are namespaced, same-neuron requests are generation
+fenced, and every exit or replacement path removes transient nodes and bridges.
+SQLite and PostgreSQL read one deterministically ordered, indexed 96-row
+evidence prefix before authorization and deduplication; the response exposes at
+most 12 bridges and keeps corroboration documented as historical evidence.
+
+The floating Connectome instruction card is removed. Guidance uses the existing
+reading panel, while native controls retain keyboard focus, stable toggle
+semantics, visible dark/light pressed states, intentional mobile Reset behavior,
+and a live assistive status announcement.
+
+Claude's production MCP wake source is opt-in through `SAGE_CLAUDE_CHANNEL` and
+consumes the existing signed, payload-free SSE route with a random process lease
+and resumable cursor. Saturated delivery is lossless and shutdown releases the
+reader before a consumer drains buffered events.
+
+Canonical typed message-reply denials no longer fall through the deprecated
+pipe mutation. The hidden compatibility alias supplies the active claimant
+session, preserves genuine plain-404 old-node fallback, and reports truthful
+local/federated scope. This patch introduces no new consensus application
+version or state migration: app-v26 remains the ceiling and v11.18.13 does not
+introduce app-v27.
 
 ## v11.18.12 patch
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -103,6 +103,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.10 | Same-agent MCP claimant-session ownership and atomic handoff, stale-session reply rejection, passive recovery, the CEREBRUM agent-connectome view, and bounded upgrade-watchdog broadcasts that retain indeterminate signer fencing; no new app version; app-v26 remains the ceiling |
 | v11.18.11 | Operator-only live connectome firing via contentless ticks and authorized snapshot refetch, contentless retrieval activity, payload-free Claude inbox visibility with hook self-heal, chain-ID locality, Windows executable checksums, and patched Go 1.25.13; no new app version; app-v26 remains the ceiling |
 | v11.18.12 | Projection-safe agent-as-lobe engrams, exact dashboard SSE registry coverage, signed task-status repair across official clients, exact-agent message presentation, and fail-closed documentation citation coverage; no new app version; app-v26 remains the ceiling |
+| v11.18.13 | Hubanov distributed-engram bridges with bounded deterministic corroborator evidence, accessible Connectome guidance without a floating card, Claude signed production wake source with lossless shutdown, and claimant-session-safe reply fallback; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.12. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.13. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -34,7 +34,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.12 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.13 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -205,7 +205,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.12)
+## Related docs (reconciled through v11.18.13)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.12.
+Status: implementation contract through SAGE v11.18.13.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.12 authorization layer is off-consensus and does not require
+The current v11.18.13 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/memory-lifecycle.md
+++ b/docs/reference/concepts/memory-lifecycle.md
@@ -135,6 +135,14 @@ Memory type, author-supplied confidence, and caller-supplied challenge strength 
 
 `TxTypeMemoryCorroborate` writes a `Corroboration` row to the serving projection and, under app-v10+, one deduplicated `corrob:<memory>:<agent>` marker to AppHash-covered BadgerDB. It does **not** change the memory's lifecycle status. The SQL distinct-agent count drives query-time confidence; the canonical markers are the only corroborations app-v21 may consult during deterministic challenge execution.
 
+The CEREBRUM distributed-engram projection treats those corroborations as
+historical support evidence. A bridge means that a registered, caller-visible
+agent corroborated the memory; it does not assert current possession, liveness,
+or an active message session. The projection names only a bounded visible
+subset and preserves the full distinct total as `corroboration_count`.
+Challenged and deprecated memories do not bloom. A governed reinstatement
+returns the memory to `committed`, making it eligible for the projection again.
+
 ---
 
 ## Node-Local vs. On-Chain Data

--- a/docs/reference/concepts/memory-lifecycle.md
+++ b/docs/reference/concepts/memory-lifecycle.md
@@ -138,8 +138,11 @@ Memory type, author-supplied confidence, and caller-supplied challenge strength 
 The CEREBRUM distributed-engram projection treats those corroborations as
 historical support evidence. A bridge means that a registered, caller-visible
 agent corroborated the memory; it does not assert current possession, liveness,
-or an active message session. The projection names only a bounded visible
-subset and preserves the full distinct total as `corroboration_count`.
+or an active message session. The projection reads at most the first 96 raw rows
+ordered by `created_at`, `agent_id`, and row `id`, then visibility-filters and
+deduplicates that prefix to at most 12 named bridges. Eligible identities beyond
+the raw prefix can therefore remain count-only. The full distinct total is
+preserved separately as `corroboration_count`.
 Challenged and deprecated memories do not bloom. A governed reinstatement
 returns the memory to `committed`, making it eligible for the projection again.
 

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.12 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.13 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/message-wake-bus.md
+++ b/docs/reference/concepts/message-wake-bus.md
@@ -79,3 +79,29 @@ pipeline-agent boundary. It does not use the dashboard `OnEvent` broadcaster.
 The older HTTP-MCP `notifications/sage_message` bridge remains a separate,
 best-effort compatibility notification for already-open MCP SSE sessions and
 does not define this durable sequence contract.
+
+## Claude wake channel enablement
+
+The Claude host adapter is the one shipped consumer of this route. It is
+**off by default** and is armed only by setting `SAGE_CLAUDE_CHANNEL` for
+`sage-gui mcp`, the stdio MCP server a Claude host launches
+(`cmd/sage-gui/mcp.go:224`). Constructing an MCP `Server` never advertises or
+emits the experimental protocol on its own; enabling is an explicit call
+(`internal/mcp/claude_wake_source.go:84`, `internal/mcp/claude_channel.go:50`).
+
+When armed, the adapter subscribes to this agent's own signed wake stream and
+turns a new durable cursor into a `notifications/claude/channel` JSON-RPC
+notification, so the host can stop polling its inbox on a timer.
+
+The channel is **only a poll accelerator, and it is payload-free**. A wake
+carries `version`, `seq`, and `pending` and nothing else, so the host learns
+that unclaimed work exists and never learns its content, its sender, or how
+many messages are waiting. The host still calls the canonical inbox operation
+to see or claim anything, and that operation remains the only thing that
+affects message lifecycle state.
+
+Two consequences follow from the lease described above. A second runtime for
+the same agent is rejected with 409 rather than silently sharing the wake, so
+the wake accelerates exactly one runtime at a time. And because the channel
+only accelerates polling, failing to arm it is not fatal: a host that cannot
+open the stream still gets an ordinary MCP session and ordinary polling.

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.12/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.13/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.12. Legacy organization/federation sections retain
+Verified against SAGE v11.18.13. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.12. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.13. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.12**.
+and is **not in v11.18.13**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.12. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.13. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -154,6 +154,7 @@ legacy Ollama vector space over a requested custom one (`cmd/amid/main.go`).
 |----------|--------------|---------|---------|--------|
 | `SAGE_SNAPSHOT_KEEP` | Snapshots to retain (newest N + per-version anchors, which are never pruned). Integer ≥ 1. | `5` | sage-gui | `cmd/sage-gui/node.go:262`, `cmd/sage-gui/snapshot.go:56` |
 | `SAGE_BRANCH_TAG` | Set `0`/`false`/`no` to disable branch tagging of memories. | on | MCP | `internal/mcp/branch.go:27` |
+| `SAGE_CLAUDE_CHANNEL` | Opt-in for the experimental Claude wake channel. When on, `sage-gui mcp` subscribes to this agent's signed `/v1/messages/wake` stream and emits a `notifications/claude/channel` JSON-RPC notification so the host can stop polling. Payload-free: the host learns only a durable wake cursor, never message content or sender. Accepts the usual boolean spellings; an unrecognized value warns and stays off. Failure to arm is non-fatal and leaves an ordinary MCP session. | off | sage-gui MCP (stdio) | `cmd/sage-gui/mcp.go:224`, `internal/mcp/claude_wake_source.go:84` |
 
 ---
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.12 code (2026-08-14). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.13 code (2026-08-15). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1041,6 +1041,12 @@ state; no original request workflow/read state or result content is exposed.
 
 **REST:** `POST /v1/messages/{message_id}/reply`.
 
+MCP falls back to the deprecated pipe-result route only when an older node
+returns a non-Problem-Details 404 for the missing Messages route. A current
+typed `https://sage.dev/errors/404` response is an authoritative
+non-enumerating denial, including after a claimant-session handoff, and is
+never retried through the compatibility endpoint.
+
 ---
 
 ### sage_message_status
@@ -1892,6 +1898,12 @@ labels, result bytes, or pipe identifiers; foreign completion returns
 says the result was **queued for delivery**, not delivered; if retry later
 becomes terminal, the completing agent receives a `message_delivery_updates`
 notice on `sage_turn`.
+
+For local canonical messages, this compatibility alias supplies the current
+MCP runtime's claimant session and obeys the same typed-404 fence as
+`sage_message_reply`; it cannot be used by a sibling runtime to complete work
+after that claim was handed away. Responses report the actual `scope` as
+`local` or `federated`, and expose `reply_event_id` only for a federated result.
 
 **REST:** `PUT /v1/pipe/{pipe_id}/result`
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.12.
+Reconciled against internal/mcp for SAGE v11.18.13.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.12. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.13. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.12
+**Package:** `sage-agent-sdk` **Version:** 11.18.13
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -999,7 +999,7 @@ Pre-app-v23 nodes retain their legacy projection behavior.
 | `GET /v1/dashboard/memory/adoption-progress` | Root/operator aggregate App-v25 historical-recovery progress. It returns counts and state only—never the hidden records' content, domains, authors, or reasons. |
 | `POST /v1/dashboard/memory/adoption-retry` | Current-Root-only request for a fresh scan of the exact unresolved App-v25 snapshot. Requires the `projection_revision` field (zero is valid for a first upgraded snapshot) and a positive `expected_count`; it never deletes rows or clears earlier dispositions. |
 | `POST /v1/dashboard/memory/adoption-deprecate` | Current-Root-only retirement of the exact unresolved snapshot. Requires the `projection_revision` field (including valid zero), positive `expected_count`, and typed `DEPRECATE <count>` confirmation. Records remain preserved for audit and are skipped by future automatic repair. |
-| `GET /v1/dashboard/network/synapses` | Operator-only Connectome snapshot: registered agent neurons plus directed retained-message traffic, filtered so both edge endpoints are visible to the caller. |
+| `GET /v1/dashboard/network/synapses` | Operator-only Connectome snapshot: current active ordinary app-v23 agent neurons plus directed retained-message traffic, filtered so both edge endpoints are visible to the caller. Pending, removed, and Root identities are not rendered. Pre-app-v23 nodes retain the legacy registered-agent roster. |
 | `GET /v1/dashboard/memory/engrams?agent={id}` | Operator-only, projection-gated top committed memories authored by one visible neuron, with bounded corroborator bridge identities. |
 
 The engram response is capped at 24 memories in descending confidence order.
@@ -1007,15 +1007,15 @@ Each item contains the true distinct `corroboration_count`, while
 `corroborators` contains at most 12 identities selected from the first 96 raw
 corroboration rows ordered by `created_at`, `agent_id`, then row `id`; that raw
 prefix is bounded in SQL before filtering and deduplication. An identity is
-named only when it is already a registered Connectome neuron and is visible to
+named only when it is already a current active ordinary Connectome neuron and is visible to
 the caller. Hidden, external, duplicate, excess, unavailable, and otherwise
 eligible identities beyond the 96-row prefix remain anonymous inside the true
 distinct count. A missing registry or failed bounded read withholds all bridge
 identities without hiding the count. The
 identity list is historical corroboration evidence, not a claim that the peer
 currently possesses a copy. Challenged and deprecated memories are omitted;
-reinstatement makes a memory eligible again because it is committed. Registered
-neurons remain the Connectome identity boundary even when traffic has gone
+reinstatement makes a memory eligible again because it is committed. Active
+ordinary neurons remain the Connectome identity boundary even when traffic has gone
 dormant—the view represents dormancy by activity, not by rewriting history
 (`handleEngrams`, `web/engrams_handler.go`; `handleSynapses`,
 `web/synapse_handler.go`).

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.12. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.13. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -999,6 +999,23 @@ Pre-app-v23 nodes retain their legacy projection behavior.
 | `GET /v1/dashboard/memory/adoption-progress` | Root/operator aggregate App-v25 historical-recovery progress. It returns counts and state only—never the hidden records' content, domains, authors, or reasons. |
 | `POST /v1/dashboard/memory/adoption-retry` | Current-Root-only request for a fresh scan of the exact unresolved App-v25 snapshot. Requires the `projection_revision` field (zero is valid for a first upgraded snapshot) and a positive `expected_count`; it never deletes rows or clears earlier dispositions. |
 | `POST /v1/dashboard/memory/adoption-deprecate` | Current-Root-only retirement of the exact unresolved snapshot. Requires the `projection_revision` field (including valid zero), positive `expected_count`, and typed `DEPRECATE <count>` confirmation. Records remain preserved for audit and are skipped by future automatic repair. |
+| `GET /v1/dashboard/network/synapses` | Operator-only Connectome snapshot: registered agent neurons plus directed retained-message traffic, filtered so both edge endpoints are visible to the caller. |
+| `GET /v1/dashboard/memory/engrams?agent={id}` | Operator-only, projection-gated top committed memories authored by one visible neuron, with bounded corroborator bridge identities. |
+
+The engram response is capped at 24 memories in descending confidence order.
+Each item contains the true distinct `corroboration_count`, while
+`corroborators` contains at most 12 identities from a stable, SQL-bounded raw
+prefix. An identity is named only when it is already a registered Connectome
+neuron and is visible to the caller; hidden, external, excess, and unavailable
+identities remain anonymous inside the count. A missing registry or failed
+bounded read withholds all bridge identities without hiding the count. The
+identity list is historical corroboration evidence, not a claim that the peer
+currently possesses a copy. Challenged and deprecated memories are omitted;
+reinstatement makes a memory eligible again because it is committed. Registered
+neurons remain the Connectome identity boundary even when traffic has gone
+dormant—the view represents dormancy by activity, not by rewriting history
+(`handleEngrams`, `web/engrams_handler.go`; `handleSynapses`,
+`web/synapse_handler.go`).
 
 In v11.18.0 CEREBRUM presents this control plane as three explicit tabs:
 **Agents**, **Groups**, and **Federation**. Each tab uses a bounded compact list
@@ -2253,7 +2270,7 @@ address resolved from a bounded legacy-status offline cache can be accepted
 locally while the peer is down. Delivery waits for that peer to return and pass
 the fresh live authorization preflight above.
 
-**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:513-515`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6338` payload, `:6341` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:527-529`) to 413.
+**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:513-515`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6367` payload, `:6370` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:527-529`) to 413.
 
 **Open-pipe quota → HTTP 429 + `Retry-After`.** A single verified agent identity may hold at most 256 non-terminal (pending or claimed) pipes open at once, and a node caps 10000 across all requesters (`MaxOpenPipesPerAgent`/`MaxOpenPipesGlobal`). An index-backed COUNT and its INSERT run under the same write critical section, so parallel sends cannot race past either cap. Over-quota inserts are rejected as **429 with `Retry-After`** (`ErrPipeQuotaPerAgent`/`ErrPipeQuotaGlobal`), keyed on the Ed25519-verified `from_agent`, not the spoofable rate-limit header. This mirrors the mempool-full recipe (see `GET /v1/chain/backpressure` below): treat it as backpressure and retry after the hinted interval, not as a per-agent rate-limit breach.
 
@@ -2475,7 +2492,7 @@ the result over the original agreement-bound return route
 | `source_pipe_id` | string | for foreign work | Stable source proof/event ID returned with the inbox item; prevents replying against stale foreign metadata |
 | `source_chain_id` | string | for foreign work | Exact local reply-source chain returned as `reply_source_chain_id` by the pipe status preflight; prevents another node relabeling the signed result |
 
-`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:513`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6604`, mapping `ErrPipeResultTooLarge`).
+`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:513`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6633`, mapping `ErrPipeResultTooLarge`).
 
 **Response** (HTTP 200):
 `{"status":"completed","journal_id":"<memory_id or empty>","journaled":true|false}`.

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -2253,7 +2253,7 @@ address resolved from a bounded legacy-status offline cache can be accepted
 locally while the peer is down. Delivery waits for that peer to return and pass
 the fresh live authorization preflight above.
 
-**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:513-515`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6333` payload, `:6336` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:527-529`) to 413.
+**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:513-515`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6338` payload, `:6341` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:527-529`) to 413.
 
 **Open-pipe quota → HTTP 429 + `Retry-After`.** A single verified agent identity may hold at most 256 non-terminal (pending or claimed) pipes open at once, and a node caps 10000 across all requesters (`MaxOpenPipesPerAgent`/`MaxOpenPipesGlobal`). An index-backed COUNT and its INSERT run under the same write critical section, so parallel sends cannot race past either cap. Over-quota inserts are rejected as **429 with `Retry-After`** (`ErrPipeQuotaPerAgent`/`ErrPipeQuotaGlobal`), keyed on the Ed25519-verified `from_agent`, not the spoofable rate-limit header. This mirrors the mempool-full recipe (see `GET /v1/chain/backpressure` below): treat it as backpressure and retry after the hinted interval, not as a per-agent rate-limit breach.
 
@@ -2475,7 +2475,7 @@ the result over the original agreement-bound return route
 | `source_pipe_id` | string | for foreign work | Stable source proof/event ID returned with the inbox item; prevents replying against stale foreign metadata |
 | `source_chain_id` | string | for foreign work | Exact local reply-source chain returned as `reply_source_chain_id` by the pipe status preflight; prevents another node relabeling the signed result |
 
-`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:513`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6597`, mapping `ErrPipeResultTooLarge`).
+`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:513`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6604`, mapping `ErrPipeResultTooLarge`).
 
 **Response** (HTTP 200):
 `{"status":"completed","journal_id":"<memory_id or empty>","journaled":true|false}`.

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1004,11 +1004,14 @@ Pre-app-v23 nodes retain their legacy projection behavior.
 
 The engram response is capped at 24 memories in descending confidence order.
 Each item contains the true distinct `corroboration_count`, while
-`corroborators` contains at most 12 identities from a stable, SQL-bounded raw
-prefix. An identity is named only when it is already a registered Connectome
-neuron and is visible to the caller; hidden, external, excess, and unavailable
-identities remain anonymous inside the count. A missing registry or failed
-bounded read withholds all bridge identities without hiding the count. The
+`corroborators` contains at most 12 identities selected from the first 96 raw
+corroboration rows ordered by `created_at`, `agent_id`, then row `id`; that raw
+prefix is bounded in SQL before filtering and deduplication. An identity is
+named only when it is already a registered Connectome neuron and is visible to
+the caller. Hidden, external, duplicate, excess, unavailable, and otherwise
+eligible identities beyond the 96-row prefix remain anonymous inside the true
+distinct count. A missing registry or failed bounded read withholds all bridge
+identities without hiding the count. The
 identity list is historical corroboration evidence, not a claim that the peer
 currently possesses a copy. Challenged and deprecated memories are omitted;
 reinstatement makes a memory eligible again because it is committed. Registered

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.12 lineage implementation (2026-08-14). -->
+<!-- Verified against SAGE v11.18.13 lineage implementation (2026-08-15). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/internal/mcp/claude_wake_source.go
+++ b/internal/mcp/claude_wake_source.go
@@ -165,7 +165,9 @@ func (s *restClaudeWakeSubscription) Close() error {
 // reconnect; it never reconnects on its own.
 func (s *restClaudeWakeSubscription) read() {
 	defer close(s.events)
-	defer s.Close()
+	// Close is idempotent and always reports nil; the deferred call exists to
+	// release the connection when the stream ends on its own.
+	defer func() { _ = s.Close() }()
 
 	scanner := bufio.NewScanner(s.body)
 	scanner.Buffer(make([]byte, 0, 4096), claudeWakeMaxFrameBytes)

--- a/internal/mcp/claude_wake_source.go
+++ b/internal/mcp/claude_wake_source.go
@@ -28,9 +28,10 @@ const (
 	// small fields by design; anything larger is a malformed or hostile stream
 	// rather than a wake this adapter should try to parse.
 	claudeWakeMaxFrameBytes = 8 * 1024
-	// claudeWakeEventBuffer keeps a slow adapter from blocking the reader
-	// goroutine. Wakes coalesce by sequence downstream, so a dropped duplicate
-	// costs nothing; only the highest sequence matters.
+	// claudeWakeEventBuffer absorbs a burst while the adapter is mid-write.
+	// It is a smoothing buffer, not a drop threshold: delivery past it blocks
+	// rather than discarding, because the event that would be discarded is the
+	// newest one and therefore the one that matters.
 	claudeWakeEventBuffer = 8
 )
 
@@ -132,6 +133,7 @@ func (w *restClaudeWakeSource) Subscribe(ctx context.Context, afterSeq uint64) (
 		events: make(chan ClaudeWakeEvent, claudeWakeEventBuffer),
 		body:   resp.Body,
 		cancel: cancel,
+		done:   make(chan struct{}),
 	}
 	go subscription.read()
 	return subscription, nil
@@ -144,6 +146,10 @@ type restClaudeWakeSubscription struct {
 	events chan ClaudeWakeEvent
 	body   io.ReadCloser
 	cancel context.CancelFunc
+	// done is closed exactly once by Close. The reader selects on it while
+	// sending so that backpressure from a busy adapter can never strand the
+	// reader goroutine past shutdown.
+	done chan struct{}
 
 	closeOnce sync.Once
 }
@@ -152,8 +158,10 @@ func (s *restClaudeWakeSubscription) Events() <-chan ClaudeWakeEvent { return s.
 
 func (s *restClaudeWakeSubscription) Close() error {
 	s.closeOnce.Do(func() {
-		// Cancel first: it unblocks a read parked on a quiet stream so the
-		// reader goroutine cannot outlive Close.
+		// Close done first: it releases a reader parked on a full events
+		// buffer. Cancel then unblocks a read parked on a quiet stream. Between
+		// them the reader goroutine cannot outlive Close.
+		close(s.done)
 		s.cancel()
 		_ = s.body.Close()
 	})
@@ -203,12 +211,19 @@ func (s *restClaudeWakeSubscription) read() {
 				Seq:     payload.Seq,
 				Pending: payload.Pending,
 			}
+			// Delivery is lossless. An earlier revision dropped the event
+			// when the buffer was full, reasoning that only the highest
+			// sequence matters — but the event being dropped IS the highest
+			// sequence, and the stream stays open, so nothing later forces a
+			// catch-up. A burst of pending:false frames arriving while the
+			// adapter is blocked on stdout could therefore swallow the
+			// pending:true that follows them and suppress a real wake until
+			// unrelated traffic happened along. Blocking applies backpressure
+			// instead; done releases the reader if Close wins the race.
 			select {
 			case s.events <- event:
-			default:
-				// Buffer full: the adapter is mid-write and already owes a
-				// notification for a sequence at least this recent. Dropping is
-				// safe precisely because wakes carry no content to lose.
+			case <-s.done:
+				return
 			}
 		}
 	}

--- a/internal/mcp/claude_wake_source.go
+++ b/internal/mcp/claude_wake_source.go
@@ -130,10 +130,11 @@ func (w *restClaudeWakeSource) Subscribe(ctx context.Context, afterSeq uint64) (
 	}
 
 	subscription := &restClaudeWakeSubscription{
-		events: make(chan ClaudeWakeEvent, claudeWakeEventBuffer),
-		body:   resp.Body,
-		cancel: cancel,
-		done:   make(chan struct{}),
+		events:     make(chan ClaudeWakeEvent, claudeWakeEventBuffer),
+		body:       resp.Body,
+		cancel:     cancel,
+		done:       make(chan struct{}),
+		readerDone: make(chan struct{}),
 	}
 	go subscription.read()
 	return subscription, nil
@@ -150,6 +151,9 @@ type restClaudeWakeSubscription struct {
 	// sending so that backpressure from a busy adapter can never strand the
 	// reader goroutine past shutdown.
 	done chan struct{}
+	// readerDone is an internal lifecycle signal used to verify that shutdown
+	// releases the reader without a consumer first draining events.
+	readerDone chan struct{}
 
 	closeOnce sync.Once
 }
@@ -173,6 +177,7 @@ func (s *restClaudeWakeSubscription) Close() error {
 // reconnect; it never reconnects on its own.
 func (s *restClaudeWakeSubscription) read() {
 	defer close(s.events)
+	defer close(s.readerDone)
 	// Close is idempotent and always reports nil; the deferred call exists to
 	// release the connection when the stream ends on its own.
 	defer func() { _ = s.Close() }()

--- a/internal/mcp/claude_wake_source.go
+++ b/internal/mcp/claude_wake_source.go
@@ -1,0 +1,213 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// The Claude channel adapter shipped in v11.18.9 with no production
+// ClaudeWakeSource behind it: every implementation lived in a test file, so
+// ConfigureClaudeChannel had no caller outside the package and the adapter was
+// unreachable from any shipped binary. The node half — the signed
+// /v1/messages/wake SSE route — shipped separately and is live. This file is
+// the seam between them, and nothing here widens either contract.
+
+const (
+	// claudeWakeConsumerPrefix labels this runtime's lease so an operator
+	// reading node logs can tell which host holds the wake.
+	claudeWakeConsumerPrefix = "claude-code"
+	// claudeWakeMaxFrameBytes bounds one SSE frame. The wake payload is three
+	// small fields by design; anything larger is a malformed or hostile stream
+	// rather than a wake this adapter should try to parse.
+	claudeWakeMaxFrameBytes = 8 * 1024
+	// claudeWakeEventBuffer keeps a slow adapter from blocking the reader
+	// goroutine. Wakes coalesce by sequence downstream, so a dropped duplicate
+	// costs nothing; only the highest sequence matters.
+	claudeWakeEventBuffer = 8
+)
+
+// restClaudeWakeSource subscribes to this node's signed exact-recipient wake
+// route on behalf of the server's own agent identity. It is deliberately the
+// narrowest possible node dependency: it can observe a durable cursor and
+// nothing else. It holds no ability to receive, claim, read, or acknowledge a
+// message, and it never sees sender or content.
+type restClaudeWakeSource struct {
+	server     *Server
+	consumerID string
+
+	// stream is separate from server.httpClient on purpose. That client sets
+	// Timeout (75s by default), which bounds the WHOLE request including body
+	// reads — it would sever a healthy long-lived SSE stream on a fixed timer
+	// and mask the break as a reconnect. The transport, and therefore the TLS
+	// configuration and CA resolution, is shared exactly.
+	stream *http.Client
+}
+
+// newRESTClaudeWakeSource binds a wake source to this server's exact identity.
+//
+// The consumer ID is random per process rather than derived from the project or
+// provider, and that is a correctness requirement rather than a detail. The
+// node supersedes an existing stream when the SAME consumer reconnects, and
+// rejects a DIFFERENT consumer with 409 until the lease expires. A stable ID
+// would therefore let a second Claude runtime silently steal the wake from a
+// live one, which is exactly what the lease exists to prevent.
+func newRESTClaudeWakeSource(server *Server) (*restClaudeWakeSource, error) {
+	if server == nil {
+		return nil, fmt.Errorf("claude wake source requires a server")
+	}
+	if server.httpClient == nil {
+		return nil, fmt.Errorf("claude wake source requires an http client")
+	}
+	suffix := make([]byte, 8)
+	if _, err := rand.Read(suffix); err != nil {
+		return nil, fmt.Errorf("generate wake consumer id: %w", err)
+	}
+	return &restClaudeWakeSource{
+		server:     server,
+		consumerID: claudeWakeConsumerPrefix + "-" + hex.EncodeToString(suffix),
+		stream:     &http.Client{Transport: server.httpClient.Transport},
+	}, nil
+}
+
+// EnableRESTClaudeChannel binds the shipped Claude channel adapter to this
+// node's signed wake route. It stays an explicit call rather than something
+// NewServer does, because the adapter's own contract is that merely
+// constructing a Server never advertises or emits the experimental protocol.
+func (s *Server) EnableRESTClaudeChannel() error {
+	source, err := newRESTClaudeWakeSource(s)
+	if err != nil {
+		return err
+	}
+	return s.ConfigureClaudeChannel(source)
+}
+
+// Subscribe opens one signed wake stream positioned after afterSeq. It returns
+// promptly on ctx cancellation because the request carries ctx, and it reports
+// a non-200 as an error so the adapter's bounded backoff — not this code — owns
+// the retry policy.
+func (w *restClaudeWakeSource) Subscribe(ctx context.Context, afterSeq uint64) (ClaudeWakeSubscription, error) {
+	path := fmt.Sprintf("/v1/messages/wake?after_seq=%d&consumer_id=%s", afterSeq, w.consumerID)
+	prepared, err := w.server.prepareSignedRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("sign wake subscribe: %w", err)
+	}
+
+	streamCtx, cancel := context.WithCancel(ctx)
+	req, err := http.NewRequestWithContext(streamCtx, prepared.method, w.server.baseURL+prepared.path, nil)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("create wake request: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("X-Agent-ID", prepared.agentID)
+	req.Header.Set("X-Signature", prepared.signature)
+	req.Header.Set("X-Timestamp", prepared.timestamp)
+	req.Header.Set("X-Nonce", prepared.nonce)
+
+	resp, err := w.stream.Do(req)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("open wake stream: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Drain a bounded prefix so the connection can be reused, then discard.
+		// The body is a problem+json document; it is diagnostic only and must
+		// not reach the host, which is entitled to a cursor and nothing else.
+		_, _ = io.CopyN(io.Discard, resp.Body, claudeWakeMaxFrameBytes)
+		_ = resp.Body.Close()
+		cancel()
+		return nil, fmt.Errorf("wake stream rejected: %s", resp.Status)
+	}
+
+	subscription := &restClaudeWakeSubscription{
+		events: make(chan ClaudeWakeEvent, claudeWakeEventBuffer),
+		body:   resp.Body,
+		cancel: cancel,
+	}
+	go subscription.read()
+	return subscription, nil
+}
+
+// restClaudeWakeSubscription owns exactly one live stream. Close is idempotent
+// and Events is closed exactly once when the stream ends, both of which the
+// ClaudeWakeSubscription contract requires.
+type restClaudeWakeSubscription struct {
+	events chan ClaudeWakeEvent
+	body   io.ReadCloser
+	cancel context.CancelFunc
+
+	closeOnce sync.Once
+}
+
+func (s *restClaudeWakeSubscription) Events() <-chan ClaudeWakeEvent { return s.events }
+
+func (s *restClaudeWakeSubscription) Close() error {
+	s.closeOnce.Do(func() {
+		// Cancel first: it unblocks a read parked on a quiet stream so the
+		// reader goroutine cannot outlive Close.
+		s.cancel()
+		_ = s.body.Close()
+	})
+	return nil
+}
+
+// read translates SSE frames into wake events until the stream ends. It closes
+// events on exit so the adapter observes the break and schedules its own
+// reconnect; it never reconnects on its own.
+func (s *restClaudeWakeSubscription) read() {
+	defer close(s.events)
+	defer s.Close()
+
+	scanner := bufio.NewScanner(s.body)
+	scanner.Buffer(make([]byte, 0, 4096), claudeWakeMaxFrameBytes)
+
+	var isWake bool
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == "":
+			// Frame boundary. Reset so a data line can never be attributed to
+			// a previous frame's event type.
+			isWake = false
+		case strings.HasPrefix(line, ":"):
+			// Heartbeat comment. Proves liveness, carries nothing.
+		case strings.HasPrefix(line, "event:"):
+			isWake = strings.TrimSpace(strings.TrimPrefix(line, "event:")) == "wake"
+		case strings.HasPrefix(line, "data:"):
+			if !isWake {
+				continue
+			}
+			var payload struct {
+				Version int    `json:"version"`
+				Seq     uint64 `json:"seq"`
+				Pending bool   `json:"pending"`
+			}
+			raw := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+				// A frame we cannot parse is not a frame we may guess at.
+				continue
+			}
+			event := ClaudeWakeEvent{
+				Version: payload.Version,
+				Seq:     payload.Seq,
+				Pending: payload.Pending,
+			}
+			select {
+			case s.events <- event:
+			default:
+				// Buffer full: the adapter is mid-write and already owes a
+				// notification for a sequence at least this recent. Dropping is
+				// safe precisely because wakes carry no content to lose.
+			}
+		}
+	}
+}

--- a/internal/mcp/claude_wake_source_test.go
+++ b/internal/mcp/claude_wake_source_test.go
@@ -1,0 +1,239 @@
+package mcp
+
+import (
+	"context"
+	"crypto/ed25519"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testWakeServer(t *testing.T, handler http.HandlerFunc) (*Server, *httptest.Server) {
+	t.Helper()
+	node := httptest.NewServer(handler)
+	t.Cleanup(node.Close)
+	_, key, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	return NewServer(node.URL, key), node
+}
+
+func flushWrite(t *testing.T, w http.ResponseWriter, format string, args ...any) {
+	t.Helper()
+	_, err := fmt.Fprintf(w, format, args...)
+	require.NoError(t, err)
+	w.(http.Flusher).Flush()
+}
+
+// The wake source must not reuse the server's request client. That client sets
+// Timeout, which bounds the entire request including body reads, so a healthy
+// SSE stream would be severed on a fixed timer and the break would masquerade
+// as a reconnect. This pins the separation.
+func TestClaudeWakeSourceStreamClientHasNoRequestTimeout(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	require.Zero(t, source.stream.Timeout, "SSE client must not carry a whole-request timeout")
+	require.NotZero(t, server.httpClient.Timeout, "the ordinary request client should still be bounded")
+	require.Same(t, server.httpClient.Transport, source.stream.Transport,
+		"the stream client must share the server transport so TLS and CA resolution match")
+}
+
+// Two runtimes for the same agent must not both believe they own the wake. The
+// node supersedes a reconnect from the same consumer and rejects a different
+// one, so the consumer ID has to be unique per process.
+func TestClaudeWakeSourceConsumerIDIsUniquePerSource(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {})
+	first, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+	second, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	require.NotEqual(t, first.consumerID, second.consumerID)
+	require.True(t, strings.HasPrefix(first.consumerID, claudeWakeConsumerPrefix))
+}
+
+func TestClaudeWakeSourceSignsAndPositionsSubscribe(t *testing.T) {
+	type observed struct {
+		agentID, signature, timestamp, nonce, accept, query string
+	}
+	seen := make(chan observed, 1)
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		seen <- observed{
+			agentID:   r.Header.Get("X-Agent-ID"),
+			signature: r.Header.Get("X-Signature"),
+			timestamp: r.Header.Get("X-Timestamp"),
+			nonce:     r.Header.Get("X-Nonce"),
+			accept:    r.Header.Get("Accept"),
+			query:     r.URL.RawQuery,
+		}
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	subscription, err := source.Subscribe(ctx, 42)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, subscription.Close()) }()
+
+	got := <-seen
+	require.NotEmpty(t, got.agentID)
+	require.NotEmpty(t, got.signature)
+	require.NotEmpty(t, got.timestamp)
+	require.NotEmpty(t, got.nonce)
+	require.Equal(t, "text/event-stream", got.accept)
+	require.Contains(t, got.query, "after_seq=42")
+	require.Contains(t, got.query, "consumer_id="+source.consumerID)
+}
+
+// A rejected subscribe must surface as an error so the adapter's bounded
+// backoff owns retry. A 409 is the lease conflict and must not be swallowed.
+func TestClaudeWakeSourceReportsRejectedSubscribe(t *testing.T) {
+	for _, status := range []int{http.StatusConflict, http.StatusUnauthorized, http.StatusNotImplemented} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"title":"nope"}`))
+			})
+			source, err := newRESTClaudeWakeSource(server)
+			require.NoError(t, err)
+
+			subscription, err := source.Subscribe(context.Background(), 0)
+			require.Error(t, err)
+			require.Nil(t, subscription)
+		})
+	}
+}
+
+func TestClaudeWakeSourceTranslatesEventsAndIgnoresHeartbeats(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		flushWrite(t, w, ": heartbeat\n\n")
+		flushWrite(t, w, "id: 7\nevent: wake\ndata: {\"version\":1,\"seq\":7,\"pending\":true}\n\n")
+		flushWrite(t, w, ": heartbeat\n\n")
+		flushWrite(t, w, "id: 9\nevent: wake\ndata: {\"version\":1,\"seq\":9,\"pending\":false}\n\n")
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	subscription, err := source.Subscribe(ctx, 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, subscription.Close()) }()
+
+	first := requireWakeEvent(t, subscription)
+	require.Equal(t, ClaudeWakeEvent{Version: 1, Seq: 7, Pending: true}, first)
+	second := requireWakeEvent(t, subscription)
+	require.Equal(t, ClaudeWakeEvent{Version: 1, Seq: 9, Pending: false}, second)
+}
+
+// The host is entitled to a cursor and nothing else. If the node ever grows
+// extra fields, they must not reach the adapter — the event type is the whole
+// contract and this fails if that stops being true.
+func TestClaudeWakeSourceNeverSurfacesSenderOrContent(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":3,\"pending\":true,"+
+			"\"from_agent\":\"mallory\",\"payload\":\"secret\",\"intent\":\"leak\"}\n\n")
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	subscription, err := source.Subscribe(ctx, 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, subscription.Close()) }()
+
+	event := requireWakeEvent(t, subscription)
+	require.Equal(t, ClaudeWakeEvent{Version: 1, Seq: 3, Pending: true}, event)
+
+	// The notification the host actually receives must not carry the extras
+	// either, whatever the node sent.
+	rendered := fmt.Sprintf("%v", claudeChannelNotification(event.Seq))
+	require.NotContains(t, rendered, "mallory")
+	require.NotContains(t, rendered, "secret")
+	require.NotContains(t, rendered, "leak")
+}
+
+// A data line must never be attributed to a previous frame's event type.
+func TestClaudeWakeSourceIgnoresDataOutsideAWakeFrame(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		flushWrite(t, w, "event: other\ndata: {\"version\":1,\"seq\":5,\"pending\":true}\n\n")
+		flushWrite(t, w, "data: {\"version\":1,\"seq\":6,\"pending\":true}\n\n")
+		flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":8,\"pending\":true}\n\n")
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	subscription, err := source.Subscribe(ctx, 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, subscription.Close()) }()
+
+	// The first event delivered must be seq 8: the non-wake frame and the
+	// orphaned data line are both dropped.
+	require.Equal(t, uint64(8), requireWakeEvent(t, subscription).Seq)
+}
+
+func TestClaudeWakeSourceClosesEventsWhenStreamEndsAndCloseIsIdempotent(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":2,\"pending\":true}\n\n")
+		// Handler returns: the stream ends.
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	subscription, err := source.Subscribe(context.Background(), 0)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(2), requireWakeEvent(t, subscription).Seq)
+
+	require.Eventually(t, func() bool {
+		select {
+		case _, ok := <-subscription.Events():
+			return !ok
+		default:
+			return false
+		}
+	}, 5*time.Second, 10*time.Millisecond, "Events must close when the stream ends")
+
+	require.NoError(t, subscription.Close())
+	require.NoError(t, subscription.Close())
+}
+
+func requireWakeEvent(t *testing.T, subscription ClaudeWakeSubscription) ClaudeWakeEvent {
+	t.Helper()
+	select {
+	case event, ok := <-subscription.Events():
+		require.True(t, ok, "stream closed before an event arrived")
+		return event
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a wake event")
+		return ClaudeWakeEvent{}
+	}
+}

--- a/internal/mcp/claude_wake_source_test.go
+++ b/internal/mcp/claude_wake_source_test.go
@@ -305,7 +305,13 @@ func TestClaudeWakeSourceCloseReleasesReaderBlockedOnFullBuffer(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.(http.Flusher).Flush()
 		for seq := 1; seq <= claudeWakeEventBuffer*4; seq++ {
-			flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":%d,\"pending\":true}\n\n", seq)
+			// Close intentionally tears down the response while this producer may
+			// still be filling the socket. A post-close broken pipe is the expected
+			// server-side observation, not a test failure.
+			if _, writeErr := fmt.Fprintf(w, "event: wake\ndata: {\"version\":1,\"seq\":%d,\"pending\":true}\n\n", seq); writeErr != nil {
+				return
+			}
+			w.(http.Flusher).Flush()
 		}
 		<-r.Context().Done()
 	})

--- a/internal/mcp/claude_wake_source_test.go
+++ b/internal/mcp/claude_wake_source_test.go
@@ -237,3 +237,110 @@ func requireWakeEvent(t *testing.T, subscription ClaudeWakeSubscription) ClaudeW
 		return ClaudeWakeEvent{}
 	}
 }
+
+// Losslessness under saturation. An earlier revision dropped the event when the
+// buffer was full, on the reasoning that only the highest sequence matters —
+// but the dropped event IS the highest sequence, and the stream stays open so
+// nothing forces a catch-up.
+//
+// The test must not begin draining until the buffer has actually saturated,
+// otherwise the consumer keeps pace, the buffer never fills, and the assertion
+// passes against the very drop it exists to forbid. Waiting on the handler to
+// finish writing cannot be the synchronisation either: correct backpressure
+// blocks the handler, so that would deadlock the fixed implementation. Waiting
+// on the buffer to reach capacity is the condition that works for both.
+func TestClaudeWakeSourceDeliversNewestEventUnderBufferSaturation(t *testing.T) {
+	const total = claudeWakeEventBuffer * 4
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		// A burst of non-pending frames first, exactly the shape that used to
+		// fill the buffer and swallow the pending wake that follows.
+		for seq := 1; seq < total; seq++ {
+			flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":%d,\"pending\":false}\n\n", seq)
+		}
+		flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":%d,\"pending\":true}\n\n", total)
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	subscription, err := source.Subscribe(ctx, 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, subscription.Close()) }()
+
+	// Saturate first, draining nothing. Only now is a drop observable.
+	require.Eventually(t, func() bool {
+		return len(subscription.(*restClaudeWakeSubscription).events) == claudeWakeEventBuffer
+	}, 10*time.Second, 10*time.Millisecond, "buffer should saturate while nothing drains")
+
+	deadline := time.After(10 * time.Second)
+	var highest uint64
+	var sawPending bool
+	for highest < total {
+		select {
+		case event, ok := <-subscription.Events():
+			require.True(t, ok, "stream closed before the newest wake arrived")
+			require.GreaterOrEqual(t, event.Seq, highest, "sequences must not go backwards")
+			highest = event.Seq
+			if event.Seq == total {
+				sawPending = event.Pending
+			}
+		case <-deadline:
+			t.Fatalf("newest wake was dropped; highest seen was %d of %d", highest, total)
+		}
+	}
+	require.Equal(t, uint64(total), highest, "the newest cursor must survive a saturated buffer")
+	require.True(t, sawPending, "the surviving newest event must retain pending=true")
+}
+
+// Close must release a reader parked on a full buffer rather than stranding the
+// goroutine, and must stay idempotent while doing it.
+func TestClaudeWakeSourceCloseReleasesReaderBlockedOnFullBuffer(t *testing.T) {
+	server, _ := testWakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		for seq := 1; seq <= claudeWakeEventBuffer*4; seq++ {
+			flushWrite(t, w, "event: wake\ndata: {\"version\":1,\"seq\":%d,\"pending\":true}\n\n", seq)
+		}
+		<-r.Context().Done()
+	})
+	source, err := newRESTClaudeWakeSource(server)
+	require.NoError(t, err)
+
+	subscription, err := source.Subscribe(context.Background(), 0)
+	require.NoError(t, err)
+
+	// Let the reader fill the buffer and park on the send. Never drain.
+	require.Eventually(t, func() bool {
+		return len(subscription.(*restClaudeWakeSubscription).events) == claudeWakeEventBuffer
+	}, 5*time.Second, 10*time.Millisecond, "buffer should saturate while nothing drains")
+
+	closed := make(chan error, 1)
+	go func() { closed <- subscription.Close() }()
+	select {
+	case closeErr := <-closed:
+		require.NoError(t, closeErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close blocked behind a parked reader")
+	}
+
+	// The reader must finish and close Events even though it was mid-send.
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for range subscription.Events() {
+		}
+	}()
+	select {
+	case <-drained:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reader goroutine was stranded; Events never closed")
+	}
+
+	require.NoError(t, subscription.Close())
+}

--- a/internal/mcp/claude_wake_source_test.go
+++ b/internal/mcp/claude_wake_source_test.go
@@ -329,6 +329,15 @@ func TestClaudeWakeSourceCloseReleasesReaderBlockedOnFullBuffer(t *testing.T) {
 		t.Fatal("Close blocked behind a parked reader")
 	}
 
+	// Prove the reader exited before consuming from Events. Draining first would
+	// release a bare blocking send even if Close stopped selecting on done,
+	// making this shutdown regression test pass against the broken code.
+	select {
+	case <-subscription.(*restClaudeWakeSubscription).readerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reader goroutine remained blocked until Events was drained")
+	}
+
 	// The reader must finish and close Events even though it was mid-send.
 	drained := make(chan struct{})
 	go func() {

--- a/internal/mcp/messages_tools_test.go
+++ b/internal/mcp/messages_tools_test.go
@@ -266,6 +266,7 @@ func TestMessageReplyRetainsPlain404LegacyFallbackAndLocalScope(t *testing.T) {
 		legacyResultCalls++
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"status": "completed", "journal_id": "journal-legacy", "journaled": true,
+			"reply_event_id": "must-not-be-local", "reply_status": "forged",
 		})
 	})
 	ts := httptest.NewServer(mux)
@@ -281,6 +282,7 @@ func TestMessageReplyRetainsPlain404LegacyFallbackAndLocalScope(t *testing.T) {
 	response := result.(map[string]any)
 	require.Equal(t, "local", response["scope"])
 	require.NotContains(t, response, "reply_event_id")
+	require.NotContains(t, response, "reply_status")
 	require.Contains(t, response["message"], "legacy local pipeline")
 	require.Equal(t, 2, canonicalCalls,
 		"the compatibility helper rechecks canonical Messages before using the old endpoint")

--- a/internal/mcp/messages_tools_test.go
+++ b/internal/mcp/messages_tools_test.go
@@ -131,6 +131,165 @@ func TestCanonicalMessageToolsSendReceiveReplyAndStatus(t *testing.T) {
 	require.Contains(t, status.(map[string]any)["message"], "does not prove comprehension")
 }
 
+func writeCanonical404ForMCPTest(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(http.StatusNotFound)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"type": canonicalNotFoundProblemType, "title": "Message not found",
+		"status": http.StatusNotFound, "detail": "The message is unavailable to this claimant session.",
+	})
+}
+
+func TestMessageReplyCannotFallbackAcrossSameAgentClaimantSessions(t *testing.T) {
+	var claimA string
+	canonicalCalls := 0
+	pipePreflightCalls := 0
+	legacyResultCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/messages/msg-session/reply", func(w http.ResponseWriter, r *http.Request) {
+		canonicalCalls++
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		if body["claimant_session_id"] != claimA {
+			writeCanonical404ForMCPTest(w)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"message_id": "msg-session", "status": "completed"})
+	})
+	mux.HandleFunc("/v1/pipe/msg-session", func(w http.ResponseWriter, _ *http.Request) {
+		pipePreflightCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"pipe_id": "msg-session", "status": "claimed"})
+	})
+	mux.HandleFunc("/v1/pipe/msg-session/result", func(w http.ResponseWriter, _ *http.Request) {
+		legacyResultCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "completed"})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	sessionA := NewServer(ts.URL, privateKey)
+	sessionB := NewServer(ts.URL, privateKey)
+	claimA, err = sessionA.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	claimB, err := sessionB.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	require.NotEqual(t, claimA, claimB)
+
+	_, err = sessionB.toolMessageReply(context.Background(), map[string]any{
+		"message_id": "msg-session", "result": "stale",
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, canonicalCalls, "a typed denial must be the only attempt")
+	require.Zero(t, pipePreflightCalls, "a typed denial must not enter the compatibility path")
+	require.Zero(t, legacyResultCalls, "a sibling session must not bypass through pipe result")
+
+	result, err := sessionA.toolMessageReply(context.Background(), map[string]any{
+		"message_id": "msg-session", "result": "done",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "local", result.(map[string]any)["scope"])
+	require.Equal(t, 2, canonicalCalls)
+	require.Zero(t, pipePreflightCalls)
+	require.Zero(t, legacyResultCalls)
+}
+
+func TestPipeResultAliasCannotOmitOrBypassClaimantSession(t *testing.T) {
+	var claimA, seenSession string
+	canonicalCalls := 0
+	legacyResultCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/pipe/msg-hidden", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"pipe_id": "msg-hidden", "status": "claimed"})
+	})
+	mux.HandleFunc("/v1/messages/msg-hidden/reply", func(w http.ResponseWriter, r *http.Request) {
+		canonicalCalls++
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		seenSession, _ = body["claimant_session_id"].(string)
+		if seenSession != claimA {
+			writeCanonical404ForMCPTest(w)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"message_id": "msg-hidden", "status": "completed"})
+	})
+	mux.HandleFunc("/v1/pipe/msg-hidden/result", func(w http.ResponseWriter, _ *http.Request) {
+		legacyResultCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "completed"})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	sessionA := NewServer(ts.URL, privateKey)
+	sessionB := NewServer(ts.URL, privateKey)
+	claimA, err = sessionA.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	claimB, err := sessionB.claimantSessionID(context.Background())
+	require.NoError(t, err)
+
+	_, err = sessionB.toolPipeResult(context.Background(), map[string]any{
+		"pipe_id": "msg-hidden", "result": "stale",
+	})
+	require.Error(t, err)
+	require.Equal(t, claimB, seenSession, "the hidden alias must send its runtime claimant session")
+	require.Equal(t, 1, canonicalCalls)
+	require.Zero(t, legacyResultCalls, "a canonical typed denial must not fall through")
+
+	result, err := sessionA.toolPipeResult(context.Background(), map[string]any{
+		"pipe_id": "msg-hidden", "result": "done",
+	})
+	require.NoError(t, err)
+	require.Equal(t, claimA, seenSession)
+	require.Equal(t, "local", result.(map[string]any)["scope"])
+	require.Equal(t, 2, canonicalCalls)
+	require.Zero(t, legacyResultCalls)
+}
+
+func TestMessageReplyRetainsPlain404LegacyFallbackAndLocalScope(t *testing.T) {
+	canonicalCalls := 0
+	legacyResultCalls := 0
+	var claimantSessions []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/messages/msg-legacy/reply", func(w http.ResponseWriter, r *http.Request) {
+		canonicalCalls++
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		claimantSession, _ := body["claimant_session_id"].(string)
+		claimantSessions = append(claimantSessions, claimantSession)
+		http.Error(w, "route not found", http.StatusNotFound)
+	})
+	mux.HandleFunc("/v1/pipe/msg-legacy", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"pipe_id": "msg-legacy", "status": "claimed"})
+	})
+	mux.HandleFunc("/v1/pipe/msg-legacy/result", func(w http.ResponseWriter, r *http.Request) {
+		legacyResultCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "completed", "journal_id": "journal-legacy", "journaled": true,
+		})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	s := NewServer(ts.URL, privateKey)
+
+	result, err := s.toolMessageReply(context.Background(), map[string]any{
+		"message_id": "msg-legacy", "result": "done",
+	})
+	require.NoError(t, err)
+	response := result.(map[string]any)
+	require.Equal(t, "local", response["scope"])
+	require.NotContains(t, response, "reply_event_id")
+	require.Contains(t, response["message"], "legacy local pipeline")
+	require.Equal(t, 2, canonicalCalls,
+		"the compatibility helper rechecks canonical Messages before using the old endpoint")
+	require.Equal(t, 1, legacyResultCalls)
+	require.Len(t, claimantSessions, 2)
+	require.NotEmpty(t, claimantSessions[0])
+	require.Equal(t, claimantSessions[0], claimantSessions[1])
+}
+
 func TestMessageSendSurfacesInboundThatArrivedAfterPriorEmptyPoll(t *testing.T) {
 	var inboxChecks int
 	var sendSucceeded bool

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -6462,7 +6462,7 @@ func (s *Server) toolPipeResult(ctx context.Context, params map[string]any) (any
 		"scope":      scope,
 		"message":    message,
 	}
-	if resp.ReplyEventID != "" {
+	if federated && resp.ReplyEventID != "" {
 		response["reply_event_id"] = resp.ReplyEventID
 		response["reply_status"] = resp.ReplyStatus
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -675,6 +675,20 @@ func isLegacySelfPolicyRouteNotFound(err error) bool {
 		!strings.HasPrefix(problem.ContentType, "application/problem+json")
 }
 
+const canonicalNotFoundProblemType = "https://sage.dev/errors/404"
+
+// isLegacyMessagesRouteNotFound recognizes only an older node that lacks the
+// canonical Messages route. A current node intentionally uses the same
+// non-enumerating typed 404 for missing, unauthorized, and stale-session
+// replies; treating that denial as a route miss would let the compatibility
+// pipe endpoint bypass the claimant-session fence.
+func isLegacyMessagesRouteNotFound(err error) bool {
+	if !isAPIStatus(err, http.StatusNotFound) {
+		return false
+	}
+	return !isCanonicalAPIProblem(err, canonicalNotFoundProblemType, http.StatusNotFound)
+}
+
 // resolveWriteDomain preserves an explicitly requested domain exactly. Only an
 // omitted/empty domain is eligible for the app-v23 convenience default: the
 // signed caller's approved owned home domain from its self-scoped profile.
@@ -4836,19 +4850,23 @@ func (s *Server) toolMessageReply(ctx context.Context, params map[string]any) (a
 	body, _ := json.Marshal(map[string]any{"result": result, "claimant_session_id": claimantSessionID})
 	var response map[string]any
 	if err := s.doSignedJSON(ctx, http.MethodPost, "/v1/messages/"+url.PathEscape(messageID)+"/reply", body, &response); err != nil {
-		if !isAPIStatus(err, http.StatusNotFound) {
+		if !isLegacyMessagesRouteNotFound(err) {
 			return nil, fmt.Errorf("message reply: %w", err)
 		}
 		legacy, legacyErr := s.toolPipeResult(ctx, map[string]any{"pipe_id": messageID, "result": result})
 		if legacyErr != nil {
-			return nil, fmt.Errorf("federated message reply: %w", legacyErr)
+			return nil, fmt.Errorf("legacy message reply: %w", legacyErr)
 		}
 		response = legacy.(map[string]any)
 		response["message_id"] = messageID
-		response["scope"] = "federated"
-		response["message"] = "Reply queued over the trusted connection. reply_event_id is the immutable outbound reply receipt; pass it to sage_message_status to inspect delivery without creating another inbox request. Repeating the same federated event is deduplicated by the receiving SAGE."
+		if response["scope"] == "federated" {
+			response["message"] = "Reply queued over the trusted connection. reply_event_id is the immutable outbound reply receipt; pass it to sage_message_status to inspect delivery without creating another inbox request. Repeating the same federated event is deduplicated by the receiving SAGE."
+		} else {
+			response["message"] = "Reply recorded through the legacy local pipeline service."
+		}
 		return response, nil
 	}
+	response["scope"] = "local"
 	response["message"] = "Reply recorded. Repeating this exact reply is safe; a different second reply is rejected."
 	return response, nil
 }
@@ -6394,15 +6412,23 @@ func (s *Server) toolPipeResult(ctx context.Context, params map[string]any) (any
 	}
 	body, _ := json.Marshal(bodyFields)
 	if !federated {
+		claimantSessionID, err := s.claimantSessionID(ctx)
+		if err != nil {
+			return nil, err
+		}
+		canonicalBody, _ := json.Marshal(map[string]any{
+			"result": result, "claimant_session_id": claimantSessionID,
+		})
 		var canonical map[string]any
-		err := s.doSignedJSON(ctx, http.MethodPost, "/v1/messages/"+url.PathEscape(pipeID)+"/reply", body, &canonical)
+		err = s.doSignedJSON(ctx, http.MethodPost, "/v1/messages/"+url.PathEscape(pipeID)+"/reply", canonicalBody, &canonical)
 		if err == nil {
 			return map[string]any{
 				"status": canonical["status"], "journal_id": "", "journaled": false,
+				"scope":   "local",
 				"message": "Result delivered through the idempotent local Messages service. The requesting agent can query exact workflow and read status.",
 			}, nil
 		}
-		if !isAPIStatus(err, http.StatusNotFound) {
+		if !isLegacyMessagesRouteNotFound(err) {
 			return nil, fmt.Errorf("pipeline result: %w", err)
 		}
 		// Definite route miss on an older node: use the compatibility endpoint.
@@ -6425,10 +6451,15 @@ func (s *Server) toolPipeResult(ctx context.Context, params map[string]any) (any
 	} else if resp.Journaled {
 		message += " A local journal entry was created summarizing the exchange."
 	}
+	scope := "local"
+	if federated {
+		scope = "federated"
+	}
 	response := map[string]any{
 		"status":     resp.Status,
 		"journal_id": resp.JournalID,
 		"journaled":  resp.Journaled,
+		"scope":      scope,
 		"message":    message,
 	}
 	if resp.ReplyEventID != "" {

--- a/internal/store/engram_index_test.go
+++ b/internal/store/engram_index_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -26,6 +27,72 @@ func TestEngramIndexDeclaredOnBothBackends(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(pgSrc), "idx_memories_submitting_agent ON memories (submitting_agent, confidence_score)",
 		"postgres must declare the submitting_agent index too")
+}
+
+// TestCorroborationIndexDeclaredOnBothBackends mirrors the engram-index guard for
+// idx_corroborations_memory. The corroborations child FK column is not
+// auto-indexed by sqlite, so the CEREBRUM distributed-engram per-memory read
+// (and GetCorroborationCounts) would full-scan without it. It must be declared for
+// NEW databases (initSchema) AND EXISTING ones (the migration mirror) on sqlite,
+// and on postgres.
+func TestCorroborationIndexDeclaredOnBothBackends(t *testing.T) {
+	const idx = "idx_corroborations_memory ON corroborations(memory_id)"
+	sqlSrc, err := os.ReadFile("sqlite.go")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, strings.Count(string(sqlSrc), idx), 2,
+		"sqlite must declare the corroborations index in BOTH initSchema and the migration mirror")
+
+	pgSrc, err := os.ReadFile("postgres.go")
+	require.NoError(t, err)
+	require.Contains(t, string(pgSrc), "idx_corroborations_memory ON corroborations (memory_id)",
+		"postgres must declare the corroborations index too")
+}
+
+// TestCorroborationIndexServesPerMemoryRead pins the plan for GetCorroborations'
+// query (WHERE memory_id = ? ORDER BY created_at): idx_corroborations_memory must
+// turn the per-memory read into a SEARCH (a seek), not a full scan of every
+// corroboration on the node — which is what the CEREBRUM lobe issues per
+// corroborated engram.
+//
+// Like the engram-index test, this deliberately does NOT ANALYZE: SAGE never runs
+// ANALYZE, so a real node has no sqlite_stat1. A plain equality on a single-column
+// index is used without stats, but pinning it here catches a regression to a scan
+// (which would need an INDEXED BY hint, per PR #181).
+func TestCorroborationIndexServesPerMemoryRead(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	at := time.Unix(1_700_000_000, 0).UTC()
+	for i := 0; i < 20; i++ {
+		id := fmt.Sprintf("m%03d", i)
+		require.NoError(t, s.InsertMemory(ctx, testMemory(id, "author", "content-"+id, "dom")))
+	}
+	for i := 0; i < 200; i++ {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{
+			MemoryID:  fmt.Sprintf("m%03d", i%20),
+			AgentID:   fmt.Sprintf("agent-%d", i),
+			CreatedAt: at.Add(time.Duration(i) * time.Second),
+		}))
+	}
+
+	rows, err := s.conn.QueryContext(ctx,
+		"EXPLAIN QUERY PLAN SELECT id, memory_id, agent_id, evidence, created_at FROM corroborations WHERE memory_id = ? ORDER BY created_at",
+		"m003")
+	require.NoError(t, err)
+	defer rows.Close() //nolint:errcheck
+	var plan string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		plan += detail + "\n"
+	}
+	require.NoError(t, rows.Err())
+
+	require.Contains(t, plan, "idx_corroborations_memory",
+		"the per-memory corroborator read must SEARCH via the index, not a full scan; plan was:\n"+plan)
+	require.NotContains(t, plan, "SCAN corroborations",
+		"a full scan of corroborations per engram is exactly what the index must prevent; plan was:\n"+plan)
 }
 
 // The CEREBRUM agent-as-lobe read is `WHERE submitting_agent = ? [AND status = ?]

--- a/internal/store/engram_index_test.go
+++ b/internal/store/engram_index_test.go
@@ -30,34 +30,38 @@ func TestEngramIndexDeclaredOnBothBackends(t *testing.T) {
 }
 
 // TestCorroborationIndexDeclaredOnBothBackends mirrors the engram-index guard for
-// idx_corroborations_memory. The corroborations child FK column is not
+// idx_corroborations_memory_order. The corroborations child FK column is not
 // auto-indexed by sqlite, so the CEREBRUM distributed-engram per-memory read
 // (and GetCorroborationCounts) would full-scan without it. It must be declared for
 // NEW databases (initSchema) AND EXISTING ones (the migration mirror) on sqlite,
 // and on postgres.
 func TestCorroborationIndexDeclaredOnBothBackends(t *testing.T) {
-	const idx = "idx_corroborations_memory ON corroborations(memory_id)"
+	const idx = "idx_corroborations_memory_order"
 	sqlSrc, err := os.ReadFile("sqlite.go")
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, strings.Count(string(sqlSrc), idx), 2,
 		"sqlite must declare the corroborations index in BOTH initSchema and the migration mirror")
+	require.Contains(t, string(sqlSrc),
+		"WHERE memory_id = ? ORDER BY created_at, agent_id, id LIMIT ?",
+		"sqlite must apply the total order and row bound in SQL")
 
 	pgSrc, err := os.ReadFile("postgres.go")
 	require.NoError(t, err)
-	require.Contains(t, string(pgSrc), "idx_corroborations_memory ON corroborations (memory_id)",
+	require.Contains(t, string(pgSrc), "idx_corroborations_memory_order ON corroborations (memory_id, created_at, agent_id, id)",
 		"postgres must declare the corroborations index too")
+	require.Contains(t, string(pgSrc),
+		"ORDER BY created_at, agent_id, id LIMIT $2",
+		"postgres must keep the same total order and database-side row bound")
 }
 
-// TestCorroborationIndexServesPerMemoryRead pins the plan for GetCorroborations'
-// query (WHERE memory_id = ? ORDER BY created_at): idx_corroborations_memory must
-// turn the per-memory read into a SEARCH (a seek), not a full scan of every
-// corroboration on the node — which is what the CEREBRUM lobe issues per
-// corroborated engram.
+// TestCorroborationIndexServesPerMemoryRead pins the bounded CEREBRUM query:
+// it must seek one memory, satisfy the total order from the composite index,
+// and apply LIMIT without a table scan or temporary sort.
 //
 // Like the engram-index test, this deliberately does NOT ANALYZE: SAGE never runs
-// ANALYZE, so a real node has no sqlite_stat1. A plain equality on a single-column
-// index is used without stats, but pinning it here catches a regression to a scan
-// (which would need an INDEXED BY hint, per PR #181).
+// ANALYZE, so a real node has no sqlite_stat1. Pinning the production query here
+// catches a regression to a scan or a temporary sort (the former needs the same
+// INDEXED BY protection learned in PR #181).
 func TestCorroborationIndexServesPerMemoryRead(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
@@ -76,8 +80,10 @@ func TestCorroborationIndexServesPerMemoryRead(t *testing.T) {
 	}
 
 	rows, err := s.conn.QueryContext(ctx,
-		"EXPLAIN QUERY PLAN SELECT id, memory_id, agent_id, evidence, created_at FROM corroborations WHERE memory_id = ? ORDER BY created_at",
-		"m003")
+		`EXPLAIN QUERY PLAN SELECT id, memory_id, agent_id, evidence, created_at
+		 FROM corroborations INDEXED BY idx_corroborations_memory_order
+		 WHERE memory_id = ? ORDER BY created_at, agent_id, id LIMIT ?`,
+		"m003", 12)
 	require.NoError(t, err)
 	defer rows.Close() //nolint:errcheck
 	var plan string
@@ -89,10 +95,34 @@ func TestCorroborationIndexServesPerMemoryRead(t *testing.T) {
 	}
 	require.NoError(t, rows.Err())
 
-	require.Contains(t, plan, "idx_corroborations_memory",
+	require.Contains(t, plan, "idx_corroborations_memory_order",
 		"the per-memory corroborator read must SEARCH via the index, not a full scan; plan was:\n"+plan)
 	require.NotContains(t, plan, "SCAN corroborations",
 		"a full scan of corroborations per engram is exactly what the index must prevent; plan was:\n"+plan)
+	require.NotContains(t, plan, "USE TEMP B-TREE",
+		"the composite index must satisfy the deterministic order without a temp sort; plan was:\n"+plan)
+}
+
+func TestGetCorroborationsBoundedCapsAndTotallyOrdersRows(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	at := time.Unix(1_700_000_000, 0).UTC()
+	require.NoError(t, s.InsertMemory(ctx, testMemory("m1", "author", "content-m1", "dom")))
+	for i := 19; i >= 0; i-- {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{
+			MemoryID: "m1", AgentID: fmt.Sprintf("agent-%02d", i), CreatedAt: at,
+		}))
+	}
+
+	got, err := s.GetCorroborationsBounded(ctx, "m1", 12)
+	require.NoError(t, err)
+	require.Len(t, got, 12, "the database result itself must be capped")
+	for i, corr := range got {
+		require.Equal(t, fmt.Sprintf("agent-%02d", i), corr.AgentID,
+			"same-timestamp rows must use agent_id as a stable tie-breaker")
+	}
+	_, err = s.GetCorroborationsBounded(ctx, "m1", 0)
+	require.Error(t, err, "an absent SQL bound must fail closed")
 }
 
 // The CEREBRUM agent-as-lobe read is `WHERE submitting_agent = ? [AND status = ?]

--- a/internal/store/engram_postgres_integration_test.go
+++ b/internal/store/engram_postgres_integration_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+package store
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/memory"
+)
+
+// TestPostgresGetCorroborationsBoundedCapsAndTotallyOrdersRows exercises the
+// production PostgreSQL query, not a source-string mirror. It pins database-side
+// LIMIT, deterministic same-timestamp ordering, and fail-closed invalid limits.
+func TestPostgresGetCorroborationsBoundedCapsAndTotallyOrdersRows(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+	memoryID := uuid.NewString()
+	content := "postgres bounded engram " + memoryID
+	record := &memory.MemoryRecord{
+		MemoryID:        memoryID,
+		SubmittingAgent: "engram-postgres-test",
+		Content:         content,
+		ContentHash:     memory.ComputeContentHash(content),
+		MemoryType:      memory.TypeFact,
+		DomainTag:       "engram-postgres-test",
+		ConfidenceScore: 0.9,
+		Status:          memory.StatusCommitted,
+		CreatedAt:       time.Now().UTC(),
+	}
+	require.NoError(t, s.InsertMemory(ctx, record))
+	t.Cleanup(func() {
+		_, _ = s.db.Exec(ctx, `DELETE FROM corroborations WHERE memory_id = $1`, memoryID)
+		_, _ = s.db.Exec(ctx, `DELETE FROM memories WHERE memory_id = $1`, memoryID)
+	})
+
+	at := time.Unix(1_700_000_000, 0).UTC()
+	for i := 19; i >= 0; i-- {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{
+			MemoryID:  memoryID,
+			AgentID:   fmt.Sprintf("agent-%02d", i),
+			Evidence:  fmt.Sprintf("evidence-%02d", i),
+			CreatedAt: at,
+		}))
+	}
+
+	got, err := s.GetCorroborationsBounded(ctx, memoryID, 12)
+	require.NoError(t, err)
+	require.Len(t, got, 12, "PostgreSQL must apply LIMIT before returning rows")
+	for i, corr := range got {
+		require.Equal(t, fmt.Sprintf("agent-%02d", i), corr.AgentID,
+			"same-timestamp PostgreSQL rows must use agent_id as the next tie-breaker")
+	}
+	for _, invalid := range []int{0, -1} {
+		_, err = s.GetCorroborationsBounded(ctx, memoryID, invalid)
+		require.Error(t, err, "invalid PostgreSQL bounds must fail closed")
+	}
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -421,9 +421,9 @@ var postgresTaskAssignmentSchema = []string{
 	// CEREBRUM agent-as-lobe: each agent's top memories by confidence
 	// (WHERE submitting_agent = ? ORDER BY confidence_score DESC), index-satisfiable.
 	`CREATE INDEX IF NOT EXISTS idx_memories_submitting_agent ON memories (submitting_agent, confidence_score)`,
-	// CEREBRUM distributed engrams: per-memory corroborator set + count
-	// (WHERE memory_id = ?), so the read is a seek, not a full scan.
-	`CREATE INDEX IF NOT EXISTS idx_corroborations_memory ON corroborations (memory_id)`,
+	// CEREBRUM distributed engrams: bounded deterministic per-memory prefix.
+	// The memory_id prefix continues to serve the distinct-count aggregation.
+	`CREATE INDEX IF NOT EXISTS idx_corroborations_memory_order ON corroborations (memory_id, created_at, agent_id, id)`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories (created_at)`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_projection_page ON memories (created_at, memory_id)`,
 	// FindByContentHash became a live query in v11.11 (it previously returned a
@@ -1252,6 +1252,32 @@ func (s *PostgresStore) GetCorroborations(ctx context.Context, memoryID string) 
 		corrs = append(corrs, c)
 	}
 	return corrs, nil
+}
+
+// GetCorroborationsBounded returns a stable raw projection prefix for UI reads.
+// LIMIT applies in PostgreSQL before the caller performs visibility filtering.
+func (s *PostgresStore) GetCorroborationsBounded(ctx context.Context, memoryID string, limit int) ([]*Corroboration, error) {
+	if limit <= 0 {
+		return nil, errors.New("corroboration limit must be positive")
+	}
+	rows, err := s.db.Query(ctx,
+		`SELECT id, memory_id, agent_id, evidence, created_at
+		 FROM corroborations WHERE memory_id = $1
+		 ORDER BY created_at, agent_id, id LIMIT $2`, memoryID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("get bounded corroborations: %w", err)
+	}
+	defer rows.Close()
+
+	corrs := make([]*Corroboration, 0, limit)
+	for rows.Next() {
+		c := &Corroboration{}
+		if scanErr := rows.Scan(&c.ID, &c.MemoryID, &c.AgentID, &c.Evidence, &c.CreatedAt); scanErr != nil {
+			return nil, fmt.Errorf("scan bounded corroboration: %w", scanErr)
+		}
+		corrs = append(corrs, c)
+	}
+	return corrs, rows.Err()
 }
 
 func (s *PostgresStore) GetPendingByDomain(ctx context.Context, domainTag string, limit int) ([]*memory.MemoryRecord, error) {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -421,6 +421,9 @@ var postgresTaskAssignmentSchema = []string{
 	// CEREBRUM agent-as-lobe: each agent's top memories by confidence
 	// (WHERE submitting_agent = ? ORDER BY confidence_score DESC), index-satisfiable.
 	`CREATE INDEX IF NOT EXISTS idx_memories_submitting_agent ON memories (submitting_agent, confidence_score)`,
+	// CEREBRUM distributed engrams: per-memory corroborator set + count
+	// (WHERE memory_id = ?), so the read is a seek, not a full scan.
+	`CREATE INDEX IF NOT EXISTS idx_corroborations_memory ON corroborations (memory_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories (created_at)`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_projection_page ON memories (created_at, memory_id)`,
 	// FindByContentHash became a live query in v11.11 (it previously returned a

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -520,10 +520,11 @@ func (s *SQLiteStore) initSchema(ctx context.Context) error {
 		evidence   TEXT,
 		created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 	);
-	-- corroborations is read by memory_id (per-memory corroborator set + count for
-	-- the CEREBRUM distributed-engram view, and GetCorroborationCounts); without
-	-- this the child FK column is unindexed and every such read is a full scan.
-	CREATE INDEX IF NOT EXISTS idx_corroborations_memory ON corroborations(memory_id);
+	-- CEREBRUM reads one bounded, deterministic corroboration prefix by memory.
+	-- The total-order suffix also lets SQLite satisfy ORDER BY without a temp sort;
+	-- the memory_id prefix continues to serve GetCorroborationCounts.
+	CREATE INDEX IF NOT EXISTS idx_corroborations_memory_order
+		ON corroborations(memory_id, created_at, agent_id, id);
 
 	CREATE TABLE IF NOT EXISTS challenges (
 		id             INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1376,7 +1377,7 @@ func (s *SQLiteStore) migrateTaskSupport(ctx context.Context) {
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_provider ON memories(provider)`)
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_task_status ON memories(task_status) WHERE task_status != ''`)
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_submitting_agent ON memories(submitting_agent, confidence_score)`)
-	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_corroborations_memory ON corroborations(memory_id)`)
+	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_corroborations_memory_order ON corroborations(memory_id, created_at, agent_id, id)`)
 }
 
 // --- Helper functions ---
@@ -2736,6 +2737,36 @@ func (s *SQLiteStore) GetCorroborations(ctx context.Context, memoryID string) ([
 		corrs = append(corrs, c)
 	}
 	return corrs, nil
+}
+
+// GetCorroborationsBounded returns a stable raw projection prefix for UI reads.
+// The SQL LIMIT bounds row materialization before caller-side visibility and
+// duplicate filtering; GetCorroborationCounts remains the source of the true
+// distinct total.
+func (s *SQLiteStore) GetCorroborationsBounded(ctx context.Context, memoryID string, limit int) ([]*Corroboration, error) {
+	if limit <= 0 {
+		return nil, errors.New("corroboration limit must be positive")
+	}
+	rows, err := s.conn.QueryContext(ctx,
+		`SELECT id, memory_id, agent_id, evidence, created_at
+		 FROM corroborations INDEXED BY idx_corroborations_memory_order
+		 WHERE memory_id = ? ORDER BY created_at, agent_id, id LIMIT ?`, memoryID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("get bounded corroborations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	corrs := make([]*Corroboration, 0, limit)
+	for rows.Next() {
+		c := &Corroboration{}
+		var createdAt string
+		if scanErr := rows.Scan(&c.ID, &c.MemoryID, &c.AgentID, &c.Evidence, &createdAt); scanErr != nil {
+			return nil, fmt.Errorf("scan bounded corroboration: %w", scanErr)
+		}
+		c.CreatedAt = parseTime(createdAt)
+		corrs = append(corrs, c)
+	}
+	return corrs, rows.Err()
 }
 
 func (s *SQLiteStore) GetPendingByDomain(ctx context.Context, domainTag string, limit int) ([]*memory.MemoryRecord, error) {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -520,6 +520,10 @@ func (s *SQLiteStore) initSchema(ctx context.Context) error {
 		evidence   TEXT,
 		created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 	);
+	-- corroborations is read by memory_id (per-memory corroborator set + count for
+	-- the CEREBRUM distributed-engram view, and GetCorroborationCounts); without
+	-- this the child FK column is unindexed and every such read is a full scan.
+	CREATE INDEX IF NOT EXISTS idx_corroborations_memory ON corroborations(memory_id);
 
 	CREATE TABLE IF NOT EXISTS challenges (
 		id             INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1372,6 +1376,7 @@ func (s *SQLiteStore) migrateTaskSupport(ctx context.Context) {
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_provider ON memories(provider)`)
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_task_status ON memories(task_status) WHERE task_status != ''`)
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_submitting_agent ON memories(submitting_agent, confidence_score)`)
+	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_corroborations_memory ON corroborations(memory_id)`)
 }
 
 // --- Helper functions ---

--- a/scripts/connectome-engrams.test.mjs
+++ b/scripts/connectome-engrams.test.mjs
@@ -44,6 +44,37 @@ test('an engram is NOT a neuron (renders via the memory node path, not neuronTin
   assert.notEqual(n.isNeuron, true, 'no isNeuron flag → memory styling, not a neuron');
 });
 
+// --- distributed engram (Phase B): corroborator bridges ---
+
+test('mapEngrams carries the server-disclosed corroborators; defaults to []', () => {
+  const [withCorr, without, bad] = mapEngrams({
+    engrams: [
+      { id: 'm1', content: 'shared', corroborators: ['bob', 'carol'] },
+      { id: 'm2', content: 'solo' },
+      { id: 'm3', content: 'malformed', corroborators: 'nope' },
+    ],
+  });
+  assert.deepEqual(withCorr.corroborators, ['bob', 'carol'], 'the RBAC-filtered corroborators pass through');
+  assert.deepEqual(without.corroborators, [], 'a solitary memory defaults to no corroborators');
+  assert.deepEqual(bad.corroborators, [], 'a non-array corroborators field is coerced to []');
+});
+
+test('stripBloom removes engram-bridge links (transient), keeps real synapses', () => {
+  const gd = {
+    nodes: [{ id: 'author', isNeuron: true }, { id: 'peer', isNeuron: true }, { id: 'm1', _added: true }],
+    links: [
+      { source: 'a', target: 'b', link_type: 'synapse' },
+      { source: 'author', target: 'm1', link_type: 'focus' },
+      { source: 'm1', target: 'peer', link_type: 'engram-bridge' },
+    ],
+  };
+  const out = stripBloom(gd);
+  assert.deepEqual(out.links.map(l => l.link_type), ['synapse'],
+    'both focus tethers AND engram-bridges are stripped; the real synapse stays');
+  assert.deepEqual(out.nodes.map(n => n.id), ['author', 'peer'],
+    'permanent neurons kept, transient engram removed');
+});
+
 // --- scoped mri-brain wiring ---
 const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
 function functionBody(src, name) {
@@ -112,4 +143,17 @@ test('only a NEURON click blooms engrams — clicking a bloomed engram does not 
   // node. Guard: connectome click blooms only when n.isNeuron.
   assert.match(mriSource, /mode==='connectome'\)\s*\{\s*if \(n\.isNeuron\) bloomEngrams\(n\); \}\s*else exploreNode\(n\)/,
     'connectome click must bloom only neurons; memory-mode click keeps exploreNode');
+});
+
+test('bloomEngrams bridges an engram to its corroborating NEURONS using node objects', () => {
+  const body = functionBody(mriSource, 'bloomEngrams');
+  // gate: only bridge to a node that is present AND a neuron
+  assert.match(body, /cn && cn\.isNeuron/,
+    'a corroborator is bridged only when it resolves to a rendered NEURON node');
+  assert.match(body, /link_type:\s*'engram-bridge'/, 'the bridge carries the engram-bridge link_type');
+  // endpoints must be node OBJECTS (em and cn), not string ids (#188)
+  assert.match(body, /gd\.links\.push\(\{\s*source:\s*em,\s*target:\s*cn,\s*link_type:\s*'engram-bridge'\s*\}\)/,
+    'source/target must be the engram and neuron OBJECTS so the bridge renders under the pinned layout');
+  // never bridge back to the author neuron itself
+  assert.match(body, /if \(cid === n\.id\) return/, 'a self-bridge to the author neuron is skipped');
 });

--- a/scripts/connectome-engrams.test.mjs
+++ b/scripts/connectome-engrams.test.mjs
@@ -179,6 +179,59 @@ test('every renderer focus-exit path strips bridges and invalidates in-flight bl
     'background exit must remove focus and distributed-engram links together');
 });
 
+test('failed graph replacements cannot strand a distributed-engram bloom', async () => {
+  const bloom = {
+    nodes: [{ id: 'agent:alice', isNeuron: true }, { id: 'memory:m1', _added: true }],
+    links: [
+      { source: 'agent:alice', target: 'memory:m1', link_type: 'focus' },
+      { source: 'memory:m1', target: 'agent:bob', link_type: 'engram-bridge' },
+    ],
+  };
+  let graphData = bloom;
+  let focusId = 'agent:alice';
+  let focusSet = new Set(['agent:alice', 'memory:m1', 'agent:bob']);
+  let invalidated = 0;
+  let hidden = 0;
+  let markerCleared = 0;
+  const Graph = { graphData(next) { if (arguments.length) graphData = next; return graphData; } };
+  const bloomLoads = { invalidate() { invalidated++; } };
+  const clearBloom = () => Graph.graphData(stripBloom(Graph.graphData()));
+  const hideExplorePanel = () => { hidden++; };
+  const clearFocusMarker = () => { markerCleared++; };
+  const body = functionBody(mriSource, 'leaveFocusForGraphReplacement');
+  const run = new Function(
+    'bloomLoads', 'clearBloom', 'hideExplorePanel', 'clearFocusMarker', 'focusId', 'focusSet',
+    `${body}\nreturn { focusId, focusSet };`,
+  );
+
+  const state = run(bloomLoads, clearBloom, hideExplorePanel, clearFocusMarker, focusId, focusSet);
+  focusId = state.focusId;
+  focusSet = state.focusSet;
+  await assert.rejects(Promise.reject(new Error('replacement unavailable')));
+
+  assert.equal(focusId, null);
+  assert.equal(focusSet, null);
+  assert.equal(invalidated, 1);
+  assert.equal(hidden, 1);
+  assert.equal(markerCleared, 1);
+  assert.deepEqual(graphData.nodes.map(node => node.id), ['agent:alice']);
+  assert.deepEqual(graphData.links, [], 'focus and engram-bridge artifacts are gone before rejection');
+});
+
+test('reload and mode-switch replacement paths tear down the bloom before fetching', () => {
+  const loadBody = functionBody(mriSource, 'load');
+  const reloadCleanup = loadBody.indexOf('leaveFocusForGraphReplacement()');
+  const reloadFetch = loadBody.indexOf('fetchActive(request.mode)');
+  assert.ok(reloadCleanup !== -1 && reloadFetch !== -1 && reloadCleanup < reloadFetch,
+    'an SSE/domain reload must strip its bloom before the fallible replacement fetch');
+
+  const modeBody = functionBody(mriSource, 'setMode');
+  const modeCleanup = modeBody.indexOf('leaveFocusForGraphReplacement()');
+  const modeFetch = modeBody.indexOf('load()');
+  assert.ok(modeCleanup !== -1 && modeFetch !== -1 && modeCleanup < modeFetch,
+    'a mode switch must strip its bloom before the fallible replacement load');
+});
+
 test('the 50ms deep-link bloom timer is tracked and cleared on dispose', () => {
   assert.match(mriSource, /deepLinkTimer = setTimeout\(\(\) => \{ if \(!disposed\) bloomEngrams/,
     'the deep-link timer must be assigned (trackable) and guard disposed');

--- a/scripts/connectome-engrams.test.mjs
+++ b/scripts/connectome-engrams.test.mjs
@@ -2,7 +2,15 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
-import { mapEngrams, stripBloom } from '../web/static/js/connectome-map.js';
+import {
+  agentNodeID,
+  applyEngramBloom,
+  createEngramBloomCoordinator,
+  engramNodeID,
+  mapConnectome,
+  mapEngrams,
+  stripBloom,
+} from '../web/static/js/connectome-map.js';
 
 // Agent-as-lobe (#182): clicking a neuron blooms its authored memories. mapEngrams
 // projects the /memory/engrams payload into transient memory nodes that orbit the
@@ -24,7 +32,8 @@ test('engrams map to transient memory nodes with sensible fallbacks', () => {
   });
   assert.equal(nodes.length, 2);
   const m1 = nodes[0];
-  assert.equal(m1.id, 'm1');
+  assert.equal(m1.id, 'memory:m1');
+  assert.equal(m1.memory_id, 'm1');
   assert.equal(m1.label, 'a fact');       // label from content
   assert.equal(m1.domain, 'ops');
   assert.equal(m1.confidence, 0.9);
@@ -75,6 +84,39 @@ test('stripBloom removes engram-bridge links (transient), keeps real synapses', 
     'permanent neurons kept, transient engram removed');
 });
 
+test('agent and memory identities are structurally namespaced on an exact raw-ID collision', () => {
+  const rawID = 'same-id';
+  const connectome = mapConnectome({
+    neurons: [{ agent_id: rawID, name: 'Author' }, { agent_id: 'peer', name: 'Peer' }],
+    synapses: [],
+  });
+  const [engram] = mapEngrams({
+    engrams: [{ id: rawID, content: 'memory', corroborators: ['peer'] }],
+  });
+  const author = connectome.nodes.find(node => node.agent_id === rawID);
+  const composed = applyEngramBloom(connectome, [engram], author, new Set([author.id]));
+
+  assert.equal(author.id, agentNodeID(rawID));
+  assert.equal(engram.id, engramNodeID(rawID));
+  assert.notEqual(author.id, engram.id);
+  assert.deepEqual(composed.graphData.nodes.map(node => node.id).sort(),
+    [agentNodeID(rawID), agentNodeID('peer'), engramNodeID(rawID)].sort());
+  const bridge = composed.graphData.links.find(link => link.link_type === 'engram-bridge');
+  assert.equal(bridge.source, engram, 'the bridge must use the inserted memory node object');
+  assert.equal(bridge.target.agent_id, 'peer');
+});
+
+test('bloom generations reject an older response for the same neuron', () => {
+  const loads = createEngramBloomCoordinator();
+  const older = loads.begin('alice');
+  const newer = loads.begin('alice');
+  assert.equal(loads.isCurrent(older, 'alice'), false);
+  assert.equal(loads.isCurrent(newer, 'alice'), true);
+  loads.invalidate();
+  assert.equal(loads.isCurrent(newer, 'alice'), false,
+    'background exit, mode change, or disposal must invalidate the in-flight bloom');
+});
+
 // --- scoped mri-brain wiring ---
 const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
 function functionBody(src, name) {
@@ -91,15 +133,15 @@ function functionBody(src, name) {
 
 test('bloomEngrams fetches one agent from /memory/engrams and maps the result', () => {
   const body = functionBody(mriSource, 'bloomEngrams');
-  assert.match(body, /ENGRAMS_URL \+ '\?agent=' \+ encodeURIComponent\(n\.id\)/,
-    'must fetch a single agent on demand, not the whole brain');
+  assert.match(body, /ENGRAMS_URL \+ '\?agent=' \+ encodeURIComponent\(agentID\)/,
+    'must fetch a single raw agent identity, not the namespaced renderer id');
   assert.match(body, /mapEngrams\(payload\)/, 'must project via mapEngrams');
 });
 
-test('engram tethers use node OBJECTS so they render under the pinned layout', () => {
+test('renderer applies the behavior-tested bloom composition', () => {
   const body = functionBody(mriSource, 'bloomEngrams');
-  assert.match(body, /gd\.links\.push\(\{\s*source:\s*n,\s*target:\s*em,\s*link_type:\s*'focus'\s*\}\)/,
-    'source/target must be node objects (string ids go unresolved once forces are nulled — #188)');
+  assert.match(body, /applyEngramBloom\(Graph\.graphData\(\), engrams, n, focusSet, placeNear\)/,
+    'renderer must use the pure composition whose object endpoints and collisions are tested');
 });
 
 test('stripBloom removes _added engram nodes and focus tethers, keeps everything else', () => {
@@ -126,8 +168,15 @@ test('bloomEngrams clears the prior lobe BEFORE fetching — no stale bloom on f
   const fetchIdx = body.indexOf('await fetch');
   assert.ok(clearIdx !== -1 && fetchIdx !== -1 && clearIdx < fetchIdx,
     'clearBloom() must run before the fetch, so a failed/superseded request leaves nothing stranded');
-  assert.match(body, /focusId !== n\.id\) return/,
-    'a superseded response (another neuron clicked mid-flight) must be dropped, not bloomed');
+  assert.match(body, /!bloomLoads\.isCurrent\(bloomRequest, agentID\)\) return/,
+    'a superseded response, including the same neuron, must be generation-fenced');
+});
+
+test('every renderer focus-exit path strips bridges and invalidates in-flight blooms', () => {
+  const body = functionBody(mriSource, 'exitFocus');
+  assert.match(body, /bloomLoads\.invalidate\(\)/);
+  assert.match(body, /Graph\.graphData\(stripBloom\(Graph\.graphData\(\)\)\)/,
+    'background exit must remove focus and distributed-engram links together');
 });
 
 test('the 50ms deep-link bloom timer is tracked and cleared on dispose', () => {
@@ -145,15 +194,26 @@ test('only a NEURON click blooms engrams — clicking a bloomed engram does not 
     'connectome click must bloom only neurons; memory-mode click keeps exploreNode');
 });
 
-test('bloomEngrams bridges an engram to its corroborating NEURONS using node objects', () => {
-  const body = functionBody(mriSource, 'bloomEngrams');
-  // gate: only bridge to a node that is present AND a neuron
-  assert.match(body, /cn && cn\.isNeuron/,
-    'a corroborator is bridged only when it resolves to a rendered NEURON node');
-  assert.match(body, /link_type:\s*'engram-bridge'/, 'the bridge carries the engram-bridge link_type');
-  // endpoints must be node OBJECTS (em and cn), not string ids (#188)
-  assert.match(body, /gd\.links\.push\(\{\s*source:\s*em,\s*target:\s*cn,\s*link_type:\s*'engram-bridge'\s*\}\)/,
-    'source/target must be the engram and neuron OBJECTS so the bridge renders under the pinned layout');
-  // never bridge back to the author neuron itself
-  assert.match(body, /if \(cid === n\.id\) return/, 'a self-bridge to the author neuron is skipped');
+test('bloom composition bridges only rendered peer neurons and strips on background exit', () => {
+  const connectome = mapConnectome({
+    neurons: [{ agent_id: 'alice' }, { agent_id: 'bob' }],
+    synapses: [{ from_agent: 'alice', to_agent: 'bob', count: 1 }],
+  });
+  const author = connectome.nodes.find(node => node.agent_id === 'alice');
+  const [engram] = mapEngrams({
+    engrams: [{ id: 'm1', corroborators: ['alice', 'bob', 'not-rendered'] }],
+  });
+  const composed = applyEngramBloom(connectome, [engram], author, new Set([author.id]));
+  const bridges = composed.graphData.links.filter(link => link.link_type === 'engram-bridge');
+  assert.equal(bridges.length, 1, 'self and absent corroborators must not create bridges');
+  assert.equal(bridges[0].source, engram);
+  assert.equal(bridges[0].target.agent_id, 'bob');
+  assert.equal(composed.graphData.links.find(link => link.link_type === 'focus').target, engram);
+  assert.equal(composed.focusSet.has(agentNodeID('bob')), true,
+    'a bridged corroborator must stay lit with the distributed engram');
+
+  const exited = stripBloom(composed.graphData);
+  assert.deepEqual(exited.nodes.map(node => node.id).sort(),
+    [agentNodeID('alice'), agentNodeID('bob')].sort());
+  assert.deepEqual(exited.links.map(link => link.link_type), ['synapse']);
 });

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -6,6 +6,8 @@ import { createGraphLoadCoordinator, mapConnectome, diffConnectomeActivity, crea
 
 const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
 const appSource = await readFile(new URL('../web/static/js/app.js', import.meta.url), 'utf8');
+const cssSource = await readFile(new URL('../web/static/css/sage.css', import.meta.url), 'utf8');
+const mriPageSource = await readFile(new URL('../web/static/mri.html', import.meta.url), 'utf8');
 
 // The CEREBRUM connectome view renders the agent message-bus in the brain hull.
 // mapConnectome() is the pure projection from the /network/synapses payload onto
@@ -144,11 +146,39 @@ test('renderer wires mode invalidation into both initial acquisition and reloads
     'a toggle must invalidate old work and refetch even before Graph exists');
 });
 
-test('connectome explanation stays in the existing guide instead of covering the graph', () => {
-  assert.doesNotMatch(mriSource, /\bmodeCap\b|mode-cap/,
+test('connectome guidance is reachable without adding another floating panel', () => {
+  const templateStart = mriSource.indexOf('root.innerHTML = `');
+  const templateEnd = mriSource.indexOf('`;\n  container.appendChild(root);', templateStart);
+  assert.ok(templateStart >= 0 && templateEnd > templateStart, 'renderer root template must remain inspectable');
+  const rootTemplate = mriSource.slice(templateStart, templateEnd);
+
+  const panelClasses = [...rootTemplate.matchAll(/class="panel ([^"]+)"/g)].map(match => match[1]).sort();
+  assert.deepEqual(panelClasses, ['hud', 'legend', 'scan'],
+    'the renderer must retain only its established scan, legend, and HUD panels');
+  assert.doesNotMatch(rootTemplate, /\bmodeCap\b|mode-cap/,
     'connectome mode must not create a free-floating explanatory panel');
-  assert.match(appSource, /<b>Connectome mode:<\/b> agents are neurons/,
-    'the existing How to read guide must retain the connectome explanation');
+
+  assert.match(rootTemplate, /class="lg-detail guide-connectome" hidden>[\s\S]*Agents are neurons[\s\S]*Click one to bloom its memories/i,
+    'standalone MRI must keep connectome guidance inside its existing reading legend');
+  assert.match(mriPageSource, /mountMriBrain\([\s\S]*showScan: true/,
+    'standalone MRI must continue mounting the renderer with its default reading legend');
+  assert.match(rootTemplate, /<button type="button" class="lg-toggle" aria-expanded="false">/,
+    'the standalone reading guide must be keyboard reachable');
+  assert.match(rootTemplate, /<button type="button" class="btn b-mode" aria-pressed="false">/,
+    'the mode toggle must be a keyboard-reachable button');
+  assert.match(mriSource, /connectomeGuide\.hidden = !connectome/,
+    'mode changes must associate the standalone guide with the active view');
+  assert.match(mriSource, /class="sr-status" role="status" aria-live="polite"/,
+    'mode changes must have a non-visual screen-reader announcement target');
+
+  assert.match(appSource, /<section class="brain-domain-guide" aria-label="How to read the brain">[\s\S]*<b>Connectome mode:<\/b> agents are neurons/,
+    'the dashboard How to read guide must retain the connectome explanation');
+  assert.match(appSource, /class="brain-domain-reset"/,
+    'the mobile-only action hiding rule needs an explicit Reset target');
+  assert.match(cssSource, /\.brain-domain-head-actions \.brain-domain-reset\s*\{\s*display:\s*none;/,
+    'mobile may hide Reset, not the How to read button');
+  assert.doesNotMatch(cssSource, /\.brain-domain-head-actions button:first-child\s*\{\s*display:\s*none;/,
+    'mobile must not hide whichever action happens to be first');
 });
 
 // Live firing pulses only the synapses that actually carried a message. The

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -157,6 +157,12 @@ test('connectome guidance is reachable without adding another floating panel', (
     'the renderer must retain only its established scan, legend, and HUD panels');
   assert.doesNotMatch(rootTemplate, /\bmodeCap\b|mode-cap/,
     'connectome mode must not create a free-floating explanatory panel');
+  const dynamicRootAppends = [...mriSource.matchAll(/\broot\.appendChild\(([^)]+)\)/g)]
+    .map(match => match[1].trim());
+  assert.deepEqual(dynamicRootAppends, ['p'],
+    'the only dynamic root child may be the established click-to-explore panel');
+  assert.match(mriSource, /p\.className = 'panel explore'; root\.appendChild\(p\)/,
+    'the dynamic-root allow-list must stay bound to the click-to-explore panel');
 
   assert.match(rootTemplate, /class="lg-detail guide-connectome" hidden>[\s\S]*Agents are neurons[\s\S]*Click one to bloom its memories/i,
     'standalone MRI must keep connectome guidance inside its existing reading legend');

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -9,6 +9,43 @@ const appSource = await readFile(new URL('../web/static/js/app.js', import.meta.
 const cssSource = await readFile(new URL('../web/static/css/sage.css', import.meta.url), 'utf8');
 const mriPageSource = await readFile(new URL('../web/static/mri.html', import.meta.url), 'utf8');
 
+function bracedBlock(source, marker, from = 0) {
+  const start = source.indexOf(marker, from);
+  assert.notEqual(start, -1, `${marker} not found`);
+  const open = source.indexOf('{', start + marker.length);
+  assert.notEqual(open, -1, `${marker} block did not open`);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}' && --depth === 0) {
+      return { body: source.slice(open + 1, i), start, end: i + 1 };
+    }
+  }
+  assert.fail(`${marker} block did not close`);
+}
+
+function cssDeclarations(source, exactSelector) {
+  const executable = source.replace(/\/\*[\s\S]*?\*\//g, '');
+  let cursor = 0;
+  let found = null;
+  while (cursor < executable.length) {
+    const open = executable.indexOf('{', cursor);
+    if (open === -1) break;
+    const close = executable.indexOf('}', open + 1);
+    if (close === -1) break;
+    const boundary = Math.max(executable.lastIndexOf('}', open - 1), executable.lastIndexOf('{', open - 1));
+    const selector = executable.slice(boundary + 1, open).trim();
+    if (selector === exactSelector) found = executable.slice(open + 1, close);
+    cursor = close + 1;
+  }
+  assert.notEqual(found, null, `${exactSelector} rule not found`);
+  return Object.fromEntries(found.split(';').map(part => part.trim()).filter(Boolean).map(part => {
+    const colon = part.indexOf(':');
+    assert.ok(colon > 0, `invalid declaration in ${exactSelector}: ${part}`);
+    return [part.slice(0, colon).trim(), part.slice(colon + 1).trim()];
+  }));
+}
+
 // The CEREBRUM connectome view renders the agent message-bus in the brain hull.
 // mapConnectome() is the pure projection from the /network/synapses payload onto
 // the MRI render contract; these tests pin the invariants the renderer relies on:
@@ -193,10 +230,34 @@ test('connectome guidance is reachable without adding another floating panel', (
     'the dashboard How to read guide must retain the connectome explanation');
   assert.match(appSource, /class="brain-domain-reset"/,
     'the mobile-only action hiding rule needs an explicit Reset target');
-  assert.match(cssSource, /\.brain-domain-head-actions \.brain-domain-reset\s*\{\s*display:\s*none;/,
+  const executableCss = cssSource.replace(/\/\*[\s\S]*?\*\//g, '');
+  const mobileBlocks = [];
+  let mobileCursor = 0;
+  while ((mobileCursor = executableCss.indexOf('@media (max-width: 760px)', mobileCursor)) !== -1) {
+    const block = bracedBlock(executableCss, '@media (max-width: 760px)', mobileCursor);
+    mobileBlocks.push(block.body);
+    mobileCursor = block.end;
+  }
+  const inventoryMobile = mobileBlocks.find(block => block.includes('.brain-domain-head-actions .brain-domain-reset'));
+  assert.ok(inventoryMobile, 'the executable 760px mobile block must target Reset explicitly');
+  assert.equal(cssDeclarations(inventoryMobile, '.brain-domain-head-actions .brain-domain-reset').display, 'none',
     'mobile may hide Reset, not the How to read button');
-  assert.doesNotMatch(cssSource, /\.brain-domain-head-actions button:first-child\s*\{\s*display:\s*none;/,
+  assert.doesNotMatch(executableCss, /\.brain-domain-head-actions button:first-child\s*\{\s*display:\s*none;/,
     'mobile must not hide whichever action happens to be first');
+});
+
+test('mode controls retain visible pressed and keyboard-focus styling in both themes', () => {
+  const styleStart = mriSource.indexOf('const STYLE = `');
+  const styleEnd = mriSource.indexOf('`;\n\nfunction injectStyleOnce', styleStart);
+  assert.ok(styleStart >= 0 && styleEnd > styleStart, 'the executable MRI stylesheet must remain inspectable');
+  const style = mriSource.slice(styleStart, styleEnd);
+  const darkPressed = cssDeclarations(style, '.mrib .hud .b-mode[aria-pressed="true"]');
+  const lightPressed = cssDeclarations(style, ':root[data-theme="light"] .mrib .hud .b-mode[aria-pressed="true"]');
+  const focus = cssDeclarations(style, '.mrib .hud .btn:focus-visible,.mrib .lg-toggle:focus-visible');
+
+  assert.deepEqual(darkPressed, { background: '#0e2943', 'border-color': '#39d0ff' });
+  assert.deepEqual(lightPressed, { background: '#dff5fb', 'border-color': '#0e7490' });
+  assert.deepEqual(focus, { outline: '2px solid #39d0ff', 'outline-offset': '2px' });
 });
 
 test('mode chrome exposes coherent toggle state, active guidance, and live status', () => {
@@ -249,8 +310,23 @@ test('mode chrome exposes coherent toggle state, active guidance, and live statu
   const executableSetMode = functionBody('setMode')
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/\/\/.*$/gm, '');
-  assert.match(executableSetMode, /updateModeChrome\(true\);/,
-    'a real mode transition must invoke the announcing path');
+  const modeAnnouncements = [];
+  const runSetMode = new Function(
+    'next', 'mode', 'allowConnectome', 'graphLoads', 'bloomLoads', 'connectomeActivity',
+    'connectomeReloadIntent', 'neuronBirths', 'currentDomain', 'focusId', 'focusSet',
+    'hideExplorePanel', 'clearFocusMarker', 'updateModeChrome', 'hullState', '$',
+    'sliderUnits', 'setHullOpacity', 'Graph', 'load', 'zoomOut', 'acquireInitialGraph',
+    executableSetMode,
+  );
+  const resettable = () => ({ reset() {} });
+  runSetMode(
+    'connectome', 'memory', true, { invalidate() {} }, { invalidate() {} }, resettable(),
+    resettable(), resettable(), null, null, null, () => {}, () => {},
+    announce => modeAnnouncements.push(announce), { valueFor: () => 0.03 }, () => null,
+    value => value, () => {}, null, () => {}, () => {}, () => {},
+  );
+  assert.deepEqual(modeAnnouncements, [true],
+    'the executable mode transition must invoke the announcing chrome path exactly once');
 });
 
 // Live firing pulses only the synapses that actually carried a message. The

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -5,6 +5,7 @@ import test from 'node:test';
 import { createGraphLoadCoordinator, mapConnectome, diffConnectomeActivity, createConnectomeActivityTracker, createConnectomeReloadIntent } from '../web/static/js/connectome-map.js';
 
 const mriSource = await readFile(new URL('../web/static/js/mri-brain.js', import.meta.url), 'utf8');
+const appSource = await readFile(new URL('../web/static/js/app.js', import.meta.url), 'utf8');
 
 // The CEREBRUM connectome view renders the agent message-bus in the brain hull.
 // mapConnectome() is the pure projection from the /network/synapses payload onto
@@ -141,6 +142,13 @@ test('renderer wires mode invalidation into both initial acquisition and reloads
     'a stale initial response must fail closed after a mode change');
   assert.match(mriSource, /function setMode\(next\)\{[\s\S]*graphLoads\.invalidate\(\);[\s\S]*else acquireInitialGraph\(\);/,
     'a toggle must invalidate old work and refetch even before Graph exists');
+});
+
+test('connectome explanation stays in the existing guide instead of covering the graph', () => {
+  assert.doesNotMatch(mriSource, /\bmodeCap\b|mode-cap/,
+    'connectome mode must not create a free-floating explanatory panel');
+  assert.match(appSource, /<b>Connectome mode:<\/b> agents are neurons/,
+    'the existing How to read guide must retain the connectome explanation');
 });
 
 // Live firing pulses only the synapses that actually carried a message. The

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -28,7 +28,7 @@ const payload = {
 test('neurons become nodes with normalized degree (busiest = 1)', () => {
   const g = mapConnectome(payload);
   assert.equal(g.nodes.length, 3);
-  const by = Object.fromEntries(g.nodes.map(n => [n.id, n]));
+  const by = Object.fromEntries(g.nodes.map(n => [n.agent_id, n]));
   // total traffic (in+out): bob 5+2+1=8 (busiest), alice 5+2=7, carol 1
   assert.equal(by.bob._w, 8);
   assert.equal(by.alice._w, 7);
@@ -47,7 +47,7 @@ test('node fields map from the payload with sensible fallbacks', () => {
     ],
     synapses: [],
   });
-  const by = Object.fromEntries(g.nodes.map(n => [n.id, n]));
+  const by = Object.fromEntries(g.nodes.map(n => [n.agent_id, n]));
   assert.equal(by.x.label, 'X');
   assert.equal(by.x.domain, 'd');
   assert.equal(by.x.role, 'r');
@@ -61,19 +61,19 @@ test('synapses become weighted links normalized by the busiest edge', () => {
   const g = mapConnectome(payload);
   assert.equal(g.links.length, 3);
   const by = Object.fromEntries(g.links.map(l => [`${l.source}>${l.target}`, l]));
-  assert.equal(by['alice>bob'].count, 5);
-  assert.equal(by['alice>bob']._w, 1);        // busiest edge
-  assert.equal(by['bob>alice']._w, 2 / 5);
-  assert.equal(by['bob>carol']._w, 1 / 5);
+  assert.equal(by['agent:alice>agent:bob'].count, 5);
+  assert.equal(by['agent:alice>agent:bob']._w, 1);        // busiest edge
+  assert.equal(by['agent:bob>agent:alice']._w, 2 / 5);
+  assert.equal(by['agent:bob>agent:carol']._w, 1 / 5);
   assert.ok(g.links.every(l => l.link_type === 'synapse'));
-  assert.equal(by['alice>bob'].last_fired, '2026-08-12T10:00:00Z');
+  assert.equal(by['agent:alice>agent:bob'].last_fired, '2026-08-12T10:00:00Z');
 });
 
 test('direction is preserved: A->B is distinct from B->A', () => {
   const g = mapConnectome(payload);
   const keys = g.links.map(l => `${l.source}>${l.target}`);
-  assert.ok(keys.includes('alice>bob'));
-  assert.ok(keys.includes('bob>alice'));
+  assert.ok(keys.includes('agent:alice>agent:bob'));
+  assert.ok(keys.includes('agent:bob>agent:alice'));
 });
 
 test('edges to unknown agents are dropped (no ghost nodes)', () => {

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -226,15 +226,20 @@ test('mode chrome exposes coherent toggle state, active guidance, and live statu
   const $ = selector => elements[selector];
 
   runChrome($, root, 'connectome', true);
+  assert.equal(elements['.b-mode'].textContent, '◉ connectome',
+    'a toggle button keeps one visible label; aria-pressed carries its state');
   assert.equal(elements['.b-mode'].attrs['aria-label'], 'Connectome view',
     'aria-pressed needs a stable toggle name, not a changing action label');
   assert.equal(elements['.b-mode'].attrs['aria-pressed'], 'true');
+  assert.match(mriSource, /\.b-mode\[aria-pressed="true"\]\{[^}]*background:/,
+    'pressed state must remain visible without changing the toggle label');
   assert.equal(elements['.guide-memory'].hidden, true);
   assert.equal(elements['.guide-connectome'].hidden, false);
   assert.match(elements['.sr-status'].textContent, /Connectome view/);
   assert.deepEqual(labels.map(label => label.textContent), ['neurons', 'synapses', 'hubs']);
 
   runChrome($, root, 'memory', true);
+  assert.equal(elements['.b-mode'].textContent, '◉ connectome');
   assert.equal(elements['.b-mode'].attrs['aria-label'], 'Connectome view');
   assert.equal(elements['.b-mode'].attrs['aria-pressed'], 'false');
   assert.equal(elements['.guide-memory'].hidden, false);

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -157,27 +157,39 @@ test('connectome guidance is reachable without adding another floating panel', (
     'the renderer must retain only its established scan, legend, and HUD panels');
   assert.doesNotMatch(rootTemplate, /\bmodeCap\b|mode-cap/,
     'connectome mode must not create a free-floating explanatory panel');
-  const dynamicRootAppends = [...mriSource.matchAll(/\broot\.appendChild\(([^)]+)\)/g)]
-    .map(match => match[1].trim());
-  assert.deepEqual(dynamicRootAppends, ['p'],
-    'the only dynamic root child may be the established click-to-explore panel');
+  const executableMri = mriSource
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  const childMutations = [...executableMri.matchAll(
+    /\b(root|container)\.(appendChild|append|prepend|insertBefore|replaceChildren|insertAdjacentElement|insertAdjacentHTML|before|after|replaceWith)\s*\(([^;\n]*)\)/g,
+  )].map(match => `${match[1]}.${match[2]}(${match[3].trim()})`);
+  assert.deepEqual(childMutations, ['container.appendChild(root)', 'root.appendChild(p)'],
+    'the mount root and established Explore panel are the only root-level insertions, through any DOM insertion API');
   assert.match(mriSource, /p\.className = 'panel explore'; root\.appendChild\(p\)/,
     'the dynamic-root allow-list must stay bound to the click-to-explore panel');
 
   assert.match(rootTemplate, /class="lg-detail guide-connectome" hidden>[\s\S]*Agents are neurons[\s\S]*Click one to bloom its memories/i,
     'standalone MRI must keep connectome guidance inside its existing reading legend');
-  assert.match(mriPageSource, /mountMriBrain\([\s\S]*showScan: true/,
-    'standalone MRI must continue mounting the renderer with its default reading legend');
+  const standaloneMountStart = mriPageSource.indexOf("mountMriBrain(document.getElementById('mount')");
+  const standaloneMountEnd = mriPageSource.indexOf('});', standaloneMountStart);
+  assert.ok(standaloneMountStart >= 0 && standaloneMountEnd > standaloneMountStart,
+    'standalone MRI mount options must remain inspectable');
+  const standaloneMount = mriPageSource.slice(standaloneMountStart, standaloneMountEnd);
+  assert.match(standaloneMount, /showScan:\s*true/);
+  assert.doesNotMatch(standaloneMount, /showDomainLegend:\s*false|allowConnectome:\s*false/,
+    'standalone MRI must keep both the connectome toggle and its reading guide enabled');
   assert.match(rootTemplate, /<button type="button" class="lg-toggle" aria-expanded="false">/,
     'the standalone reading guide must be keyboard reachable');
-  assert.match(rootTemplate, /<button type="button" class="btn b-mode" aria-pressed="false">/,
+  assert.match(rootTemplate, /<button type="button" class="btn b-mode" aria-label="Connectome view" aria-pressed="false">/,
     'the mode toggle must be a keyboard-reachable button');
-  assert.match(mriSource, /connectomeGuide\.hidden = !connectome/,
-    'mode changes must associate the standalone guide with the active view');
   assert.match(mriSource, /class="sr-status" role="status" aria-live="polite"/,
     'mode changes must have a non-visual screen-reader announcement target');
 
-  assert.match(appSource, /<section class="brain-domain-guide" aria-label="How to read the brain">[\s\S]*<b>Connectome mode:<\/b> agents are neurons/,
+  const guideStart = appSource.indexOf('showGuide && html`<section class="brain-domain-guide"');
+  const guideEnd = appSource.indexOf('</section>`}', guideStart);
+  assert.ok(guideStart >= 0 && guideEnd > guideStart, 'dashboard guide template must remain inspectable');
+  const dashboardGuide = appSource.slice(guideStart, guideEnd);
+  assert.match(dashboardGuide, /<b>Connectome mode:<\/b> agents are neurons/,
     'the dashboard How to read guide must retain the connectome explanation');
   assert.match(appSource, /class="brain-domain-reset"/,
     'the mobile-only action hiding rule needs an explicit Reset target');
@@ -185,6 +197,55 @@ test('connectome guidance is reachable without adding another floating panel', (
     'mobile may hide Reset, not the How to read button');
   assert.doesNotMatch(cssSource, /\.brain-domain-head-actions button:first-child\s*\{\s*display:\s*none;/,
     'mobile must not hide whichever action happens to be first');
+});
+
+test('mode chrome exposes coherent toggle state, active guidance, and live status', () => {
+  const functionBody = name => {
+    const start = mriSource.indexOf(`function ${name}(`);
+    assert.notEqual(start, -1, `${name}() not found`);
+    const open = mriSource.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < mriSource.length; i++) {
+      if (mriSource[i] === '{') depth++;
+      else if (mriSource[i] === '}' && --depth === 0) return mriSource.slice(open + 1, i);
+    }
+    assert.fail(`${name}() body did not close`);
+  };
+
+  const body = functionBody('updateModeChrome');
+  const runChrome = new Function('$', 'root', 'mode', 'announce', body);
+  const elements = {
+    '.b-mode': { textContent: '', attrs: {}, setAttribute(k, v) { this.attrs[k] = v; } },
+    '.lg-title': { textContent: '' },
+    '.guide-memory': { hidden: false },
+    '.guide-connectome': { hidden: true },
+    '.sr-status': { textContent: '' },
+  };
+  const labels = [{ textContent: '' }, { textContent: '' }, { textContent: '' }];
+  const root = { querySelectorAll: () => labels };
+  const $ = selector => elements[selector];
+
+  runChrome($, root, 'connectome', true);
+  assert.equal(elements['.b-mode'].attrs['aria-label'], 'Connectome view',
+    'aria-pressed needs a stable toggle name, not a changing action label');
+  assert.equal(elements['.b-mode'].attrs['aria-pressed'], 'true');
+  assert.equal(elements['.guide-memory'].hidden, true);
+  assert.equal(elements['.guide-connectome'].hidden, false);
+  assert.match(elements['.sr-status'].textContent, /Connectome view/);
+  assert.deepEqual(labels.map(label => label.textContent), ['neurons', 'synapses', 'hubs']);
+
+  runChrome($, root, 'memory', true);
+  assert.equal(elements['.b-mode'].attrs['aria-label'], 'Connectome view');
+  assert.equal(elements['.b-mode'].attrs['aria-pressed'], 'false');
+  assert.equal(elements['.guide-memory'].hidden, false);
+  assert.equal(elements['.guide-connectome'].hidden, true);
+  assert.match(elements['.sr-status'].textContent, /Memory view/);
+
+  const executableSetMode = functionBody('setMode')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  assert.match(executableSetMode, /updateModeChrome\(true\);/,
+    'a real mode transition must invoke the announcing path');
 });
 
 // Live firing pulses only the synapses that actually carried a message. The

--- a/scripts/connectome-neurogenesis.test.mjs
+++ b/scripts/connectome-neurogenesis.test.mjs
@@ -85,7 +85,7 @@ test('a neuron _activity is the most recent last_fired across its incident edges
       { from_agent: 'b', to_agent: 'a', count: 1, last_fired: '2026-08-14T11:00:00Z' },
     ],
   });
-  const by = Object.fromEntries(g.nodes.map(n => [n.id, n]));
+  const by = Object.fromEntries(g.nodes.map(n => [n.agent_id, n]));
   assert.equal(by.a._activity, '2026-08-14T11:00:00Z', 'latest across both directions');
   assert.equal(by.b._activity, '2026-08-14T11:00:00Z');
   assert.equal(by.lonely._activity, '', 'a neuron with no edges has never fired');
@@ -256,7 +256,7 @@ test('a malformed last_fired never replaces a valid neuron _activity', () => {
       { from_agent: 'b', to_agent: 'a', count: 1, last_fired: '2026-02-30T00:00:00Z' },  // Feb 30 → rolls to Mar 2 (later) if trusted
     ],
   });
-  const a = g.nodes.find(n => n.id === 'a');
+  const a = g.nodes.find(n => n.agent_id === 'a');
   assert.equal(a._activity, '2026-01-01T00:00:00Z', 'the rolled-later impossible date must not win');
 });
 
@@ -273,7 +273,7 @@ test('a neuron _activity picks the true latest instant across varied precision',
       { from_agent: 'b', to_agent: 'a', count: 1, last_fired: '2026-08-14T12:00:00.1Z' },  // 100ms — earlier
     ],
   });
-  const a = g.nodes.find(n => n.id === 'a');
+  const a = g.nodes.find(n => n.agent_id === 'a');
   assert.equal(a._activity, '2026-08-14T12:00:00.12Z', 'must not pick the lexically-larger .1Z');
 });
 

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -60,7 +60,7 @@ test('release-facing version metadata stays aligned', () => {
     ['deploy/federation-acceptance/README.md', `# v${version} federation Docker acceptance`],
     ['docs/FEDERATION.md', `Verified against SAGE v${version} federation behavior`],
     ['docs/reference/concepts/message-reply-lifecycle.md', `SAGE v${version} code`],
-    ['docs/UPGRADING.md', `| v${version} | Projection-safe agent-as-lobe engrams`],
+    ['docs/UPGRADING.md', `| v${version} | Hubanov distributed-engram bridges`],
     ['docs/ROADMAP.md', `## v${version} patch`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.12 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.13 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.12"
+version = "11.18.13"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.12"
+__version__ = "11.18.13"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.12",
+  "version": "11.18.13",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.12",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.13",
       "transport": {
         "type": "stdio"
       }

--- a/web/engrams_corroborators_test.go
+++ b/web/engrams_corroborators_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -18,6 +19,92 @@ type failingBoundedEngramStore struct {
 	store.MemoryStore
 	calls  int
 	limits []int
+}
+
+func TestAppV23ConnectomeAndEngramBridgesExcludeInactiveAndPendingAgents(t *testing.T) {
+	fixture := newAppV23AccessFixture(t)
+	h, sqlStore := newTestHandler(t)
+	h.BadgerStore = fixture.badger
+
+	registerPending := func(name string, height int64) string {
+		_, key, err := ed25519.GenerateKey(nil)
+		require.NoError(t, err)
+		agentID := agentIDForKey(key)
+		require.NoError(t, fixture.badger.RegisterAgentWithCapabilities(
+			agentID, name, store.AppV23RoleMember, "connectome test", "test", "", height,
+			store.DefaultSelfRegisteredAgentCapabilities,
+		))
+		return agentID
+	}
+	activate := func(agentID, home string, height int64) {
+		require.NoError(t, fixture.badger.ApproveAppV23LocalAgent(
+			store.AppV23LocalEnrollment{
+				AgentID: agentID, ApprovedBy: fixture.rootID, RootGeneration: 1,
+				Profile: store.AppV23ProfileStandard, HomeDomain: home,
+				Clearance: 1, Capabilities: 0, Active: true, UpdatedHeight: height,
+			},
+			store.AppV23RoleMember, 0, 0,
+		))
+	}
+
+	activePeer := registerPending("Active peer", 2)
+	activate(activePeer, "active-peer-home", 3)
+	inactivePeer := registerPending("Removed peer", 4)
+	activate(inactivePeer, "removed-peer-home", 5)
+	inactiveEnrollment, err := fixture.badger.GetAppV23Enrollment(inactivePeer)
+	require.NoError(t, err)
+	inactiveRole, err := fixture.badger.GetAppV23Role(inactivePeer)
+	require.NoError(t, err)
+	require.NoError(t, fixture.badger.ApproveAppV23LocalAgent(
+		store.AppV23LocalEnrollment{
+			AgentID: inactivePeer, ApprovedBy: fixture.rootID, RootGeneration: 1,
+			Profile: inactiveEnrollment.Profile, HomeDomain: inactiveEnrollment.HomeDomain,
+			Clearance: inactiveEnrollment.Clearance, Capabilities: inactiveEnrollment.Capabilities,
+			Active: false, UpdatedHeight: 6, RetireOwnedDomainsToRoot: true,
+		},
+		inactiveRole.Role, inactiveEnrollment.Revision, inactiveRole.Revision,
+	))
+	pendingPeer := registerPending("Pending peer", 7)
+
+	base := time.Now().UTC().Truncate(time.Second)
+	insertSynapseMessage(t, sqlStore, "active-edge", fixture.agentID, activePeer, base)
+	insertSynapseMessage(t, sqlStore, "inactive-edge", fixture.agentID, inactivePeer, base.Add(time.Second))
+	insertSynapseMessage(t, sqlStore, "pending-edge", fixture.agentID, pendingPeer, base.Add(2*time.Second))
+
+	synapseRec := httptest.NewRecorder()
+	h.handleSynapses(synapseRec, httptest.NewRequest(http.MethodGet, "/v1/dashboard/network/synapses", nil))
+	require.Equal(t, http.StatusOK, synapseRec.Code, synapseRec.Body.String())
+	connectome := decodeSynapseBody(t, synapseRec)
+	neurons := make(map[string]bool, len(connectome.Neurons))
+	for _, neuron := range connectome.Neurons {
+		neurons[neuron.AgentID] = true
+	}
+	require.True(t, neurons[fixture.agentID])
+	require.True(t, neurons[activePeer])
+	require.False(t, neurons[inactivePeer], "a removed enrollment is historical, not a current neuron")
+	require.False(t, neurons[pendingPeer], "a pending registration is not a current neuron")
+	require.False(t, neurons[fixture.rootID], "CEREBRUM Root is not an ordinary Connectome neuron")
+	require.Len(t, connectome.Synapses, 1, "edges touching non-current neurons must be omitted")
+	require.Equal(t, activePeer, connectome.Synapses[0].ToAgent)
+
+	seedEngramMemory(t, sqlStore, "active-memory", fixture.agentID, "historical evidence", "ops", 0.9, memory.StatusCommitted)
+	seedCorroboration(t, sqlStore, "active-memory", activePeer, base)
+	seedCorroboration(t, sqlStore, "active-memory", inactivePeer, base.Add(time.Second))
+	seedCorroboration(t, sqlStore, "active-memory", pendingPeer, base.Add(2*time.Second))
+	engramRec := httptest.NewRecorder()
+	h.handleEngrams(engramRec, httptest.NewRequest(
+		http.MethodGet, "/v1/dashboard/memory/engrams?agent="+fixture.agentID, nil,
+	))
+	require.Equal(t, http.StatusOK, engramRec.Code, engramRec.Body.String())
+	var engrams struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(engramRec.Body.Bytes(), &engrams))
+	require.Len(t, engrams.Engrams, 1)
+	require.Equal(t, 3, engrams.Engrams[0].CorroborationCount,
+		"historical distinct evidence remains counted")
+	require.Equal(t, []string{activePeer}, engrams.Engrams[0].Corroborators,
+		"only current rendered neurons may be named as bridge endpoints")
 }
 
 func (s *failingBoundedEngramStore) GetCorroborationsBounded(_ context.Context, _ string, limit int) ([]*store.Corroboration, error) {

--- a/web/engrams_corroborators_test.go
+++ b/web/engrams_corroborators_test.go
@@ -49,8 +49,20 @@ func TestAppV23ConnectomeAndEngramBridgesExcludeInactiveAndPendingAgents(t *test
 
 	activePeer := registerPending("Active peer", 2)
 	activate(activePeer, "active-peer-home", 3)
-	inactivePeer := registerPending("Removed peer", 4)
-	activate(inactivePeer, "removed-peer-home", 5)
+	handoverAdmin := registerPending("Handover admin", 4)
+	activate(handoverAdmin, "handover-admin-home", 5)
+	adminEnrollment, err := fixture.badger.GetAppV23Enrollment(handoverAdmin)
+	require.NoError(t, err)
+	adminRole, err := fixture.badger.GetAppV23Role(handoverAdmin)
+	require.NoError(t, err)
+	require.NoError(t, fixture.badger.SetAppV23Policy(
+		fixture.rootID, handoverAdmin,
+		store.AppV23RoleAdmin, adminEnrollment.Profile, store.AppV23ProfileStandard,
+		4, store.AgentCapabilityReadAllDomains,
+		adminRole.Revision, adminEnrollment.Revision, 6,
+	))
+	inactivePeer := registerPending("Removed peer", 7)
+	activate(inactivePeer, "removed-peer-home", 8)
 	inactiveEnrollment, err := fixture.badger.GetAppV23Enrollment(inactivePeer)
 	require.NoError(t, err)
 	inactiveRole, err := fixture.badger.GetAppV23Role(inactivePeer)
@@ -60,51 +72,95 @@ func TestAppV23ConnectomeAndEngramBridgesExcludeInactiveAndPendingAgents(t *test
 			AgentID: inactivePeer, ApprovedBy: fixture.rootID, RootGeneration: 1,
 			Profile: inactiveEnrollment.Profile, HomeDomain: inactiveEnrollment.HomeDomain,
 			Clearance: inactiveEnrollment.Clearance, Capabilities: inactiveEnrollment.Capabilities,
-			Active: false, UpdatedHeight: 6, RetireOwnedDomainsToRoot: true,
+			Active: false, UpdatedHeight: 9, RetireOwnedDomainsToRoot: true,
 		},
 		inactiveRole.Role, inactiveEnrollment.Revision, inactiveRole.Revision,
 	))
-	pendingPeer := registerPending("Pending peer", 7)
+	pendingPeer := registerPending("Pending peer", 10)
 
 	base := time.Now().UTC().Truncate(time.Second)
 	insertSynapseMessage(t, sqlStore, "active-edge", fixture.agentID, activePeer, base)
-	insertSynapseMessage(t, sqlStore, "inactive-edge", fixture.agentID, inactivePeer, base.Add(time.Second))
-	insertSynapseMessage(t, sqlStore, "pending-edge", fixture.agentID, pendingPeer, base.Add(2*time.Second))
-
-	synapseRec := httptest.NewRecorder()
-	h.handleSynapses(synapseRec, httptest.NewRequest(http.MethodGet, "/v1/dashboard/network/synapses", nil))
-	require.Equal(t, http.StatusOK, synapseRec.Code, synapseRec.Body.String())
-	connectome := decodeSynapseBody(t, synapseRec)
-	neurons := make(map[string]bool, len(connectome.Neurons))
-	for _, neuron := range connectome.Neurons {
-		neurons[neuron.AgentID] = true
-	}
-	require.True(t, neurons[fixture.agentID])
-	require.True(t, neurons[activePeer])
-	require.False(t, neurons[inactivePeer], "a removed enrollment is historical, not a current neuron")
-	require.False(t, neurons[pendingPeer], "a pending registration is not a current neuron")
-	require.False(t, neurons[fixture.rootID], "CEREBRUM Root is not an ordinary Connectome neuron")
-	require.Len(t, connectome.Synapses, 1, "edges touching non-current neurons must be omitted")
-	require.Equal(t, activePeer, connectome.Synapses[0].ToAgent)
+	insertSynapseMessage(t, sqlStore, "admin-edge", fixture.agentID, handoverAdmin, base.Add(time.Second))
+	insertSynapseMessage(t, sqlStore, "inactive-edge", fixture.agentID, inactivePeer, base.Add(2*time.Second))
+	insertSynapseMessage(t, sqlStore, "pending-edge", fixture.agentID, pendingPeer, base.Add(3*time.Second))
 
 	seedEngramMemory(t, sqlStore, "active-memory", fixture.agentID, "historical evidence", "ops", 0.9, memory.StatusCommitted)
 	seedCorroboration(t, sqlStore, "active-memory", activePeer, base)
-	seedCorroboration(t, sqlStore, "active-memory", inactivePeer, base.Add(time.Second))
-	seedCorroboration(t, sqlStore, "active-memory", pendingPeer, base.Add(2*time.Second))
-	engramRec := httptest.NewRecorder()
-	h.handleEngrams(engramRec, httptest.NewRequest(
-		http.MethodGet, "/v1/dashboard/memory/engrams?agent="+fixture.agentID, nil,
-	))
-	require.Equal(t, http.StatusOK, engramRec.Code, engramRec.Body.String())
-	var engrams struct {
-		Engrams []engramNode `json:"engrams"`
+	seedCorroboration(t, sqlStore, "active-memory", handoverAdmin, base.Add(time.Second))
+	seedCorroboration(t, sqlStore, "active-memory", inactivePeer, base.Add(2*time.Second))
+	seedCorroboration(t, sqlStore, "active-memory", pendingPeer, base.Add(3*time.Second))
+
+	readConnectome := func() synapseBody {
+		rec := httptest.NewRecorder()
+		h.handleSynapses(rec, httptest.NewRequest(http.MethodGet, "/v1/dashboard/network/synapses", nil))
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+		return decodeSynapseBody(t, rec)
 	}
-	require.NoError(t, json.Unmarshal(engramRec.Body.Bytes(), &engrams))
-	require.Len(t, engrams.Engrams, 1)
-	require.Equal(t, 3, engrams.Engrams[0].CorroborationCount,
+	readEngram := func() engramNode {
+		rec := httptest.NewRecorder()
+		h.handleEngrams(rec, httptest.NewRequest(
+			http.MethodGet, "/v1/dashboard/memory/engrams?agent="+fixture.agentID, nil,
+		))
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+		var body struct {
+			Engrams []engramNode `json:"engrams"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		require.Len(t, body.Engrams, 1)
+		return body.Engrams[0]
+	}
+	assertRoster := func(connectome synapseBody, wantAdmin bool) {
+		neurons := make(map[string]bool, len(connectome.Neurons))
+		for _, neuron := range connectome.Neurons {
+			neurons[neuron.AgentID] = true
+		}
+		require.True(t, neurons[fixture.agentID])
+		require.True(t, neurons[activePeer])
+		require.Equal(t, wantAdmin, neurons[handoverAdmin])
+		require.False(t, neurons[inactivePeer], "a removed enrollment is historical, not a current neuron")
+		require.False(t, neurons[pendingPeer], "a pending registration is not a current neuron")
+		require.False(t, neurons[fixture.rootID], "CEREBRUM Root is not an ordinary Connectome neuron")
+		toAgents := make(map[string]bool, len(connectome.Synapses))
+		for _, edge := range connectome.Synapses {
+			toAgents[edge.ToAgent] = true
+		}
+		require.True(t, toAgents[activePeer])
+		require.Equal(t, wantAdmin, toAgents[handoverAdmin])
+		require.False(t, toAgents[inactivePeer])
+		require.False(t, toAgents[pendingPeer])
+	}
+
+	assertRoster(readConnectome(), true)
+	beforeHandover := readEngram()
+	require.Equal(t, 4, beforeHandover.CorroborationCount)
+	require.ElementsMatch(t, []string{activePeer, handoverAdmin}, beforeHandover.Corroborators)
+
+	_, replacementKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	replacementRoot := agentIDForKey(replacementKey)
+	require.NoError(t, fixture.badger.RotateAppV23RootCredential(1, replacementRoot, 11))
+	assertRoster(readConnectome(), false)
+	afterHandover := readEngram()
+	require.Equal(t, 4, afterHandover.CorroborationCount,
 		"historical distinct evidence remains counted")
-	require.Equal(t, []string{activePeer}, engrams.Engrams[0].Corroborators,
-		"only current rendered neurons may be named as bridge endpoints")
+	require.Equal(t, []string{activePeer}, afterHandover.Corroborators,
+		"a prior-generation Admin is suspended from current bridge endpoints")
+
+	adminEnrollment, err = fixture.badger.GetAppV23Enrollment(handoverAdmin)
+	require.NoError(t, err)
+	adminRole, err = fixture.badger.GetAppV23Role(handoverAdmin)
+	require.NoError(t, err)
+	require.NoError(t, fixture.badger.SetAppV23Policy(
+		replacementRoot, handoverAdmin,
+		store.AppV23RoleAdmin, adminEnrollment.Profile, adminEnrollment.Profile,
+		adminEnrollment.Clearance, adminEnrollment.Capabilities,
+		adminRole.Revision, adminEnrollment.Revision, 12,
+	))
+	assertRoster(readConnectome(), true)
+	afterReauthorization := readEngram()
+	require.Equal(t, 4, afterReauthorization.CorroborationCount)
+	require.ElementsMatch(t, []string{activePeer, handoverAdmin}, afterReauthorization.Corroborators,
+		"current-Root reauthorization restores the Admin as a visible bridge endpoint")
 }
 
 func (s *failingBoundedEngramStore) GetCorroborationsBounded(_ context.Context, _ string, limit int) ([]*store.Corroboration, error) {

--- a/web/engrams_corroborators_test.go
+++ b/web/engrams_corroborators_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,6 +13,18 @@ import (
 	"github.com/l33tdawg/sage/internal/store"
 	"github.com/stretchr/testify/require"
 )
+
+type failingBoundedEngramStore struct {
+	store.MemoryStore
+	calls  int
+	limits []int
+}
+
+func (s *failingBoundedEngramStore) GetCorroborationsBounded(_ context.Context, _ string, limit int) ([]*store.Corroboration, error) {
+	s.calls++
+	s.limits = append(s.limits, limit)
+	return nil, errors.New("bounded corroboration read unavailable")
+}
 
 // seedCorroboration records that agentID corroborated memID, the off-chain
 // corroborations table the distributed-engram disclosure reads (the same table
@@ -113,6 +126,41 @@ func TestHandleEngramsDisclosesAllNeuronCorroboratorsForHumanDashboard(t *testin
 		"even seeAll never names a non-neuron corroborator — the neuron registry is the boundary")
 }
 
+// Bridge eligibility follows the actual Connectome projection, not an unrelated
+// node-local activity/status table. A registered neuron with no retained traffic
+// is dormant but still rendered, so historical corroboration may bridge to it.
+func TestHandleEngramBridgeEndpointsMatchRenderedConnectomeNeurons(t *testing.T) {
+	h, s := newSynapseTestHandler(t)
+	for i, id := range []string{"alice", "bob"} {
+		require.NoError(t, h.BadgerStore.RegisterAgent(id, id, "member", "", "test", "", int64(i+1)))
+	}
+	seedEngramMemory(t, s, "m1", "alice", "a shared fact", "ops", 0.9, memory.StatusCommitted)
+	seedCorroboration(t, s, "m1", "bob", time.Now().UTC())
+
+	synapseRec := httptest.NewRecorder()
+	h.handleSynapses(synapseRec, httptest.NewRequest(http.MethodGet, "/v1/dashboard/network/synapses", nil))
+	require.Equal(t, http.StatusOK, synapseRec.Code, synapseRec.Body.String())
+	connectome := decodeSynapseBody(t, synapseRec)
+	rendered := make(map[string]bool, len(connectome.Neurons))
+	for _, neuron := range connectome.Neurons {
+		rendered[neuron.AgentID] = true
+	}
+	require.True(t, rendered["bob"], "a registered zero-traffic neuron remains visible as dormant")
+
+	engramRec := httptest.NewRecorder()
+	h.handleEngrams(engramRec, httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent=alice", nil))
+	require.Equal(t, http.StatusOK, engramRec.Code, engramRec.Body.String())
+	var body struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(engramRec.Body.Bytes(), &body))
+	require.Len(t, body.Engrams, 1)
+	require.Equal(t, []string{"bob"}, body.Engrams[0].Corroborators)
+	for _, agentID := range body.Engrams[0].Corroborators {
+		require.True(t, rendered[agentID], "every bridge endpoint must exist in the rendered Connectome")
+	}
+}
+
 // TestHandleEngramsWithholdsCorroboratorsWithoutRegistry: with no neuron registry
 // we cannot confirm a corroborator is an already-visible neuron, so we disclose
 // NONE rather than risk naming an unconfirmed identity. The count is unaffected,
@@ -140,6 +188,35 @@ func TestHandleEngramsWithholdsCorroboratorsWithoutRegistry(t *testing.T) {
 	require.Equal(t, 1, body.Engrams[0].CorroborationCount, "the count still reflects the corroboration")
 	require.Empty(t, body.Engrams[0].Corroborators,
 		"without a registry to confirm neuron membership, no corroborator is named")
+}
+
+// A bounded per-engram identity read is optional and fail-closed. The separately
+// batched total remains useful, but a store error must never trigger the legacy
+// unbounded fallback or disclose an identity from a partial result.
+func TestHandleEngramsWithholdsCorroboratorsWhenBoundedReadFails(t *testing.T) {
+	h, s := newSynapseTestHandler(t)
+	require.NoError(t, h.BadgerStore.RegisterAgent("alice", "alice", "member", "", "test", "", 1))
+	require.NoError(t, h.BadgerStore.RegisterAgent("bob", "bob", "member", "", "test", "", 2))
+	seedEngramMemory(t, s, "m1", "alice", "a fact", "ops", 0.9, memory.StatusCommitted)
+	seedCorroboration(t, s, "m1", "bob", time.Now().UTC())
+
+	wrapped := &failingBoundedEngramStore{MemoryStore: h.store}
+	h.store = wrapped
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent=alice", nil)
+	rec := httptest.NewRecorder()
+	h.handleEngrams(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Engrams, 1)
+	require.Equal(t, 1, body.Engrams[0].CorroborationCount)
+	require.Empty(t, body.Engrams[0].Corroborators)
+	require.Equal(t, 1, wrapped.calls)
+	require.Equal(t, []int{engramCorroboratorScanLimit}, wrapped.limits,
+		"the handler must request the fixed raw-row cap")
 }
 
 // TestHandleEngramsCapsCorroboratorBridges: a memory corroborated by more neurons

--- a/web/engrams_corroborators_test.go
+++ b/web/engrams_corroborators_test.go
@@ -1,0 +1,178 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/l33tdawg/sage/internal/memory"
+	"github.com/l33tdawg/sage/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+// seedCorroboration records that agentID corroborated memID, the off-chain
+// corroborations table the distributed-engram disclosure reads (the same table
+// GetCorroborationCounts already tallies for corroboration_count).
+func seedCorroboration(t *testing.T, s *store.SQLiteStore, memID, agentID string, at time.Time) {
+	t.Helper()
+	require.NoError(t, s.InsertCorroboration(context.Background(), &store.Corroboration{
+		MemoryID: memID, AgentID: agentID, CreatedAt: at,
+	}))
+}
+
+// TestHandleEngramsDisclosesVisibleCorroboratorsOnly is the headline security
+// property of the distributed engram: a memory's corroborators are bridged to
+// their neurons, but ONLY the corroborators the caller is cleared to see — under
+// exactly the both-endpoints rule the connectome synapse guard applies. A
+// corroborator the caller cannot see, and a corroborator that is not a registered
+// neuron, are never named; they survive only inside the true corroboration_count
+// as the anonymous remainder the view renders as "+N held elsewhere".
+//
+// Written to FAIL if either half of the guard is removed: dropping the RBAC
+// (!seeAll && !visible[id]) check leaks the hidden peer; dropping the neuronSet
+// intersection leaks the non-neuron corroborator.
+func TestHandleEngramsDisclosesVisibleCorroboratorsOnly(t *testing.T) {
+	h, s := newSynapseTestHandler(t) // wires the on-chain neuron registry
+
+	const (
+		author   = "alice"
+		cVisible = "bob"   // a neuron alice may see → bridged
+		cHidden  = "carol" // a neuron alice may NOT see → count-only
+		cExtern  = "ext-x" // corroborated but never a registered neuron → count-only
+	)
+	for i, id := range []string{author, cVisible, cHidden} {
+		require.NoError(t, h.BadgerStore.RegisterAgent(id, id, "member", "", "test", "", int64(i+1)))
+	}
+	// alice is a member whose visibility list names exactly bob. carol is hidden.
+	require.NoError(t, h.BadgerStore.SetAgentPermission(author, 1, "", `["`+cVisible+`"]`, "", ""))
+
+	base := time.Now().UTC().Truncate(time.Second)
+	seedEngramMemory(t, s, "m1", author, "a shared fact", "ops", 0.9, memory.StatusCommitted)
+	seedCorroboration(t, s, "m1", cVisible, base)
+	seedCorroboration(t, s, "m1", cHidden, base.Add(time.Second))
+	seedCorroboration(t, s, "m1", cExtern, base.Add(2*time.Second))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent="+author, nil)
+	req = req.WithContext(context.WithValue(req.Context(), verifiedDashboardAgentKey{}, author))
+	rec := httptest.NewRecorder()
+	h.handleEngrams(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Engrams, 1)
+	e := body.Engrams[0]
+
+	require.Equal(t, 3, e.CorroborationCount, "the true total counts every corroborator, seen or not")
+	require.Equal(t, []string{cVisible}, e.Corroborators,
+		"only a corroborator that is BOTH a neuron AND visible to the caller is disclosed")
+	require.NotContains(t, e.Corroborators, cHidden, "a corroborator the caller may not see must never be named")
+	require.NotContains(t, e.Corroborators, cExtern, "a non-neuron corroborator must never be named")
+}
+
+// TestHandleEngramsDisclosesAllNeuronCorroboratorsForHumanDashboard: a human
+// dashboard (no agent identity → seeAll) bridges every corroborating NEURON, so
+// the distributed engram renders in full — but a corroborator that is not a
+// registered neuron is STILL never named, because the neuron registry is the
+// connectome's disclosure boundary. seeAll relaxes RBAC, not the neuron gate.
+func TestHandleEngramsDisclosesAllNeuronCorroboratorsForHumanDashboard(t *testing.T) {
+	h, s := newSynapseTestHandler(t)
+
+	const author, cA, cB, cExtern = "alice", "bob", "carol", "ext-x"
+	for i, id := range []string{author, cA, cB} {
+		require.NoError(t, h.BadgerStore.RegisterAgent(id, id, "member", "", "test", "", int64(i+1)))
+	}
+	base := time.Now().UTC().Truncate(time.Second)
+	seedEngramMemory(t, s, "m1", author, "a widely shared fact", "ops", 0.9, memory.StatusCommitted)
+	seedCorroboration(t, s, "m1", cA, base)
+	seedCorroboration(t, s, "m1", cB, base.Add(time.Second))
+	seedCorroboration(t, s, "m1", cExtern, base.Add(2*time.Second))
+
+	// No verified agent → human dashboard, seeAll.
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent="+author, nil)
+	rec := httptest.NewRecorder()
+	h.handleEngrams(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Engrams, 1)
+	e := body.Engrams[0]
+
+	require.Equal(t, 3, e.CorroborationCount)
+	require.ElementsMatch(t, []string{cA, cB}, e.Corroborators,
+		"a human dashboard bridges every corroborating neuron")
+	require.NotContains(t, e.Corroborators, cExtern,
+		"even seeAll never names a non-neuron corroborator — the neuron registry is the boundary")
+}
+
+// TestHandleEngramsWithholdsCorroboratorsWithoutRegistry: with no neuron registry
+// we cannot confirm a corroborator is an already-visible neuron, so we disclose
+// NONE rather than risk naming an unconfirmed identity. The count is unaffected,
+// so the lobe still conveys that the memory is distributed — it just cannot draw
+// the bridges. This is the fail-closed degradation, not a functional path (a nil
+// Badger store is fatal at node startup).
+func TestHandleEngramsWithholdsCorroboratorsWithoutRegistry(t *testing.T) {
+	h, s := newTestHandler(t) // no BadgerStore
+	require.Nil(t, h.BadgerStore, "precondition: no registry attached")
+
+	base := time.Now().UTC().Truncate(time.Second)
+	seedEngramMemory(t, s, "m1", "alice", "a fact", "ops", 0.9, memory.StatusCommitted)
+	seedCorroboration(t, s, "m1", "bob", base)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent=alice", nil)
+	rec := httptest.NewRecorder()
+	h.handleEngrams(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Engrams, 1)
+	require.Equal(t, 1, body.Engrams[0].CorroborationCount, "the count still reflects the corroboration")
+	require.Empty(t, body.Engrams[0].Corroborators,
+		"without a registry to confirm neuron membership, no corroborator is named")
+}
+
+// TestHandleEngramsCapsCorroboratorBridges: a memory corroborated by more neurons
+// than the bridge cap discloses at most engramCorroboratorLimit — the bridges
+// illustrate distribution, they are not an exhaustive dump — while the count still
+// carries the true total.
+func TestHandleEngramsCapsCorroboratorBridges(t *testing.T) {
+	h, s := newSynapseTestHandler(t)
+
+	const author = "alice"
+	require.NoError(t, h.BadgerStore.RegisterAgent(author, author, "member", "", "test", "", 1))
+	base := time.Now().UTC().Truncate(time.Second)
+	seedEngramMemory(t, s, "m1", author, "a very widely held fact", "ops", 0.9, memory.StatusCommitted)
+
+	total := engramCorroboratorLimit + 5
+	for i := 0; i < total; i++ {
+		id := "corr-" + string(rune('a'+i))
+		require.NoError(t, h.BadgerStore.RegisterAgent(id, id, "member", "", "test", "", int64(i+2)))
+		seedCorroboration(t, s, "m1", id, base.Add(time.Duration(i)*time.Second))
+	}
+
+	// Human dashboard so every corroborator is RBAC-visible; the cap is the only bound.
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent="+author, nil)
+	rec := httptest.NewRecorder()
+	h.handleEngrams(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Engrams, 1)
+	require.Equal(t, total, body.Engrams[0].CorroborationCount, "count is the true total")
+	require.Len(t, body.Engrams[0].Corroborators, engramCorroboratorLimit,
+		"bridges are capped; the remainder survives only in the count")
+}

--- a/web/engrams_handler.go
+++ b/web/engrams_handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -9,6 +10,14 @@ import (
 	"github.com/l33tdawg/sage/internal/memory"
 	"github.com/l33tdawg/sage/internal/store"
 )
+
+// boundedEngramCorroborationReader is deliberately optional: a store that
+// cannot apply the row bound in SQL discloses no bridge identities rather than
+// falling back to an unbounded projection read. The distinct total is fetched
+// separately through the required OffchainStore contract.
+type boundedEngramCorroborationReader interface {
+	GetCorroborationsBounded(ctx context.Context, memoryID string, limit int) ([]*store.Corroboration, error)
+}
 
 // engramNode is one memory authored by an agent — an "engram" that orbits its
 // author neuron in the CEREBRUM agent-as-lobe view.
@@ -58,6 +67,12 @@ const engramRawScanCap = engramFetchLimit * 8
 // of edges; the bridges illustrate that a memory is distributed across cells, and
 // CorroborationCount still carries the true total for the anonymous remainder.
 const engramCorroboratorLimit = 12
+
+// Filtering happens after the SQL read because registry membership lives in
+// Badger. Bound the raw deterministic prefix as well as the rendered bridge
+// count so historical duplicates or very large corroborator sets cannot turn
+// one lobe request into unbounded row materialization.
+const engramCorroboratorScanLimit = engramCorroboratorLimit * 8
 
 // handleEngrams returns ONE agent's authored memories — the "engrams" that
 // re-anchor to their author neuron in the agent-as-lobe view. It is loaded on
@@ -213,6 +228,7 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 			}
 		}
 	}
+	corroborationReader, canReadBoundedCorroborations := h.store.(boundedEngramCorroborationReader)
 
 	engrams := make([]engramNode, 0, len(records))
 	for _, rec := range records {
@@ -223,7 +239,7 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 		// under the same rule the synapse edge guard applies, and (c) not the author
 		// itself; the rest survive only in CorroborationCount as the anonymous "+N".
 		var corroborators []string
-		if neuronSet != nil && corrCounts[rec.MemoryID] > 0 {
+		if neuronSet != nil && canReadBoundedCorroborations && corrCounts[rec.MemoryID] > 0 {
 			// A per-engram corroborator read failure degrades to "no bridges for this
 			// engram" rather than failing the whole lobe — the same fail-closed choice
 			// the missing-registry path makes above, applied per record because this
@@ -231,7 +247,9 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 			// corroboration_count still conveys the memory is distributed; only the
 			// bridges are withheld. The count is a separate batch read that already
 			// succeeded, so the "held across N" total is unaffected.
-			corrs, cErr := h.store.GetCorroborations(ctx, rec.MemoryID)
+			corrs, cErr := corroborationReader.GetCorroborationsBounded(
+				ctx, rec.MemoryID, engramCorroboratorScanLimit,
+			)
 			if cErr != nil {
 				corrs = nil
 			}

--- a/web/engrams_handler.go
+++ b/web/engrams_handler.go
@@ -22,6 +22,18 @@ type engramNode struct {
 	CreatedAt          string   `json:"created_at"`
 	CorroborationCount int      `json:"corroboration_count"`
 	Tags               []string `json:"tags,omitempty"`
+	// Corroborators is the subset of agents who corroborated this memory that the
+	// caller is cleared to see AND that exist as neurons — the endpoints the
+	// agent-as-lobe view bridges the engram to. A memory bridged to several neurons
+	// is a "distributed engram": one memory consolidated across multiple cells. It
+	// is RBAC-filtered exactly as the connectome synapse edge guard filters its
+	// endpoints — an author's own lobe is already visible, so a corroborator is
+	// disclosed only when it is itself a visible neuron. Corroborators the caller
+	// may NOT see are never named; they survive only inside CorroborationCount, so
+	// CorroborationCount - len(Corroborators) is the anonymous remainder the view
+	// renders as "+N held elsewhere". This is a pure off-chain read of the
+	// corroborations table — no consensus surface, nothing anchored.
+	Corroborators []string `json:"corroborators,omitempty"`
 }
 
 // engramPerAgentLimit caps how many memories one neuron blooms. Kept small: the
@@ -40,6 +52,12 @@ const engramFetchLimit = engramPerAgentLimit * 4
 // mostly canonically hidden can never turn the fetch into a full-table walk. Each
 // page is an index seek; this only caps how many pages the backfill will chase.
 const engramRawScanCap = engramFetchLimit * 8
+
+// engramCorroboratorLimit caps how many corroborator bridges one engram
+// discloses. A memory corroborated by hundreds of agents must not draw hundreds
+// of edges; the bridges illustrate that a memory is distributed across cells, and
+// CorroborationCount still carries the true total for the anonymous remainder.
+const engramCorroboratorLimit = 12
 
 // handleEngrams returns ONE agent's authored memories — the "engrams" that
 // re-anchor to their author neuron in the agent-as-lobe view. It is loaded on
@@ -66,23 +84,20 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 	}
 
 	allowed, seeAll := h.resolveAgentRBAC(r)
+	// The set of agents the caller may see, reused by both the neuron-visibility
+	// gate below and the corroborator (distributed-engram) disclosure further down.
+	visible := make(map[string]bool, len(allowed))
+	for _, a := range allowed {
+		visible[a] = true
+	}
 
 	// Neuron-visibility gate: if the caller cannot see this agent at all, do not
 	// disclose the shape of its lobe — return an empty engram set, the same as a
 	// neuron with no memories. Under appV23 seeAll is true and agent visibility is
 	// domain-derived per-record below, so this only bites legacy RBAC.
-	if !seeAll {
-		visible := false
-		for _, a := range allowed {
-			if a == agentID {
-				visible = true
-				break
-			}
-		}
-		if !visible {
-			_ = json.NewEncoder(w).Encode(map[string]any{"agent_id": agentID, "engrams": []engramNode{}})
-			return
-		}
+	if !seeAll && !visible[agentID] {
+		_ = json.NewEncoder(w).Encode(map[string]any{"agent_id": agentID, "engrams": []engramNode{}})
+		return
 	}
 
 	// The lobe is a TRUE highest-confidence top-N, not a representative spread. The
@@ -181,8 +196,61 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Neuron set for the distributed-engram bridges: a corroborator is only
+	// disclosed if it is itself a registered neuron, because the connectome renders
+	// no node for a non-registered corroborator and, more importantly, the neuron
+	// registry is the disclosure boundary the whole connectome uses — an identity
+	// absent from it must not be named here either. When the registry is
+	// unavailable (a store without a Badger registry, or an unreadable one), we
+	// disclose NO corroborators rather than risk naming an identity we cannot
+	// confirm is already a visible neuron; the count still conveys distribution.
+	var neuronSet map[string]bool
+	if h.BadgerStore != nil {
+		if regs, regErr := h.BadgerStore.ListRegisteredAgents(); regErr == nil {
+			neuronSet = make(map[string]bool, len(regs))
+			for _, a := range regs {
+				neuronSet[a.AgentID] = true
+			}
+		}
+	}
+
 	engrams := make([]engramNode, 0, len(records))
 	for _, rec := range records {
+		// Distributed-engram disclosure: the corroborators the caller is cleared to
+		// see. Fetched only for a memory that actually has corroborations (most have
+		// none), so a lobe of solitary memories costs no extra reads. Each disclosed
+		// corroborator must be (a) a registered neuron, (b) visible to the caller
+		// under the same rule the synapse edge guard applies, and (c) not the author
+		// itself; the rest survive only in CorroborationCount as the anonymous "+N".
+		var corroborators []string
+		if neuronSet != nil && corrCounts[rec.MemoryID] > 0 {
+			// A per-engram corroborator read failure degrades to "no bridges for this
+			// engram" rather than failing the whole lobe — the same fail-closed choice
+			// the missing-registry path makes above, applied per record because this
+			// read is in the loop. The engram still renders (it was read fine) and
+			// corroboration_count still conveys the memory is distributed; only the
+			// bridges are withheld. The count is a separate batch read that already
+			// succeeded, so the "held across N" total is unaffected.
+			corrs, cErr := h.store.GetCorroborations(ctx, rec.MemoryID)
+			if cErr != nil {
+				corrs = nil
+			}
+			seen := make(map[string]bool, len(corrs))
+			for _, c := range corrs {
+				id := c.AgentID
+				if id == "" || id == rec.SubmittingAgent || seen[id] {
+					continue
+				}
+				if !neuronSet[id] || (!seeAll && !visible[id]) {
+					continue
+				}
+				seen[id] = true
+				corroborators = append(corroborators, id)
+				if len(corroborators) >= engramCorroboratorLimit {
+					break
+				}
+			}
+		}
 		engrams = append(engrams, engramNode{
 			ID:                 rec.MemoryID,
 			Content:            truncate(rec.Content, 200),
@@ -193,6 +261,7 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 			CreatedAt:          rec.CreatedAt.Format(time.RFC3339),
 			CorroborationCount: corrCounts[rec.MemoryID],
 			Tags:               tagMap[rec.MemoryID],
+			Corroborators:      corroborators,
 		})
 	}
 

--- a/web/engrams_handler.go
+++ b/web/engrams_handler.go
@@ -221,7 +221,7 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 	// confirm is already a visible neuron; the count still conveys distribution.
 	var neuronSet map[string]bool
 	if h.BadgerStore != nil {
-		if regs, regErr := h.BadgerStore.ListRegisteredAgents(); regErr == nil {
+		if regs, regErr := listCurrentConnectomeAgents(h.BadgerStore); regErr == nil {
 			neuronSet = make(map[string]bool, len(regs))
 			for _, a := range regs {
 				neuronSet[a.AgentID] = true

--- a/web/engrams_handler_test.go
+++ b/web/engrams_handler_test.go
@@ -44,6 +44,8 @@ func TestHandleEngrams(t *testing.T) {
 	seedEngramMemory(t, s, "a2", "alice", "beta", "ops", 0.7, memory.StatusCommitted)
 	seedEngramMemory(t, s, "a3", "alice", "gamma", "research", 0.8, memory.StatusCommitted)
 	seedEngramMemory(t, s, "a4", "alice", "draft", "ops", 0.95, memory.StatusProposed) // not committed
+	seedEngramMemory(t, s, "a5", "alice", "disputed", "ops", 0.96, memory.StatusChallenged)
+	seedEngramMemory(t, s, "a6", "alice", "deprecated", "ops", 0.97, memory.StatusDeprecated)
 	seedEngramMemory(t, s, "b1", "bob", "bobmem", "ops", 0.99, memory.StatusCommitted)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent=alice", nil)
@@ -70,6 +72,8 @@ func TestHandleEngrams(t *testing.T) {
 	require.Contains(t, byID, "a2")
 	require.Contains(t, byID, "a3")
 	require.NotContains(t, byID, "a4", "a proposed memory is not a committed engram")
+	require.NotContains(t, byID, "a5", "a challenged memory is withheld until reinstated")
+	require.NotContains(t, byID, "a6", "a deprecated memory is not an active engram")
 	require.NotContains(t, byID, "b1", "another agent's memory must never leak into this lobe")
 
 	// ordered by confidence descending (a1 0.9, a3 0.8, a2 0.7)

--- a/web/static/css/sage.css
+++ b/web/static/css/sage.css
@@ -6160,7 +6160,7 @@ input[type="range"]::-moz-range-thumb {
         min-width: 240px;
     }
     .brain-domain-guide-grid { grid-template-columns: 1fr; }
-    .brain-domain-head-actions button:first-child { display: none; }
+    .brain-domain-head-actions .brain-domain-reset { display: none; }
 }
 
 /* Tasks board first-run empty state (v11 UX uplift) */

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1020,7 +1020,7 @@ function BrainDomainInventory({ onInventory, onAvailability, selectedDomain, onS
             </div>
         `}
         ${!collapsed && html`<div class="brain-domain-body">
-            ${showGuide && html`<section class="brain-domain-guide" aria-label="How to read the memory brain">
+            ${showGuide && html`<section class="brain-domain-guide" aria-label="How to read the brain">
                 <p>SAGE captures episodic memories; corroboration and decay shape what consolidates.</p>
                 <div class="brain-domain-guide-grid">
                     <span><b>◍ Size + glow</b> corroboration</span>
@@ -1031,6 +1031,7 @@ function BrainDomainInventory({ onInventory, onAvailability, selectedDomain, onS
                     <span><b>◈ Angle</b> domain</span>
                 </div>
                 <p>Click a local domain below to isolate its lobe. Click a memory to follow its train of thought.</p>
+                <p><b>Connectome mode:</b> agents are neurons, domains set their hue, and message traffic drives synapse thickness and pulses. Active hubs sit near the core; click a neuron to bloom its memories.</p>
             </section>`}
             <section aria-labelledby="brain-local-domains">
                 <div class="brain-domain-section-head">

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.12';
+const SAGE_VERSION = 'v11.18.13';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -999,7 +999,7 @@ function BrainDomainInventory({ onInventory, onAvailability, selectedDomain, onS
             <div class="brain-domain-head-actions">
                 ${!collapsed && html`<button type="button" onClick=${toggleGuide}
                     aria-expanded=${showGuide}>${showGuide ? 'Less' : 'How to read'}</button>`}
-                <button type="button" onClick=${resetLayout} title="Reset panel position and size">Reset</button>
+                <button type="button" class="brain-domain-reset" onClick=${resetLayout} title="Reset panel position and size">Reset</button>
                 <button type="button" onClick=${toggle}
                     aria-expanded=${!collapsed}
                     aria-label=${collapsed ? 'Show domain sources' : 'Hide domain sources'}>

--- a/web/static/js/connectome-map.js
+++ b/web/static/js/connectome-map.js
@@ -227,7 +227,10 @@ export function stripBloom(graphData) {
   const links = (graphData && Array.isArray(graphData.links)) ? graphData.links : [];
   return {
     nodes: nodes.filter(n => !n._added),
-    links: links.filter(l => l.link_type !== 'focus'),
+    // Both bloom artifacts are transient: the 'focus' tethers from the neuron to
+    // its engrams, and the 'engram-bridge' links from an engram to the other
+    // neurons that corroborate it (the distributed engram). Real synapses stay.
+    links: links.filter(l => l.link_type !== 'focus' && l.link_type !== 'engram-bridge'),
   };
 }
 
@@ -246,6 +249,11 @@ export function mapEngrams(g) {
     status: e.status || 'committed',
     confidence: typeof e.confidence === 'number' ? e.confidence : 0.5,
     corroboration_count: e.corroboration_count || 0,
+    // The corroborating neurons the viewer is cleared to see — the endpoints the
+    // agent-as-lobe view bridges this engram to (the "distributed engram"). The
+    // server has already RBAC-filtered these; corroborators the viewer may not see
+    // survive only inside corroboration_count as the anonymous remainder.
+    corroborators: Array.isArray(e.corroborators) ? e.corroborators : [],
     memory_type: e.memory_type || '',
     created_at: e.created_at || '',
     _added: true,

--- a/web/static/js/connectome-map.js
+++ b/web/static/js/connectome-map.js
@@ -51,6 +51,12 @@ export function isLater(a, b) {
   return ka.nanos > kb.nanos;                  // fixed 9-digit width → lexical === numeric
 }
 
+// Neurons and memories share one graph, so their renderer IDs must not share a
+// raw keyspace. Prefixing both kinds makes collisions structurally impossible
+// even when a client-selected memory ID exactly equals an agent ID.
+export const agentNodeID = agentID => `agent:${String(agentID || '')}`;
+export const engramNodeID = memoryID => `memory:${String(memoryID || '')}`;
+
 export function mapConnectome(g) {
   const srcNeurons = (g && Array.isArray(g.neurons)) ? g.neurons : [];
   const srcSynapses = (g && Array.isArray(g.synapses)) ? g.synapses : [];
@@ -75,7 +81,8 @@ export function mapConnectome(g) {
   for (const w of Object.values(weight)) { if (w > maxWeight) maxWeight = w; }
 
   const nodes = srcNeurons.map(n => ({
-    id: n.agent_id,
+    id: agentNodeID(n.agent_id),
+    agent_id: n.agent_id,
     domain: n.domain || n.role || 'agent',
     label: n.name || n.agent_id,
     role: n.role || '',
@@ -93,7 +100,7 @@ export function mapConnectome(g) {
   const links = srcSynapses
     .filter(s => ids.has(s.from_agent) && ids.has(s.to_agent))
     .map(s => ({
-      source: s.from_agent, target: s.to_agent, link_type: 'synapse',
+      source: agentNodeID(s.from_agent), target: agentNodeID(s.to_agent), link_type: 'synapse',
       count: s.count || 0, last_fired: s.last_fired || '',
       _w: maxCount ? (s.count || 0) / maxCount : 0,
     }));
@@ -113,6 +120,19 @@ export function createGraphLoadCoordinator() {
     invalidate() { generation += 1; },
     isCurrent(request, mode) {
       return request && request.generation === generation && request.mode === mode;
+    },
+  };
+}
+
+// Each neuron bloom owns one generation. Agent ID alone is not a sufficient
+// fence: two requests for the same neuron can complete in reverse order.
+export function createEngramBloomCoordinator() {
+  let generation = 0;
+  return {
+    begin(agentID) { return { generation: ++generation, agentID }; },
+    invalidate() { generation += 1; },
+    isCurrent(request, agentID) {
+      return request && request.generation === generation && request.agentID === agentID;
     },
   };
 }
@@ -234,6 +254,37 @@ export function stripBloom(graphData) {
   };
 }
 
+// Compose one transient lobe onto a connectome graph. Kept pure (placement is a
+// callback) so cleanup, ID collisions, and bridge endpoints are behaviorally
+// testable without a WebGL renderer.
+export function applyEngramBloom(graphData, engrams, authorNode, focusSet, placeNode = () => {}) {
+  const gd = stripBloom(graphData);
+  const nodeByID = new Map(gd.nodes.map(node => [node.id, node]));
+  const nextFocus = new Set(focusSet || [authorNode.id]);
+
+  (Array.isArray(engrams) ? engrams : []).forEach((candidate, index) => {
+    let engram = nodeByID.get(candidate.id);
+    if (!engram) {
+      engram = candidate;
+      placeNode(engram, authorNode, index);
+      gd.nodes.push(engram);
+      nodeByID.set(engram.id, engram);
+    }
+    gd.links.push({ source: authorNode, target: engram, link_type: 'focus' });
+    nextFocus.add(engram.id);
+    (engram.corroborators || []).forEach(agentID => {
+      if (agentID === authorNode.agent_id) return;
+      const neuron = nodeByID.get(agentNodeID(agentID));
+      if (neuron && neuron.isNeuron) {
+        gd.links.push({ source: engram, target: neuron, link_type: 'engram-bridge' });
+        nextFocus.add(neuron.id);
+      }
+    });
+  });
+
+  return { graphData: gd, focusSet: nextFocus };
+}
+
 // Maps the /v1/dashboard/memory/engrams payload (one agent's authored memories)
 // into memory node objects that orbit their author neuron in the agent-as-lobe
 // view. Pure. `_added` marks them transient (the renderer strips _added nodes on
@@ -243,7 +294,8 @@ export function stripBloom(graphData) {
 export function mapEngrams(g) {
   const src = (g && Array.isArray(g.engrams)) ? g.engrams : [];
   return src.map(e => ({
-    id: e.id,
+    id: engramNodeID(e.id),
+    memory_id: e.id,
     domain: e.domain || 'unknown',
     label: e.content || e.id,
     status: e.status || 'committed',

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -34,6 +34,12 @@ const LINK_TYPES = {
   // scale with traffic (Hebbian weight), so this one entry is styled dynamically
   // by the link accessors rather than by a fixed width like the memory link types.
   synapse:     { color: '#39d0ff', label: 'synapse',     typed: true },
+  // Connectome mode: a "distributed engram" bridge — a memory (engram) that a
+  // second neuron has also corroborated, drawn from the engram to that
+  // corroborating neuron. One memory bridged to several neurons is the same
+  // knowledge consolidated across cells. Kept faint so the neuron synapses stay
+  // dominant; styled dynamically by the width accessor like the synapse.
+  'engram-bridge': { color: '#d98cff', label: 'distributed engram', typed: false },
 };
 const PALETTE = ['#ff6b9d','#ffd166','#5ee2a0','#5ab0ff','#c08bff','#ff9f5a','#4dd6c4','#f7748a','#9ad14b','#7aa0ff'];
 function hexToRgb(h){ const n = parseInt(h.slice(1), 16); return [n >> 16 & 255, n >> 8 & 255, n & 255]; }
@@ -498,6 +504,7 @@ export function mountMriBrain(container, opts = {}) {
   const restingWeight = l => (l._w||0) * plasticityOf(l);
   function linkWidthFor(l){
     if(l.link_type==='synapse') return 0.25 + restingWeight(l)*2.4 + synapsePulse(l)*2.0;
+    if(l.link_type==='engram-bridge') return 0.5;
     return l.link_type==='focus'?0.8 : l.link_type==='contradicts'?0.6 : (LINK_TYPES[l.link_type]||{}).typed?0.35:0.18;
   }
   function linkParticlesFor(l){
@@ -561,18 +568,30 @@ export function mountMriBrain(container, opts = {}) {
     if (disposed || !Graph || mode !== 'connectome' || focusId !== n.id) return;
     const engrams = mapEngrams(payload);
     const gd = stripBloom(Graph.graphData());
-    const present = new Set(gd.nodes.map(nn => nn.id));
+    const nodeById = new Map(gd.nodes.map(nn => [nn.id, nn]));
     const fs = new Set(focusSet || [n.id]);
     engrams.forEach((em, i) => {
-      if (!present.has(em.id)) {
+      if (!nodeById.has(em.id)) {
         placeNear(em, n, i);
         gd.nodes.push(em);
-        present.add(em.id);
+        nodeById.set(em.id, em);
       }
       // endpoints are node OBJECTS so the tether renders under the pinned layout
       // (string ids go unresolved once the link force is nulled — see #188).
       gd.links.push({ source: n, target: em, link_type: 'focus' });
       fs.add(em.id);
+      // Distributed-engram bridges: this memory is also held by other neurons the
+      // viewer is cleared to see (the server already RBAC-filtered em.corroborators).
+      // Bridge the engram to each such corroborating neuron ALREADY rendered in the
+      // connectome — a memory spanning several neurons is one engram distributed
+      // across cells. Endpoints are node OBJECTS (#188). A corroborator absent from
+      // the graph (not a rendered neuron) is never bridged; it stays in the
+      // anonymous corroboration_count.
+      (em.corroborators || []).forEach(cid => {
+        if (cid === n.id) return;
+        const cn = nodeById.get(cid);
+        if (cn && cn.isNeuron) gd.links.push({ source: em, target: cn, link_type: 'engram-bridge' });
+      });
     });
     focusId = n.id; focusSet = fs;
     Graph.graphData(gd);

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -550,6 +550,16 @@ export function mountMriBrain(container, opts = {}) {
     if (!Graph) return;
     Graph.graphData(stripBloom(Graph.graphData()));
   }
+  // Any graph replacement leaves focus before the replacement fetch settles.
+  // Strip transient nodes/links first: if the fetch fails, clearing focus state
+  // first would make exitFocus() return early and strand the old bloom forever.
+  function leaveFocusForGraphReplacement(){
+    bloomLoads.invalidate();
+    clearBloom();
+    focusId = null; focusSet = null;
+    hideExplorePanel();
+    clearFocusMarker();
+  }
   async function bloomEngrams(n){
     if (disposed || !Graph || !rendered || mode !== 'connectome') return;
     const agentID = n.agent_id || n.id;
@@ -882,8 +892,8 @@ export function mountMriBrain(container, opts = {}) {
     const request = graphLoads.begin(mode);
     const tickGeneration = connectomeReloadIntent.begin(request.mode);
     const tickAware = tickGeneration > 0;
-    // A drill / reload leaves focus mode.
-    focusId = null; focusSet = null; hideExplorePanel(); clearFocusMarker();
+    // A drill / reload leaves focus mode even when the replacement fetch fails.
+    leaveFocusForGraphReplacement();
     fetchActive(request.mode).then(d => {
       if (disposed || !Graph || !graphLoads.isCurrent(request, mode)) return;
       clearTimeout(graphRetryTimer);
@@ -1443,7 +1453,7 @@ export function mountMriBrain(container, opts = {}) {
     connectomeReloadIntent.reset();
     neuronBirths.reset();
     currentDomain = null;
-    focusId=null; focusSet=null; hideExplorePanel(); clearFocusMarker();
+    leaveFocusForGraphReplacement();
     updateModeChrome();
     // Recall this view's remembered skull opacity (its default, or the operator's
     // last manual choice for this view) and reflect it on the slider, so a round

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -161,6 +161,7 @@ const STYLE = `
 .mrib .hud .l{color:#5d7395;font-size:10px;letter-spacing:1px;text-transform:uppercase}
 .mrib .hud .btn{cursor:pointer;color:#39d0ff;background:transparent;font:inherit;border:1px solid #15233b;border-radius:8px;padding:6px 11px;user-select:none}
 .mrib .hud .btn:hover{background:#0e1b30}
+.mrib .hud .b-mode[aria-pressed="true"]{background:#0e2943;border-color:#39d0ff}
 .mrib .hud .btn:focus-visible,.mrib .lg-toggle:focus-visible{outline:2px solid #39d0ff;outline-offset:2px}
 .mrib .hud .sld{display:flex;align-items:center;gap:7px;color:#5d7395;font-size:10px;letter-spacing:1px;text-transform:uppercase}
 .mrib .hud .sld input{width:84px;accent-color:#39d0ff;cursor:pointer}
@@ -224,6 +225,7 @@ const STYLE = `
 :root[data-theme="light"] .mrib .hud .btn:hover,
 :root[data-theme="light"] .mrib .explore .ex-back:hover,
 :root[data-theme="light"] .mrib .explore .ex-font button:hover:not(:disabled){background:#e9eef4;color:#0e7490}
+:root[data-theme="light"] .mrib .hud .b-mode[aria-pressed="true"]{background:#dff5fb;border-color:#0e7490}
 :root[data-theme="light"] .mrib .legend .cls,
 :root[data-theme="light"] .mrib .legend .row .t span,
 :root[data-theme="light"] .mrib .lobes .more,
@@ -1439,7 +1441,7 @@ export function mountMriBrain(container, opts = {}) {
     const connectome = mode === 'connectome';
     const btn=$('.b-mode');
     if(btn) {
-      btn.textContent = connectome ? '◈ memory' : '◉ connectome';
+      btn.textContent = '◉ connectome';
       btn.setAttribute('aria-label', 'Connectome view');
       btn.setAttribute('aria-pressed', connectome ? 'true' : 'false');
     }

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -361,7 +361,7 @@ export function mountMriBrain(container, opts = {}) {
       <div><div class="n nc">0</div><div class="l">consolidated</div></div>
       <button type="button" class="btn b-rot">⏸ pause</button>
       <button type="button" class="btn b-flow">⚡ flow: on</button>
-      ${allowConnectome ? '<button type="button" class="btn b-mode" aria-pressed="false">◉ connectome</button>' : ''}
+      ${allowConnectome ? '<button type="button" class="btn b-mode" aria-label="Connectome view" aria-pressed="false">◉ connectome</button>' : ''}
       <label class="sld">skull <input class="b-op" type="range" min="0" max="60" value="8"></label>
     </div>
     <div class="tip"></div>
@@ -1440,7 +1440,7 @@ export function mountMriBrain(container, opts = {}) {
     const btn=$('.b-mode');
     if(btn) {
       btn.textContent = connectome ? '◈ memory' : '◉ connectome';
-      btn.setAttribute('aria-label', connectome ? 'Show memory view' : 'Show connectome view');
+      btn.setAttribute('aria-label', 'Connectome view');
       btn.setAttribute('aria-pressed', connectome ? 'true' : 'false');
     }
     const title = $('.lg-title'); if (title) title.textContent = connectome ? 'Connectome' : 'Domain tags';

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -17,7 +17,7 @@
 
 import { THREE, ForceGraph3D, UnrealBloomPass } from '/ui/js/vendor/sage-graph.bundle.js';
 import { MRI_LAYOUT, mriDepthForAge, mriVerticalPosition } from '/ui/js/mri-layout.js';
-import { createGraphLoadCoordinator, mapConnectome, createConnectomeActivityTracker, createConnectomeReloadIntent, synapsePlasticity, neuronDormancy, createNeuronBirthTracker, neuronTint, mapEngrams, stripBloom } from '/ui/js/connectome-map.js';
+import { createGraphLoadCoordinator, createEngramBloomCoordinator, mapConnectome, createConnectomeActivityTracker, createConnectomeReloadIntent, synapsePlasticity, neuronDormancy, createNeuronBirthTracker, neuronTint, mapEngrams, stripBloom, applyEngramBloom } from '/ui/js/connectome-map.js';
 import { createModeHull } from '/ui/js/mode-hull.js';
 
 const LINK_TYPES = {
@@ -552,6 +552,8 @@ export function mountMriBrain(container, opts = {}) {
   }
   async function bloomEngrams(n){
     if (disposed || !Graph || !rendered || mode !== 'connectome') return;
+    const agentID = n.agent_id || n.id;
+    const bloomRequest = bloomLoads.begin(agentID);
     focusNeuron(n);
     // Clear any prior bloom IMMEDIATELY, before the fetch — so a failed, errored,
     // or superseded request never strands the previous agent's engrams under this
@@ -559,42 +561,18 @@ export function mountMriBrain(container, opts = {}) {
     clearBloom();
     let payload;
     try {
-      const resp = await fetch(ENGRAMS_URL + '?agent=' + encodeURIComponent(n.id), { credentials: 'same-origin' });
+      const resp = await fetch(ENGRAMS_URL + '?agent=' + encodeURIComponent(agentID), { credentials: 'same-origin' });
       if (!resp.ok) return;
       payload = await resp.json();
     } catch (e) { console.warn('[mri] engrams unavailable:', e.message); return; }
     // Superseded (another neuron clicked while this was in flight) or torn down:
     // drop the stale response rather than bloom it under the wrong focus.
-    if (disposed || !Graph || mode !== 'connectome' || focusId !== n.id) return;
+    if (disposed || !Graph || mode !== 'connectome' || focusId !== n.id ||
+        !bloomLoads.isCurrent(bloomRequest, agentID)) return;
     const engrams = mapEngrams(payload);
-    const gd = stripBloom(Graph.graphData());
-    const nodeById = new Map(gd.nodes.map(nn => [nn.id, nn]));
-    const fs = new Set(focusSet || [n.id]);
-    engrams.forEach((em, i) => {
-      if (!nodeById.has(em.id)) {
-        placeNear(em, n, i);
-        gd.nodes.push(em);
-        nodeById.set(em.id, em);
-      }
-      // endpoints are node OBJECTS so the tether renders under the pinned layout
-      // (string ids go unresolved once the link force is nulled — see #188).
-      gd.links.push({ source: n, target: em, link_type: 'focus' });
-      fs.add(em.id);
-      // Distributed-engram bridges: this memory is also held by other neurons the
-      // viewer is cleared to see (the server already RBAC-filtered em.corroborators).
-      // Bridge the engram to each such corroborating neuron ALREADY rendered in the
-      // connectome — a memory spanning several neurons is one engram distributed
-      // across cells. Endpoints are node OBJECTS (#188). A corroborator absent from
-      // the graph (not a rendered neuron) is never bridged; it stays in the
-      // anonymous corroboration_count.
-      (em.corroborators || []).forEach(cid => {
-        if (cid === n.id) return;
-        const cn = nodeById.get(cid);
-        if (cn && cn.isNeuron) gd.links.push({ source: em, target: cn, link_type: 'engram-bridge' });
-      });
-    });
-    focusId = n.id; focusSet = fs;
-    Graph.graphData(gd);
+    const composed = applyEngramBloom(Graph.graphData(), engrams, n, focusSet, placeNear);
+    focusId = n.id; focusSet = composed.focusSet;
+    Graph.graphData(composed.graphData);
     Graph.nodeColor(nodeColorRGBA);
     setFocusMarkerNode(n);
   }
@@ -696,6 +674,7 @@ export function mountMriBrain(container, opts = {}) {
   // Mode-aware source: the memory graph (domain-drillable) or the connectome.
   const fetchActive = requestMode => requestMode === 'connectome' ? loadSynapses(SYNAPSE_URL) : loadGraph(urlFor());
   const graphLoads = createGraphLoadCoordinator();
+  const bloomLoads = createEngramBloomCoordinator();
   let rendered = null;   // last graph data handed to ForceGraph (for neuron focus)
   const subs = [];
   let graphRetryTimer = null;
@@ -974,13 +953,11 @@ export function mountMriBrain(container, opts = {}) {
 
   function exitFocus(){
     if (!focusId) return;
+    bloomLoads.invalidate();
     focusId = null; focusSet = null;
     clearFocusMarker();
     if (Graph) {
-      const gd = Graph.graphData();
-      gd.nodes = gd.nodes.filter(n => !n._added);
-      gd.links = gd.links.filter(l => l.link_type !== 'focus');
-      Graph.graphData(gd);
+      Graph.graphData(stripBloom(Graph.graphData()));
       Graph.nodeColor(nodeColorRGBA);
     }
     hideExplorePanel();
@@ -1400,7 +1377,7 @@ export function mountMriBrain(container, opts = {}) {
       initializeGraph(d);
       // Deep-link: auto-bloom a requested agent's lobe on first connectome paint.
       if (focusAgent && !autoBloomed && mode === 'connectome' && rendered) {
-        const target = rendered.nodes.find(nd => nd.isNeuron && nd.id === focusAgent);
+        const target = rendered.nodes.find(nd => nd.isNeuron && (nd.agent_id || nd.id) === focusAgent);
         if (target) { autoBloomed = true; deepLinkTimer = setTimeout(() => { if (!disposed) bloomEngrams(target); }, 50); }
       }
     }).catch(() => {
@@ -1460,6 +1437,7 @@ export function mountMriBrain(container, opts = {}) {
   function setMode(next){
     if (mode===next || (next==='connectome' && !allowConnectome)) return;
     graphLoads.invalidate();
+    bloomLoads.invalidate();
     mode = next;
     connectomeActivity.reset();
     connectomeReloadIntent.reset();
@@ -1484,6 +1462,7 @@ export function mountMriBrain(container, opts = {}) {
 
   return function cleanup(){
     disposed = true;
+    bloomLoads.invalidate();
     clearTimeout(graphRetryTimer);
     clearInterval(plasticityTimer);
     clearTimeout(birthDecayTimer);

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -1419,19 +1419,13 @@ export function mountMriBrain(container, opts = {}) {
   root.addEventListener('mousemove', onMove);
   root.addEventListener('pointerdown', onGraphPointerDown);
   root.addEventListener('click', onGraphClick);
-  // Connectome legend caption — appended once, shown only in connectome mode.
-  const modeCap = document.createElement('div');
-  modeCap.className = 'panel mode-cap';
-  modeCap.style.cssText = 'position:absolute;left:auto;bottom:44px;top:auto;right:12px;display:none;max-width:236px;font-size:11px;line-height:1.55';
-  modeCap.innerHTML = '<b>Connectome</b> · the agent message-bus<br>◉ neuron = agent · hue = domain<br>synapse thickness + pulse = traffic (Hebbian)<br>idle synapses thin & fade · use it or lose it<br>new agents grow in · dormant ones grey out<br>hubs sink to the core · click a neuron → its memories bloom';
-  root.appendChild(modeCap);
-
-  // Relabel the stat panel + button and toggle the caption for the active mode.
+  // Relabel the stat panel and button for the active mode. The explanatory
+  // copy lives in CEREBRUM's existing "How to read" guide instead of covering
+  // the graph with a second floating panel.
   function updateModeChrome(){
     const btn=$('.b-mode'); if(btn) btn.textContent = mode==='connectome' ? '◈ memory' : '◉ connectome';
     const set = mode==='connectome' ? ['neurons','synapses','hubs'] : ['memories','synapses','consolidated'];
     root.querySelectorAll('.hud .l').forEach((el,i)=>{ if(set[i]) el.textContent=set[i]; });
-    modeCap.style.display = mode==='connectome' ? '' : 'none';
   }
   updateModeChrome();
 

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -144,7 +144,7 @@ const STYLE = `
 .mrib .legend.collapsed .lg-detail{display:none}
 .mrib .legend.collapsed{max-height:70%}
 .mrib .lg-head{display:flex;align-items:center;justify-content:space-between;gap:8px}
-.mrib .lg-toggle{cursor:pointer;color:#39d0ff;font-size:10px;letter-spacing:1px;text-transform:uppercase;border:1px solid #15233b;border-radius:7px;padding:3px 8px;user-select:none;white-space:nowrap}
+.mrib .lg-toggle{cursor:pointer;color:#39d0ff;background:transparent;font:inherit;font-size:10px;letter-spacing:1px;text-transform:uppercase;border:1px solid #15233b;border-radius:7px;padding:3px 8px;user-select:none;white-space:nowrap}
 .mrib .lg-toggle:hover{background:#0e1b30}
 .mrib .lobes .more{color:#5d7395;font-size:11px;margin-top:7px}
 .mrib .legend h4{margin:0 0 4px;font-size:11px;letter-spacing:1.5px;color:#39d0ff;text-transform:uppercase}
@@ -159,8 +159,9 @@ const STYLE = `
 .mrib .hud{bottom:16px;left:16px;padding:10px 14px;display:flex;gap:16px;align-items:center}
 .mrib .hud .n{color:#eaf4ff;font-size:17px;font-weight:700}
 .mrib .hud .l{color:#5d7395;font-size:10px;letter-spacing:1px;text-transform:uppercase}
-.mrib .hud .btn{cursor:pointer;color:#39d0ff;border:1px solid #15233b;border-radius:8px;padding:6px 11px;user-select:none}
+.mrib .hud .btn{cursor:pointer;color:#39d0ff;background:transparent;font:inherit;border:1px solid #15233b;border-radius:8px;padding:6px 11px;user-select:none}
 .mrib .hud .btn:hover{background:#0e1b30}
+.mrib .hud .btn:focus-visible,.mrib .lg-toggle:focus-visible{outline:2px solid #39d0ff;outline-offset:2px}
 .mrib .hud .sld{display:flex;align-items:center;gap:7px;color:#5d7395;font-size:10px;letter-spacing:1px;text-transform:uppercase}
 .mrib .hud .sld input{width:84px;accent-color:#39d0ff;cursor:pointer}
 .mrib .scan{position:absolute;top:16px;left:16px;padding:10px 14px}
@@ -171,6 +172,7 @@ const STYLE = `
 .mrib .tip .m{color:#5d7395;font-size:11px}
 .mrib .tip .chip{font-size:10px;padding:1px 6px;border-radius:6px;background:#0e1b30;color:#aecbf0;margin-right:4px}
 .mrib .flag{position:absolute;bottom:16px;right:16px;color:#3a4a66;font-size:10px;letter-spacing:1px}
+.mrib .sr-status{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .mrib .boot{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#5d7395;letter-spacing:2px;font-size:12px}
 .mrib .explore{--ex-font:12px;display:none;left:16px;right:306px;bottom:14px;height:47%;min-height:210px;max-height:72%;flex-direction:column;padding:0;overflow:hidden}
 .mrib .explore .ex-resize{position:absolute;top:0;left:12px;right:12px;height:10px;cursor:ns-resize;z-index:2}
@@ -329,8 +331,8 @@ export function mountMriBrain(container, opts = {}) {
     <div class="boot">◉ ACQUIRING HIPPOCAMPAL FIELD…</div>
     ${showScan ? '<div class="panel scan"><b>CEREBRUM · MRI</b><div class="s">◉ SCANNING</div></div>' : ''}
     ${showDomainLegend ? `<div class="panel legend">
-      <div class="lg-head"><h4>Domain tags</h4><span class="lg-toggle"></span></div>
-      <div class="lg-detail">
+      <div class="lg-head"><h4 class="lg-title">Domain tags</h4><button type="button" class="lg-toggle" aria-expanded="false"></button></div>
+      <div class="lg-detail guide-memory">
         <div class="cls">A complementary-learning-systems view: SAGE is the <b>hippocampus</b>
           (episodic capture); corroboration + decay is the <b>sleep/consolidation</b> cycle.</div>
         <div class="seg">Nodes — memories</div>
@@ -343,6 +345,13 @@ export function mountMriBrain(container, opts = {}) {
         <div class="row"><span class="k">◈</span><div class="t"><b>Angle = domain</b><br><span>each topic is a radial stream</span></div></div>
         <div class="row"><span class="k">◉</span><div class="t"><b>Click a memory</b><br><span>see its train of thought</span></div></div>
       </div>
+      <div class="lg-detail guide-connectome" hidden>
+        <div class="cls">Agents are neurons, domains set their hue, and message traffic drives synapse thickness and pulses.</div>
+        <div class="seg">Connectome</div>
+        <div class="row"><span class="k">◉</span><div class="t"><b>Neuron = agent</b><br><span>click one to bloom its memories</span></div></div>
+        <div class="row"><span class="k">↝</span><div class="t"><b>Thickness + pulse = traffic</b><br><span>active channels strengthen</span></div></div>
+        <div class="row"><span class="k">⊙</span><div class="t"><b>Depth = activity</b><br><span>active hubs sit near the core</span></div></div>
+      </div>
       <div class="seg">Lobes — domains</div><div class="lobes"></div>
       <div class="lg-detail"><div class="seg">Connectome — typed links</div><div class="linktypes"></div></div>
     </div>` : ''}
@@ -350,13 +359,14 @@ export function mountMriBrain(container, opts = {}) {
       <div><div class="n nn">0</div><div class="l">memories</div></div>
       <div><div class="n ne">0</div><div class="l">synapses</div></div>
       <div><div class="n nc">0</div><div class="l">consolidated</div></div>
-      <div class="btn b-rot">⏸ pause</div>
-      <div class="btn b-flow">⚡ flow: on</div>
-      ${allowConnectome ? '<div class="btn b-mode">◉ connectome</div>' : ''}
+      <button type="button" class="btn b-rot">⏸ pause</button>
+      <button type="button" class="btn b-flow">⚡ flow: on</button>
+      ${allowConnectome ? '<button type="button" class="btn b-mode" aria-pressed="false">◉ connectome</button>' : ''}
       <label class="sld">skull <input class="b-op" type="range" min="0" max="60" value="8"></label>
     </div>
     <div class="tip"></div>
-    <div class="flag"></div>`;
+    <div class="flag"></div>
+    <div class="sr-status" role="status" aria-live="polite"></div>`;
   container.appendChild(root);
   // Reflect the active view's skull opacity on the slider from the start.
   { const _op = root.querySelector('.b-op'); if (_op) _op.value = sliderUnits(hullState.valueFor(mode)); }
@@ -372,7 +382,10 @@ export function mountMriBrain(container, opts = {}) {
     const lg = $('.legend'); if (!lg) return;
     lg.classList.toggle('collapsed', legendMode !== 'full');
     const t = $('.lg-toggle');
-    if (t) t.textContent = legendMode === 'full' ? '▴ less' : '▾ how to read';
+    if (t) {
+      t.textContent = legendMode === 'full' ? '▴ less' : '▾ how to read';
+      t.setAttribute('aria-expanded', legendMode === 'full' ? 'true' : 'false');
+    }
   }
   applyLegendMode();
   const lgToggle = $('.lg-toggle');
@@ -1419,13 +1432,28 @@ export function mountMriBrain(container, opts = {}) {
   root.addEventListener('mousemove', onMove);
   root.addEventListener('pointerdown', onGraphPointerDown);
   root.addEventListener('click', onGraphClick);
-  // Relabel the stat panel and button for the active mode. The explanatory
-  // copy lives in CEREBRUM's existing "How to read" guide instead of covering
-  // the graph with a second floating panel.
-  function updateModeChrome(){
-    const btn=$('.b-mode'); if(btn) btn.textContent = mode==='connectome' ? '◈ memory' : '◉ connectome';
+  // Relabel the stat panel and expose mode-specific guidance through the
+  // existing reading panel. Mode changes are announced without placing another
+  // visible panel over the graph.
+  function updateModeChrome(announce=false){
+    const connectome = mode === 'connectome';
+    const btn=$('.b-mode');
+    if(btn) {
+      btn.textContent = connectome ? '◈ memory' : '◉ connectome';
+      btn.setAttribute('aria-label', connectome ? 'Show memory view' : 'Show connectome view');
+      btn.setAttribute('aria-pressed', connectome ? 'true' : 'false');
+    }
+    const title = $('.lg-title'); if (title) title.textContent = connectome ? 'Connectome' : 'Domain tags';
+    const memoryGuide = $('.guide-memory'); if (memoryGuide) memoryGuide.hidden = connectome;
+    const connectomeGuide = $('.guide-connectome'); if (connectomeGuide) connectomeGuide.hidden = !connectome;
     const set = mode==='connectome' ? ['neurons','synapses','hubs'] : ['memories','synapses','consolidated'];
     root.querySelectorAll('.hud .l').forEach((el,i)=>{ if(set[i]) el.textContent=set[i]; });
+    if (announce) {
+      const status = $('.sr-status');
+      if (status) status.textContent = connectome
+        ? 'Connectome view. Agents are neurons and message traffic drives synapses.'
+        : 'Memory view. Memories are grouped by domain and consolidation.';
+    }
   }
   updateModeChrome();
 
@@ -1441,7 +1469,7 @@ export function mountMriBrain(container, opts = {}) {
     neuronBirths.reset();
     currentDomain = null;
     focusId=null; focusSet=null; hideExplorePanel(); clearFocusMarker();
-    updateModeChrome();
+    updateModeChrome(true);
     // Recall this view's remembered skull opacity (its default, or the operator's
     // last manual choice for this view) and reflect it on the slider, so a round
     // trip preserves each view's setting independently.

--- a/web/synapse_handler.go
+++ b/web/synapse_handler.go
@@ -161,6 +161,12 @@ func listCurrentConnectomeAgents(badgerStore *store.BadgerStore) ([]store.OnChai
 		if !enrollment.Active {
 			continue
 		}
+		// Root handover suspends every delegated Admin from the previous
+		// generation until the current Root explicitly reauthorizes it.
+		if role.Role == store.AppV23RoleAdmin &&
+			enrollment.RootGeneration != root.Generation {
+			continue
+		}
 		if err := store.ValidateAppV23EnrollmentPolicy(
 			role.Role, enrollment.Profile, enrollment.Capabilities,
 			enrollment.Clearance, enrollment.Active,

--- a/web/synapse_handler.go
+++ b/web/synapse_handler.go
@@ -3,6 +3,8 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/l33tdawg/sage/internal/store"
@@ -53,11 +55,15 @@ func (h *DashboardHandler) handleSynapses(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	agents, err := h.BadgerStore.ListRegisteredAgents()
+	agents, err := listCurrentConnectomeAgents(h.BadgerStore)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]any{"error": "neuron read failed"})
 		return
+	}
+	currentNeurons := make(map[string]bool, len(agents))
+	for _, agent := range agents {
+		currentNeurons[agent.AgentID] = true
 	}
 
 	allowed, seeAll := h.resolveAgentRBAC(r)
@@ -95,6 +101,9 @@ func (h *DashboardHandler) handleSynapses(w http.ResponseWriter, r *http.Request
 			return
 		}
 		for _, e := range edges {
+			if !currentNeurons[e.FromAgent] || !currentNeurons[e.ToAgent] {
+				continue
+			}
 			if !seeAll && (!visible[e.FromAgent] || !visible[e.ToAgent]) {
 				continue
 			}
@@ -106,4 +115,59 @@ func (h *DashboardHandler) handleSynapses(w http.ResponseWriter, r *http.Request
 		"neurons":  neurons,
 		"synapses": synapses,
 	})
+}
+
+// listCurrentConnectomeAgents keeps the immutable registration ledger separate
+// from the current app-v23 serving roster. Before app-v23 activation every
+// registration remains a neuron for compatibility. Once a Root exists, only a
+// complete, active ordinary enrollment may render; pending, removed, and any
+// current or retired Root credential stay outside both the neuron list and the
+// distributed-engram bridge boundary.
+func listCurrentConnectomeAgents(badgerStore *store.BadgerStore) ([]store.OnChainAgent, error) {
+	agents, err := badgerStore.ListRegisteredAgents()
+	if err != nil {
+		return nil, err
+	}
+	root, err := badgerStore.GetAppV23Root()
+	if err != nil {
+		return nil, err
+	}
+	if root == nil {
+		return agents, nil
+	}
+
+	active := make([]store.OnChainAgent, 0, len(agents))
+	for _, agent := range agents {
+		wasRoot, rootErr := badgerStore.IsAppV23RootCredential(agent.AgentID)
+		if rootErr != nil {
+			return nil, rootErr
+		}
+		if wasRoot || agent.AgentID == root.PrincipalID || agent.AgentID == root.CredentialID {
+			continue
+		}
+		enrollment, enrollmentErr := badgerStore.GetAppV23Enrollment(agent.AgentID)
+		role, roleErr := badgerStore.GetAppV23Role(agent.AgentID)
+		if enrollmentErr != nil || roleErr != nil {
+			return nil, errors.Join(enrollmentErr, roleErr)
+		}
+		// A post-activation self-registration remains pending until Root review.
+		if enrollment == nil && role == nil {
+			continue
+		}
+		if enrollment == nil || role == nil ||
+			enrollment.AgentID != agent.AgentID || role.AgentID != agent.AgentID {
+			return nil, fmt.Errorf("incomplete app-v23 Connectome policy for agent %s", agent.AgentID)
+		}
+		if !enrollment.Active {
+			continue
+		}
+		if err := store.ValidateAppV23EnrollmentPolicy(
+			role.Role, enrollment.Profile, enrollment.Capabilities,
+			enrollment.Clearance, enrollment.Active,
+		); err != nil {
+			return nil, fmt.Errorf("invalid app-v23 Connectome policy for agent %s: %w", agent.AgentID, err)
+		}
+		active = append(active, agent)
+	}
+	return active, nil
 }

--- a/web/synapse_handler_test.go
+++ b/web/synapse_handler_test.go
@@ -51,6 +51,9 @@ func decodeSynapseBody(t *testing.T, rec *httptest.ResponseRecorder) synapseBody
 // applies.
 func TestHandleSynapses(t *testing.T) {
 	h, s := newSynapseTestHandler(t)
+	for i, id := range []string{"alice", "bob"} {
+		require.NoError(t, h.BadgerStore.RegisterAgent(id, id, "member", "", "test", "", int64(i+1)))
+	}
 
 	base := time.Now().UTC().Truncate(time.Second)
 	insertSynapseMessage(t, s, "p1", "alice", "bob", base)


### PR DESCRIPTION
Integrated v11.18.13 release candidate from exact v11.18.12 base ba006fa0.\n\nIncluded stacks:\n- Hubanov distributed engrams, preserving original commit 95c04e17 in ancestry, plus lifecycle/query hardening\n- Connectome floating-caption removal and accessible mode guidance\n- Claude signed production wake source, preserving the complete PR #222 stack, plus owner shutdown proof\n- claimant-session-safe canonical reply fallback and hidden alias fence\n- aligned 11.18.13 desktop, SDK, container, docs, and update metadata; no app-v27\n\nCombined local verification:\n- frontend/static/docs 375/375\n- Python SDK 174/174 against workspace source\n- full internal/store, web, and internal/mcp packages\n- real PostgreSQL 16 bounded corroborator integration\n- targeted REST/store claimant-session tests, race suites, go vet, and mutation replays\n\nDraft only. Final exact-head CODE GOs and all hosted gates are required before main merge or tag.