### PR TITLE
fix(messages): backfill wake state for claimed work

### DIFF
--- a/internal/store/message_wake_test.go
+++ b/internal/store/message_wake_test.go
@@ -115,6 +115,38 @@ func TestMessageWakeStateSurvivesRestartAndBackfillsPendingUpgrade(t *testing.T)
 	require.Equal(t, MessageWakeState{Seq: 1, Pending: true}, state)
 }
 
+func TestMessageWakeStateBackfillsClaimedOnlyUpgrade(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "wake-claimed-upgrade.db")
+	s, err := NewSQLiteStore(ctx, path)
+	require.NoError(t, err)
+	_, _, err = s.SendLocalMessage(ctx, "wake-claimed-upgrade",
+		testLocalMessage("msg-wake-claimed-upgrade", "alice", "bob", "work"))
+	require.NoError(t, err)
+
+	// Model an upgraded database whose only live canonical work was already
+	// claimed through the production receive path before the Wake Bus side table
+	// existed. Claimed work is still unfinished, so startup must allocate a
+	// non-zero catch-up sequence.
+	claimed, replayed, err := s.ReceiveLocalMessages(
+		ctx, "bob", "upgrade-session", "wake-claimed-receive", 1)
+	require.NoError(t, err)
+	require.False(t, replayed)
+	require.Len(t, claimed, 1)
+	_, err = s.writeExecContext(ctx,
+		`DELETE FROM message_wake_state WHERE recipient_agent_id='bob'`)
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	s, err = NewSQLiteStore(ctx, path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	state, err := s.GetMessageWakeState(ctx, "bob")
+	require.NoError(t, err)
+	require.Equal(t, MessageWakeState{Seq: 1, Pending: true}, state,
+		"claimed-only upgraded work must never expose the silent {seq:0,pending:true} state")
+}
+
 func TestMessageWakeSchemaRejectsNegativeSequence(t *testing.T) {
 	s := newMessageTestStore(t)
 	_, err := s.writeExecContext(t.Context(),

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -152,7 +152,7 @@ func (s *SQLiteStore) migrateMessages(ctx context.Context) error {
 	if _, err := s.writeExecContext(ctx, `INSERT OR IGNORE INTO message_wake_state(recipient_agent_id,seq)
 		SELECT DISTINCT to_agent,1 FROM pipeline_messages
 		WHERE source_chain_id='' AND destination_chain_id='' AND to_provider=''
-		  AND to_agent<>'' AND status='pending' AND expires_at>strftime('%Y-%m-%dT%H:%M:%fZ','now')`); err != nil {
+		  AND to_agent<>'' AND status IN ('pending','claimed') AND expires_at>strftime('%Y-%m-%dT%H:%M:%fZ','now')`); err != nil {
 		return fmt.Errorf("backfill canonical message wake state: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Defect

The v11.18.14 startup backfill seeded `message_wake_state` only from pending rows, while `GetMessageWakeState` correctly treats both pending and claimed canonical messages as unfinished. An upgraded database containing only claimed live work therefore returned `{seq:0,pending:true}`. The Stop hook treats zero sequence as an unavailable wake surface, so the claimed work produced no nudge.

## Fix

- Seed the startup wake baseline from both pending and claimed exact-local live rows.
- Add a production-shaped regression that claims through `ReceiveLocalMessages`, deletes the Wake Bus side-table row to model a pre-Wake-Bus database, restarts, and requires `{seq:1,pending:true}`.

## Independent proof

- Published v11.18.14 predicate reproduced `{seq:0,pending:true}`.
- Mutating this head back to pending-only makes the new regression fail with actual `{seq:0,pending:true}`.
- Restored head: full `go test ./internal/store -count=1` passes; `git diff --check` clean.

Draft pending exact-head independent review and combined v11.18.15 integration gates. Do not merge independently of the release candidate.
