### PR TITLE
fix(mcp): document sage_timeline 31-day range bound

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -442,13 +442,17 @@ func TestHandleToolsList(t *testing.T) {
 	assert.Contains(t, idempotencySchema["description"], "every later identical call returns that existing task")
 
 	require.NotNil(t, sageTimeline)
+	assert.Contains(t, sageTimeline["description"], "maximum span of 31 days")
 	timelineSchema := sageTimeline["inputSchema"].(map[string]any)
 	timelineProperties := timelineSchema["properties"].(map[string]any)
 	for _, name := range []string{"from", "to"} {
 		bound := timelineProperties[name].(map[string]any)
 		assert.Equal(t, "date-time", bound["format"])
 		assert.Contains(t, bound["description"], "RFC3339")
+		assert.Contains(t, bound["description"], "maximum span: 31 days")
 	}
+	assert.Contains(t, timelineProperties["from"].(map[string]any)["description"], "2026-08-01T00:00:00Z")
+	assert.Contains(t, timelineProperties["to"].(map[string]any)["description"], "2026-08-15T00:00:00Z")
 }
 
 func TestToolRegistrySchemasAreSelfContained(t *testing.T) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -162,12 +162,12 @@ func (s *Server) registerTools() map[string]Tool {
 		},
 		"sage_timeline": {
 			Name:        "sage_timeline",
-			Description: "Get memories in a time range, grouped by time buckets. Use this to see memory activity over time.",
+			Description: "Get memories in a time range, grouped by time buckets. Use this to see memory activity over time. App-v23 limits each request to a maximum span of 31 days.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"from":   map[string]any{"type": "string", "format": "date-time", "description": "Start instant (RFC3339, e.g. 2024-01-01T00:00:00Z)"},
-					"to":     map[string]any{"type": "string", "format": "date-time", "description": "End instant (RFC3339, e.g. 2024-12-31T23:59:59Z)"},
+					"from":   map[string]any{"type": "string", "format": "date-time", "description": "Start instant (RFC3339, e.g. 2026-08-01T00:00:00Z; maximum span: 31 days)"},
+					"to":     map[string]any{"type": "string", "format": "date-time", "description": "End instant (RFC3339, e.g. 2026-08-15T00:00:00Z; maximum span: 31 days)"},
 					"domain": map[string]any{"type": "string", "description": "Filter by domain tag"},
 				},
 			},


### PR DESCRIPTION
## Summary
- make the MCP tool description state the app-v23 31-day maximum span
- replace the invalid year-long examples with a valid bounded range
- pin the contract in the tool-registry test

## Verification
- env GOCACHE=/private/tmp/sage-timeline-gocache go test ./internal/mcp -run 'TestToolRegistry' -count=1
- git diff --check

Reported by claude-code/sage-voice-bridge and independently verified against the v11.18.14 base.