### PR TITLE
fix(store): deterministic memory_id tiebreak for GetPendingByDomain

### DIFF
--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -1321,7 +1321,7 @@ func (s *PostgresStore) GetPendingByDomain(ctx context.Context, domainTag string
 		`SELECT memory_id, submitting_agent, content, content_hash,
 			memory_type, domain_tag, confidence_score, status, created_at
 		FROM memories WHERE status = 'proposed' AND domain_tag LIKE $1
-		ORDER BY created_at LIMIT $2`, domainTag, limit)
+		ORDER BY created_at ASC, memory_id ASC LIMIT $2`, domainTag, limit)
 	if err != nil {
 		return nil, fmt.Errorf("get pending: %w", err)
 	}

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -4,6 +4,7 @@ package store
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -314,4 +315,45 @@ func TestVotes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, votes, 1)
 	assert.Equal(t, "accept", votes[0].Decision)
+}
+
+// TestPostgresGetPendingByDomainTotallyOrdered pins the deterministic memory_id tiebreak on
+// real PostgreSQL: same-timestamp proposed rows must come back in memory_id order, matching the
+// paginated sibling. Dropping the tiebreak returns them in heap order and fails this. memory_id
+// is a UUID column, so the ids are real UUIDs sorted lexically — the order ORDER BY memory_id
+// yields for canonical lowercase UUIDs.
+func TestPostgresGetPendingByDomainTotallyOrdered(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+	domain := "pending-order-" + uuid.NewString()
+	at := time.Unix(1_700_000_000, 0).UTC()
+
+	ids := make([]string, 10)
+	for i := range ids {
+		ids[i] = uuid.NewString()
+	}
+	sort.Strings(ids) // the order ORDER BY memory_id yields
+	// Insert in REVERSE sorted order, all sharing ONE timestamp, so only the tiebreak orders them.
+	for i := len(ids) - 1; i >= 0; i-- {
+		content := "pending " + ids[i]
+		require.NoError(t, store.InsertMemory(ctx, &memory.MemoryRecord{
+			MemoryID:        ids[i],
+			SubmittingAgent: "agent-test",
+			Content:         content,
+			ContentHash:     memory.ComputeContentHash(content),
+			MemoryType:      memory.TypeObservation,
+			DomainTag:       domain,
+			ConfidenceScore: 0.8,
+			Status:          memory.StatusProposed,
+			CreatedAt:       at,
+		}))
+	}
+
+	got, err := store.GetPendingByDomain(ctx, domain, 100)
+	require.NoError(t, err)
+	require.Len(t, got, 10)
+	for i, r := range got {
+		require.Equal(t, ids[i], r.MemoryID,
+			"same-timestamp PostgreSQL proposed rows must be ordered by the memory_id tiebreak")
+	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -2828,7 +2828,7 @@ func (s *SQLiteStore) GetPendingByDomain(ctx context.Context, domainTag string, 
 		`SELECT memory_id, submitting_agent, content, content_hash,
 			memory_type, domain_tag, confidence_score, status, created_at
 		FROM memories WHERE status = 'proposed' AND domain_tag LIKE ?
-		ORDER BY created_at LIMIT ?`, domainTag, limit)
+		ORDER BY created_at ASC, memory_id ASC LIMIT ?`, domainTag, limit)
 	if err != nil {
 		return nil, fmt.Errorf("get pending: %w", err)
 	}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -2094,3 +2094,40 @@ func TestGetDomainLastActivity(t *testing.T) {
 	assert.True(t, dl["busy-domain"] > dl["quiet-domain"], "busy domain must sort newer: %v", dl)
 	assert.Contains(t, dl["busy-domain"], "2026-07-02", "MAX(created_at) per domain")
 }
+
+// TestGetPendingByDomainTotallyOrdered pins the deterministic order of the pending-by-domain
+// read: created_at alone is not a total order (proposed memories minted in the same block/second
+// tie), so without the memory_id tiebreak the order is arbitrary and diverges across runs and
+// backends. This matches the order its paginated sibling GetPendingByDomainPage already uses.
+// Removing the tiebreak fails this.
+func TestGetPendingByDomainTotallyOrdered(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	at := time.Unix(1_700_000_000, 0).UTC()
+	// 10 proposed memories in one domain sharing ONE timestamp, inserted in REVERSE id order,
+	// so only the memory_id tiebreak yields a stable order.
+	for i := 9; i >= 0; i-- {
+		rec := testMemory(fmt.Sprintf("m%02d", i), "agent1", fmt.Sprintf("content %d", i), "general")
+		rec.CreatedAt = at
+		require.NoError(t, s.InsertMemory(ctx, rec))
+	}
+
+	got, err := s.GetPendingByDomain(ctx, "general", 100)
+	require.NoError(t, err)
+	require.Len(t, got, 10)
+	for i, r := range got {
+		require.Equal(t, fmt.Sprintf("m%02d", i), r.MemoryID,
+			"same-timestamp proposed memories must be ordered by the memory_id tiebreak, not arbitrary order")
+	}
+
+	names := func(rs []*memory.MemoryRecord) []string {
+		out := make([]string, len(rs))
+		for i, r := range rs {
+			out[i] = r.MemoryID
+		}
+		return out
+	}
+	again, err := s.GetPendingByDomain(ctx, "general", 100)
+	require.NoError(t, err)
+	require.Equal(t, names(got), names(again), "the pending-by-domain read must be a stable total order")
+}


### PR DESCRIPTION
## What

`GetPendingByDomain` ordered proposed memories by `created_at` alone, with no tiebreak. Memories minted in the same block share that block's timestamp, so same-block rows tie and their order is arbitrary — nondeterministic across runs and divergent between the SQLite and PostgreSQL backends. This adds the `memory_id` tiebreak, bringing it to the **same total order its paginated sibling `GetPendingByDomainPage` already uses** (`created_at, memory_id`).

## Why this is not consensus-load-bearing

I traced every caller before touching it, since the pending queue feeds validation:

- The **built-in voter** reads through `GetPendingByDomainPage` (line ~298 in `internal/voter/voter.go`), which is **already totally ordered** — this function isn't on that path.
- `GetPendingByDomain` serves the **REST vote display** (`api/rest/vote_handler.go`) and the **third-party-store voter fallback** (the compatibility lane; the comment there notes built-in stores always take the paged branch).
- The voter is an **off-chain, per-node 2s poll** that decides which votes to cast — its read order is local scheduling, and the vote tally is order-independent. It is **not** in `FinalizeBlock`/ABCI, so the order is never an AppHash input.

So this is a determinism / cross-backend-consistency hygiene fix, same class as the merged corroboration tiebreak (#229). No consensus surface, no ABCI path.

## Tests

- `TestGetPendingByDomainTotallyOrdered` (SQLite) — same-timestamp rows come back in `memory_id` order, stable across reads; mutation-verified (reverting the tiebreak fails it).
- `TestPostgresGetPendingByDomainTotallyOrdered` (integration) — the same on real PostgreSQL, using sorted real UUIDs (memory_id is a UUID column).

## ABCI determinism

Consensus path untouched — off-chain voter poll + REST display read only, no AppHash input.
