### PR TITLE
fix(messages): stop a claimant-session fence rejection from masquerading as a missing message

### DIFF
--- a/api/rest/messages_handler.go
+++ b/api/rest/messages_handler.go
@@ -313,6 +313,10 @@ func (s *Server) handleMessageHandoff(w http.ResponseWriter, r *http.Request) {
 		"claimant_session_id": req.ToSessionID, "idempotent_replay": replayed})
 }
 
+// messageClaimSessionProblemType marks a claimant-session fence rejection so a
+// caller can tell it apart from a genuinely absent message.
+const messageClaimSessionProblemType = "https://sage.dev/errors/message-claim-session-mismatch"
+
 func (s *Server) handleMessageReply(w http.ResponseWriter, r *http.Request) {
 	if !requireExactSignedMessageAction(w, r) {
 		return
@@ -344,6 +348,13 @@ func (s *Server) handleMessageReply(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, store.ErrMessageReplyConflict):
 			writeProblem(w, http.StatusConflict, "Reply conflict", "This message already has a different reply.")
+		case errors.Is(err, store.ErrMessageClaimedByOtherSession):
+			// Deliberately NOT a 404. The MCP client's compatibility fallback
+			// treats any 404 as an older node missing this route and retries
+			// without a claimant session, which would bypass the very fence
+			// that just rejected the call.
+			writeProblemTyped(w, http.StatusConflict, messageClaimSessionProblemType, "Claimed by another session",
+				"Another session of this agent holds this message's claim. Use sage_message_handoff to take it over, or reply from the claiming session.")
 		case errors.Is(err, store.ErrPipeResultTooLarge):
 			writeProblemTyped(w, http.StatusRequestEntityTooLarge, pipeTooLargeProblemType, "Reply too large", err.Error())
 		default:

--- a/api/rest/messages_handler_test.go
+++ b/api/rest/messages_handler_test.go
@@ -404,3 +404,75 @@ func TestCanonicalMessageSendDoesNotFailWhenOptionalNotifierDrops(t *testing.T) 
 	require.NoError(t, err)
 	require.Len(t, pipes, 1)
 }
+
+// The wire status is the whole point of this fix. The MCP client's older-node
+// fallback triggers on 404 and retries the same route WITHOUT a claimant
+// session, so collapsing a fence rejection into 404 hands the client a licence
+// to bypass the fence it just failed. A fence rejection must therefore be
+// distinguishable on the wire, while a genuinely absent message must stay 404
+// so the compatibility path keeps working.
+func TestMessageReplyFenceRejectionIsNotAFourOhFour(t *testing.T) {
+	s, sqlite := newPipeServer(t)
+	addMessageAgent(t, sqlite, "alice")
+	addMessageAgent(t, sqlite, "bob")
+	addMessageAgent(t, sqlite, "mallory")
+
+	sent := callMessageJSON(t, messageRouterAs(s, "alice", true), http.MethodPost, "/v1/messages",
+		map[string]any{"to_agent": "bob", "intent": "review", "payload": "private request", "idempotency_key": "fence-send"})
+	require.Equal(t, http.StatusCreated, sent.Code, sent.Body.String())
+	var sendResponse map[string]any
+	require.NoError(t, json.Unmarshal(sent.Body.Bytes(), &sendResponse))
+	messageID := sendResponse["message_id"].(string)
+
+	received := callMessageJSON(t, messageRouterAs(s, "bob", true), http.MethodPost, "/v1/messages/receive",
+		map[string]any{"receive_token": "fence-receive", "limit": 5, "claimant_session_id": "session-a"})
+	require.Equal(t, http.StatusOK, received.Code, received.Body.String())
+
+	// Same agent, second session, no handoff.
+	fenced := callMessageJSON(t, messageRouterAs(s, "bob", true), http.MethodPost, "/v1/messages/"+messageID+"/reply",
+		map[string]any{"result": "from-session-b", "claimant_session_id": "session-b"})
+	require.Equal(t, http.StatusConflict, fenced.Code, fenced.Body.String())
+	require.NotEqual(t, http.StatusNotFound, fenced.Code,
+		"a 404 here is what lets the client retry unfenced")
+	require.Contains(t, fenced.Body.String(), "message-claim-session-mismatch",
+		"the rejection needs a distinct problem type, not just a distinct status")
+
+	// The fence must not have completed anything.
+	stillOpen := callMessageJSON(t, messageRouterAs(s, "bob", true), http.MethodPost, "/v1/messages/"+messageID+"/reply",
+		map[string]any{"result": "from-session-a", "claimant_session_id": "session-a"})
+	require.Equal(t, http.StatusOK, stillOpen.Code, stillOpen.Body.String())
+
+	// A genuinely absent message stays 404 so the older-node fallback survives.
+	absent := callMessageJSON(t, messageRouterAs(s, "bob", true), http.MethodPost, "/v1/messages/msg-does-not-exist/reply",
+		map[string]any{"result": "x", "claimant_session_id": "session-a"})
+	require.Equal(t, http.StatusNotFound, absent.Code, absent.Body.String())
+	require.NotContains(t, absent.Body.String(), "message-claim-session-mismatch")
+}
+
+// Anti-enumeration: the new status must never become the thing that tells a
+// different agent the message exists.
+func TestMessageReplyFenceNeverLeaksAcrossAgents(t *testing.T) {
+	s, sqlite := newPipeServer(t)
+	addMessageAgent(t, sqlite, "alice")
+	addMessageAgent(t, sqlite, "bob")
+	addMessageAgent(t, sqlite, "mallory")
+
+	sent := callMessageJSON(t, messageRouterAs(s, "alice", true), http.MethodPost, "/v1/messages",
+		map[string]any{"to_agent": "bob", "intent": "review", "payload": "private", "idempotency_key": "leak-send"})
+	require.Equal(t, http.StatusCreated, sent.Code)
+	var sendResponse map[string]any
+	require.NoError(t, json.Unmarshal(sent.Body.Bytes(), &sendResponse))
+	messageID := sendResponse["message_id"].(string)
+
+	received := callMessageJSON(t, messageRouterAs(s, "bob", true), http.MethodPost, "/v1/messages/receive",
+		map[string]any{"receive_token": "leak-receive", "limit": 5, "claimant_session_id": "session-a"})
+	require.Equal(t, http.StatusOK, received.Code)
+
+	// Mallory is not the recipient. She must get the same 404 as for a message
+	// that does not exist — never the session-mismatch signal.
+	intruder := callMessageJSON(t, messageRouterAs(s, "mallory", true), http.MethodPost, "/v1/messages/"+messageID+"/reply",
+		map[string]any{"result": "stolen", "claimant_session_id": "session-b"})
+	require.Equal(t, http.StatusNotFound, intruder.Code, intruder.Body.String())
+	require.NotContains(t, intruder.Body.String(), "message-claim-session-mismatch",
+		"the fence must never reveal another agent's message to a non-recipient")
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -675,11 +675,20 @@ func (s *SQLiteStore) ReplyLocalMessage(ctx context.Context, receiverID, message
 		if err != nil || !fetched || provider != "" || claimed != receiverID || sourceChain != "" || destinationChain != "" {
 			return ErrMessageNotFound
 		}
+		// The fence runs only after the caller has been proven to be this
+		// message's addressed recipient (claimed == receiverID above), so it
+		// separates SESSIONS of one agent, never one agent from another. It
+		// therefore reports a distinct error rather than collapsing into
+		// ErrMessageNotFound: a 404 is indistinguishable from an absent route,
+		// and the MCP client treats an absent route as licence to retry the
+		// same call without a session id — bypassing this check entirely.
 		if claimantSessionID != "" {
 			var currentSessionID string
 			if sessionErr := tx.conn.QueryRowContext(ctx, `SELECT claimant_session_id FROM message_fetch_receipts
-				WHERE receiver_agent_id=? AND message_id=?`, receiverID, messageID).Scan(&currentSessionID); sessionErr != nil || currentSessionID != claimantSessionID {
+				WHERE receiver_agent_id=? AND message_id=?`, receiverID, messageID).Scan(&currentSessionID); sessionErr != nil {
 				return ErrMessageNotFound
+			} else if currentSessionID != claimantSessionID {
+				return ErrMessageClaimedByOtherSession
 			}
 		}
 		if completeErr := tx.CompletePipeline(ctx, messageID, receiverID, result, ""); completeErr != nil {

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -355,8 +355,13 @@ func TestMessageReceiveAttributesWinningSessionAndDeterministicHandoff(t *testin
 	history, err = s.GetInboxHistory(ctx, "bob", "", 10)
 	require.NoError(t, err)
 	require.Equal(t, target, history[0].ClaimedSessionID)
+	// Was ErrMessageNotFound. That expectation encoded the collapsing this
+	// package now avoids: a stale session and an absent message reported the
+	// same error, the REST layer turned both into 404, and the MCP client's
+	// older-node fallback retried the call without a session id — bypassing
+	// this fence. The refusal itself is unchanged; only its precision is.
 	_, err = s.ReplyLocalMessage(ctx, "bob", "msg-session", "stale", winner)
-	require.ErrorIs(t, err, ErrMessageNotFound)
+	require.ErrorIs(t, err, ErrMessageClaimedByOtherSession)
 	_, err = s.ReplyLocalMessage(ctx, "bob", "msg-session", "done", target)
 	require.NoError(t, err)
 }

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -688,3 +688,69 @@ func TestMessageFingerprintsAreVaultSealedAndStillReplay(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, replayed)
 }
+
+// A fence rejection and a missing message are different facts and must not
+// collapse into the same error. Collapsing them is what let the MCP client
+// treat "another session holds this claim" as "this node is too old for this
+// route" and retry the same call without a session id, bypassing the fence.
+//
+// Distinguishing them leaks nothing across an agent boundary: the fence is
+// reached only after the caller is proven to be the addressed recipient, so it
+// separates sessions of ONE agent.
+func TestMessageReplyDistinguishesAnotherSessionsClaimFromAMissingMessage(t *testing.T) {
+	ctx := context.Background()
+	s := newMessageTestStore(t)
+	_, _, err := s.SendLocalMessage(ctx, "send", testLocalMessage("msg", "alice", "bob", "work"))
+	require.NoError(t, err)
+	_, _, err = s.ReceiveLocalMessages(ctx, "bob", "", "receive", 1, "session-a")
+	require.NoError(t, err)
+
+	// Same agent, different session, no handoff: refused, and refused
+	// DISTINGUISHABLY.
+	_, err = s.ReplyLocalMessage(ctx, "bob", "msg", "from-b", "session-b")
+	require.ErrorIs(t, err, ErrMessageClaimedByOtherSession)
+	require.NotErrorIs(t, err, ErrMessageNotFound,
+		"a fence rejection must not masquerade as an absent message")
+
+	// A genuinely absent message stays a plain not-found, so the older-node
+	// compatibility path keeps working.
+	_, err = s.ReplyLocalMessage(ctx, "bob", "no-such-message", "from-a", "session-a")
+	require.ErrorIs(t, err, ErrMessageNotFound)
+	require.NotErrorIs(t, err, ErrMessageClaimedByOtherSession)
+
+	// A different AGENT is still an ordinary not-found: the fence must never be
+	// the thing that reveals another agent's message exists.
+	_, err = s.ReplyLocalMessage(ctx, "mallory", "msg", "from-mallory", "session-m")
+	require.ErrorIs(t, err, ErrMessageNotFound)
+	require.NotErrorIs(t, err, ErrMessageClaimedByOtherSession)
+
+	// The claiming session still succeeds, and an unfenced caller still
+	// succeeds, so the fix does not tighten anything it should not.
+	replayed, err := s.ReplyLocalMessage(ctx, "bob", "msg", "from-a", "session-a")
+	require.NoError(t, err)
+	require.False(t, replayed)
+}
+
+// After a documented handoff the new session owns the claim and the old one
+// loses it — still distinguishably.
+func TestMessageReplyFenceFollowsAnExplicitHandoff(t *testing.T) {
+	ctx := context.Background()
+	s := newMessageTestStore(t)
+	_, _, err := s.SendLocalMessage(ctx, "send", testLocalMessage("msg", "alice", "bob", "work"))
+	require.NoError(t, err)
+	_, _, err = s.ReceiveLocalMessages(ctx, "bob", "", "receive", 1, "session-a")
+	require.NoError(t, err)
+
+	// The bool is "replayed" (an idempotent re-handoff), not "moved": a fresh
+	// handoff reports false.
+	replayedHandoff, err := s.HandoffLocalMessageClaim(ctx, "bob", "msg", "session-a", "session-b")
+	require.NoError(t, err)
+	require.False(t, replayedHandoff)
+
+	_, err = s.ReplyLocalMessage(ctx, "bob", "msg", "stale", "session-a")
+	require.ErrorIs(t, err, ErrMessageClaimedByOtherSession)
+
+	replayed, err := s.ReplyLocalMessage(ctx, "bob", "msg", "fresh", "session-b")
+	require.NoError(t, err)
+	require.False(t, replayed)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -791,6 +791,12 @@ var (
 	ErrMessageReceiveExpired      = errors.New("message receive replay is no longer retained")
 	ErrMessageReplyConflict       = errors.New("message already has a different reply")
 	ErrMessageNotFound            = errors.New("message not found")
+	// ErrMessageClaimedByOtherSession separates "another session of THIS
+	// agent holds the claim" from "no such message". Collapsing the two let
+	// the MCP client treat a fence rejection as an absent route and retry
+	// unfenced. Distinguishing them leaks nothing: the caller has already
+	// been proven to be the addressed recipient before the fence is applied.
+	ErrMessageClaimedByOtherSession = errors.New("message is claimed by another session of this agent")
 )
 
 // PipelineMessage represents an ephemeral agent-to-agent work item.


### PR DESCRIPTION
## The bypass

The claimant-session fence refuses a reply from a session that does not hold the claim. It refused by returning `ErrMessageNotFound`, which REST mapped to **404 — the same 404 as a genuinely absent message**.

The MCP client treats any 404 on that route as an older node missing it, and falls back to `toolPipeResult`, which re-POSTs **the identical canonical route** `/v1/messages/{id}/reply` with `{"result": ...}` and **no `claimant_session_id`**. The fence is skipped (`if claimantSessionID != ""`), the shared agent id passes, and the reply completes.

So a second session holding no claim and performing no handoff was refused — and then immediately succeeded by asking again without the session id. The claiming session's later reply took a 409 and its work was discarded: exactly the duplicated ownership `sage_message_handoff` promises cannot happen.

Found by a 6-dimension adversarial audit of the control plane; two dimensions surfaced it independently, and all four links were then re-verified by hand.

## The fix

Make the two facts distinguishable, so the client's compatibility path can no longer be triggered by a fence rejection.

- New `store.ErrMessageClaimedByOtherSession`, returned on a genuine session **mismatch**. A failed receipt lookup still returns not-found.
- Mapped in REST to **409** with a distinct problem type `https://sage.dev/errors/message-claim-session-mismatch`, alongside the existing "Reply conflict" 409 which keeps its own type.
- **The client is unchanged.** Its fallback is gated on `isAPIStatus(err, http.StatusNotFound)`, so a 409 surfaces the error and the unfenced retry never happens.
- A genuinely absent message still returns 404, so the older-node compatibility path is untouched.

## Why distinguishing leaks nothing

The fence is reached **only after** the caller is proven to be the addressed recipient — `claimed != receiverID` already returns not-found above it. So the new status separates **sessions of one agent**, never one agent from another. A non-recipient gets the identical 404 they always got, pinned by a dedicated test using a third agent.

## Why not fix it client-side

It would have moved the bypass rather than removed it: the legacy `PUT /v1/pipe/{id}/result` authorizes on the shared agent id, so a second session could still complete another session's work by taking the older path.

**Deliberately not included:** fencing that legacy compatibility route. It predates sessions and is the federated/older-node surface; changing it is a behavioural change to a compatibility path and belongs in its own PR.

## Tests — all mutation-verified

Reverting the fence to `ErrMessageNotFound` fails them: 5 store failures, and the REST test fails with `expected: 409`.

- session mismatch yields the distinct error and **not** not-found; absent message yields not-found and **not** the fence error; a **different agent** yields not-found; the claiming session still succeeds
- the fence follows an explicit handoff — new owner replies, old session refused
- REST: rejection is 409 with the distinct problem type, the refused call does **not** complete the message, the claiming session still succeeds after, an absent message is still 404 without the problem type
- REST: a non-recipient gets a plain 404 with no session-mismatch signal

## One existing expectation changed

`TestMessageReceiveAttributesWinningSessionAndDeterministicHandoff` asserted a stale-session reply returns `ErrMessageNotFound`. That assertion **encoded the ambiguity this PR removes**. The refusal is unchanged; only its precision is. Called out explicitly because a reviewer should scrutinise any PR that edits an existing assertion.

## Gates

`go build ./...` clean · golangci-lint (repo config, v2.12.2) **0 issues** · `go test ./internal/store/ ./api/rest/ ./internal/mcp/` all **ok**.

Base `2eea658b` (current protected main = v11.18.13), **not** the `ba006fa0` originally suggested — that is v11.18.12 and now superseded. Draft; codex holds merge authority.