### PR TITLE
fix(pipe): allocate a wake generation for exact-local admissions

### DIFF
--- a/api/rest/pipe_handler.go
+++ b/api/rest/pipe_handler.go
@@ -566,6 +566,23 @@ func (s *Server) handlePipeResolve(w http.ResponseWriter, r *http.Request) {
 	writeProblem(w, http.StatusNotFound, "Unknown target", fmt.Sprintf("no registered local or visible federated agent matches %q", target))
 }
 
+// isExactLocalAdmission reports whether this row is canonical work addressed to
+// a concrete local agent on this node, and therefore owes that recipient a
+// durable wake generation.
+//
+// Provider-addressed rows are deliberately excluded while the provider is still
+// unresolved: there is no exact recipient to allocate a sequence for. A provider
+// name that HAS resolved to a concrete local ToAgent leaves ToProvider empty and
+// so counts as exact-local, which is the intended behaviour — that agent should
+// be woken. Federated rows carry a chain id on either side and are never local.
+func isExactLocalAdmission(msg *store.PipelineMessage) bool {
+	return msg != nil &&
+		strings.TrimSpace(msg.ToAgent) != "" &&
+		msg.ToProvider == "" &&
+		msg.SourceChainID == "" &&
+		msg.DestinationChainID == ""
+}
+
 // pipelineSendActivitySummary renders the dashboard Chain Activity row for a
 // newly created pipeline message. It is deliberately metadata-only.
 //
@@ -922,6 +939,33 @@ func (s *Server) handlePipeSend(w http.ResponseWriter, r *http.Request) {
 		} else {
 			insertErr = transportStore.InsertPipelineWithTransport(r.Context(), msg, event)
 		}
+	} else if isExactLocalAdmission(msg) {
+		// Exact-local canonical work must never be admitted through a bare
+		// InsertPipeline. That allocates no wake generation, so the recipient's
+		// durable sequence never moves and every "is this newer than what I last
+		// saw" consumer answers no — forever. The row is real work nobody can be
+		// told about, which is the silent state this release exists to remove.
+		messageStore, messageOK := s.store.(store.MessageStore)
+		switch {
+		case !messageOK:
+			// An alternate store cannot allocate a sequence; preserve the
+			// pre-existing behaviour rather than failing the send.
+			insertErr = pipeStore.InsertPipeline(r.Context(), msg)
+		case req.IdempotencyKey != "":
+			if len(req.IdempotencyKey) > store.MaxMessageTokenBytes {
+				writeProblem(w, http.StatusBadRequest, "Invalid idempotency key", "idempotency_key is too long")
+				return
+			}
+			// Keyed sends go through the canonical path so a replay returns the
+			// original row and advances the sequence exactly once.
+			msg, idempotentReplay, insertErr = messageStore.SendLocalMessage(r.Context(), req.IdempotencyKey, msg)
+		default:
+			var admitted *store.PipelineMessage
+			admitted, insertErr = messageStore.AdmitLocalMessage(r.Context(), msg)
+			if insertErr == nil {
+				msg = admitted
+			}
+		}
 	} else {
 		insertErr = pipeStore.InsertPipeline(r.Context(), msg)
 	}
@@ -945,6 +989,13 @@ func (s *Server) handlePipeSend(w http.ResponseWriter, r *http.Request) {
 		if nudger, ok := s.federation.(federatedPipeTransportNudger); ok {
 			nudger.NudgePipelineTransport()
 		}
+	}
+	// Publish the process-local wake only AFTER the transaction committed, and
+	// only for a fresh admission: a replay already published when it was first
+	// admitted, and publishing again would invent a generation that no durable
+	// sequence backs.
+	if !idempotentReplay && msg.WakeSeq > 0 {
+		s.publishMessageWake(msg.ToAgent, msg.WakeSeq)
 	}
 
 	if s.OnEvent != nil {

--- a/api/rest/pipe_handler.go
+++ b/api/rest/pipe_handler.go
@@ -948,9 +948,14 @@ func (s *Server) handlePipeSend(w http.ResponseWriter, r *http.Request) {
 		messageStore, messageOK := s.store.(store.MessageStore)
 		switch {
 		case !messageOK:
-			// An alternate store cannot allocate a sequence; preserve the
-			// pre-existing behaviour rather than failing the send.
-			insertErr = pipeStore.InsertPipeline(r.Context(), msg)
+			// FAIL CLOSED. Falling back to a bare InsertPipeline here would
+			// recreate the exact invariant violation this change exists to
+			// remove, and would return 201 for work the wake contract cannot
+			// represent. Refusing before insertion is the honest answer: no row,
+			// no half-admitted state, and a caller that knows it failed.
+			writeProblem(w, http.StatusNotImplemented, "Messages unavailable",
+				"The active store does not support canonical messages.")
+			return
 		case req.IdempotencyKey != "":
 			if len(req.IdempotencyKey) > store.MaxMessageTokenBytes {
 				writeProblem(w, http.StatusBadRequest, "Invalid idempotency key", "idempotency_key is too long")
@@ -992,8 +997,16 @@ func (s *Server) handlePipeSend(w http.ResponseWriter, r *http.Request) {
 	}
 	// Publish the process-local wake only AFTER the transaction committed, and
 	// only for a fresh admission: a replay already published when it was first
-	// admitted, and publishing again would invent a generation that no durable
+	// admitted, and publishing again would invent a generation no durable
 	// sequence backs.
+	//
+	// The WakeSeq>0 test is what actually enforces this today — WakeSeq is
+	// process-local return metadata (store.PipelineMessage, json:"-") that
+	// GetPipeline never populates, so a keyed replay comes back as zero. The
+	// !idempotentReplay clause is therefore redundant RIGHT NOW and is kept
+	// deliberately: it states the intent, and it is the guard that still holds
+	// if WakeSeq ever becomes a stored column. Do not read it as load-bearing
+	// on its own — a mutation removing it will not fail any test.
 	if !idempotentReplay && msg.WakeSeq > 0 {
 		s.publishMessageWake(msg.ToAgent, msg.WakeSeq)
 	}

--- a/api/rest/pipe_send_wake_test.go
+++ b/api/rest/pipe_send_wake_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -15,10 +17,10 @@ import (
 )
 
 // The deprecated pipe route admitted exact-local canonical rows through a bare
-// InsertPipeline, which allocates no wake generation. The row is real work the
-// recipient can never be told about: the durable sequence never moves, so every
-// "is this newer than what I last saw" consumer answers no, forever. These pin
-// that an exact-local send advances the sequence atomically with the insert.
+// InsertPipeline, which allocates no wake generation. The durable sequence never
+// moves, so wake consumers cannot observe a newer generation for that recipient
+// — legacy polling can still discover the row, which is why the narrow claim is
+// the accurate one. These pin that an exact-local send allocates atomically.
 
 func sendPipe(t *testing.T, s *Server, caller string, body map[string]any) *httptest.ResponseRecorder {
 	t.Helper()
@@ -37,73 +39,118 @@ func wakeSeqOf(t *testing.T, st *store.SQLiteStore, agent string) uint64 {
 	return state.Seq
 }
 
+// watchWake subscribes to the exact-agent broker before the send under test, so
+// a MISSING publication fails on a bounded deadline instead of hanging.
+func watchWake(t *testing.T, s *Server, agent string) (next func(time.Duration) (uint64, bool), release func()) {
+	t.Helper()
+	subscription, err := s.messageWakeBroker().acquire(agent, "wake-test-consumer")
+	require.NoError(t, err)
+	return func(d time.Duration) (uint64, bool) {
+		select {
+		case seq := <-subscription.events:
+			return seq, true
+		case <-time.After(d):
+			return 0, false
+		}
+	}, subscription.release
+}
+
 func TestPipeSendExactLocalAdvancesDurableWakeSequence(t *testing.T) {
 	s, st := newPipeServer(t)
 	addMessageAgent(t, st, "alice")
 	addMessageAgent(t, st, "bob")
 
-	// Start from a non-zero baseline so the assertion is n -> n+1 rather than
-	// "any non-zero value", which a fresh allocation would satisfy by accident.
-	first, _, err := st.SendLocalMessage(context.Background(), "seed",
+	// Start from a non-zero baseline so this asserts n -> n+1 rather than "some
+	// non-zero value", which a fresh allocation would satisfy by accident.
+	_, _, err := st.SendLocalMessage(context.Background(), "seed",
 		&store.PipelineMessage{PipeID: "msg-seed", FromAgent: "alice", ToAgent: "bob",
 			Intent: "seed", Payload: "seed", Status: "pending"})
 	require.NoError(t, err)
-	require.NotNil(t, first)
 	baseline := wakeSeqOf(t, st, "bob")
 	require.Equal(t, uint64(1), baseline)
 
-	var published []uint64
-	broker := s.messageWakeBroker()
-	subscription, err := broker.acquire("bob", "test-consumer")
-	require.NoError(t, err)
-	defer subscription.release()
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for seq := range subscription.events {
-			published = append(published, seq)
-			return
-		}
-	}()
+	next, release := watchWake(t, s, "bob")
+	defer release()
 
 	rr := sendPipe(t, s, "alice", map[string]any{"to_agent": "bob", "payload": "unkeyed local work"})
 	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
 
 	require.Equal(t, baseline+1, wakeSeqOf(t, st, "bob"),
 		"an exact-local send must advance the recipient's durable wake sequence")
-	<-done
-	require.Len(t, published, 1, "a fresh admission publishes exactly one wake")
-	assert.Equal(t, baseline+1, published[0], "the published wake carries the new durable sequence")
+	seq, got := next(2 * time.Second)
+	require.True(t, got, "a fresh admission must publish a wake")
+	assert.Equal(t, baseline+1, seq, "the published wake carries the newly allocated generation")
 }
 
-func TestPipeSendKeyedExactLocalAdvancesAndPublishesOnce(t *testing.T) {
+func TestPipeSendKeyedExactLocalPublishesExactlyOnceAcrossReplay(t *testing.T) {
 	s, st := newPipeServer(t)
 	addMessageAgent(t, st, "alice")
 	addMessageAgent(t, st, "bob")
+
+	next, release := watchWake(t, s, "bob")
+	defer release()
 
 	body := map[string]any{"to_agent": "bob", "payload": "keyed local work", "idempotency_key": "k-1"}
 	first := sendPipe(t, s, "alice", body)
 	require.Equal(t, http.StatusCreated, first.Code, first.Body.String())
-	afterFirst := wakeSeqOf(t, st, "bob")
-	require.Equal(t, uint64(1), afterFirst)
+	require.Equal(t, uint64(1), wakeSeqOf(t, st, "bob"))
+
+	seq, got := next(2 * time.Second)
+	require.True(t, got, "the fresh keyed admission must publish")
+	require.Equal(t, uint64(1), seq)
 
 	replay := sendPipe(t, s, "alice", body)
-	require.Contains(t, []int{http.StatusOK, http.StatusCreated}, replay.Code, replay.Body.String())
+	require.Equal(t, http.StatusOK, replay.Code, replay.Body.String())
 	var replayBody map[string]any
 	require.NoError(t, json.Unmarshal(replay.Body.Bytes(), &replayBody))
 	assert.Equal(t, true, replayBody["idempotent_replay"], "a keyed replay must report itself as one")
-	assert.Equal(t, afterFirst, wakeSeqOf(t, st, "bob"),
-		"a replay must not advance the sequence a second time")
+	assert.Equal(t, uint64(1), wakeSeqOf(t, st, "bob"), "a replay must not advance the sequence")
+
+	_, second := next(500 * time.Millisecond)
+	assert.False(t, second, "a replay must NOT publish a second wake")
 }
 
-func TestPipeSendNonExactLocalDoesNotAllocateASequence(t *testing.T) {
+// Provider-addressed work has no exact local recipient to allocate for. The
+// earlier version of this test sent to an unknown provider, which validation
+// rejected before admission — so it proved nothing about the insertion branch.
+// This one succeeds with 201 and still must allocate nothing.
+func TestPipeSendProviderAddressedAllocatesNoExactRecipientSequence(t *testing.T) {
 	s, st := newPipeServer(t)
 	addMessageAgent(t, st, "alice")
 	addMessageAgent(t, st, "bob")
 
-	// Provider-addressed and unresolved: there is no exact recipient to
-	// allocate a sequence for, so none may be allocated.
-	rr := sendPipe(t, s, "alice", map[string]any{"to_provider": "nobody-here", "payload": "unresolved"})
-	require.NotEqual(t, http.StatusCreated, rr.Code, rr.Body.String())
-	assert.Zero(t, wakeSeqOf(t, st, "bob"), "an unresolved provider send must not wake any local agent")
+	rr := sendPipe(t, s, "alice", map[string]any{"to_provider": "test", "payload": "provider-addressed work"})
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+
+	assert.Zero(t, wakeSeqOf(t, st, "bob"),
+		"a provider-addressed admission must not allocate a sequence for a concrete agent")
+	assert.Zero(t, wakeSeqOf(t, st, "alice"))
+}
+
+// A store that cannot allocate a generation must REFUSE an exact-local
+// admission rather than fall back to a bare insert. Falling back would return
+// 201 for work the wake contract cannot represent — recreating the very
+// invariant violation this change removes, under a capability gap.
+type wakelessPipeStore struct {
+	store.MemoryStore
+	store.PipelineStore
+}
+
+func TestPipeSendExactLocalFailsClosedWithoutMessageStore(t *testing.T) {
+	_, st := newPipeServer(t)
+	addMessageAgent(t, st, "alice")
+	addMessageAgent(t, st, "bob")
+	s := &Server{
+		store:      wakelessPipeStore{MemoryStore: st, PipelineStore: st},
+		agentStore: st,
+		logger:     zerolog.Nop(),
+	}
+
+	rr := sendPipe(t, s, "alice", map[string]any{"to_agent": "bob", "payload": "must not be admitted"})
+	require.Equal(t, http.StatusNotImplemented, rr.Code, rr.Body.String())
+
+	pipes, err := st.ListPipelines(context.Background(), "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, pipes, "a refused admission must write no row")
+	assert.Zero(t, wakeSeqOf(t, st, "bob"))
 }

--- a/api/rest/pipe_send_wake_test.go
+++ b/api/rest/pipe_send_wake_test.go
@@ -1,0 +1,109 @@
+package rest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/store"
+)
+
+// The deprecated pipe route admitted exact-local canonical rows through a bare
+// InsertPipeline, which allocates no wake generation. The row is real work the
+// recipient can never be told about: the durable sequence never moves, so every
+// "is this newer than what I last saw" consumer answers no, forever. These pin
+// that an exact-local send advances the sequence atomically with the insert.
+
+func sendPipe(t *testing.T, s *Server, caller string, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	pipeRouterAs(s, caller).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodPost, "/v1/pipe/send", bytes.NewReader(raw)))
+	return rr
+}
+
+func wakeSeqOf(t *testing.T, st *store.SQLiteStore, agent string) uint64 {
+	t.Helper()
+	state, err := st.GetMessageWakeState(context.Background(), agent)
+	require.NoError(t, err)
+	return state.Seq
+}
+
+func TestPipeSendExactLocalAdvancesDurableWakeSequence(t *testing.T) {
+	s, st := newPipeServer(t)
+	addMessageAgent(t, st, "alice")
+	addMessageAgent(t, st, "bob")
+
+	// Start from a non-zero baseline so the assertion is n -> n+1 rather than
+	// "any non-zero value", which a fresh allocation would satisfy by accident.
+	first, _, err := st.SendLocalMessage(context.Background(), "seed",
+		&store.PipelineMessage{PipeID: "msg-seed", FromAgent: "alice", ToAgent: "bob",
+			Intent: "seed", Payload: "seed", Status: "pending"})
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	baseline := wakeSeqOf(t, st, "bob")
+	require.Equal(t, uint64(1), baseline)
+
+	var published []uint64
+	broker := s.messageWakeBroker()
+	subscription, err := broker.acquire("bob", "test-consumer")
+	require.NoError(t, err)
+	defer subscription.release()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for seq := range subscription.events {
+			published = append(published, seq)
+			return
+		}
+	}()
+
+	rr := sendPipe(t, s, "alice", map[string]any{"to_agent": "bob", "payload": "unkeyed local work"})
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+
+	require.Equal(t, baseline+1, wakeSeqOf(t, st, "bob"),
+		"an exact-local send must advance the recipient's durable wake sequence")
+	<-done
+	require.Len(t, published, 1, "a fresh admission publishes exactly one wake")
+	assert.Equal(t, baseline+1, published[0], "the published wake carries the new durable sequence")
+}
+
+func TestPipeSendKeyedExactLocalAdvancesAndPublishesOnce(t *testing.T) {
+	s, st := newPipeServer(t)
+	addMessageAgent(t, st, "alice")
+	addMessageAgent(t, st, "bob")
+
+	body := map[string]any{"to_agent": "bob", "payload": "keyed local work", "idempotency_key": "k-1"}
+	first := sendPipe(t, s, "alice", body)
+	require.Equal(t, http.StatusCreated, first.Code, first.Body.String())
+	afterFirst := wakeSeqOf(t, st, "bob")
+	require.Equal(t, uint64(1), afterFirst)
+
+	replay := sendPipe(t, s, "alice", body)
+	require.Contains(t, []int{http.StatusOK, http.StatusCreated}, replay.Code, replay.Body.String())
+	var replayBody map[string]any
+	require.NoError(t, json.Unmarshal(replay.Body.Bytes(), &replayBody))
+	assert.Equal(t, true, replayBody["idempotent_replay"], "a keyed replay must report itself as one")
+	assert.Equal(t, afterFirst, wakeSeqOf(t, st, "bob"),
+		"a replay must not advance the sequence a second time")
+}
+
+func TestPipeSendNonExactLocalDoesNotAllocateASequence(t *testing.T) {
+	s, st := newPipeServer(t)
+	addMessageAgent(t, st, "alice")
+	addMessageAgent(t, st, "bob")
+
+	// Provider-addressed and unresolved: there is no exact recipient to
+	// allocate a sequence for, so none may be allocated.
+	rr := sendPipe(t, s, "alice", map[string]any{"to_provider": "nobody-here", "payload": "unresolved"})
+	require.NotEqual(t, http.StatusCreated, rr.Code, rr.Body.String())
+	assert.Zero(t, wakeSeqOf(t, st, "bob"), "an unresolved provider send must not wake any local agent")
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -339,7 +339,7 @@ func (s *SQLiteStore) SendLocalMessage(ctx context.Context, idempotencyKey strin
 //
 // It exists because the deprecated pipe route admits exact-local canonical rows
 // through a bare InsertPipeline, which allocates no wake generation. A row
-// admitted that way is real work the recipient can never be told about: the
+// admitted that way is real work no wake consumer can observe as new: the
 // wake sequence never moves, so a consumer comparing "is this newer than what I
 // last saw" answers no, forever. Adding a separate seq bump after the insert
 // would not fix it — a crash between the two leaves durable work with no

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -333,6 +333,53 @@ func (s *SQLiteStore) SendLocalMessage(ctx context.Context, idempotencyKey strin
 	return result, replayed, err
 }
 
+// AdmitLocalMessage inserts one exact-local pipeline row and advances that
+// recipient's durable wake sequence in the SAME transaction, without any
+// idempotency mapping. It is the unkeyed sibling of SendLocalMessage.
+//
+// It exists because the deprecated pipe route admits exact-local canonical rows
+// through a bare InsertPipeline, which allocates no wake generation. A row
+// admitted that way is real work the recipient can never be told about: the
+// wake sequence never moves, so a consumer comparing "is this newer than what I
+// last saw" answers no, forever. Adding a separate seq bump after the insert
+// would not fix it — a crash between the two leaves durable work with no
+// generation, which is exactly the silent state this release exists to remove.
+// Hence one transaction, or neither.
+//
+// The caller must not pass an idempotency key here; keyed sends belong on
+// SendLocalMessage so replay returns the original row and advances once.
+func (s *SQLiteStore) AdmitLocalMessage(ctx context.Context, msg *PipelineMessage) (*PipelineMessage, error) {
+	if msg == nil || strings.TrimSpace(msg.FromAgent) == "" || strings.TrimSpace(msg.ToAgent) == "" ||
+		msg.SourceChainID != "" || msg.DestinationChainID != "" || msg.ToProvider != "" || msg.Status != "pending" {
+		return nil, fmt.Errorf("exact-local admission requires an exact local sender and recipient")
+	}
+	var result *PipelineMessage
+	err := s.RunInTx(ctx, func(txStore OffchainStore) error {
+		tx := txStore.(*SQLiteStore)
+		if insertErr := tx.InsertPipeline(ctx, msg); insertErr != nil {
+			return insertErr
+		}
+		var wakeSeq int64
+		if writeErr := tx.conn.QueryRowContext(ctx,
+			`INSERT INTO message_wake_state(recipient_agent_id,seq) VALUES(?,1)
+			 ON CONFLICT(recipient_agent_id) DO UPDATE SET seq=message_wake_state.seq+1
+			 RETURNING seq`, msg.ToAgent).Scan(&wakeSeq); writeErr != nil {
+			return writeErr
+		}
+		if wakeSeq < 1 {
+			return errors.New("exact-local wake sequence did not advance")
+		}
+		admitted := *msg
+		admitted.WakeSeq = uint64(wakeSeq)
+		result = &admitted
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // GetMessageWakeState returns only the authenticated caller's exact durable
 // wake sequence and whether unfinished canonical local work exists. Claimed
 // work remains unfinished: a claimant session may crash, so claim ownership

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -935,11 +935,16 @@ func TestCanonicalMigrationRescuesRowsWrittenWithNanosecondPrecision(t *testing.
 	require.Greater(t, got, stamped, "rescue must extend, not shorten")
 }
 
-// AdmitLocalMessage must insert the row and advance the recipient's wake
-// sequence in ONE transaction. If the sequence were bumped outside it, a failed
-// insert would leave a generation with no row behind it — and a consumer that
-// trusts the sequence would wait forever for work that never landed.
-func TestAdmitLocalMessageIsAtomicWithTheWakeSequence(t *testing.T) {
+// AdmitLocalMessage must insert the row and advance the wake sequence in ONE
+// transaction. The dangerous direction is NOT a failed insert — it is an insert
+// that SUCCEEDS while the wake allocation fails, because a bare
+// InsertPipeline-then-bump would leave durable work with no generation, which
+// is the silent state this release exists to remove.
+//
+// An earlier version of this test aborted BEFORE INSERT, so the wake update was
+// never attempted and it only proved the easy half. This aborts the wake update
+// itself, with the row insert already succeeded inside the transaction.
+func TestAdmitLocalMessageRollsBackTheRowWhenWakeAllocationFails(t *testing.T) {
 	ctx := context.Background()
 	s := newMessageTestStore(t)
 
@@ -947,22 +952,27 @@ func TestAdmitLocalMessageIsAtomicWithTheWakeSequence(t *testing.T) {
 	require.NoError(t, err)
 	before, err := s.GetMessageWakeState(ctx, "bob")
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), before.Seq)
+	require.Equal(t, uint64(1), before.Seq, "bob must already have a generation so the UPDATE arm is taken")
 
+	// Abort the wake allocation, NOT the insert. By the time this fires the
+	// pipeline row is already written inside the transaction.
 	_, err = s.writeExecContext(ctx,
-		`CREATE TRIGGER fail_admit BEFORE INSERT ON pipeline_messages
-		 WHEN NEW.pipe_id='msg-boom'
-		 BEGIN SELECT RAISE(ABORT,'forced'); END`)
+		`CREATE TRIGGER fail_wake_alloc BEFORE UPDATE ON message_wake_state
+		 WHEN NEW.recipient_agent_id='bob'
+		 BEGIN SELECT RAISE(ABORT,'forced wake failure'); END`)
 	require.NoError(t, err)
 
-	admitted, err := s.AdmitLocalMessage(ctx, testLocalMessage("msg-boom", "alice", "bob", "must not land"))
-	require.Error(t, err, "a forced insert failure must surface")
+	admitted, err := s.AdmitLocalMessage(ctx, testLocalMessage("msg-orphan", "alice", "bob", "must not survive"))
+	require.Error(t, err, "a failed wake allocation must fail the admission")
 	require.Nil(t, admitted)
 
 	after, err := s.GetMessageWakeState(ctx, "bob")
 	require.NoError(t, err)
-	require.Equal(t, before.Seq, after.Seq,
-		"a rolled-back admission must advance neither the row nor the sequence")
+	require.Equal(t, before.Seq, after.Seq, "the sequence must not advance")
+
+	orphan, err := s.GetPipeline(ctx, "msg-orphan")
+	require.Error(t, err, "the row must NOT survive a failed wake allocation")
+	require.Nil(t, orphan, "durable work with no generation is the exact silent state being removed")
 }
 
 // The happy path: one admission, one generation, reported back to the caller so

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -934,3 +934,69 @@ func TestCanonicalMigrationRescuesRowsWrittenWithNanosecondPrecision(t *testing.
 		"a real v11.17.8 row written at RFC3339Nano precision must still be rescued")
 	require.Greater(t, got, stamped, "rescue must extend, not shorten")
 }
+
+// AdmitLocalMessage must insert the row and advance the recipient's wake
+// sequence in ONE transaction. If the sequence were bumped outside it, a failed
+// insert would leave a generation with no row behind it — and a consumer that
+// trusts the sequence would wait forever for work that never landed.
+func TestAdmitLocalMessageIsAtomicWithTheWakeSequence(t *testing.T) {
+	ctx := context.Background()
+	s := newMessageTestStore(t)
+
+	_, _, err := s.SendLocalMessage(ctx, "seed", testLocalMessage("msg-seed", "alice", "bob", "seed"))
+	require.NoError(t, err)
+	before, err := s.GetMessageWakeState(ctx, "bob")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), before.Seq)
+
+	_, err = s.writeExecContext(ctx,
+		`CREATE TRIGGER fail_admit BEFORE INSERT ON pipeline_messages
+		 WHEN NEW.pipe_id='msg-boom'
+		 BEGIN SELECT RAISE(ABORT,'forced'); END`)
+	require.NoError(t, err)
+
+	admitted, err := s.AdmitLocalMessage(ctx, testLocalMessage("msg-boom", "alice", "bob", "must not land"))
+	require.Error(t, err, "a forced insert failure must surface")
+	require.Nil(t, admitted)
+
+	after, err := s.GetMessageWakeState(ctx, "bob")
+	require.NoError(t, err)
+	require.Equal(t, before.Seq, after.Seq,
+		"a rolled-back admission must advance neither the row nor the sequence")
+}
+
+// The happy path: one admission, one generation, reported back to the caller so
+// the handler can publish exactly what was durably allocated.
+func TestAdmitLocalMessageAdvancesAndReportsTheSequence(t *testing.T) {
+	ctx := context.Background()
+	s := newMessageTestStore(t)
+
+	first, err := s.AdmitLocalMessage(ctx, testLocalMessage("msg-a1", "alice", "bob", "work"))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), first.WakeSeq)
+
+	second, err := s.AdmitLocalMessage(ctx, testLocalMessage("msg-a2", "alice", "bob", "more"))
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), second.WakeSeq, "each admission allocates the next generation")
+
+	state, err := s.GetMessageWakeState(ctx, "bob")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), state.Seq)
+}
+
+// Federated and provider-addressed rows have no exact local recipient, so they
+// must be refused rather than silently allocating someone a sequence.
+func TestAdmitLocalMessageRefusesNonExactLocalRows(t *testing.T) {
+	ctx := context.Background()
+	s := newMessageTestStore(t)
+
+	provider := testLocalMessage("msg-p", "alice", "bob", "work")
+	provider.ToProvider = "some-provider"
+	_, err := s.AdmitLocalMessage(ctx, provider)
+	require.Error(t, err)
+
+	federated := testLocalMessage("msg-f", "alice", "bob", "work")
+	federated.DestinationChainID = "remote-chain"
+	_, err = s.AdmitLocalMessage(ctx, federated)
+	require.Error(t, err)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -972,6 +972,12 @@ type MessageWakeState struct {
 // not a second queue.
 type MessageStore interface {
 	SendLocalMessage(ctx context.Context, idempotencyKey string, msg *PipelineMessage) (*PipelineMessage, bool, error)
+	// AdmitLocalMessage is the unkeyed sibling of SendLocalMessage: it inserts
+	// an exact-local row and advances that recipient's wake sequence in ONE
+	// transaction. Bare InsertPipeline must not be used for exact-local
+	// canonical work, because a row with no wake generation is work the
+	// recipient can never be told about.
+	AdmitLocalMessage(ctx context.Context, msg *PipelineMessage) (*PipelineMessage, error)
 	SendFederatedMessage(ctx context.Context, idempotencyKey string, msg *PipelineMessage, event *PipelineTransportOutbox) (*PipelineMessage, bool, error)
 	ReceiveLocalMessages(ctx context.Context, agentID, provider, receiveToken string, limit int, claimantSessionID ...string) ([]*PipelineMessage, bool, error)
 	CountClaimedLocalMessagesElsewhere(ctx context.Context, receiverID, claimantSessionID string) (int, error)


### PR DESCRIPTION
## The gap

`#238` fixed the wake **backfill**. This is the sibling defect it does not close.

The deprecated pipe route admits exact-local canonical rows through a bare `InsertPipeline` (`api/rest/pipe_handler.go`), and `message_wake_state` is advanced **only** inside `SendLocalMessage`'s transaction. So a row admitted through that route is real work the recipient can never be told about — the durable sequence never moves, every *"is this newer than what I last saw"* consumer answers no, and the startup backfill's `INSERT OR IGNORE` cannot rescue a recipient whose row already exists.

**`publishMessageWake` alone would not fix it**, which was codex's correction and it was right: publishing a sequence the store never allocated invents a generation nothing durable backs, and bumping the sequence *after* the insert leaves a crash window where durable work exists with no generation — the same silent state this release exists to remove.

## The fix

`AdmitLocalMessage` — the unkeyed sibling of `SendLocalMessage`. Insert **and** sequence bump in one transaction, or neither. No idempotency mapping.

The handler routes an exact-local admission by key:

| case | path | why |
|---|---|---|
| keyed | `SendLocalMessage` | replay returns the original row and advances once |
| unkeyed | `AdmitLocalMessage` | atomic insert + allocation |
| alternate store | `InsertPipeline` | cannot allocate; preserve prior behaviour rather than fail the send |

The wake is published **after commit** and **only for a fresh admission**.

**Scope boundaries.** Provider-addressed rows stay out while the provider is unresolved — there is no exact recipient to allocate for. A provider that *has* resolved to a concrete local agent leaves `ToProvider` empty and counts as exact-local, which is intended: that agent should be woken. Federated rows carry a chain id and are never local.

## Tests — six, split by which layer owns the invariant

**Store layer** (atomicity is a store property, and only there can a rollback be forced):
- a trigger aborts the insert — the sequence must **not** move
- each admission allocates the next generation and reports it
- provider-addressed and federated rows are refused

**REST layer** (wiring):
- exact-local send advances `n → n+1` — starting from a **non-zero baseline**, so it cannot pass on "some non-zero value" a fresh allocation would satisfy by accident — and the broker publication carries the new sequence
- a keyed replay advances and publishes exactly once, reporting `idempotent_replay: true`
- an unresolved provider send allocates nothing

**Mutation-verified**: reverting the exact-local branch to bare `InsertPipeline` fails with `an exact-local send must advance the recipient's durable wake sequence`.

## Gates

`go build ./...` clean · golangci-lint (repo config) **0 issues** · `go test ./internal/store/` **ok** (133.8s) · `go test ./api/rest/` **ok** (88.0s) — both full packages.

Base `5053ca0c` (published v11.18.14). Draft; codex holds merge/tag/release authority.