### PR TITLE
release: SAGE v11.18.17 durable MCP claimant identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.17
+
+**Routine MCP restarts no longer make the same stdio agent disown its own
+unfinished messages.** The primary stdio runtime now persists one opaque
+claimant identity per exact signed agent, provider, and project under
+`SAGE_HOME`, and holds an OS advisory lock as the liveness fence. A later
+runtime reuses that identity only after the earlier process is no longer live;
+a genuinely concurrent runtime receives an independent identity and retains
+the existing one-handler and compare-and-swap handoff boundary. In-place
+installed-binary handoff also carries the current claimant identity while the
+old process keeps the lock alive.
+
+The fix is deliberately prospective and does not bulk-transfer historical
+claims created by pre-v11.18.17 random process identities. Those rows remain
+visible through `claimed_elsewhere_count` and passive history and can still be
+transferred one at a time with the existing CAS-fenced handoff after the old
+claimant is known dead. HTTP MCP conversations remain transport-scoped. This
+patch introduces no new consensus application version or state migration. The
+ceiling remains app-v26; **v11.18.17 introduces no app-v27**.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.17`. SDK 11.18.17.
+
 ## What's New in v11.18.16
 
 **Claimed agent work no longer disappears from the inbox that claimed it.**
@@ -1913,7 +1935,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.16`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.17`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/SECURITY_FAQ.md
+++ b/SECURITY_FAQ.md
@@ -11,7 +11,7 @@ SAGE has two distinct deployment models with fundamentally different threat mode
 | **Who** | One user, one local operator | Multiple agents, teams, organizations |
 | **Trust model** | User IS the only validator | Byzantine fault tolerance across validators |
 | **Database** | Local BadgerDB/SQLite stores in `~/.sage/data/` | BadgerDB consensus state plus off-chain mirror |
-| **Release** | v11.18.16 personal-node surface | v11.18.16 quorum/federation surface |
+| **Release** | v11.18.17 personal-node surface | v11.18.17 quorum/federation surface |
 
 Many concerns raised about the enterprise codebase do not apply to SAGE Personal, and vice versa. Each item below is tagged with which deployment it affects.
 
@@ -108,7 +108,7 @@ The `make byzantine` target and GitHub Actions CI job spin up a 4-validator Dock
 
 The following boundaries describe the current v11 codebase:
 
-**SAGE Personal (sage-gui v11.18.16):**
+**SAGE Personal (sage-gui v11.18.17):**
 - Designed for one operator. The management dashboard/API remains a local surface; anyone with access to the operator session or machine should be treated as trusted.
 - Federation is an explicit network-facing feature, off by default. When enabled it uses a separate pinned-mTLS listener, active on-chain treaty checks, chain-qualified signed requests, and replay protection. That authenticated protocol now runs over libp2p NAT traversal and Circuit Relay v2; the relay sees encrypted traffic and connection metadata, not plaintext memories or federation keys.
 - SQLite database supports optional AES-256-GCM encryption at rest (Synaptic Ledger). Enable from CEREBRUM Settings → Security.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.16
+  version: 11.18.17
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.16-acceptance
+ARG VERSION=v11.18.17-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.16 federation Docker acceptance
+# v11.18.17 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.16-acceptance
+        VERSION: v11.18.17-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.16"
+version = "11.18.17"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.16"
+version = "11.18.17"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.16",
+  "version": "11.18.17",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.16/app-v26. -->
+<!-- Reconciled through SAGE v11.18.17/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.16 federation behavior. -->
+<!-- Verified against SAGE v11.18.17 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.16
+# sage-gui v11.18.17
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.16 advertises 33 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.17 advertises 33 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.16 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.17 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -65,13 +65,32 @@ adds deterministic `memory_id` ordering for timestamp ties, and makes citation
 repair anchor-aware and fail-closed over new parser debt. v11.18.16 gives the
 exact current claimant a bounded passive view of its unfinished work, keeps
 new-work counts and claim ownership unchanged, and makes hook inbox status
-consult the payload-free durable wake snapshot. The supported consensus ceiling
-remains app-v26; **v11.18.16 does not introduce app-v27**.
+consult the payload-free durable wake snapshot. v11.18.17 persists the primary
+stdio claimant identity per exact agent/provider/project and reuses it only
+after an OS liveness lock proves the prior runtime is gone, while concurrent
+runtimes remain independently fenced. The supported consensus ceiling remains
+app-v26; **v11.18.17 does not introduce app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.17 patch
+
+The primary stdio MCP runtime now stores one opaque claimant identity under
+`SAGE_HOME/runtime/mcp-claimants/`, scoped by the exact signed agent, provider,
+and project. It holds a platform-native advisory lock for the runtime lifetime.
+An ordinary restart therefore reopens the same session's unfinished work only
+after the earlier process is dead, while a concurrent process falls back to a
+separate random claimant and cannot silently share ownership. Installed-runtime
+handoff carries the identity while the parent retains the lock.
+
+Pre-v11.18.17 random claimant IDs are not bulk-adopted; explicit CAS-fenced
+handoff remains their recovery path. HTTP MCP conversation identities remain
+transport-scoped. This patch introduces no new consensus application version
+or state migration: app-v26 remains the ceiling and v11.18.17 does not
+introduce app-v27.
 
 ## v11.18.16 patch
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -107,6 +107,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.14 | Unfinished-message wake and exact stranded-claim visibility, lease-free monotonic Stop nudges, sender-TTL-preserving canonical migration, persistent accessible Connectome agent details, batched totally ordered corroborator presentation, and the truthful 31-day timeline contract; no new app version; app-v26 remains the ceiling |
 | v11.18.15 | Unfinished-message wake backfill for claimed-only upgrades, default-on fail-open Stop nudges for Claude Code and Codex, atomic exact-local legacy-pipe admission, explicit opt-in for the experimental Claude notification adapter, deterministic pending-memory tiebreaks, canonical linked-worktree identities, live directed Connectome inspection, and anchor-aware citation repair with pinned parser debt; no new app version; app-v26 remains the ceiling |
 | v11.18.16 | Unfinished-message wake and passive exact-session claim visibility in `sage_inbox`, payload-free hook parity for claimed work, and fail-soft compatibility when that additive projection is unavailable; no automatic ownership transfer; no new app version; app-v26 remains the ceiling |
+| v11.18.17 | Durable primary stdio claimant identity scoped by exact agent/provider/project, OS-lock liveness fencing across ordinary restarts, distinct concurrent-session ownership, and installed-runtime identity carry-forward; pre-v11.18.17 claims still require explicit CAS handoff; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.16. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.17. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -34,7 +34,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.16 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.17 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -205,7 +205,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.16)
+## Related docs (reconciled through v11.18.17)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.16.
+Status: implementation contract through SAGE v11.18.17.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.16 authorization layer is off-consensus and does not require
+The current v11.18.17 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.16 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.17 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.16/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.17/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.16. Legacy organization/federation sections retain
+Verified against SAGE v11.18.17. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.16. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.17. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.16**.
+and is **not in v11.18.17**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.16. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.17. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.16 code (2026-08-17). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.17 code (2026-08-17). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.16.
+Reconciled against internal/mcp for SAGE v11.18.17.
 
 # SAGE MCP Tools Reference
 
@@ -994,7 +994,19 @@ reassigns the message to the calling MCP session. A stale or concurrent handoff
 returns a conflict instead of silently duplicating ownership. Session IDs are
 opaque coordination metadata, not authorization principals.
 
-**Source:** `internal/mcp/tools.go` (`sage_message_handoff`);
+For stdio MCP, the primary runtime persists one claimant identity per exact
+signed agent, provider, and project under `SAGE_HOME/runtime/mcp-claimants/`.
+It holds an OS advisory lock for the runtime lifetime, so an ordinary restart
+reuses that identity only after the prior process is no longer live. A truly
+concurrent runtime cannot acquire the lock and keeps an independent opaque
+session ID, preserving one-handler and compare-and-swap handoff semantics. An
+installed-runtime executable handoff carries the current identity while the
+old process retains the lock as its liveness fence. HTTP transport conversation
+IDs remain transport-scoped and are not collapsed into the stdio identity.
+
+**Source:** `internal/mcp/claimant_identity.go` (`acquireDurableClaimantIdentity`);
+`internal/mcp/server.go` (`conversation`, `trustedHandoffClaimantSessionID`);
+`internal/mcp/tools.go` (`sage_message_handoff`);
 `api/rest/messages_handler.go` (`handleMessageHandoff`);
 `internal/store/messages.go` (`HandoffLocalMessageClaim`).
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.16. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.17. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.16
+**Package:** `sage-agent-sdk` **Version:** 11.18.17
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.16. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.17. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.16 lineage implementation (2026-08-17). -->
+<!-- Verified against SAGE v11.18.17 lineage implementation (2026-08-17). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/internal/mcp/claimant_identity.go
+++ b/internal/mcp/claimant_identity.go
@@ -35,7 +35,7 @@ func acquireDurableClaimantIdentity(agentID, provider, project string) (string, 
 	}
 	scope := sha256.Sum256([]byte(agentID + "\x00" + provider + "\x00" + project))
 	dir := filepath.Join(home, "runtime", "mcp-claimants")
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil { //nolint:gosec // operator-selected SAGE_HOME, scope leaf is a local hash
 		return "", nil, fmt.Errorf("create claimant identity directory: %w", err)
 	}
 	base := hex.EncodeToString(scope[:])
@@ -75,7 +75,7 @@ func acquireDurableClaimantIdentity(agentID, provider, project string) (string, 
 		return "", nil, fmt.Errorf("create claimant identity temp file: %w", err)
 	}
 	tmpPath := tmp.Name()
-	defer func() { _ = os.Remove(tmpPath) }()
+	defer func() { _ = os.Remove(tmpPath) }() //nolint:gosec // path returned by os.CreateTemp in the private claimant directory
 	if chmodErr := tmp.Chmod(0600); chmodErr != nil {
 		_ = tmp.Close()
 		_ = lease.Close()
@@ -95,7 +95,7 @@ func acquireDurableClaimantIdentity(agentID, provider, project string) (string, 
 		_ = lease.Close()
 		return "", nil, closeErr
 	}
-	if renameErr := os.Rename(tmpPath, identityPath); renameErr != nil {
+	if renameErr := os.Rename(tmpPath, identityPath); renameErr != nil { //nolint:gosec // both paths are fixed children of the private claimant directory
 		_ = lease.Close()
 		return "", nil, fmt.Errorf("persist claimant identity: %w", renameErr)
 	}

--- a/internal/mcp/claimant_identity.go
+++ b/internal/mcp/claimant_identity.go
@@ -1,0 +1,111 @@
+package mcp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type durableClaimantIdentity struct {
+	Version           int    `json:"version"`
+	AgentID           string `json:"agent_id"`
+	Provider          string `json:"provider"`
+	Project           string `json:"project"`
+	ClaimantSessionID string `json:"claimant_session_id"`
+}
+
+// acquireDurableClaimantIdentity gives the primary stdio runtime for one
+// (agent, provider, project) tuple a claimant identity that survives ordinary
+// process restarts. The OS lock is the liveness fence: a concurrent runtime
+// cannot reuse the durable identity and must keep its independently generated
+// session ID, preserving one-handler and CAS-handoff semantics.
+func acquireDurableClaimantIdentity(agentID, provider, project string) (string, io.Closer, error) {
+	home := strings.TrimSpace(os.Getenv("SAGE_HOME"))
+	if home == "" {
+		userHome, err := os.UserHomeDir()
+		if err != nil {
+			return "", nil, fmt.Errorf("resolve SAGE home for claimant identity: %w", err)
+		}
+		home = filepath.Join(userHome, ".sage")
+	}
+	scope := sha256.Sum256([]byte(agentID + "\x00" + provider + "\x00" + project))
+	dir := filepath.Join(home, "runtime", "mcp-claimants")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", nil, fmt.Errorf("create claimant identity directory: %w", err)
+	}
+	base := hex.EncodeToString(scope[:])
+	lease, acquired, err := tryLockClaimantFile(filepath.Join(dir, base+".lock"))
+	if err != nil {
+		return "", nil, err
+	}
+	if !acquired {
+		return "", nil, fmt.Errorf("durable claimant identity is owned by a live concurrent runtime")
+	}
+
+	identityPath := filepath.Join(dir, base+".json")
+	if raw, readErr := os.ReadFile(identityPath); readErr == nil { //nolint:gosec // private path under SAGE_HOME
+		var saved durableClaimantIdentity
+		if json.Unmarshal(raw, &saved) == nil && saved.Version == 1 && saved.AgentID == agentID &&
+			saved.Provider == provider && saved.Project == project && validMCPClaimantSessionID(saved.ClaimantSessionID) {
+			return saved.ClaimantSessionID, lease, nil
+		}
+	}
+
+	id := newMCPClaimantSessionID()
+	if id == "" {
+		_ = lease.Close()
+		return "", nil, fmt.Errorf("generate durable claimant identity")
+	}
+	record := durableClaimantIdentity{
+		Version: 1, AgentID: agentID, Provider: provider, Project: project, ClaimantSessionID: id,
+	}
+	raw, err := json.Marshal(record)
+	if err != nil {
+		_ = lease.Close()
+		return "", nil, err
+	}
+	tmp, err := os.CreateTemp(dir, base+".tmp-") //nolint:gosec // private path under SAGE_HOME
+	if err != nil {
+		_ = lease.Close()
+		return "", nil, fmt.Errorf("create claimant identity temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if chmodErr := tmp.Chmod(0600); chmodErr != nil {
+		_ = tmp.Close()
+		_ = lease.Close()
+		return "", nil, chmodErr
+	}
+	if _, writeErr := tmp.Write(raw); writeErr != nil {
+		_ = tmp.Close()
+		_ = lease.Close()
+		return "", nil, writeErr
+	}
+	if syncErr := tmp.Sync(); syncErr != nil {
+		_ = tmp.Close()
+		_ = lease.Close()
+		return "", nil, syncErr
+	}
+	if closeErr := tmp.Close(); closeErr != nil {
+		_ = lease.Close()
+		return "", nil, closeErr
+	}
+	if renameErr := os.Rename(tmpPath, identityPath); renameErr != nil {
+		_ = lease.Close()
+		return "", nil, fmt.Errorf("persist claimant identity: %w", renameErr)
+	}
+	return id, lease, nil
+}
+
+func validMCPClaimantSessionID(id string) bool {
+	if len(id) != len("mcp-")+32 || !strings.HasPrefix(id, "mcp-") {
+		return false
+	}
+	_, err := hex.DecodeString(id[len("mcp-"):])
+	return err == nil
+}

--- a/internal/mcp/claimant_lock_unix.go
+++ b/internal/mcp/claimant_lock_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package mcp
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+type claimantFileLease struct{ file *os.File }
+
+func tryLockClaimantFile(path string) (*claimantFileLease, bool, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600) //nolint:gosec // private path under SAGE_HOME
+	if err != nil {
+		return nil, false, fmt.Errorf("open claimant identity lock: %w", err)
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = f.Close()
+		if err == unix.EWOULDBLOCK || err == unix.EAGAIN {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("lock claimant identity: %w", err)
+	}
+	return &claimantFileLease{file: f}, true, nil
+}
+
+func (l *claimantFileLease) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	_ = unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+	return l.file.Close()
+}

--- a/internal/mcp/claimant_lock_windows.go
+++ b/internal/mcp/claimant_lock_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package mcp
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+type claimantFileLease struct {
+	file       *os.File
+	overlapped windows.Overlapped
+}
+
+func tryLockClaimantFile(path string) (*claimantFileLease, bool, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600) //nolint:gosec // private path under SAGE_HOME
+	if err != nil {
+		return nil, false, fmt.Errorf("open claimant identity lock: %w", err)
+	}
+	lease := &claimantFileLease{file: f}
+	err = windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &lease.overlapped)
+	if err != nil {
+		_ = f.Close()
+		if err == windows.ERROR_LOCK_VIOLATION {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("lock claimant identity: %w", err)
+	}
+	return lease, true, nil
+}
+
+func (l *claimantFileLease) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	_ = windows.UnlockFileEx(windows.Handle(l.file.Fd()), 0, 1, 0, &l.overlapped)
+	return l.file.Close()
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -37,6 +37,7 @@ const mcpRuntimeHandoffEnv = "SAGE_MCP_RUNTIME_HANDOFF"
 const (
 	mcpRuntimeHandoffParentEnv      = "SAGE_MCP_RUNTIME_HANDOFF_PARENT_PID"
 	mcpRuntimeHandoffInitializedEnv = "SAGE_MCP_RUNTIME_HANDOFF_INITIALIZED"
+	mcpRuntimeHandoffClaimantEnv    = "SAGE_MCP_RUNTIME_HANDOFF_CLAIMANT_ID"
 )
 
 // mcpExecutableSnapshot identifies the exact on-disk executable that started a
@@ -96,6 +97,7 @@ type Server struct {
 
 	conversationMu sync.Mutex
 	conversations  map[string]*conversationState
+	claimantLease  io.Closer
 
 	// Cached recall settings from dashboard preferences.
 	recallTopK     int
@@ -152,9 +154,48 @@ func (s *Server) conversation(ctx context.Context) *conversationState {
 		state.lastUsed = time.Now()
 		return state
 	}
-	state := &conversationState{lastUsed: time.Now(), claimantSessionID: newMCPClaimantSessionID()}
+	claimantSessionID := newMCPClaimantSessionID()
+	if id == "stdio" {
+		if inherited := trustedHandoffClaimantSessionID(); inherited != "" {
+			claimantSessionID = inherited
+		} else if durableID, lease, err := acquireDurableClaimantIdentity(s.agentID, s.provider, s.project); err == nil {
+			claimantSessionID = durableID
+			s.claimantLease = lease
+		}
+	}
+	state := &conversationState{lastUsed: time.Now(), claimantSessionID: claimantSessionID}
 	s.conversations[id] = state
 	return state
+}
+
+func trustedHandoffClaimantSessionID() string {
+	if os.Getenv(mcpRuntimeHandoffEnv) != "1" || os.Getenv(mcpRuntimeHandoffParentEnv) != strconv.Itoa(os.Getppid()) {
+		return ""
+	}
+	id := strings.TrimSpace(os.Getenv(mcpRuntimeHandoffClaimantEnv))
+	if !validMCPClaimantSessionID(id) {
+		return ""
+	}
+	return id
+}
+
+func (s *Server) currentStdioClaimantSessionID() string {
+	s.conversationMu.Lock()
+	defer s.conversationMu.Unlock()
+	if state := s.conversations["stdio"]; state != nil {
+		return state.claimantSessionID
+	}
+	return ""
+}
+
+func (s *Server) closeClaimantLease() {
+	s.conversationMu.Lock()
+	lease := s.claimantLease
+	s.claimantLease = nil
+	s.conversationMu.Unlock()
+	if lease != nil {
+		_ = lease.Close()
+	}
 }
 
 func newMCPClaimantSessionID() string {
@@ -247,6 +288,7 @@ func (s *Server) requireBoundFederatedCaller(ctx context.Context) error {
 
 // Run starts the stdio MCP server loop.
 func (s *Server) Run(ctx context.Context) error {
+	defer s.closeClaimantLease()
 	reader := bufio.NewReaderSize(os.Stdin, 64<<10)
 	out := newStdioOutbound(ctx, os.Stdout)
 	var channelCancel context.CancelFunc
@@ -325,7 +367,11 @@ func (s *Server) Run(ctx context.Context) error {
 			shutdown()
 			// Pass the buffered reader, not raw os.Stdin: ReadSlice may already
 			// have pulled bytes from following frames into reader's buffer.
-			started, err := handoffMCPProcess(ctx, executable.path, os.Args[1:], line, reader, os.Stdout, os.Stderr, os.Environ(), lifecycle.initialized)
+			handoffEnv := os.Environ()
+			if claimantSessionID := s.currentStdioClaimantSessionID(); claimantSessionID != "" {
+				handoffEnv = withMCPEnvironment(handoffEnv, mcpRuntimeHandoffClaimantEnv, claimantSessionID)
+			}
+			started, err := handoffMCPProcess(ctx, executable.path, os.Args[1:], line, reader, os.Stdout, os.Stderr, handoffEnv, lifecycle.initialized)
 			if started {
 				// Once the replacement owns stdin the current runtime must never
 				// execute the replayed frame, even if the child later exits with an

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -91,6 +92,7 @@ func TestConversationStateIsIsolatedAndReleased(t *testing.T) {
 }
 
 func TestClaimantSessionIdentityIsStablePerConversationAndOpaque(t *testing.T) {
+	t.Setenv("SAGE_HOME", t.TempDir())
 	s, _ := testServer(t)
 	ctxA := WithConversationID(context.Background(), "sse:A")
 	ctxB := WithConversationID(context.Background(), "sse:B")
@@ -104,6 +106,97 @@ func TestClaimantSessionIdentityIsStablePerConversationAndOpaque(t *testing.T) {
 	require.NotEqual(t, a1, b)
 	require.Regexp(t, `^mcp-[0-9a-f]{32}$`, a1)
 	require.NotContains(t, a1, "sse:A")
+}
+
+func TestStdioClaimantIdentitySurvivesProcessRestart(t *testing.T) {
+	t.Setenv("SAGE_HOME", t.TempDir())
+	t.Setenv("SAGE_PROVIDER", "codex")
+	_, key, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	first := NewServer("http://localhost:9999", key)
+	first.SetProject("sage")
+	firstID, err := first.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, first.claimantLease)
+	require.NoError(t, first.claimantLease.Close())
+
+	restarted := NewServer("http://localhost:9999", key)
+	restarted.SetProject("sage")
+	restartedID, err := restarted.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = restarted.claimantLease.Close() })
+	require.Equal(t, firstID, restartedID)
+}
+
+func TestConcurrentStdioRuntimeCannotShareDurableClaimantIdentity(t *testing.T) {
+	t.Setenv("SAGE_HOME", t.TempDir())
+	t.Setenv("SAGE_PROVIDER", "codex")
+	_, key, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	primary := NewServer("http://localhost:9999", key)
+	primary.SetProject("sage")
+	primaryID, err := primary.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, primary.claimantLease)
+
+	concurrent := NewServer("http://localhost:9999", key)
+	concurrent.SetProject("sage")
+	concurrentID, err := concurrent.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, concurrent.claimantLease)
+	require.NotEqual(t, primaryID, concurrentID)
+
+	require.NoError(t, primary.claimantLease.Close())
+	restarted := NewServer("http://localhost:9999", key)
+	restarted.SetProject("sage")
+	restartedID, err := restarted.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = restarted.claimantLease.Close() })
+	require.Equal(t, primaryID, restartedID)
+}
+
+func TestRuntimeHandoffRetainsClaimantIdentityWhileParentHoldsLease(t *testing.T) {
+	t.Setenv("SAGE_HOME", t.TempDir())
+	t.Setenv("SAGE_PROVIDER", "codex")
+	_, key, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	parent := NewServer("http://localhost:9999", key)
+	parent.SetProject("sage")
+	parentID, err := parent.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = parent.claimantLease.Close() })
+
+	t.Setenv(mcpRuntimeHandoffEnv, "1")
+	t.Setenv(mcpRuntimeHandoffParentEnv, strconv.Itoa(os.Getppid()))
+	t.Setenv(mcpRuntimeHandoffClaimantEnv, parentID)
+	child := NewServer("http://localhost:9999", key)
+	child.SetProject("sage")
+	childID, err := child.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, parentID, childID)
+	require.Nil(t, child.claimantLease)
+}
+
+func TestRuntimeHandoffRejectsMalformedClaimantIdentity(t *testing.T) {
+	t.Setenv("SAGE_HOME", t.TempDir())
+	t.Setenv("SAGE_PROVIDER", "codex")
+	t.Setenv(mcpRuntimeHandoffEnv, "1")
+	t.Setenv(mcpRuntimeHandoffParentEnv, strconv.Itoa(os.Getppid()))
+	t.Setenv(mcpRuntimeHandoffClaimantEnv, "mcp-not-an-opaque-id")
+	_, key, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	server := NewServer("http://localhost:9999", key)
+	server.SetProject("sage")
+	id, err := server.claimantSessionID(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(server.closeClaimantLease)
+	require.Regexp(t, `^mcp-[0-9a-f]{32}$`, id)
+	require.NotEqual(t, "mcp-not-an-opaque-id", id)
+	require.NotNil(t, server.claimantLease)
 }
 
 func TestHandleInitialize(t *testing.T) {

--- a/scripts/doc-citations.mjs
+++ b/scripts/doc-citations.mjs
@@ -45,8 +45,14 @@ const RAW_REFERENCE = /([A-Za-z0-9_/.-]*[a-z0-9_]\.go):(\d+)/g;
 // A top-level func begins at column 0; anything indented is a body line.
 const FUNC_DECL = /^func (?:\([^)]*\) )?([A-Za-z0-9_]+)/;
 
+const WALK_SKIP = new Set(['node_modules', '.git', '.claude', 'third_party', 'vendor', 'dist', 'scratchpad']);
+
 function walk(dir, pred, out = []) {
   for (const entry of readdirSync(dir)) {
+    // Skip generated/dependency trees before stat/recurse. Filtering the final
+    // .go list is too late: recursive packaging symlinks can exceed PATH_MAX
+    // while the walker is still descending into an ignored directory.
+    if (WALK_SKIP.has(entry)) continue;
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) walk(full, pred, out);
     else if (pred(full)) out.push(full);
@@ -55,10 +61,11 @@ function walk(dir, pred, out = []) {
 }
 
 export function goFiles() {
-  const skip = new Set(['node_modules', '.git', 'third_party', 'vendor']);
-  return walk(root, (p) => p.endsWith('.go'), []).filter(
-    (p) => !relative(root, p).split('/').some((s) => skip.has(s)),
-  );
+  return goFilesUnder(root);
+}
+
+export function goFilesUnder(scanRoot) {
+  return walk(scanRoot, (p) => p.endsWith('.go'), []);
 }
 
 export function docFiles() {

--- a/scripts/doc-citations.test.mjs
+++ b/scripts/doc-citations.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -16,11 +16,28 @@ import {
   newUnchecked,
   anchorId,
   repairEligibility,
+  goFilesUnder,
 } from './doc-citations.mjs';
 
 const readJson = (name) => JSON.parse(readFileSync(new URL(name, import.meta.url), 'utf8'));
 const baseline = readJson('./doc-citations.baseline.json');
 const legacyBaseline = readJson('./doc-citations.legacy.json');
+
+test('Go source discovery skips generated and worktree roots before recursion', () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'sage-doc-walk-'));
+  try {
+    writeFileSync(join(fixture, 'kept.go'), 'package fixture\n');
+    for (const skipped of ['dist', '.claude', 'scratchpad']) {
+      const dir = join(fixture, skipped);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'duplicate.go'), 'package duplicate\n');
+      if (process.platform !== 'win32') symlinkSync('loop', join(dir, 'loop'));
+    }
+    assert.deepEqual(goFilesUnder(fixture), [join(fixture, 'kept.go')]);
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
 
 // docs/reference/ is where CLAUDE.md sends agents INSTEAD of reading the source,
 // and it supersedes api/openapi.yaml and ARCHITECTURE.md where they disagree.

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -60,7 +60,7 @@ test('release-facing version metadata stays aligned', () => {
     ['deploy/federation-acceptance/README.md', `# v${version} federation Docker acceptance`],
     ['docs/FEDERATION.md', `Verified against SAGE v${version} federation behavior`],
     ['docs/reference/concepts/message-reply-lifecycle.md', `SAGE v${version} code`],
-    ['docs/UPGRADING.md', `| v${version} | Unfinished-message wake`],
+    ['docs/UPGRADING.md', `| v${version} | Durable primary stdio claimant identity`],
     ['docs/ROADMAP.md', `## v${version} patch`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.16 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.17 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.16"
+version = "11.18.17"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.16"
+__version__ = "11.18.17"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.16",
+  "version": "11.18.17",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.16",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.17",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.16';
+const SAGE_VERSION = 'v11.18.17';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
## Summary
- persist the primary stdio MCP claimant identity per exact agent/provider/project
- fence reuse with a platform-native OS lock so restarts recover ownership only after the prior runtime is gone
- preserve distinct concurrent-session and CAS handoff semantics, including installed-runtime handoff
- harden citation source discovery against generated dist trees, Claude worktrees, and scratchpads
- align release metadata and notes for v11.18.17

## Compatibility boundary
Pre-v11.18.17 random claimant IDs are not bulk-adopted. Their claims remain visible through claimed_elsewhere/history and require explicit CAS-fenced handoff after liveness is judged.

## Verification
- go build ./...
- go vet ./internal/mcp ./cmd/sage-gui
- go test ./internal/mcp -count=1
- go test -race ./internal/mcp -count=1
- go test ./cmd/sage-gui -count=1
- Windows amd64 cross-compile of internal/mcp tests
- npm test: 400/400
- version alignment and citation guards green