### PR TITLE
perf(store): batch the agent-as-lobe corroborator reads to drop the N+1

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -2273,7 +2273,7 @@ address resolved from a bounded legacy-status offline cache can be accepted
 locally while the peer is down. Delivery waits for that peer to return and pass
 the fresh live authorization preflight above.
 
-**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:513-515`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6370` payload, `:6373` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:527-529`) to 413.
+**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:513-515`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6420` payload, `:6423` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:527-529`) to 413.
 
 **Open-pipe quota → HTTP 429 + `Retry-After`.** A single verified agent identity may hold at most 256 non-terminal (pending or claimed) pipes open at once, and a node caps 10000 across all requesters (`MaxOpenPipesPerAgent`/`MaxOpenPipesGlobal`). An index-backed COUNT and its INSERT run under the same write critical section, so parallel sends cannot race past either cap. Over-quota inserts are rejected as **429 with `Retry-After`** (`ErrPipeQuotaPerAgent`/`ErrPipeQuotaGlobal`), keyed on the Ed25519-verified `from_agent`, not the spoofable rate-limit header. This mirrors the mempool-full recipe (see `GET /v1/chain/backpressure` below): treat it as backpressure and retry after the hinted interval, not as a per-agent rate-limit breach.
 
@@ -2495,7 +2495,7 @@ the result over the original agreement-bound return route
 | `source_pipe_id` | string | for foreign work | Stable source proof/event ID returned with the inbox item; prevents replying against stale foreign metadata |
 | `source_chain_id` | string | for foreign work | Exact local reply-source chain returned as `reply_source_chain_id` by the pipe status preflight; prevents another node relabeling the signed result |
 
-`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:513`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6636`, mapping `ErrPipeResultTooLarge`).
+`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:513`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6686`, mapping `ErrPipeResultTooLarge`).
 
 **Response** (HTTP 200):
 `{"status":"completed","journal_id":"<memory_id or empty>","journaled":true|false}`.

--- a/internal/store/engram_index_test.go
+++ b/internal/store/engram_index_test.go
@@ -218,6 +218,88 @@ func TestGetCorroborationsServesIndexNoTempSort(t *testing.T) {
 		"the composite index must satisfy the order without a temp sort; plan was:\n"+plan)
 }
 
+// TestGetCorroborationsBoundedBatch pins the batched read that backs the agent-as-lobe
+// bridges (replacing the per-engram N+1): in ONE query it caps EACH memory at perLimit and
+// returns the same total order (created_at, agent_id, id) as the single-memory reader.
+func TestGetCorroborationsBoundedBatch(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	at := time.Unix(1_700_000_000, 0).UTC()
+	for _, m := range []string{"m1", "m2", "m3"} {
+		require.NoError(t, s.InsertMemory(ctx, testMemory(m, "author", "c-"+m, "dom")))
+	}
+	// m1: 20 corroborators sharing one timestamp, inserted in reverse — only the tiebreak orders them.
+	for i := 19; i >= 0; i-- {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{MemoryID: "m1", AgentID: fmt.Sprintf("agent-%02d", i), CreatedAt: at}))
+	}
+	for i := 0; i < 3; i++ {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{MemoryID: "m2", AgentID: fmt.Sprintf("b-%d", i), CreatedAt: at.Add(time.Duration(i) * time.Second)}))
+	}
+	// m3: no corroborations.
+
+	got, err := s.GetCorroborationsBoundedBatch(ctx, []string{"m1", "m2", "m3"}, 12)
+	require.NoError(t, err)
+	require.Len(t, got["m1"], 12, "each memory is capped at perLimit inside the single batched query")
+	for i, c := range got["m1"] {
+		require.Equal(t, fmt.Sprintf("agent-%02d", i), c.AgentID,
+			"same-timestamp rows use the agent_id tiebreak, per memory")
+	}
+	require.Len(t, got["m2"], 3, "a memory under the cap returns all its rows")
+	require.Equal(t, "b-0", got["m2"][0].AgentID)
+	require.NotContains(t, got, "m3", "a memory with no corroborations is absent from the batch result")
+
+	again, err := s.GetCorroborationsBoundedBatch(ctx, []string{"m1"}, 12)
+	require.NoError(t, err)
+	require.Equal(t, got["m1"][0].AgentID, again["m1"][0].AgentID, "the batch read is stable")
+	_, err = s.GetCorroborationsBoundedBatch(ctx, []string{"m1"}, 0)
+	require.Error(t, err, "a non-positive limit must fail closed")
+	empty, err := s.GetCorroborationsBoundedBatch(ctx, nil, 12)
+	require.NoError(t, err)
+	require.Empty(t, empty, "no memory IDs is a no-op, not an error")
+}
+
+// TestGetCorroborationsBoundedBatchSeeksNoFullScan pins the batch plan: the windowed
+// per-memory-capped read must SEARCH the composite index per memory rather than scan the
+// whole corroborations table, WITHOUT ANALYZE — so a heavily corroborated table can never
+// turn the batch into a full scan.
+func TestGetCorroborationsBoundedBatchSeeksNoFullScan(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	at := time.Unix(1_700_000_000, 0).UTC()
+	for i := 0; i < 20; i++ {
+		require.NoError(t, s.InsertMemory(ctx, testMemory(fmt.Sprintf("m%03d", i), "author", "c", "dom")))
+	}
+	for i := 0; i < 400; i++ {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{
+			MemoryID: fmt.Sprintf("m%03d", i%20), AgentID: fmt.Sprintf("a%d", i),
+			CreatedAt: at.Add(time.Duration(i) * time.Second),
+		}))
+	}
+
+	rows, err := s.conn.QueryContext(ctx,
+		`EXPLAIN QUERY PLAN SELECT memory_id, id, agent_id, evidence, created_at FROM (
+			SELECT id, memory_id, agent_id, evidence, created_at,
+				ROW_NUMBER() OVER (PARTITION BY memory_id ORDER BY created_at, agent_id, id) AS rn
+			FROM corroborations INDEXED BY idx_corroborations_memory_order
+			WHERE memory_id IN (?, ?, ?)
+		) WHERE rn <= ? ORDER BY memory_id, created_at, agent_id, id`, "m001", "m002", "m003", 12)
+	require.NoError(t, err)
+	defer rows.Close() //nolint:errcheck
+	var plan string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		plan += detail + "\n"
+	}
+	require.NoError(t, rows.Err())
+
+	require.Contains(t, plan, "idx_corroborations_memory_order",
+		"the batch must SEARCH the composite index per memory; plan was:\n"+plan)
+	require.NotContains(t, plan, "SCAN corroborations",
+		"a heavily corroborated table must never turn the batch into a full scan; plan was:\n"+plan)
+}
+
 // The CEREBRUM agent-as-lobe read is `WHERE submitting_agent = ? [AND status = ?]
 // ORDER BY confidence_score DESC LIMIT N`. idx_memories_submitting_agent
 // (submitting_agent, confidence_score) must satisfy BOTH the equality and the

--- a/internal/store/engram_postgres_integration_test.go
+++ b/internal/store/engram_postgres_integration_test.go
@@ -107,3 +107,47 @@ func TestPostgresGetCorroborationsTotallyOrdersRows(t *testing.T) {
 			"same-timestamp PostgreSQL rows must be ordered by the agent_id tiebreak, not heap order")
 	}
 }
+
+// TestPostgresGetCorroborationsBoundedBatch exercises the production PostgreSQL windowed batch:
+// per-memory cap + total order across multiple memories in a single query.
+func TestPostgresGetCorroborationsBoundedBatch(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+	m1, m2 := uuid.NewString(), uuid.NewString()
+	for _, id := range []string{m1, m2} {
+		content := "pg batch engram " + id
+		require.NoError(t, s.InsertMemory(ctx, &memory.MemoryRecord{
+			MemoryID: id, SubmittingAgent: "engram-postgres-test", Content: content,
+			ContentHash: memory.ComputeContentHash(content), MemoryType: memory.TypeFact,
+			DomainTag: "engram-postgres-test", ConfidenceScore: 0.9, Status: memory.StatusCommitted,
+			CreatedAt: time.Now().UTC(),
+		}))
+	}
+	t.Cleanup(func() {
+		for _, id := range []string{m1, m2} {
+			_, _ = s.db.Exec(ctx, `DELETE FROM corroborations WHERE memory_id = $1`, id)
+			_, _ = s.db.Exec(ctx, `DELETE FROM memories WHERE memory_id = $1`, id)
+		}
+	})
+
+	at := time.Unix(1_700_000_000, 0).UTC()
+	for i := 19; i >= 0; i-- {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{MemoryID: m1, AgentID: fmt.Sprintf("agent-%02d", i), Evidence: "e", CreatedAt: at}))
+	}
+	for i := 0; i < 3; i++ {
+		require.NoError(t, s.InsertCorroboration(ctx, &Corroboration{MemoryID: m2, AgentID: fmt.Sprintf("b-%d", i), Evidence: "e", CreatedAt: at.Add(time.Duration(i) * time.Second)}))
+	}
+
+	got, err := s.GetCorroborationsBoundedBatch(ctx, []string{m1, m2}, 12)
+	require.NoError(t, err)
+	require.Len(t, got[m1], 12, "PostgreSQL caps each memory at perLimit inside the window")
+	for i, c := range got[m1] {
+		require.Equal(t, fmt.Sprintf("agent-%02d", i), c.AgentID,
+			"same-timestamp PostgreSQL rows use the agent_id tiebreak, per memory")
+	}
+	require.Len(t, got[m2], 3)
+	require.Equal(t, "b-0", got[m2][0].AgentID)
+
+	_, err = s.GetCorroborationsBoundedBatch(ctx, []string{m1}, 0)
+	require.Error(t, err, "an invalid PostgreSQL batch bound must fail closed")
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -1280,6 +1280,39 @@ func (s *PostgresStore) GetCorroborationsBounded(ctx context.Context, memoryID s
 	return corrs, rows.Err()
 }
 
+// GetCorroborationsBoundedBatch — batched form (parity with SQLiteStore): up to perLimit
+// corroborations per memory_id in the total order (created_at, agent_id, id), in one windowed
+// query capped per partition so no memory can materialize its whole set. The planner uses
+// idx_corroborations_memory_order for the seek + per-partition order.
+func (s *PostgresStore) GetCorroborationsBoundedBatch(ctx context.Context, memoryIDs []string, perLimit int) (map[string][]*Corroboration, error) {
+	if perLimit <= 0 {
+		return nil, errors.New("corroboration limit must be positive")
+	}
+	out := make(map[string][]*Corroboration, len(memoryIDs))
+	if len(memoryIDs) == 0 {
+		return out, nil
+	}
+	rows, err := s.db.Query(ctx,
+		`SELECT memory_id, id, agent_id, evidence, created_at FROM (
+			SELECT id, memory_id, agent_id, evidence, created_at,
+				ROW_NUMBER() OVER (PARTITION BY memory_id ORDER BY created_at, agent_id, id) AS rn
+			FROM corroborations WHERE memory_id = ANY($1)
+		) ranked WHERE rn <= $2 ORDER BY memory_id, created_at, agent_id, id`, memoryIDs, perLimit)
+	if err != nil {
+		return nil, fmt.Errorf("get bounded corroborations batch: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		c := &Corroboration{}
+		if scanErr := rows.Scan(&c.MemoryID, &c.ID, &c.AgentID, &c.Evidence, &c.CreatedAt); scanErr != nil {
+			return nil, fmt.Errorf("scan bounded corroboration batch: %w", scanErr)
+		}
+		out[c.MemoryID] = append(out[c.MemoryID], c)
+	}
+	return out, rows.Err()
+}
+
 func (s *PostgresStore) GetPendingByDomain(ctx context.Context, domainTag string, limit int) ([]*memory.MemoryRecord, error) {
 	if limit <= 0 {
 		limit = 20

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -2770,6 +2770,56 @@ func (s *SQLiteStore) GetCorroborationsBounded(ctx context.Context, memoryID str
 	return corrs, rows.Err()
 }
 
+// GetCorroborationsBoundedBatch is the batched form of GetCorroborationsBounded: it returns,
+// per memory_id, up to perLimit corroborations in the same deterministic total order
+// (created_at, agent_id, id) — in ONE query rather than one per memory. It backs the CEREBRUM
+// agent-as-lobe bridges, where the per-record loop would otherwise fire up to
+// engramPerAgentLimit single-memory reads. A window function caps each partition to perLimit
+// so a memory corroborated by thousands can never materialize its whole set; the composite
+// idx_corroborations_memory_order serves both the seek and the per-partition order (verified
+// no full scan, WITHOUT ANALYZE). memoryIDs is sorted so partitions emit in a stable order.
+func (s *SQLiteStore) GetCorroborationsBoundedBatch(ctx context.Context, memoryIDs []string, perLimit int) (map[string][]*Corroboration, error) {
+	if perLimit <= 0 {
+		return nil, errors.New("corroboration limit must be positive")
+	}
+	out := make(map[string][]*Corroboration, len(memoryIDs))
+	if len(memoryIDs) == 0 {
+		return out, nil
+	}
+	ids := append([]string(nil), memoryIDs...)
+	sort.Strings(ids)
+	ph := make([]string, len(ids))
+	args := make([]any, 0, len(ids)+1)
+	for i, id := range ids {
+		ph[i] = "?"
+		args = append(args, id)
+	}
+	args = append(args, perLimit)
+
+	rows, err := s.conn.QueryContext(ctx,
+		`SELECT memory_id, id, agent_id, evidence, created_at FROM (
+			SELECT id, memory_id, agent_id, evidence, created_at,
+				ROW_NUMBER() OVER (PARTITION BY memory_id ORDER BY created_at, agent_id, id) AS rn
+			FROM corroborations INDEXED BY idx_corroborations_memory_order
+			WHERE memory_id IN (`+strings.Join(ph, ",")+`)
+		) WHERE rn <= ? ORDER BY memory_id, created_at, agent_id, id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("get bounded corroborations batch: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		c := &Corroboration{}
+		var createdAt string
+		if scanErr := rows.Scan(&c.MemoryID, &c.ID, &c.AgentID, &c.Evidence, &createdAt); scanErr != nil {
+			return nil, fmt.Errorf("scan bounded corroboration batch: %w", scanErr)
+		}
+		c.CreatedAt = parseTime(createdAt)
+		out[c.MemoryID] = append(out[c.MemoryID], c)
+	}
+	return out, rows.Err()
+}
+
 func (s *SQLiteStore) GetPendingByDomain(ctx context.Context, domainTag string, limit int) ([]*memory.MemoryRecord, error) {
 	if limit <= 0 {
 		limit = 20

--- a/web/engrams_corroborators_test.go
+++ b/web/engrams_corroborators_test.go
@@ -169,6 +169,72 @@ func (s *failingBoundedEngramStore) GetCorroborationsBounded(_ context.Context, 
 	return nil, errors.New("bounded corroboration read unavailable")
 }
 
+// The lobe now batches the corroborator reads, so this is the failure path the handler
+// actually exercises: a batch read error must degrade to no bridges (fail-closed) while the
+// engram and its true corroboration_count still render.
+func (s *failingBoundedEngramStore) GetCorroborationsBoundedBatch(_ context.Context, _ []string, perLimit int) (map[string][]*store.Corroboration, error) {
+	s.calls++
+	s.limits = append(s.limits, perLimit)
+	return nil, errors.New("bounded corroboration batch read unavailable")
+}
+
+// countingBatchEngramStore delegates to the real store but records how the lobe reads
+// corroborators, so a test can prove the read is batched (one query) rather than an N+1.
+type countingBatchEngramStore struct {
+	store.MemoryStore
+	batchCalls int
+	lastIDs    []string
+}
+
+func (s *countingBatchEngramStore) GetCorroborationsBounded(ctx context.Context, id string, limit int) ([]*store.Corroboration, error) {
+	return s.MemoryStore.(boundedEngramCorroborationReader).GetCorroborationsBounded(ctx, id, limit)
+}
+
+func (s *countingBatchEngramStore) GetCorroborationsBoundedBatch(ctx context.Context, ids []string, perLimit int) (map[string][]*store.Corroboration, error) {
+	s.batchCalls++
+	s.lastIDs = ids
+	return s.MemoryStore.(boundedEngramCorroborationReader).GetCorroborationsBoundedBatch(ctx, ids, perLimit)
+}
+
+// TestHandleEngramsBatchesCorroboratorReads pins the N+1 removal: several corroborated engrams
+// in one lobe must be read with a SINGLE batched corroborator query covering all of them, and
+// the bridges must still render exactly as the per-record read produced.
+func TestHandleEngramsBatchesCorroboratorReads(t *testing.T) {
+	h, s := newSynapseTestHandler(t)
+	for i, id := range []string{"alice", "bob", "carol"} {
+		require.NoError(t, h.BadgerStore.RegisterAgent(id, id, "member", "", "test", "", int64(i+1)))
+	}
+	base := time.Now().UTC().Truncate(time.Second)
+	for i, m := range []string{"m1", "m2", "m3"} {
+		seedEngramMemory(t, s, m, "alice", "fact-"+m, "ops", 0.9-float64(i)*0.01, memory.StatusCommitted)
+		seedCorroboration(t, s, m, "bob", base)
+		seedCorroboration(t, s, m, "carol", base.Add(time.Second))
+	}
+
+	counter := &countingBatchEngramStore{MemoryStore: h.store}
+	h.store = counter
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/dashboard/memory/engrams?agent=alice", nil)
+	rec := httptest.NewRecorder()
+	h.handleEngrams(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Engrams []engramNode `json:"engrams"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Engrams, 3)
+	for _, e := range body.Engrams {
+		require.ElementsMatch(t, []string{"bob", "carol"}, e.Corroborators,
+			"bridges still render correctly through the batched read")
+	}
+
+	require.Equal(t, 1, counter.batchCalls,
+		"all corroborated engrams must be read in ONE batched query, not one per engram")
+	require.ElementsMatch(t, []string{"m1", "m2", "m3"}, counter.lastIDs,
+		"the single batch covers every corroborated engram")
+}
+
 // seedCorroboration records that agentID corroborated memID, the off-chain
 // corroborations table the distributed-engram disclosure reads (the same table
 // GetCorroborationCounts already tallies for corroboration_count).

--- a/web/engrams_handler.go
+++ b/web/engrams_handler.go
@@ -17,6 +17,9 @@ import (
 // separately through the required OffchainStore contract.
 type boundedEngramCorroborationReader interface {
 	GetCorroborationsBounded(ctx context.Context, memoryID string, limit int) ([]*store.Corroboration, error)
+	// GetCorroborationsBoundedBatch fetches the per-memory-capped corroborators for many
+	// memories in one query, so the agent-as-lobe view avoids a read per engram (the N+1).
+	GetCorroborationsBoundedBatch(ctx context.Context, memoryIDs []string, perLimit int) (map[string][]*store.Corroboration, error)
 }
 
 // engramNode is one memory authored by an agent — an "engram" that orbits its
@@ -230,6 +233,29 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 	}
 	corroborationReader, canReadBoundedCorroborations := h.store.(boundedEngramCorroborationReader)
 
+	// Batch the corroborator reads into ONE windowed, per-memory-capped query instead of a
+	// read per engram (the N+1). Only memories that actually have corroborations are fetched,
+	// and only when the bridges can render at all (a registered neuron set + a store that
+	// bounds the read in SQL). A batch failure degrades to "no bridges" for the whole lobe —
+	// the same fail-closed posture as a missing registry — while the engrams and their true
+	// corroboration_count still render; only the bridge identities are withheld.
+	var corroboratorsByMemory map[string][]*store.Corroboration
+	if neuronSet != nil && canReadBoundedCorroborations {
+		corroboratedIDs := make([]string, 0, len(records))
+		for _, rec := range records {
+			if corrCounts[rec.MemoryID] > 0 {
+				corroboratedIDs = append(corroboratedIDs, rec.MemoryID)
+			}
+		}
+		if len(corroboratedIDs) > 0 {
+			if batch, bErr := corroborationReader.GetCorroborationsBoundedBatch(
+				ctx, corroboratedIDs, engramCorroboratorScanLimit,
+			); bErr == nil {
+				corroboratorsByMemory = batch
+			}
+		}
+	}
+
 	engrams := make([]engramNode, 0, len(records))
 	for _, rec := range records {
 		// Distributed-engram disclosure: the corroborators the caller is cleared to
@@ -239,20 +265,13 @@ func (h *DashboardHandler) handleEngrams(w http.ResponseWriter, r *http.Request)
 		// under the same rule the synapse edge guard applies, and (c) not the author
 		// itself; the rest survive only in CorroborationCount as the anonymous "+N".
 		var corroborators []string
-		if neuronSet != nil && canReadBoundedCorroborations && corrCounts[rec.MemoryID] > 0 {
-			// A per-engram corroborator read failure degrades to "no bridges for this
-			// engram" rather than failing the whole lobe — the same fail-closed choice
-			// the missing-registry path makes above, applied per record because this
-			// read is in the loop. The engram still renders (it was read fine) and
-			// corroboration_count still conveys the memory is distributed; only the
-			// bridges are withheld. The count is a separate batch read that already
-			// succeeded, so the "held across N" total is unaffected.
-			corrs, cErr := corroborationReader.GetCorroborationsBounded(
-				ctx, rec.MemoryID, engramCorroboratorScanLimit,
-			)
-			if cErr != nil {
-				corrs = nil
-			}
+		if corroboratorsByMemory != nil {
+			// Corroborators for this memory came from the single batched read above (nil for a
+			// memory with none). Filter to the caller-visible registered neurons, excluding the
+			// author, capped at the display limit; the rest survive only in CorroborationCount
+			// as the anonymous "+N". A batch failure left the whole map nil → no bridges
+			// lobe-wide, the same fail-closed posture as a missing registry.
+			corrs := corroboratorsByMemory[rec.MemoryID]
 			seen := make(map[string]bool, len(corrs))
 			for _, c := range corrs {
 				id := c.AgentID


### PR DESCRIPTION
## What

The agent-as-lobe view read corroborators **one memory at a time** — up to `engramPerAgentLimit` (24) single-memory `GetCorroborationsBounded` queries per lobe request, one per corroborated engram (the N+1 flagged in the #219 review). This batches them into a single query, mirroring how `GetCorroborationCounts` already batches the count path.

## How

Adds `GetCorroborationsBoundedBatch(memoryIDs, perLimit)` on both backends: one windowed query that caps **each** memory at `perLimit`:

```sql
ROW_NUMBER() OVER (PARTITION BY memory_id ORDER BY created_at, agent_id, id) <= perLimit
```

The composite `idx_corroborations_memory_order (memory_id, created_at, agent_id, id)` serves the per-memory seek **and** the per-partition order, so each partition stays bounded and index-served — verified **no full table scan, WITHOUT ANALYZE**. Same total order as the single-memory reader.

The handler prefetches the batch once (for the memories that have corroborations) before the render loop, then filters each engram's slice exactly as before.

## Fail-closed

Changes shape, not intent: a batch read failure now withholds bridges for the **whole lobe** rather than one engram — the same posture as a missing registry. The engrams and their true `corroboration_count` still render; only the bridge identities are withheld. (`TestHandleEngramsWithholdsCorroboratorsWhenBoundedReadFails` covers this.)

## Scope / safety

Not consensus-load-bearing: dashboard display read only — no AppHash input, no ABCI/FinalizeBlock path. Reuses an already-existing index.

## Tests

- `TestGetCorroborationsBoundedBatch` — per-memory cap, total order, absent/empty/invalid-limit — SQLite, and `TestPostgresGetCorroborationsBoundedBatch` on real PostgreSQL (integration).
- `TestGetCorroborationsBoundedBatchSeeksNoFullScan` — plan pin: index seek per memory, no full scan, WITHOUT ANALYZE.
- `TestHandleEngramsBatchesCorroboratorReads` — the headline pin: several corroborated engrams in one lobe are read with **one** batched query covering all of them, and the bridges render identically to the per-record path.

## ABCI determinism

Consensus path untouched — dashboard/display read only.
