### PR TITLE
fix(store): give GetCorroborations the same total order as the bounded reader

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -2273,7 +2273,7 @@ address resolved from a bounded legacy-status offline cache can be accepted
 locally while the peer is down. Delivery waits for that peer to return and pass
 the fresh live authorization preflight above.
 
-**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:513-515`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6367` payload, `:6370` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:527-529`) to 413.
+**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:513-515`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6370` payload, `:6373` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:527-529`) to 413.
 
 **Open-pipe quota → HTTP 429 + `Retry-After`.** A single verified agent identity may hold at most 256 non-terminal (pending or claimed) pipes open at once, and a node caps 10000 across all requesters (`MaxOpenPipesPerAgent`/`MaxOpenPipesGlobal`). An index-backed COUNT and its INSERT run under the same write critical section, so parallel sends cannot race past either cap. Over-quota inserts are rejected as **429 with `Retry-After`** (`ErrPipeQuotaPerAgent`/`ErrPipeQuotaGlobal`), keyed on the Ed25519-verified `from_agent`, not the spoofable rate-limit header. This mirrors the mempool-full recipe (see `GET /v1/chain/backpressure` below): treat it as backpressure and retry after the hinted interval, not as a per-agent rate-limit breach.
 
@@ -2495,7 +2495,7 @@ the result over the original agreement-bound return route
 | `source_pipe_id` | string | for foreign work | Stable source proof/event ID returned with the inbox item; prevents replying against stale foreign metadata |
 | `source_chain_id` | string | for foreign work | Exact local reply-source chain returned as `reply_source_chain_id` by the pipe status preflight; prevents another node relabeling the signed result |
 
-`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:513`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6633`, mapping `ErrPipeResultTooLarge`).
+`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:513`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6636`, mapping `ErrPipeResultTooLarge`).
 
 **Response** (HTTP 200):
 `{"status":"completed","journal_id":"<memory_id or empty>","journaled":true|false}`.

--- a/internal/store/engram_index_test.go
+++ b/internal/store/engram_index_test.go
@@ -52,6 +52,20 @@ func TestCorroborationIndexDeclaredOnBothBackends(t *testing.T) {
 	require.Contains(t, string(pgSrc),
 		"ORDER BY created_at, agent_id, id LIMIT $2",
 		"postgres must keep the same total order and database-side row bound")
+
+	// The UNBOUNDED GetCorroborations read must carry the SAME total order. The `, memoryID)`
+	// tail (no LIMIT parameter) distinguishes it from the bounded sibling above; reverting it
+	// to plain created_at reintroduces the same-block nondeterminism this closes. (The SQLite
+	// behaviour is planner-masked by its INDEXED BY hint, so the deterministic same-timestamp
+	// ordering is exercised end-to-end against real PostgreSQL in the integration test.)
+	const unboundedOrder = "ORDER BY created_at, agent_id, id`, memoryID)"
+	require.Contains(t, string(sqlSrc), unboundedOrder,
+		"sqlite GetCorroborations (unbounded) must keep the total order")
+	require.Contains(t, string(pgSrc), unboundedOrder,
+		"postgres GetCorroborations (unbounded) must keep the total order")
+	require.Contains(t, string(sqlSrc),
+		"FROM corroborations INDEXED BY idx_corroborations_memory_order\n\t\tWHERE memory_id = ? ORDER BY created_at, agent_id, id`",
+		"sqlite GetCorroborations must pin the composite index so the order needs no temp sort")
 }
 
 // TestCorroborationIndexServesPerMemoryRead pins the bounded CEREBRUM query:
@@ -123,6 +137,85 @@ func TestGetCorroborationsBoundedCapsAndTotallyOrdersRows(t *testing.T) {
 	}
 	_, err = s.GetCorroborationsBounded(ctx, "m1", 0)
 	require.Error(t, err, "an absent SQL bound must fail closed")
+}
+
+// TestGetCorroborationsTotallyOrdered pins the UNBOUNDED GetCorroborations read to the same
+// deterministic total order (created_at, agent_id, id) as its bounded sibling. created_at
+// alone is not a total order — corroborations committed in one block share the block's
+// canonical timestamp — so without the agent_id/id tiebreak the row order is arbitrary and
+// diverges across SQLite/Postgres and across runs. The detail endpoint that renders these
+// rows must not reshuffle between reads. Removing the tiebreak fails this.
+func TestGetCorroborationsTotallyOrdered(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	at := time.Unix(1_700_000_000, 0).UTC()
+	require.NoError(t, s.InsertMemory(ctx, testMemory("m1", "author", "content-m1", "dom")))
+	// All 20 share one timestamp, inserted in REVERSE, so only the tiebreak yields a stable order.
+	for i := 19; i >= 0; i-- {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{
+			MemoryID: "m1", AgentID: fmt.Sprintf("agent-%02d", i), CreatedAt: at,
+		}))
+	}
+
+	got, err := s.GetCorroborations(ctx, "m1")
+	require.NoError(t, err)
+	require.Len(t, got, 20)
+	for i, corr := range got {
+		require.Equal(t, fmt.Sprintf("agent-%02d", i), corr.AgentID,
+			"same-timestamp rows must be ordered by the agent_id tiebreak, not arbitrary order")
+	}
+
+	names := func(cs []*Corroboration) []string {
+		out := make([]string, len(cs))
+		for i, c := range cs {
+			out[i] = c.AgentID
+		}
+		return out
+	}
+	again, err := s.GetCorroborations(ctx, "m1")
+	require.NoError(t, err)
+	require.Equal(t, names(got), names(again), "the unbounded read must be a stable total order")
+}
+
+// TestGetCorroborationsServesIndexNoTempSort pins the unbounded read's plan: it must SEARCH
+// via idx_corroborations_memory_order and satisfy ORDER BY without a temp b-tree — the same
+// INDEXED BY protection the bounded read carries, verified WITHOUT ANALYZE (SAGE never runs
+// ANALYZE, per PR #181). Without the INDEXED BY hint the total order regresses to a temp sort.
+func TestGetCorroborationsServesIndexNoTempSort(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	at := time.Unix(1_700_000_000, 0).UTC()
+	for i := 0; i < 20; i++ {
+		require.NoError(t, s.InsertMemory(ctx, testMemory(fmt.Sprintf("m%03d", i), "author", "c", "dom")))
+	}
+	for i := 0; i < 200; i++ {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{
+			MemoryID: fmt.Sprintf("m%03d", i%20), AgentID: fmt.Sprintf("agent-%d", i),
+			CreatedAt: at.Add(time.Duration(i) * time.Second),
+		}))
+	}
+
+	rows, err := s.conn.QueryContext(ctx,
+		`EXPLAIN QUERY PLAN SELECT id, memory_id, agent_id, evidence, created_at
+		 FROM corroborations INDEXED BY idx_corroborations_memory_order
+		 WHERE memory_id = ? ORDER BY created_at, agent_id, id`, "m003")
+	require.NoError(t, err)
+	defer rows.Close() //nolint:errcheck
+	var plan string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		plan += detail + "\n"
+	}
+	require.NoError(t, rows.Err())
+
+	require.Contains(t, plan, "idx_corroborations_memory_order",
+		"the unbounded corroborator read must SEARCH via the composite index; plan was:\n"+plan)
+	require.NotContains(t, plan, "SCAN corroborations",
+		"a full scan is what the index must prevent; plan was:\n"+plan)
+	require.NotContains(t, plan, "USE TEMP B-TREE",
+		"the composite index must satisfy the order without a temp sort; plan was:\n"+plan)
 }
 
 // The CEREBRUM agent-as-lobe read is `WHERE submitting_agent = ? [AND status = ?]

--- a/internal/store/engram_postgres_integration_test.go
+++ b/internal/store/engram_postgres_integration_test.go
@@ -61,3 +61,49 @@ func TestPostgresGetCorroborationsBoundedCapsAndTotallyOrdersRows(t *testing.T) 
 		require.Error(t, err, "invalid PostgreSQL bounds must fail closed")
 	}
 }
+
+// TestPostgresGetCorroborationsTotallyOrdersRows pins the UNBOUNDED production query's total
+// order on real PostgreSQL — where, unlike SQLite's INDEXED BY hint, nothing forces the
+// composite index, so the ORDER BY tiebreak itself is what makes same-block rows deterministic.
+// Reverting created_at, agent_id, id to plain created_at returns same-timestamp rows in
+// arbitrary heap order and fails this — the load-bearing regression guard for the fix.
+func TestPostgresGetCorroborationsTotallyOrdersRows(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+	memoryID := uuid.NewString()
+	content := "postgres unbounded engram " + memoryID
+	record := &memory.MemoryRecord{
+		MemoryID:        memoryID,
+		SubmittingAgent: "engram-postgres-test",
+		Content:         content,
+		ContentHash:     memory.ComputeContentHash(content),
+		MemoryType:      memory.TypeFact,
+		DomainTag:       "engram-postgres-test",
+		ConfidenceScore: 0.9,
+		Status:          memory.StatusCommitted,
+		CreatedAt:       time.Now().UTC(),
+	}
+	require.NoError(t, s.InsertMemory(ctx, record))
+	t.Cleanup(func() {
+		_, _ = s.db.Exec(ctx, `DELETE FROM corroborations WHERE memory_id = $1`, memoryID)
+		_, _ = s.db.Exec(ctx, `DELETE FROM memories WHERE memory_id = $1`, memoryID)
+	})
+
+	at := time.Unix(1_700_000_000, 0).UTC()
+	for i := 19; i >= 0; i-- {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{
+			MemoryID:  memoryID,
+			AgentID:   fmt.Sprintf("agent-%02d", i),
+			Evidence:  fmt.Sprintf("evidence-%02d", i),
+			CreatedAt: at,
+		}))
+	}
+
+	got, err := s.GetCorroborations(ctx, memoryID)
+	require.NoError(t, err)
+	require.Len(t, got, 20)
+	for i, corr := range got {
+		require.Equal(t, fmt.Sprintf("agent-%02d", i), corr.AgentID,
+			"same-timestamp PostgreSQL rows must be ordered by the agent_id tiebreak, not heap order")
+	}
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -1237,7 +1237,7 @@ func (s *PostgresStore) InsertCorroboration(ctx context.Context, corr *Corrobora
 func (s *PostgresStore) GetCorroborations(ctx context.Context, memoryID string) ([]*Corroboration, error) {
 	rows, err := s.db.Query(ctx,
 		`SELECT id, memory_id, agent_id, evidence, created_at
-		FROM corroborations WHERE memory_id = $1 ORDER BY created_at`, memoryID)
+		FROM corroborations WHERE memory_id = $1 ORDER BY created_at, agent_id, id`, memoryID)
 	if err != nil {
 		return nil, fmt.Errorf("get corroborations: %w", err)
 	}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -2720,7 +2720,8 @@ func (s *SQLiteStore) InsertCorroboration(ctx context.Context, corr *Corroborati
 func (s *SQLiteStore) GetCorroborations(ctx context.Context, memoryID string) ([]*Corroboration, error) {
 	rows, err := s.conn.QueryContext(ctx,
 		`SELECT id, memory_id, agent_id, evidence, created_at
-		FROM corroborations WHERE memory_id = ? ORDER BY created_at`, memoryID)
+		FROM corroborations INDEXED BY idx_corroborations_memory_order
+		WHERE memory_id = ? ORDER BY created_at, agent_id, id`, memoryID)
 	if err != nil {
 		return nil, fmt.Errorf("get corroborations: %w", err)
 	}


### PR DESCRIPTION
## What

`GetCorroborations` ordered by `created_at` only, with no tiebreak. Corroborations committed in one block share that block's canonical timestamp, so same-block rows tie and their order is arbitrary — nondeterministic across runs and divergent between the SQLite and PostgreSQL backends. The memory-detail endpoint that renders these rows (`api/rest/memory_handler.go`) would reshuffle them between reads.

Its bounded sibling `GetCorroborationsBounded` already uses the deterministic total order `created_at, agent_id, id`, served by `idx_corroborations_memory_order`. This brings the unbounded read to the same order on both backends — closing the asymmetry the #219/v11.18.13 index work left behind.

## How

- **SQLite** pins it with `INDEXED BY idx_corroborations_memory_order`, so the composite index `(memory_id, created_at, agent_id, id)` satisfies the order with **no temp b-tree even without ANALYZE** (SAGE never runs ANALYZE — same protection as PR #181).
- **PostgreSQL** keeps the `ORDER BY created_at, agent_id, id` and lets its planner use the same index.

## Scope / safety

Not consensus-load-bearing: the only non-test caller is the memory-detail **display** path plus an order-independent distinct-agent count fallback. No AppHash input, no ABCI/FinalizeBlock path — a determinism / cross-backend-consistency hygiene fix. The only schema-adjacent touch is reusing an index that already exists.

## Tests

- `TestGetCorroborationsTotallyOrdered` — SQLite same-timestamp determinism + run-to-run stability.
- `TestGetCorroborationsServesIndexNoTempSort` — plan pin: index seek, no scan, no temp sort, **WITHOUT ANALYZE**.
- Source pin in `TestCorroborationIndexDeclaredOnBothBackends` — reliably fails on a tiebreak revert (SQLite's own row order is planner-masked by the `INDEXED BY`, so a behavioural SQLite test can't bite it; the source pin can).
- `TestPostgresGetCorroborationsTotallyOrdersRows` (integration) — the **load-bearing** guard: on real PostgreSQL, where nothing forces the index, dropping the tiebreak returns same-timestamp rows in heap order and fails.

## ABCI determinism

Consensus path untouched — dashboard/display read only, no AppHash input.
