### PR TITLE
fix(mcp): wake Claude Code for durable messages by default

### DIFF
--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -205,10 +205,11 @@ func runMCP() error {
 	if projectDir, cwdErr := os.Getwd(); cwdErr == nil {
 		selfHealProject(projectDir, home, os.Getenv("SAGE_PROVIDER"), keyPath)
 	}
-	// The Claude channel stays opt-in, and a failure to arm it is deliberately
-	// not fatal: the wake channel is an accelerator over polling, so a host
-	// that cannot open the stream must still get an ordinary working MCP
-	// session rather than no session at all.
+	// Claude Code is the shipped consumer of the payload-free wake extension,
+	// so its project-scoped MCP sessions arm the channel by default. A failure
+	// to arm remains deliberately non-fatal: the wake channel accelerates
+	// polling, and a host that cannot open the stream must still get an ordinary
+	// working MCP session rather than no session at all.
 	if claudeChannelEnabled() {
 		if err := server.EnableRESTClaudeChannel(); err != nil {
 			fmt.Fprintf(os.Stderr, "SAGE MCP: claude channel disabled: %v\n", err)
@@ -217,14 +218,14 @@ func runMCP() error {
 	return server.Run(context.Background())
 }
 
-// claudeChannelEnabled reports whether the operator explicitly armed the
-// experimental Claude wake channel. Default-off is the shipped contract of the
-// adapter itself, so absence means off and an unparseable value means off —
-// envBool already warns on the latter rather than guessing.
+// claudeChannelEnabled arms the wake extension by default only for the shipped
+// Claude Code consumer. Other MCP hosts remain off unless explicitly enabled,
+// and an operator can explicitly disable a Claude Code session. An unparseable
+// override fails closed — envBool warns rather than guessing.
 func claudeChannelEnabled() bool {
 	raw := os.Getenv("SAGE_CLAUDE_CHANNEL")
 	if strings.TrimSpace(raw) == "" {
-		return false
+		return strings.EqualFold(strings.TrimSpace(os.Getenv("SAGE_PROVIDER")), "claude-code")
 	}
 	enabled, ok := envBool("SAGE_CLAUDE_CHANNEL", raw)
 	return ok && enabled

--- a/cmd/sage-gui/mcp_test.go
+++ b/cmd/sage-gui/mcp_test.go
@@ -11,6 +11,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestClaudeChannelDefaultsOnOnlyForClaudeCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		override string
+		want     bool
+	}{
+		{name: "Claude Code default", provider: "claude-code", want: true},
+		{name: "Claude Code provider is case insensitive", provider: "CLAUDE-CODE", want: true},
+		{name: "other hosts remain off", provider: "codex", want: false},
+		{name: "explicit Claude opt out", provider: "claude-code", override: "false", want: false},
+		{name: "explicit opt in", provider: "codex", override: "true", want: true},
+		{name: "invalid override fails closed", provider: "claude-code", override: "not-a-bool", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SAGE_PROVIDER", tt.provider)
+			t.Setenv("SAGE_CLAUDE_CHANNEL", tt.override)
+			assert.Equal(t, tt.want, claudeChannelEnabled())
+		})
+	}
+}
+
 func TestInstallClaudeMD_CreateNew(t *testing.T) {
 	projectDir := t.TempDir()
 	err := installClaudeMD(projectDir)

--- a/docs/reference/concepts/message-wake-bus.md
+++ b/docs/reference/concepts/message-wake-bus.md
@@ -82,12 +82,14 @@ does not define this durable sequence contract.
 
 ## Claude wake channel enablement
 
-The Claude host adapter is the one shipped consumer of this route. It is
-**off by default** and is armed only by setting `SAGE_CLAUDE_CHANNEL` for
-`sage-gui mcp`, the stdio MCP server a Claude host launches
+The Claude host adapter is the one shipped consumer of this route. A
+project-scoped `sage-gui mcp` session whose `SAGE_PROVIDER` is `claude-code`
+arms it by default; set `SAGE_CLAUDE_CHANNEL=0` (or another accepted false
+spelling) to opt out. Other MCP hosts stay off unless explicitly enabled
 (`cmd/sage-gui/mcp.go:224`). Constructing an MCP `Server` never advertises or
-emits the experimental protocol on its own; enabling is an explicit call
-(`internal/mcp/claude_wake_source.go:84`, `internal/mcp/claude_channel.go:50`).
+emits the experimental protocol on its own; the executable still makes an
+explicit enablement call (`internal/mcp/claude_wake_source.go:84`,
+`internal/mcp/claude_channel.go:50`).
 
 When armed, the adapter subscribes to this agent's own signed wake stream and
 turns a new durable cursor into a `notifications/claude/channel` JSON-RPC

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -154,7 +154,7 @@ legacy Ollama vector space over a requested custom one (`cmd/amid/main.go`).
 |----------|--------------|---------|---------|--------|
 | `SAGE_SNAPSHOT_KEEP` | Snapshots to retain (newest N + per-version anchors, which are never pruned). Integer ≥ 1. | `5` | sage-gui | `cmd/sage-gui/node.go:262`, `cmd/sage-gui/snapshot.go:56` |
 | `SAGE_BRANCH_TAG` | Set `0`/`false`/`no` to disable branch tagging of memories. | on | MCP | `internal/mcp/branch.go:27` |
-| `SAGE_CLAUDE_CHANNEL` | Opt-in for the experimental Claude wake channel. When on, `sage-gui mcp` subscribes to this agent's signed `/v1/messages/wake` stream and emits a `notifications/claude/channel` JSON-RPC notification so the host can stop polling. Payload-free: the host learns only a durable wake cursor, never message content or sender. Accepts the usual boolean spellings; an unrecognized value warns and stays off. Failure to arm is non-fatal and leaves an ordinary MCP session. | off | sage-gui MCP (stdio) | `cmd/sage-gui/mcp.go:224`, `internal/mcp/claude_wake_source.go:84` |
+| `SAGE_CLAUDE_CHANNEL` | Controls the experimental Claude wake channel. Claude Code project sessions arm it by default; set `0`/`false`/`no` to opt out. Other MCP hosts remain off unless explicitly enabled. When on, `sage-gui mcp` subscribes to this agent's signed `/v1/messages/wake` stream and emits a `notifications/claude/channel` JSON-RPC notification so the host can stop polling. Payload-free: the host learns only a durable wake cursor, never message content or sender. An unrecognized value warns and stays off. Failure to arm is non-fatal and leaves an ordinary MCP session. | on for `claude-code`; off otherwise | sage-gui MCP (stdio) | `cmd/sage-gui/mcp.go:225`, `internal/mcp/claude_wake_source.go:84` |
 
 ---
 


### PR DESCRIPTION
## Outcome

Claude Code project MCP sessions now arm the existing payload-free durable message wake channel by default. Operators can opt out with SAGE_CLAUDE_CHANNEL=0. Other MCP hosts remain off unless explicitly enabled.

This closes the installed v11.18.13 gap where the wake adapter shipped but ordinary Claude Code configurations never enabled it, leaving durable messages pending until the runtime happened to poll.

## Boundaries

- No message content, sender, or count enters the wake notification.
- Wake still does not read, claim, or acknowledge work.
- Stream-arm failure remains non-fatal and falls back to ordinary polling.
- This does not solve dead-session claimed rows; the separate stranded-claim visibility/recovery lane remains required for v11.18.14.
- Draft and void on head movement. No release authority is claimed here.

## Verification

- Focused provider/default/override test passes.
- Full cmd/sage-gui package passes outside the network sandbox.
- npm test: 375/375.
- git diff --check clean.