### PR TITLE
feat(cerebrum): add persistent connectome agent details

### DIFF
--- a/scripts/connectome-engrams.test.mjs
+++ b/scripts/connectome-engrams.test.mjs
@@ -233,8 +233,8 @@ test('reload and mode-switch replacement paths tear down the bloom before fetchi
 });
 
 test('the 50ms deep-link bloom timer is tracked and cleared on dispose', () => {
-  assert.match(mriSource, /deepLinkTimer = setTimeout\(\(\) => \{ if \(!disposed\) bloomEngrams/,
-    'the deep-link timer must be assigned (trackable) and guard disposed');
+  assert.match(mriSource, /deepLinkTimer = setTimeout\(\(\) => \{ if \(!disposed\) selectNeuron/,
+    'the deep-link timer must select the agent persistently and remain trackable');
   assert.match(mriSource, /clearTimeout\(deepLinkTimer\)/,
     'the deep-link timer must be cleared in cleanup');
 });
@@ -243,8 +243,10 @@ test('only a NEURON click blooms engrams — clicking a bloomed engram does not 
   // clicking an engram (a memory node) must not re-run bloomEngrams with a memory
   // id as ?agent, which would strip the lobe and leave a focus ring on a removed
   // node. Guard: connectome click blooms only when n.isNeuron.
-  assert.match(mriSource, /mode==='connectome'\)\s*\{\s*if \(n\.isNeuron\) bloomEngrams\(n\); \}\s*else exploreNode\(n\)/,
-    'connectome click must bloom only neurons; memory-mode click keeps exploreNode');
+  assert.match(mriSource, /mode==='connectome'\)\s*\{\s*if \(n\.isNeuron\) selectNeuron\(n\); \}\s*else exploreNode\(n\)/,
+    'connectome click must select only neurons; selectNeuron owns the single bloom while memory mode keeps exploreNode');
+  const selectBody = functionBody(mriSource, 'selectNeuron');
+  assert.match(selectBody, /bloomEngrams\(n\)/, 'one selection must preserve the existing engram bloom');
 });
 
 test('bloom composition bridges only rendered peer neurons and strips on background exit', () => {

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -90,10 +90,12 @@ test('node fields map from the payload with sensible fallbacks', () => {
   const by = Object.fromEntries(g.nodes.map(n => [n.agent_id, n]));
   assert.equal(by.x.label, 'X');
   assert.equal(by.x.domain, 'd');
+  assert.equal(by.x.agent_domain, 'd');
   assert.equal(by.x.role, 'r');
   // label falls back to agent_id, domain falls back to role then 'agent'
   assert.equal(by.y.label, 'y');
   assert.equal(by.y.domain, 'agent');
+  assert.equal(by.y.agent_domain, '', 'display details must not mislabel the role fallback as a real domain');
   assert.equal(by.y.role, '');
 });
 
@@ -114,6 +116,35 @@ test('direction is preserved: A->B is distinct from B->A', () => {
   const keys = g.links.map(l => `${l.source}>${l.target}`);
   assert.ok(keys.includes('agent:alice>agent:bob'));
   assert.ok(keys.includes('agent:bob>agent:alice'));
+});
+
+test('nodes expose visible directional traffic, distinct peers, and strongest connection', () => {
+  const g = mapConnectome(payload);
+  const by = Object.fromEntries(g.nodes.map(n => [n.agent_id, n]));
+  assert.deepEqual(
+    { incoming:by.alice._incoming, outgoing:by.alice._outgoing, peers:by.alice._peers },
+    { incoming:2, outgoing:5, peers:1 },
+  );
+  assert.deepEqual(
+    { incoming:by.bob._incoming, outgoing:by.bob._outgoing, peers:by.bob._peers },
+    { incoming:5, outgoing:3, peers:2 },
+  );
+  assert.equal(by.bob._strongest_peer, 'alice');
+  assert.equal(by.bob._strongest_peer_traffic, 7,
+    'strongest connection combines retained traffic in both directions');
+  assert.deepEqual(
+    { incoming:by.carol._incoming, outgoing:by.carol._outgoing, peers:by.carol._peers },
+    { incoming:1, outgoing:0, peers:1 },
+  );
+});
+
+test('a self-synapse contributes directional traffic but not a connected peer', () => {
+  const [node] = mapConnectome({
+    neurons:[{agent_id:'solo'}],
+    synapses:[{from_agent:'solo',to_agent:'solo',count:3}],
+  }).nodes;
+  assert.equal(node._incoming,3); assert.equal(node._outgoing,3);
+  assert.equal(node._peers,0); assert.equal(node._strongest_peer,'');
 });
 
 test('edges to unknown agents are dropped (no ghost nodes)', () => {
@@ -207,6 +238,10 @@ test('connectome guidance is reachable without adding another floating panel', (
 
   assert.match(rootTemplate, /class="lg-detail guide-connectome" hidden>[\s\S]*Agents are neurons[\s\S]*Click one to bloom its memories/i,
     'standalone MRI must keep connectome guidance inside its existing reading legend');
+  const modeChromeStart = mriSource.indexOf('function updateModeChrome(');
+  const modeChromeEnd = mriSource.indexOf('function setMode(', modeChromeStart);
+  assert.doesNotMatch(mriSource.slice(modeChromeStart,modeChromeEnd), /legend\.hidden\s*=|\.legend[^\n]*hidden/,
+    'connectome mode must not hide the standalone reading guide to make room for agent details');
   const standaloneMountStart = mriPageSource.indexOf("mountMriBrain(document.getElementById('mount')");
   const standaloneMountEnd = mriPageSource.indexOf('});', standaloneMountStart);
   assert.ok(standaloneMountStart >= 0 && standaloneMountEnd > standaloneMountStart,
@@ -246,6 +281,76 @@ test('connectome guidance is reachable without adding another floating panel', (
     'mobile must not hide whichever action happens to be first');
 });
 
+test('connectome exposes persistent, keyboard-reachable agent identity details', () => {
+  assert.match(mriSource, /<aside class="agent-inspector" aria-label="Connectome agent details" aria-hidden="true">/,
+    'selected details must be a labelled nonmodal landmark');
+  assert.match(mriSource, /<select class="ai-select" aria-label="Browse agents">/,
+    'canvas-only neurons need a keyboard and touch selection path');
+  assert.match(mriSource, /<button type="button" class="ai-close" aria-label="Close agent details">/,
+    'persistent details need a real accessible close button');
+  assert.match(mriSource, /class="tip" role="tooltip" aria-hidden="true"/,
+    'transient hover details must expose tooltip semantics');
+  assert.match(mriSource, /\.onNodeClick\([^\n]*selectNeuron\(n\)/,
+    'a canvas click must enter the same persistent selection path as the picker');
+  assert.match(mriSource, /const onKeyDown=e=>\{ if\(e\.key==='Escape' && selectedAgentID\)/,
+    'Escape must dismiss a selected agent');
+  assert.match(mriSource, /subs\.push\(\(\)=>document\.removeEventListener\('keydown',onKeyDown\)\)/,
+    'the global Escape listener must be cleaned up with the renderer');
+});
+
+test('selection dismissal hides the large inspector and returns keyboard focus to the picker', () => {
+  const renderStart=mriSource.indexOf('function renderAgentInspector(');
+  const renderEnd=mriSource.indexOf('function clearAgentSelection(',renderStart);
+  const render=mriSource.slice(renderStart,renderEnd);
+  assert.match(render,/classList\.toggle\('visible', mode === 'connectome' && chosen\)/,
+    'the expanded panel must exist only while an agent is selected');
+  assert.match(mriSource,/\.ai-close'\)\.onclick=\(\)=>\{ exitFocus\(\); \$\('\.ai-select'\)\.focus\(\); \}/);
+  assert.match(mriSource,/e\.key==='Escape'[\s\S]{0,100}exitFocus\(\); \$\('\.ai-select'\)\.focus\(\)/);
+  assert.match(mriSource,/t\.closest\('\.panel,\.agent-browser,\.agent-inspector'\)/,
+    'picker events must be chrome, never graph-background dismissal');
+});
+
+test('a live reload restores cached selected memories or restarts an interrupted bloom', () => {
+  const start=mriSource.indexOf('function restoreSelectedAgent(');
+  const end=mriSource.indexOf('function setHullOpacity(',start);
+  const body=mriSource.slice(start,end);
+  assert.match(body,/applyEngramBloom\(Graph\.graphData\(\), selectedMemoryState\.memories\|\|\[\], selected, focusSet, placeNear\)/,
+    'ready memories must be recomposed after graph replacement strips transient nodes');
+  assert.match(body,/selectedMemoryState=\{status:'loading'\}[\s\S]*bloomEngrams\(selected\)/,
+    'an invalidated in-flight bloom must restart instead of leaving the inspector loading forever');
+  assert.match(body,/else if \(selectedMemoryState && selectedMemoryState\.status==='loading'\)/,
+    'explicit engram errors must wait for Retry rather than hammering the endpoint on every live tick');
+  assert.match(mriSource,/restoreSelectedAgent\(d\)/,
+    'successful reload reconciliation must invoke the tested restore path');
+});
+
+test('empty memory results retain projection and continuation caveats', () => {
+  const start=mriSource.indexOf('function renderMemoryState(');
+  const end=mriSource.indexOf('function renderAgentInspector(',start);
+  const body=mriSource.slice(start,end);
+  assert.match(body,/!memories\.length[\s\S]*state\.partial[\s\S]*temporarily hidden/);
+  assert.match(body,/!memories\.length[\s\S]*state\.continuation[\s\S]*More may exist/);
+});
+
+test('agent tooltip is clamped, escaped, and includes identity plus visible traffic', () => {
+  const showStart = mriSource.indexOf('function showTip(');
+  const showEnd = mriSource.indexOf('function onMove(', showStart);
+  const show = mriSource.slice(showStart, showEnd);
+  assert.match(show, /escapeHtml\(agentName\(n\)\)/);
+  assert.match(show, /escapeHtml\(agentRole\(n\)\)/);
+  assert.match(show, /escapeHtml\(agentDomain\(n\)\)/);
+  assert.match(show, /escapeHtml\(id\)/, 'canonical agent identity must be escaped');
+  assert.match(show, /n\._incoming/); assert.match(show, /n\._outgoing/); assert.match(show, /n\._peers/);
+  const positionStart = mriSource.indexOf('function positionTip(');
+  const positionEnd = mriSource.indexOf('function showTip(', positionStart);
+  const position = mriSource.slice(positionStart, positionEnd);
+  assert.match(position, /tip\.offsetWidth/); assert.match(position, /tip\.offsetHeight/);
+  assert.match(position, /Math\.max\(pad,Math\.min\(r\.width-tip\.offsetWidth-pad,left\)\)/,
+    'horizontal tooltip placement must stay inside the renderer');
+  assert.match(position, /Math\.max\(pad,Math\.min\(r\.height-tip\.offsetHeight-pad,top\)\)/,
+    'vertical tooltip placement must stay inside the renderer');
+});
+
 test('mode controls retain visible pressed and keyboard-focus styling in both themes', () => {
   const styleStart = mriSource.indexOf('const STYLE = `');
   const styleEnd = mriSource.indexOf('`;\n\nfunction injectStyleOnce', styleStart);
@@ -274,7 +379,7 @@ test('mode chrome exposes coherent toggle state, active guidance, and live statu
   };
 
   const body = functionBody('updateModeChrome');
-  const runChrome = new Function('$', 'root', 'mode', 'announce', body);
+  const runChrome = new Function('$', 'root', 'mode', 'announce', 'hideTip', 'renderAgentInspector', 'selectedAgentNode', body);
   const elements = {
     '.b-mode': { textContent: '', attrs: {}, setAttribute(k, v) { this.attrs[k] = v; } },
     '.lg-title': { textContent: '' },
@@ -286,7 +391,7 @@ test('mode chrome exposes coherent toggle state, active guidance, and live statu
   const root = { querySelectorAll: () => labels };
   const $ = selector => elements[selector];
 
-  runChrome($, root, 'connectome', true);
+  runChrome($, root, 'connectome', true, () => {}, () => {}, null);
   assert.equal(elements['.b-mode'].textContent, '◉ connectome',
     'a toggle button keeps one visible label; aria-pressed carries its state');
   assert.equal(elements['.b-mode'].attrs['aria-label'], 'Connectome view',
@@ -299,7 +404,7 @@ test('mode chrome exposes coherent toggle state, active guidance, and live statu
   assert.match(elements['.sr-status'].textContent, /Connectome view/);
   assert.deepEqual(labels.map(label => label.textContent), ['neurons', 'synapses', 'hubs']);
 
-  runChrome($, root, 'memory', true);
+  runChrome($, root, 'memory', true, () => {}, () => {}, null);
   assert.equal(elements['.b-mode'].textContent, '◉ connectome');
   assert.equal(elements['.b-mode'].attrs['aria-label'], 'Connectome view');
   assert.equal(elements['.b-mode'].attrs['aria-pressed'], 'false');
@@ -313,8 +418,7 @@ test('mode chrome exposes coherent toggle state, active guidance, and live statu
   const modeAnnouncements = [];
   const runSetMode = new Function(
     'next', 'mode', 'allowConnectome', 'graphLoads', 'bloomLoads', 'connectomeActivity',
-    'connectomeReloadIntent', 'neuronBirths', 'currentDomain', 'leaveFocusForGraphReplacement',
-    'focusId', 'focusSet',
+    'connectomeReloadIntent', 'neuronBirths', 'currentDomain', 'leaveFocusForGraphReplacement', 'clearAgentSelection',
     'hideExplorePanel', 'clearFocusMarker', 'updateModeChrome', 'hullState', '$',
     'sliderUnits', 'setHullOpacity', 'Graph', 'load', 'zoomOut', 'acquireInitialGraph',
     executableSetMode,
@@ -323,7 +427,7 @@ test('mode chrome exposes coherent toggle state, active guidance, and live statu
   let focusLeaves = 0;
   runSetMode(
     'connectome', 'memory', true, { invalidate() {} }, { invalidate() {} }, resettable(),
-    resettable(), resettable(), null, () => { focusLeaves++; }, null, null, () => {}, () => {},
+    resettable(), resettable(), null, () => { focusLeaves++; }, () => {}, () => {}, () => {},
     announce => modeAnnouncements.push(announce), { valueFor: () => 0.03 }, () => null,
     value => value, () => {}, null, () => {}, () => {}, () => {},
   );

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -351,6 +351,21 @@ test('agent tooltip is clamped, escaped, and includes identity plus visible traf
     'vertical tooltip placement must stay inside the renderer');
 });
 
+test('connectome mode suppresses memory-only empty and unavailable overlays', () => {
+  assert.match(mriSource,
+    /container\.dispatchEvent\(new CustomEvent\('sage:mri-mode-change',[\s\S]{0,100}detail: \{ mode \}/,
+    'the renderer must expose its actual active mode to the host');
+  assert.match(appSource,
+    /element\.addEventListener\('sage:mri-mode-change', onModeChange\)/,
+    'the dashboard must subscribe to renderer mode changes');
+  assert.match(appSource, /const showingMemoryView = mriMode === 'memory'/);
+  const overlayStart = appSource.indexOf('const showingMemoryView = mriMode');
+  const overlayEnd = appSource.indexOf('// Global tooltips state', overlayStart);
+  const overlayBlock = appSource.slice(overlayStart, overlayEnd);
+  assert.equal((overlayBlock.match(/showingMemoryView &&/g) || []).length, 3,
+    'all three memory-only overlays must be gated by the active MRI mode');
+});
+
 test('mode controls retain visible pressed and keyboard-focus styling in both themes', () => {
   const styleStart = mriSource.indexOf('const STYLE = `');
   const styleEnd = mriSource.indexOf('`;\n\nfunction injectStyleOnce', styleStart);
@@ -418,16 +433,19 @@ test('mode chrome exposes coherent toggle state, active guidance, and live statu
   const modeAnnouncements = [];
   const runSetMode = new Function(
     'next', 'mode', 'allowConnectome', 'graphLoads', 'bloomLoads', 'connectomeActivity',
-    'connectomeReloadIntent', 'neuronBirths', 'currentDomain', 'leaveFocusForGraphReplacement', 'clearAgentSelection',
+    'connectomeReloadIntent', 'neuronBirths', 'currentDomain', 'container', 'CustomEvent', 'leaveFocusForGraphReplacement', 'clearAgentSelection',
     'hideExplorePanel', 'clearFocusMarker', 'updateModeChrome', 'hullState', '$',
     'sliderUnits', 'setHullOpacity', 'Graph', 'load', 'zoomOut', 'acquireInitialGraph',
     executableSetMode,
   );
   const resettable = () => ({ reset() {} });
   let focusLeaves = 0;
+  const modeEvents = [];
+  function FakeCustomEvent(type, init) { this.type = type; this.detail = init.detail; }
   runSetMode(
     'connectome', 'memory', true, { invalidate() {} }, { invalidate() {} }, resettable(),
-    resettable(), resettable(), null, () => { focusLeaves++; }, () => {}, () => {}, () => {},
+    resettable(), resettable(), null, { dispatchEvent(event) { modeEvents.push(event); } }, FakeCustomEvent,
+    () => { focusLeaves++; }, () => {}, () => {}, () => {},
     announce => modeAnnouncements.push(announce), { valueFor: () => 0.03 }, () => null,
     value => value, () => {}, null, () => {}, () => {}, () => {},
   );
@@ -435,6 +453,9 @@ test('mode chrome exposes coherent toggle state, active guidance, and live statu
     'the executable mode transition must invoke the announcing chrome path exactly once');
   assert.equal(focusLeaves, 1,
     'the executable mode transition must strip any distributed-engram bloom exactly once');
+  assert.deepEqual(modeEvents.map(event => [event.type, event.detail.mode]),
+    [['sage:mri-mode-change', 'connectome']],
+    'the host must receive the actual active mode so memory-only overlays can hide');
 });
 
 // Live firing pulses only the synapses that actually carried a message. The

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1140,6 +1140,7 @@ function MriView({ sse }) {
     const [inventory, setInventory] = useState(null);
     const [projectionAvailability, setProjectionAvailability] = useState('loading');
     const [graphAvailability, setGraphAvailability] = useState('loading');
+    const [mriMode, setMriMode] = useState('memory');
     const [selectedDomain, setSelectedDomain] = useState('');
     useEffect(() => {
         if (!ref.current) return;
@@ -1150,7 +1151,12 @@ function MriView({ sse }) {
                 setGraphAvailability(state);
             }
         };
+        const onModeChange = event => {
+            const mode = event?.detail?.mode;
+            if (mode === 'memory' || mode === 'connectome') setMriMode(mode);
+        };
         element.addEventListener('sage:mri-graph-availability', onGraphAvailability);
+        element.addEventListener('sage:mri-mode-change', onModeChange);
         const cleanup = mountMriBrain(ref.current, {
             showScan: false,
             showDomainLegend: false,
@@ -1158,6 +1164,7 @@ function MriView({ sse }) {
         });
         return () => {
             element.removeEventListener('sage:mri-graph-availability', onGraphAvailability);
+            element.removeEventListener('sage:mri-mode-change', onModeChange);
             cleanup();
         };
     }, [sse]);
@@ -1175,23 +1182,24 @@ function MriView({ sse }) {
     const partialProjection = projectionAvailability === 'partial';
     const memoryViewUnavailable = projectionAvailability === 'unavailable' ||
         graphAvailability === 'unavailable';
+    const showingMemoryView = mriMode === 'memory';
     return html`<div class="mri-wrap">
         <div class="mri-stage" ref=${ref}></div>
         <${BrainDomainInventory} onInventory=${setInventory} onAvailability=${setProjectionAvailability}
             selectedDomain=${selectedDomain} onSelectDomain=${selectDomain} />
-        ${memoryViewUnavailable && html`<div class="brain-empty-overlay" role="alert">
+        ${showingMemoryView && memoryViewUnavailable && html`<div class="brain-empty-overlay" role="alert">
             <${EmptyState} icon="brain"
                 headline="Memory view temporarily unavailable"
                 hint="Your memories are still stored and unchanged. CEREBRUM refused to display an unverified or incomplete projection instead of pretending the brain is empty."
                 actionLabel="Reload CEREBRUM"
                 onAction=${() => window.location.reload()} />
         </div>`}
-        ${!memoryViewUnavailable && noLocalMemories && partialProjection && html`<div class="brain-empty-overlay" role="alert">
+        ${showingMemoryView && !memoryViewUnavailable && noLocalMemories && partialProjection && html`<div class="brain-empty-overlay" role="alert">
             <${EmptyState} icon="brain"
                 headline="No memories can be safely shown yet"
                 hint="Some historical records are hidden while CEREBRUM verifies them. Your stored data was not changed." />
         </div>`}
-        ${!memoryViewUnavailable && noLocalMemories && !partialProjection && html`<div class="brain-empty-overlay">
+        ${showingMemoryView && !memoryViewUnavailable && noLocalMemories && !partialProjection && html`<div class="brain-empty-overlay">
             <${EmptyState} icon="brain"
                 headline=${hasSharedDomains ? 'No memories stored locally' : 'Your brain is empty'}
                 hint=${hasSharedDomains

--- a/web/static/js/connectome-map.js
+++ b/web/static/js/connectome-map.js
@@ -63,11 +63,22 @@ export function mapConnectome(g) {
   const ids = new Set(srcNeurons.map(n => n.agent_id));
 
   const weight = {};
+  const incoming = {}, outgoing = {}, peers = {}, peerTraffic = {};
   const activity = {};   // most recent last_fired across a neuron's incident edges
   let maxWeight = 0, maxCount = 0;
   for (const s of srcSynapses) {
     if (!ids.has(s.from_agent) || !ids.has(s.to_agent)) continue;
     const c = s.count || 0;
+    outgoing[s.from_agent] = (outgoing[s.from_agent] || 0) + c;
+    incoming[s.to_agent] = (incoming[s.to_agent] || 0) + c;
+    if (s.from_agent !== s.to_agent) {
+      (peers[s.from_agent] ||= new Set()).add(s.to_agent);
+      (peers[s.to_agent] ||= new Set()).add(s.from_agent);
+      (peerTraffic[s.from_agent] ||= {})[s.to_agent] = peerTraffic[s.from_agent][s.to_agent] || 0;
+      peerTraffic[s.from_agent][s.to_agent] += c;
+      (peerTraffic[s.to_agent] ||= {})[s.from_agent] = peerTraffic[s.to_agent][s.from_agent] || 0;
+      peerTraffic[s.to_agent][s.from_agent] += c;
+    }
     weight[s.from_agent] = (weight[s.from_agent] || 0) + c;
     weight[s.to_agent] = (weight[s.to_agent] || 0) + c;
     if (c > maxCount) maxCount = c;
@@ -80,14 +91,23 @@ export function mapConnectome(g) {
   }
   for (const w of Object.values(weight)) { if (w > maxWeight) maxWeight = w; }
 
-  const nodes = srcNeurons.map(n => ({
+  const nodes = srcNeurons.map(n => {
+    const strongest = Object.entries(peerTraffic[n.agent_id] || {})
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0] || null;
+    return ({
     id: agentNodeID(n.agent_id),
     agent_id: n.agent_id,
+    agent_domain: n.domain || '',
     domain: n.domain || n.role || 'agent',
     label: n.name || n.agent_id,
     role: n.role || '',
     isNeuron: true,
     _w: weight[n.agent_id] || 0,
+    _incoming: incoming[n.agent_id] || 0,
+    _outgoing: outgoing[n.agent_id] || 0,
+    _peers: (peers[n.agent_id] || new Set()).size,
+    _strongest_peer: strongest ? strongest[0] : '',
+    _strongest_peer_traffic: strongest ? strongest[1] : 0,
     _deg: maxWeight ? (weight[n.agent_id] || 0) / maxWeight : 0,
     // most recent activity across this neuron's synapses ('' = never fired), used
     // by the client to grey out dormant agents (rung 5 pruning).
@@ -95,7 +115,8 @@ export function mapConnectome(g) {
     // memory fields the shared render/tip paths read, given neutral values
     status: 'committed', confidence: 1, corroboration_count: 0,
     memory_type: 'agent', created_at: '',
-  }));
+    });
+  });
 
   const links = srcSynapses
     .filter(s => ids.has(s.from_agent) && ids.has(s.to_agent))

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -178,6 +178,21 @@ const STYLE = `
 .mrib .tip .h{color:#eaf4ff;font-weight:700;margin-bottom:2px}
 .mrib .tip .m{color:#5d7395;font-size:11px}
 .mrib .tip .chip{font-size:10px;padding:1px 6px;border-radius:6px;background:#0e1b30;color:#aecbf0;margin-right:4px}
+.mrib .tip .hint{margin-top:6px;color:#39d0ff;font-size:10px}
+.mrib .agent-browser{display:none;position:absolute;top:16px;right:16px;width:min(340px,calc(100% - 32px));z-index:8;padding:8px;background:rgba(10,16,28,.9);border:1px solid #15233b;border-radius:10px;backdrop-filter:blur(10px);box-shadow:0 8px 30px #0007}
+.mrib .agent-browser.visible{display:block}
+.mrib .agent-inspector{display:none;position:absolute;top:68px;right:16px;width:min(340px,calc(100% - 32px));max-height:calc(100% - 148px);overflow:auto;z-index:8;padding:14px;background:rgba(10,16,28,.92);border:1px solid #15233b;border-radius:12px;backdrop-filter:blur(10px);box-shadow:0 12px 44px #0009}
+.mrib .agent-inspector.visible{display:block}
+.mrib.with-domain-legend .agent-browser{left:16px;right:auto;top:82px}.mrib.with-domain-legend .agent-inspector{left:16px;right:auto;top:134px;max-height:calc(100% - 214px)}
+.mrib .ai-head{display:flex;align-items:flex-start;gap:10px;margin-bottom:12px}
+.mrib .ai-neuron{width:12px;height:12px;border-radius:50%;margin-top:5px;box-shadow:0 0 12px currentColor;flex:none}
+.mrib .ai-heading{min-width:0;flex:1}.mrib .ai-kicker{color:#39d0ff;font-size:10px;letter-spacing:1.4px;text-transform:uppercase}.mrib .ai-name{color:#eaf4ff;font:700 15px/1.3 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;overflow-wrap:anywhere}.mrib .ai-role{color:#9fb6d8;font-size:11px;margin-top:2px}
+.mrib .ai-close{width:40px;height:40px;margin:-8px -8px 0 0;border:0;border-radius:9px;background:transparent;color:#9fb6d8;cursor:pointer;font:20px/1 sans-serif}.mrib .ai-close:hover{background:#0e1b30;color:#eaf4ff}
+.mrib .ai-select{min-width:0;width:100%;padding:8px 10px;color:#dceaff;background:#081221;border:1px solid #203455;border-radius:8px;font:12px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.mrib .ai-section{border-top:1px solid #15233b;padding-top:10px;margin-top:10px}.mrib .ai-label{color:#5d7395;font-size:10px;letter-spacing:1.2px;text-transform:uppercase;margin-bottom:3px}.mrib .ai-value{color:#dceaff;font-size:12px;overflow-wrap:anywhere}.mrib .ai-id-row{display:flex;gap:8px;align-items:flex-start}.mrib .ai-id{flex:1;color:#aecbf0;font-size:11px;word-break:break-all}.mrib .ai-copy,.mrib .ai-retry{border:1px solid #203455;border-radius:7px;background:transparent;color:#39d0ff;cursor:pointer;font:10px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;padding:4px 7px}.mrib .ai-copy:hover,.mrib .ai-retry:hover{background:#0e1b30}
+.mrib .ai-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;margin-top:8px}.mrib .ai-stat{padding:8px;border-radius:8px;background:rgba(14,27,48,.62)}.mrib .ai-stat b{display:block;color:#eaf4ff;font-size:14px}.mrib .ai-stat span{color:#5d7395;font-size:9px;letter-spacing:.8px;text-transform:uppercase}.mrib .ai-memory{color:#9fb6d8;font-size:11px}.mrib .ai-memory.error{color:#ff9aa5}.mrib .ai-memory-title{color:#dceaff;font-size:11px;margin:6px 0 2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.mrib .ai-empty{color:#5d7395;font-size:11px}
+.mrib .ai-selected[hidden]{display:none}
+.mrib .agent-inspector :is(button,select):focus-visible{outline:2px solid #39d0ff;outline-offset:2px}
 .mrib .flag{position:absolute;bottom:16px;right:16px;color:#3a4a66;font-size:10px;letter-spacing:1px}
 .mrib .sr-status{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .mrib .boot{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#5d7395;letter-spacing:2px;font-size:12px}
@@ -249,11 +264,18 @@ const STYLE = `
 :root[data-theme="light"] .mrib .legend h4,
 :root[data-theme="light"] .mrib .legend .cls{border-color:#e2e8f0}
 :root[data-theme="light"] .mrib .tip{background:rgba(255,255,255,.97);border-color:#dbe3ec}
+:root[data-theme="light"] .mrib .agent-inspector{background:rgba(255,255,255,.94);border-color:#dbe3ec;box-shadow:0 8px 32px rgba(15,23,42,.15)}
+:root[data-theme="light"] .mrib .agent-browser{background:rgba(255,255,255,.94);border-color:#dbe3ec;box-shadow:0 8px 32px rgba(15,23,42,.12)}
+:root[data-theme="light"] .mrib .ai-name,:root[data-theme="light"] .mrib .ai-value,:root[data-theme="light"] .mrib .ai-stat b,:root[data-theme="light"] .mrib .ai-memory-title{color:#1e293b}
+:root[data-theme="light"] .mrib .ai-select{color:#1e293b;background:#fff;border-color:#cbd5e1}
+:root[data-theme="light"] .mrib .ai-stat{background:#f1f5f9}
 :root[data-theme="light"] .mrib .explore .ex-col{background:rgba(255,255,255,.6);border-color:#e2e8f0}
 :root[data-theme="light"] .mrib .explore .ex-card{background:rgba(240,244,249,.7)}
 :root[data-theme="light"] .mrib .explore .ex-card:hover{background:#e9eef4;border-color:#cbd5e1}
 :root[data-theme="light"] .mrib .flag{color:#94a3b8}
 :root[data-theme="light"] .mrib .hud .sld input{accent-color:#0891b2}
+@media (max-width:760px),(pointer:coarse){.mrib .agent-browser,.mrib.with-domain-legend .agent-browser{top:8px;left:8px;right:8px;width:auto}.mrib .agent-inspector,.mrib.with-domain-legend .agent-inspector{top:auto;left:8px;right:8px;bottom:72px;width:auto;max-height:55vh}.mrib .ai-close{width:44px;height:44px}}
+@media (prefers-reduced-motion:reduce){.mrib .agent-inspector,.mrib .tip{transition:none!important}}
 `;
 
 function injectStyleOnce() {
@@ -334,6 +356,7 @@ export function mountMriBrain(container, opts = {}) {
 
   const root = document.createElement('div');
   root.className = 'mrib';
+  root.classList.toggle('with-domain-legend', showDomainLegend);
   root.innerHTML = `
     <div class="mrib-graph"></div>
     <div class="boot">◉ ACQUIRING HIPPOCAMPAL FIELD…</div>
@@ -372,7 +395,17 @@ export function mountMriBrain(container, opts = {}) {
       ${allowConnectome ? '<button type="button" class="btn b-mode" aria-label="Connectome view" aria-pressed="false">◉ connectome</button>' : ''}
       <label class="sld">skull <input class="b-op" type="range" min="0" max="60" value="8"></label>
     </div>
-    <div class="tip"></div>
+    <div class="agent-browser" aria-hidden="true"><select class="ai-select" aria-label="Browse agents"><option value="">Browse agents…</option></select></div>
+    <aside class="agent-inspector" aria-label="Connectome agent details" aria-hidden="true">
+      <div class="ai-selected">
+        <div class="ai-head"><span class="ai-neuron"></span><div class="ai-heading"><div class="ai-kicker">Selected agent</div><div class="ai-name"></div><div class="ai-role"></div></div><button type="button" class="ai-close" aria-label="Close agent details">×</button></div>
+        <div class="ai-section"><div class="ai-label">Agent ID</div><div class="ai-id-row"><code class="ai-id"></code><button type="button" class="ai-copy">Copy</button></div></div>
+        <div class="ai-section"><div class="ai-label">Domain</div><div class="ai-value ai-domain"></div><div class="ai-label" style="margin-top:8px">Last retained message activity</div><div class="ai-value ai-activity"></div></div>
+        <div class="ai-section"><div class="ai-label">Visible retained traffic</div><div class="ai-grid"><div class="ai-stat"><b class="ai-in">0</b><span>Incoming</span></div><div class="ai-stat"><b class="ai-out">0</b><span>Outgoing</span></div><div class="ai-stat"><b class="ai-total">0</b><span>Total</span></div><div class="ai-stat"><b class="ai-peers">0</b><span>Connected agents</span></div></div><div class="ai-value ai-strongest" style="margin-top:8px"></div></div>
+        <div class="ai-section"><div class="ai-label">Visible memory lobe</div><div class="ai-memory"></div></div>
+      </div>
+    </aside>
+    <div class="tip" role="tooltip" aria-hidden="true"></div>
     <div class="flag"></div>
     <div class="sr-status" role="status" aria-live="polite"></div>`;
   container.appendChild(root);
@@ -578,6 +611,7 @@ export function mountMriBrain(container, opts = {}) {
   async function bloomEngrams(n){
     if (disposed || !Graph || !rendered || mode !== 'connectome') return;
     const agentID = n.agent_id || n.id;
+    if (selectedAgentID === agentID) { selectedMemoryState = { status:'loading' }; renderMemoryState(); }
     const bloomRequest = bloomLoads.begin(agentID);
     focusNeuron(n);
     // Clear any prior bloom IMMEDIATELY, before the fetch — so a failed, errored,
@@ -587,14 +621,16 @@ export function mountMriBrain(container, opts = {}) {
     let payload;
     try {
       const resp = await fetch(ENGRAMS_URL + '?agent=' + encodeURIComponent(agentID), { credentials: 'same-origin' });
-      if (!resp.ok) return;
+      if (!resp.ok) { if (selectedAgentID===agentID) { selectedMemoryState={status:'error'}; renderMemoryState(); } return; }
       payload = await resp.json();
-    } catch (e) { console.warn('[mri] engrams unavailable:', e.message); return; }
+    } catch (e) { console.warn('[mri] engrams unavailable:', e.message); if (selectedAgentID===agentID) { selectedMemoryState={status:'error'}; renderMemoryState(); } return; }
     // Superseded (another neuron clicked while this was in flight) or torn down:
     // drop the stale response rather than bloom it under the wrong focus.
     if (disposed || !Graph || mode !== 'connectome' || focusId !== n.id ||
         !bloomLoads.isCurrent(bloomRequest, agentID)) return;
     const engrams = mapEngrams(payload);
+    selectedMemoryState = { status:'ready', memories:engrams, continuation:payload && payload.continuation_required === true, partial:!!(payload && payload.projection && payload.projection.partial === true) };
+    renderMemoryState();
     const composed = applyEngramBloom(Graph.graphData(), engrams, n, focusSet, placeNear);
     focusId = n.id; focusSet = composed.focusSet;
     Graph.graphData(composed.graphData);
@@ -691,6 +727,9 @@ export function mountMriBrain(container, opts = {}) {
 
   let Graph = null, controls = null, disposed = false, flow = true, scanning = true;
   let lastNodeClickAt = 0, graphPointerDown = null;
+  let selectedAgentID = null, selectedAgentNode = null;
+  let selectedMemoryState = null;
+  let pointerX = 0, pointerY = 0;
   let hullMat = null, brainMat = null, surfMat = null, curOpacity = hullState.valueFor(mode);
   let focusMarker = null, focusRingTexture = null;
   let currentDomain = null;                 // drill-down lobe (null = overview)
@@ -718,6 +757,100 @@ export function mountMriBrain(container, opts = {}) {
       detail: { state },
     }));
   };
+
+  const agentName = n => String((n && (n.label || n.agent_id)) || 'Unknown agent');
+  const agentRole = n => String((n && n.role) || 'Unknown role');
+  const agentDomain = n => String((n && n.agent_domain) || 'No domain');
+  function activityLabel(value){
+    if (!value) return 'No recorded retained activity';
+    const at = new Date(value);
+    if (Number.isNaN(at.getTime())) return 'No recorded retained activity';
+    const age = Math.max(0, Date.now() - at.getTime());
+    const relative = age < 60000 ? 'Traffic just now'
+      : age < 3600000 ? `Last traffic ${Math.floor(age/60000)}m ago`
+      : age < 86400000 ? `Last traffic ${Math.floor(age/3600000)}h ago`
+      : `Last traffic ${Math.floor(age/86400000)}d ago`;
+    return `${relative} · ${at.toLocaleString()}`;
+  }
+  function populateAgentPicker(d){
+    const select = $('.ai-select'); if (!select) return;
+    const nodes = (d && Array.isArray(d.nodes) ? d.nodes : []).filter(n => n.isNeuron && n.agent_id);
+    select.innerHTML = '<option value="">Browse agents…</option>';
+    nodes.sort((a,b)=>agentName(a).localeCompare(agentName(b))).forEach(n => {
+      const option = document.createElement('option');
+      option.value = n.agent_id; option.textContent = `${agentName(n)} · ${n.agent_id}`;
+      select.appendChild(option);
+    });
+    select.value = selectedAgentID || '';
+  }
+  function renderMemoryState(){
+    const el = $('.ai-memory'); if (!el) return;
+    const state = selectedMemoryState;
+    el.className = 'ai-memory'; el.innerHTML = '';
+    if (!state || state.status === 'loading') { el.textContent = 'Loading visible committed memories…'; return; }
+    if (state.status === 'error') {
+      el.classList.add('error'); el.textContent = 'Couldn’t load visible memories. ';
+      const retry = document.createElement('button'); retry.type = 'button'; retry.className = 'ai-retry'; retry.textContent = 'Retry';
+      retry.onclick = () => { if (selectedAgentNode) { selectedMemoryState = { status:'loading' }; renderMemoryState(); bloomEngrams(selectedAgentNode); } };
+      el.appendChild(retry); return;
+    }
+    const memories = state.memories || [];
+    if (!memories.length) {
+      el.textContent = `No visible committed memories in this result.${state.partial ? ' Some records may be temporarily hidden by projection health.' : ''}${state.continuation ? ' More may exist beyond this bounded view.' : ''}`;
+      return;
+    }
+    const summary = document.createElement('div');
+    summary.textContent = `${memories.length} visible memor${memories.length===1?'y':'ies'}${state.continuation ? ' · showing top results' : ''}${state.partial ? ' · projection partial' : ''}`;
+    el.appendChild(summary);
+    memories.slice(0,3).forEach(memory => { const row=document.createElement('div'); row.className='ai-memory-title'; row.textContent=memory.label||memory.memory_id||'Untitled memory'; el.appendChild(row); });
+  }
+  function renderAgentInspector(n, announce=false){
+    const inspector = $('.agent-inspector'); if (!inspector) return;
+    const chosen = !!(n && n.isNeuron && n.agent_id);
+    inspector.classList.toggle('visible', mode === 'connectome' && chosen);
+    inspector.setAttribute('aria-hidden', mode === 'connectome' && chosen ? 'false' : 'true');
+    if (!chosen) return;
+    selectedAgentID = n.agent_id; selectedAgentNode = n;
+    $('.ai-select').value = selectedAgentID;
+    $('.ai-neuron').style.background = domainColor(n.domain);
+    $('.ai-neuron').style.color = domainColor(n.domain);
+    $('.ai-name').textContent = agentName(n); $('.ai-role').textContent = agentRole(n);
+    $('.ai-id').textContent = n.agent_id; $('.ai-domain').textContent = agentDomain(n);
+    $('.ai-activity').textContent = activityLabel(n._activity);
+    $('.ai-in').textContent = fmtN(n._incoming); $('.ai-out').textContent = fmtN(n._outgoing);
+    $('.ai-total').textContent = fmtN(n._w); $('.ai-peers').textContent = fmtN(n._peers);
+    const peer = n._strongest_peer && rendered && rendered.nodes.find(x=>x.agent_id===n._strongest_peer);
+    $('.ai-strongest').textContent = n._strongest_peer
+      ? `Strongest visible connection: ${agentName(peer || {agent_id:n._strongest_peer})} · ${fmtN(n._strongest_peer_traffic)} retained messages`
+      : 'No visible connected agents';
+    renderMemoryState();
+    if (announce) { const status=$('.sr-status'); if(status) status.textContent=`Selected agent ${agentName(n)}, ${n.agent_id}.`; }
+  }
+  function clearAgentSelection(announce=false){
+    selectedAgentID = null; selectedAgentNode = null; selectedMemoryState = null;
+    const select=$('.ai-select'); if(select) select.value='';
+    renderAgentInspector(null);
+    if (announce) { const status=$('.sr-status'); if(status) status.textContent='Agent selection cleared.'; }
+  }
+  function selectNeuron(n){
+    if (mode !== 'connectome' || !n || !n.isNeuron || !n.agent_id) return;
+    selectedMemoryState = { status:'loading' };
+    renderAgentInspector(n, true);
+    bloomEngrams(n);
+  }
+  function restoreSelectedAgent(d){
+    if (!selectedAgentID) return;
+    const selected = d.nodes.find(n=>n.isNeuron && n.agent_id===selectedAgentID);
+    if (!selected) { clearAgentSelection(); const status=$('.sr-status'); if(status) status.textContent='Selected agent is no longer available.'; return; }
+    selectedAgentNode=selected; renderAgentInspector(selected); focusNeuron(selected);
+    if (selectedMemoryState && selectedMemoryState.status==='ready') {
+      const composed=applyEngramBloom(Graph.graphData(), selectedMemoryState.memories||[], selected, focusSet, placeNear);
+      focusId=selected.id; focusSet=composed.focusSet; Graph.graphData(composed.graphData);
+      Graph.nodeColor(nodeColorRGBA); setFocusMarkerNode(selected);
+    } else if (selectedMemoryState && selectedMemoryState.status==='loading') {
+      selectedMemoryState={status:'loading'}; renderMemoryState(); bloomEngrams(selected);
+    }
+  }
 
   function setHullOpacity(o){
     curOpacity = o;
@@ -922,6 +1055,8 @@ export function mountMriBrain(container, opts = {}) {
       rendered = d;
       refreshCounts(d);
       buildLobes(d);
+      populateAgentPicker(d);
+      restoreSelectedAgent(d);
       connectomeReloadIntent.settle(request.mode, tickGeneration, true);
     }).catch(() => {
       if (disposed || !graphLoads.isCurrent(request, mode)) return;
@@ -977,7 +1112,7 @@ export function mountMriBrain(container, opts = {}) {
   }
 
   function exitFocus(){
-    if (!focusId) return;
+    if (!focusId && !selectedAgentID) return;
     bloomLoads.invalidate();
     focusId = null; focusSet = null;
     clearFocusMarker();
@@ -986,6 +1121,7 @@ export function mountMriBrain(container, opts = {}) {
       Graph.nodeColor(nodeColorRGBA);
     }
     hideExplorePanel();
+    clearAgentSelection(true);
     zoomOut();
   }
 
@@ -1192,7 +1328,7 @@ export function mountMriBrain(container, opts = {}) {
       .linkDirectionalParticleWidth(1.1).linkDirectionalParticleSpeed(linkParticleSpeedFor)
       .warmupTicks(1).cooldownTicks(6)
       .onNodeHover(showTip)
-      .onNodeClick(n=>{ lastNodeClickAt = performance.now(); if (mode==='connectome') { if (n.isNeuron) bloomEngrams(n); } else exploreNode(n); })
+      .onNodeClick(n=>{ lastNodeClickAt = performance.now(); hideTip(); if (mode==='connectome') { if (n.isNeuron) selectNeuron(n); } else exploreNode(n); })
       .onBackgroundClick(()=>{ exitFocus(); });
 
     // Positions are pinned by placeNodes() (fx/fy/fz), so disable the force
@@ -1311,6 +1447,8 @@ export function mountMriBrain(container, opts = {}) {
     } catch(e){ /* hull optional */ }
 
     buildLobes(data);
+    populateAgentPicker(data);
+    renderAgentInspector(null);
     const lt=$('.linktypes');
     if (lt) Object.values(LINK_TYPES).filter(t=>t.typed).forEach(t=>lt.insertAdjacentHTML('beforeend',
       `<div class="row"><span class="bar" style="background:${t.color}"></span><div class="t"><span>${t.label}</span></div></div>`));
@@ -1403,7 +1541,7 @@ export function mountMriBrain(container, opts = {}) {
       // Deep-link: auto-bloom a requested agent's lobe on first connectome paint.
       if (focusAgent && !autoBloomed && mode === 'connectome' && rendered) {
         const target = rendered.nodes.find(nd => nd.isNeuron && (nd.agent_id || nd.id) === focusAgent);
-        if (target) { autoBloomed = true; deepLinkTimer = setTimeout(() => { if (!disposed) bloomEngrams(target); }, 50); }
+        if (target) { autoBloomed = true; deepLinkTimer = setTimeout(() => { if (!disposed) selectNeuron(target); }, 50); }
       }
     }).catch(() => {
       if (disposed || !graphLoads.isCurrent(request, mode)) return;
@@ -1415,20 +1553,34 @@ export function mountMriBrain(container, opts = {}) {
   }
   acquireInitialGraph();
 
-  function showTip(n){ const tip=$('.tip'); if(!n){ tip.style.display='none'; return; }
-    tip.style.display='block';
-    if(n.isNeuron){
-      tip.innerHTML=`<div class="h">${escapeHtml((n.label||'').slice(0,90))}</div><div class="m">neuron · ${escapeHtml(n.role||'agent')}${n.domain?` · ${escapeHtml(n.domain)}`:''}</div>
-        <div style="margin-top:5px"><span class="chip">traffic ${n._w|0}</span><span class="chip">${(n._deg||0)>=0.5?'hub':'node'}</span></div>`;
-      return;
+  function hideTip(){ const tip=$('.tip'); if(!tip) return; tip.style.display='none'; tip.setAttribute('aria-hidden','true'); }
+  function positionTip(){
+    const tip=$('.tip'); if(!tip || tip.style.display!=='block') return;
+    const r=root.getBoundingClientRect(), gap=14, pad=8;
+    let left=pointerX-r.left+gap, top=pointerY-r.top+gap;
+    if (left+tip.offsetWidth+pad>r.width) left=pointerX-r.left-tip.offsetWidth-gap;
+    if (top+tip.offsetHeight+pad>r.height) top=pointerY-r.top-tip.offsetHeight-gap;
+    tip.style.left=Math.max(pad,Math.min(r.width-tip.offsetWidth-pad,left))+'px';
+    tip.style.top=Math.max(pad,Math.min(r.height-tip.offsetHeight-pad,top))+'px';
+  }
+  function showTip(n){ const tip=$('.tip'); if(!n){ hideTip(); return; }
+    if (mode !== 'connectome') {
+      tip.style.display='block'; tip.setAttribute('aria-hidden','false');
+      tip.innerHTML=`<div class="h">${escapeHtml((n.label||'').slice(0,90))}</div><div class="m">${escapeHtml(n.domain)} · ${escapeHtml(n.memory_type||'—')} · ${escapeHtml(n.status)}</div><div style="margin-top:5px"><span class="chip">conf ${(+n.confidence).toFixed(2)}</span><span class="chip">corroborated ×${n.corroboration_count|0}</span></div>`;
+      positionTip(); return;
     }
-    tip.innerHTML=`<div class="h">${escapeHtml((n.label||'').slice(0,90))}</div><div class="m">${escapeHtml(n.domain)} · ${escapeHtml(n.memory_type||'—')} · ${escapeHtml(n.status)}</div>
-      <div style="margin-top:5px"><span class="chip">conf ${(+n.confidence).toFixed(2)}</span><span class="chip">corroborated ×${n.corroboration_count|0}</span></div>`; }
-  function onMove(e){ const tip=$('.tip'); if(tip.style.display==='block'){ const r=root.getBoundingClientRect();
-    tip.style.left=(e.clientX-r.left+14)+'px'; tip.style.top=(e.clientY-r.top+14)+'px'; } }
-  function isPanelTarget(t){ return !!(t && t.closest && t.closest('.panel')); }
+    if (!n.isNeuron) { hideTip(); return; }
+    const id=String(n.agent_id||'Unknown agent'), short=id.length>30?id.slice(0,14)+'…'+id.slice(-10):id;
+    tip.style.display='block'; tip.setAttribute('aria-hidden','false');
+    tip.innerHTML=`<div class="h"><span class="dot" style="width:8px;height:8px;background:${domainColor(n.domain)};margin-right:7px"></span>${escapeHtml(agentName(n))}</div><div class="m">Agent · ${escapeHtml(agentRole(n))} · ${escapeHtml(agentDomain(n))}</div><div class="m" title="${escapeHtml(id)}">${escapeHtml(short)}</div>
+      <div style="margin-top:5px"><span class="chip">in ${fmtN(n._incoming)}</span><span class="chip">out ${fmtN(n._outgoing)}</span><span class="chip">${fmtN(n._peers)} peers</span></div><div class="m" style="margin-top:5px">${escapeHtml(activityLabel(n._activity))}</div><div class="hint">Click for agent details</div>`;
+    positionTip();
+  }
+  function onMove(e){ pointerX=e.clientX; pointerY=e.clientY; positionTip(); }
+  function isPanelTarget(t){ return !!(t && t.closest && t.closest('.panel,.agent-browser,.agent-inspector')); }
   function onGraphPointerDown(e){
     if (isPanelTarget(e.target)) return;
+    hideTip();
     graphPointerDown = { x: e.clientX, y: e.clientY };
   }
   function onGraphClick(e){
@@ -1437,7 +1589,7 @@ export function mountMriBrain(container, opts = {}) {
     if (graphPointerDown && Math.hypot(e.clientX - graphPointerDown.x, e.clientY - graphPointerDown.y) > 6) return;
     exitFocus();
   }
-  root.addEventListener('mousemove', onMove);
+  root.addEventListener('pointermove', onMove, true);
   root.addEventListener('pointerdown', onGraphPointerDown);
   root.addEventListener('click', onGraphClick);
   // Relabel the stat panel and expose mode-specific guidance through the
@@ -1445,6 +1597,7 @@ export function mountMriBrain(container, opts = {}) {
   // visible panel over the graph.
   function updateModeChrome(announce=false){
     const connectome = mode === 'connectome';
+    hideTip();
     const btn=$('.b-mode');
     if(btn) {
       btn.textContent = '◉ connectome';
@@ -1452,10 +1605,12 @@ export function mountMriBrain(container, opts = {}) {
       btn.setAttribute('aria-pressed', connectome ? 'true' : 'false');
     }
     const title = $('.lg-title'); if (title) title.textContent = connectome ? 'Connectome' : 'Domain tags';
+    const browser = $('.agent-browser'); if (browser) { browser.classList.toggle('visible',connectome); browser.setAttribute('aria-hidden',connectome?'false':'true'); }
     const memoryGuide = $('.guide-memory'); if (memoryGuide) memoryGuide.hidden = connectome;
     const connectomeGuide = $('.guide-connectome'); if (connectomeGuide) connectomeGuide.hidden = !connectome;
     const set = mode==='connectome' ? ['neurons','synapses','hubs'] : ['memories','synapses','consolidated'];
     root.querySelectorAll('.hud .l').forEach((el,i)=>{ if(set[i]) el.textContent=set[i]; });
+    renderAgentInspector(connectome ? selectedAgentNode : null);
     if (announce) {
       const status = $('.sr-status');
       if (status) status.textContent = connectome
@@ -1478,6 +1633,7 @@ export function mountMriBrain(container, opts = {}) {
     neuronBirths.reset();
     currentDomain = null;
     leaveFocusForGraphReplacement();
+    clearAgentSelection(false);
     updateModeChrome(true);
     // Recall this view's remembered skull opacity (its default, or the operator's
     // last manual choice for this view) and reflect it on the slider, so a round
@@ -1493,6 +1649,21 @@ export function mountMriBrain(container, opts = {}) {
   $('.b-flow').onclick=function(){ flow=!flow; if(Graph) Graph.linkDirectionalParticles(linkParticlesFor); this.textContent=flow?'⚡ flow: on':'⚡ flow: off'; };
   $('.b-op').oninput=function(){ const o=this.value/100; setHullOpacity(o); hullState.record(mode, o); };
   if (allowConnectome) $('.b-mode').onclick=function(){ setMode(mode==='connectome'?'memory':'connectome'); };
+  $('.ai-select').onchange=function(){
+    if (!this.value) { if(selectedAgentID) exitFocus(); return; }
+    if (mode!=='connectome' || !rendered) return;
+    const n=rendered.nodes.find(node=>node.isNeuron && node.agent_id===this.value);
+    if(n) selectNeuron(n);
+  };
+  $('.ai-close').onclick=()=>{ exitFocus(); $('.ai-select').focus(); };
+  $('.ai-copy').onclick=async function(){
+    if(!selectedAgentID) return;
+    try { await navigator.clipboard.writeText(selectedAgentID); this.textContent='Copied'; setTimeout(()=>{ if(!disposed) this.textContent='Copy'; },1200); }
+    catch(e){ this.textContent='Unavailable'; }
+  };
+  const onKeyDown=e=>{ if(e.key==='Escape' && selectedAgentID) { e.preventDefault(); exitFocus(); $('.ai-select').focus(); } };
+  document.addEventListener('keydown',onKeyDown);
+  subs.push(()=>document.removeEventListener('keydown',onKeyDown));
 
   return function cleanup(){
     disposed = true;
@@ -1503,7 +1674,7 @@ export function mountMriBrain(container, opts = {}) {
     clearInterval(dormancyTimer);
     clearTimeout(deepLinkTimer);
     subs.forEach(u => { try { u && u(); } catch(e){ /* noop */ } });
-    root.removeEventListener('mousemove', onMove);
+    root.removeEventListener('pointermove', onMove, true);
     root.removeEventListener('pointerdown', onGraphPointerDown);
     root.removeEventListener('click', onGraphClick);
     try {

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -1628,6 +1628,9 @@ export function mountMriBrain(container, opts = {}) {
     graphLoads.invalidate();
     bloomLoads.invalidate();
     mode = next;
+    container.dispatchEvent(new CustomEvent('sage:mri-mode-change', {
+      detail: { mode },
+    }));
     connectomeActivity.reset();
     connectomeReloadIntent.reset();
     neuronBirths.reset();


### PR DESCRIPTION
## Summary
- add clamped, escaped identity and traffic tooltips for connectome neurons
- add a persistent nonmodal agent inspector shared by mouse, touch, and keyboard selection
- show visible retained traffic, activity, peer, and memory-lobe state with truthful partial/error/continuation wording
- preserve selection and engram state safely across live graph reloads
- add accessible agent browsing, dismissal, mobile, and reduced-motion behavior

## Verification
- node --test scripts/connectome-mapping.test.mjs scripts/connectome-engrams.test.mjs
- npm test (382/382)
- npm run check:js (29 files)
- git diff --check

Three-agent architecture, UX/accessibility, and test review reached source-level CODE GO. In-app browser visual QA was blocked by the local preview port namespace, so hosted/browser visual review remains explicit.