### PR TITLE
release: SAGE v11.18.18

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -103,7 +103,12 @@
       "mcp__sage__sage_register",
       "mcp__sage__sage_timeline",
       "mcp__sage__sage_reinstate",
-      "mcp__sage__sage_rename"
+      "mcp__sage__sage_rename",
+      "mcp__sage__sage_inbox",
+      "mcp__sage__sage_messages_receive",
+      "mcp__sage__sage_message_history",
+      "mcp__sage__sage_message_replies",
+      "mcp__sage__sage_message_status"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,8 @@ docs/*
 !docs/design/
 docs/design/*
 !docs/design/agent-message-receipts.md
+!docs/design/sage-commons-lantern-v12-support.md
+scratchpad/
 # Agent-facing code reference (public)
 !docs/reference/
 # Architecture diagram (rendered PNG embedded in ARCHITECTURE.md; .mmd source kept local/untracked)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.18
+
+**Codex upgrades now repair stale SAGE lifecycle hooks automatically.** On
+every MCP startup, the project self-healer compares all five installer-owned
+Codex hook scripts with their fully rendered current templates. A mixed
+generation can no longer pass merely because the files exist or another hook
+mentions the current binary. Upgrading therefore replaces legacy no-op Stop
+hooks and malformed prompt hooks without requiring a second manual
+`sage-gui codex install` run.
+
+**The CEREBRUM Connectome now leads with the graph itself.** Neurons have a
+larger practical click target; clicking one opens its persistent identity,
+visible incoming/outgoing traffic, strongest peer, directed connection list,
+and visible memory lobe. The compact fallback selector now shows only agents
+with visible peer relationships, ordered by retained traffic, instead of
+turning a large dormant/test roster into the primary navigation surface.
+Isolated authorized neurons remain visible and clickable in the brain and join
+the selector while selected.
+
+This patch introduces no new consensus application version or state migration.
+The ceiling remains app-v26; **v11.18.18 introduces no app-v27**.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.18`. SDK 11.18.18.
+
 ## What's New in v11.18.17
 
 **Routine MCP restarts no longer make the same stdio agent disown its own
@@ -1935,7 +1959,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.17`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.18`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,10 @@
 If you discover a security vulnerability in SAGE, please report it responsibly:
 
 1. **Do NOT open a public GitHub issue**
-2. Email the author directly via GitHub: [@l33tdawg](https://github.com/l33tdawg)
-3. Include a description of the vulnerability, steps to reproduce, and any relevant logs or screenshots
+2. Use GitHub's private vulnerability reporting: **[Security → Report a vulnerability](https://github.com/l33tdawg/sage/security/advisories/new)**. The report stays private between you and the maintainers until an advisory is published, and it lets us coordinate a fix, a CVE, and credit in one place.
+3. Include a description of the vulnerability, steps to reproduce, the affected version or commit, and any relevant logs or screenshots
+
+If the private advisory form is unavailable to you for any reason, contact [@l33tdawg](https://github.com/l33tdawg) to arrange another channel — but please still do not open a public issue.
 
 ## Response Timeline
 

--- a/SECURITY_FAQ.md
+++ b/SECURITY_FAQ.md
@@ -11,7 +11,7 @@ SAGE has two distinct deployment models with fundamentally different threat mode
 | **Who** | One user, one local operator | Multiple agents, teams, organizations |
 | **Trust model** | User IS the only validator | Byzantine fault tolerance across validators |
 | **Database** | Local BadgerDB/SQLite stores in `~/.sage/data/` | BadgerDB consensus state plus off-chain mirror |
-| **Release** | v11.18.17 personal-node surface | v11.18.17 quorum/federation surface |
+| **Release** | v11.18.18 personal-node surface | v11.18.18 quorum/federation surface |
 
 Many concerns raised about the enterprise codebase do not apply to SAGE Personal, and vice versa. Each item below is tagged with which deployment it affects.
 
@@ -108,7 +108,7 @@ The `make byzantine` target and GitHub Actions CI job spin up a 4-validator Dock
 
 The following boundaries describe the current v11 codebase:
 
-**SAGE Personal (sage-gui v11.18.17):**
+**SAGE Personal (sage-gui v11.18.18):**
 - Designed for one operator. The management dashboard/API remains a local surface; anyone with access to the operator session or machine should be treated as trusted.
 - Federation is an explicit network-facing feature, off by default. When enabled it uses a separate pinned-mTLS listener, active on-chain treaty checks, chain-qualified signed requests, and replay protection. That authenticated protocol now runs over libp2p NAT traversal and Circuit Relay v2; the relay sees encrypted traffic and connection metadata, not plaintext memories or federation keys.
 - SQLite database supports optional AES-256-GCM encryption at rest (Synaptic Ledger). Enable from CEREBRUM Settings → Security.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.17
+  version: 11.18.18
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/cmd/sage-gui/codex.go
+++ b/cmd/sage-gui/codex.go
@@ -497,7 +497,7 @@ func installAgentsMD(projectDir string) error {
 //
 // Migration triggers (any one is enough):
 //   - .codex/hooks/ missing a current script
-//   - .codex/hooks/*.sh references a stale binary path
+//   - any installer-owned hook differs from its fully rendered current template
 //   - .codex/config.toml references a stale binary path
 //   - .codex/hooks.json missing (legacy installs predate it)
 func selfHealCodex(projectDir, sageHome string, identityOverrides ...string) {
@@ -525,21 +525,18 @@ func selfHealCodex(projectDir, sageHome string, identityOverrides ...string) {
 		identityPath = identityOverride
 	}
 	needsRewrite := false
-	hasBinRef := false
 
 	if _, statErr := os.Stat(hookDir); os.IsNotExist(statErr) {
 		needsRewrite = true
 	} else {
-		for name := range hookScriptSet() {
+		for name, tpl := range hookScriptSet() {
 			data, readErr := os.ReadFile(filepath.Join(hookDir, name)) //nolint:gosec // path inside project's .codex/hooks
 			if readErr != nil {
 				needsRewrite = true
 				continue
 			}
-			if strings.Contains(string(data), binPath) {
-				hasBinRef = true
-			}
-			if hookUsesDirectWriteIdentity(name) && (!strings.Contains(string(data), `SAGE_PROVIDER="codex"`) || !strings.Contains(string(data), identityPath)) {
+			want := renderHookScript(tpl, binPath, "codex", identityPath)
+			if string(data) != want {
 				needsRewrite = true
 			}
 		}
@@ -556,7 +553,7 @@ func selfHealCodex(projectDir, sageHome string, identityOverrides ...string) {
 		needsRewrite = true
 	}
 
-	if !needsRewrite && hasBinRef {
+	if !needsRewrite {
 		return
 	}
 

--- a/cmd/sage-gui/codex_test.go
+++ b/cmd/sage-gui/codex_test.go
@@ -154,6 +154,29 @@ func TestSelfHealCodex_RewritesStaleBinaryPath(t *testing.T) {
 	assert.NotContains(t, string(startAfter), "/old/path/to/sage-gui")
 }
 
+func TestSelfHealCodex_RewritesStaleHookBytesWithCurrentPaths(t *testing.T) {
+	projectDir, sageHome := withCodexInstallEnv(t)
+	require.NoError(t, runCodexInstall())
+
+	// Reproduce the v11.18.17 field failure: the hook directory and all five
+	// filenames exist, other hooks still mention the current binary and identity,
+	// but Stop is an older installer-owned no-op. Presence/path checks alone
+	// incorrectly accepted this mixed generation as current.
+	stopPath := filepath.Join(projectDir, ".codex", "hooks", "sage-stop.sh")
+	require.NoError(t, os.WriteFile(stopPath, []byte("#!/bin/bash\n# reserved for future checks\nexit 0\n"), 0755))
+
+	selfHealCodex(projectDir, sageHome)
+
+	binPath := expectExecutable(t)
+	identityPath := codexConfigIdentityPath(filepath.Join(projectDir, ".codex", "config.toml"), sageHome, "codex")
+	for name, tpl := range hookScriptSet() {
+		got, err := os.ReadFile(filepath.Join(projectDir, ".codex", "hooks", name))
+		require.NoError(t, err, "read refreshed %s", name)
+		assert.Equal(t, renderHookScript(tpl, binPath, "codex", identityPath), string(got),
+			"self-heal must restore the complete rendered hook set when any one script is stale")
+	}
+}
+
 func TestSelfHealCodex_NoOpWhenNoCodexDir(t *testing.T) {
 	projectDir, sageHome := withCodexInstallEnv(t)
 

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.17-acceptance
+ARG VERSION=v11.18.18-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.17 federation Docker acceptance
+# v11.18.18 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.17-acceptance
+        VERSION: v11.18.18-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.17"
+version = "11.18.18"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.17"
+version = "11.18.18"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.17",
+  "version": "11.18.18",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.17/app-v26. -->
+<!-- Reconciled through SAGE v11.18.18/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/BRAIN.md
+++ b/docs/BRAIN.md
@@ -17,6 +17,25 @@ domain and how settled they are. This is the brain view: drag to orbit, scroll
 to zoom, click a memory to focus its train of thought, and click open space to
 return to all memories.
 
+### Switch to the agent Connectome
+
+Choose **◉ connectome** in the lower HUD to replace memory nodes with the
+currently authorized agent projection. Each neuron is one active ordinary
+agent; directed synapses are visible retained message traffic. Root, pending,
+removed, and caller-hidden identities are not rendered.
+
+Click a neuron to open its persistent details. The panel shows its exact agent
+ID and domain, incoming and outgoing retained-message counts, strongest visible
+peer, and a direction-preserving relationship list—**Sent** and **Received** are
+kept separate. Clicking a relationship isolates that pair in the brain; clicking
+a directed synapse opens the sender/receiver relationship directly.
+
+The compact selector is a fallback for keyboard and touch navigation, not the
+primary roster. It contains only agents with a visible peer relationship,
+ordered by visible retained traffic. Authorized isolated neurons remain in the
+brain and can be opened by clicking them; while selected, an isolated neuron is
+also retained in the selector so Close and Escape return focus coherently.
+
 ---
 
 ## What a node tells you

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.17 federation behavior. -->
+<!-- Verified against SAGE v11.18.18 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.17
+# sage-gui v11.18.18
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.17 advertises 33 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.18 advertises 33 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.17 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.18 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -68,13 +68,33 @@ new-work counts and claim ownership unchanged, and makes hook inbox status
 consult the payload-free durable wake snapshot. v11.18.17 persists the primary
 stdio claimant identity per exact agent/provider/project and reuses it only
 after an OS liveness lock proves the prior runtime is gone, while concurrent
-runtimes remain independently fenced. The supported consensus ceiling remains
-app-v26; **v11.18.17 does not introduce app-v27**.
+runtimes remain independently fenced. v11.18.18 makes the Codex startup
+self-healer compare every fully rendered lifecycle hook and makes Connectome
+neurons the primary agent-detail navigation surface, with a compact
+relationship-only fallback selector. The supported consensus ceiling remains
+app-v26; **v11.18.18 does not introduce app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.18 patch
+
+Codex project self-healing now byte-compares every installer-owned hook against
+the current template rendered with the active binary and pinned identity. Any
+stale member rewrites the complete five-script set, closing the mixed-generation
+upgrade failure where an obsolete no-op Stop hook survived because sibling
+scripts still referenced the current executable.
+
+The CEREBRUM Connectome now gives neurons a larger click target and explicitly
+leads operators to click the graph for persistent agent details and directed
+relationship inspection. Its fallback selector is bounded to agents with
+visible peer relationships, ordered by visible retained traffic; selected
+isolated neurons remain represented for keyboard continuity. The endpoint and
+both-endpoint RBAC projection are unchanged. This patch introduces no new
+consensus application version or state migration: app-v26 remains the ceiling
+and v11.18.18 does not introduce app-v27.
 
 ## v11.18.17 patch
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -108,6 +108,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.15 | Unfinished-message wake backfill for claimed-only upgrades, default-on fail-open Stop nudges for Claude Code and Codex, atomic exact-local legacy-pipe admission, explicit opt-in for the experimental Claude notification adapter, deterministic pending-memory tiebreaks, canonical linked-worktree identities, live directed Connectome inspection, and anchor-aware citation repair with pinned parser debt; no new app version; app-v26 remains the ceiling |
 | v11.18.16 | Unfinished-message wake and passive exact-session claim visibility in `sage_inbox`, payload-free hook parity for claimed work, and fail-soft compatibility when that additive projection is unavailable; no automatic ownership transfer; no new app version; app-v26 remains the ceiling |
 | v11.18.17 | Durable primary stdio claimant identity scoped by exact agent/provider/project, OS-lock liveness fencing across ordinary restarts, distinct concurrent-session ownership, and installed-runtime identity carry-forward; pre-v11.18.17 claims still require explicit CAS handoff; no new app version; app-v26 remains the ceiling |
+| v11.18.18 | Byte-exact automatic Codex lifecycle-hook self-healing plus click-first CEREBRUM Connectome agent details, larger neuron targets, and a relationship-scoped fallback selector; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/design/sage-commons-lantern-v12-support.md
+++ b/docs/design/sage-commons-lantern-v12-support.md
@@ -1,0 +1,187 @@
+# Joint SAGE v12 and SAGE Commons/Lantern roadmap contract
+
+**Status:** roadmap contract; implementation evidence is required per row  
+**Baseline:** SAGE v11.18.4 / app-v26  
+**Products:** SAGE core, SAGE Commons, SAGE Lantern, Knowledge Point, Data Donkey
+
+## Purpose
+
+SAGE v12 is the native-product capstone, but SAGE Commons and SAGE Lantern use
+the daemon and authenticated APIs directly on Linux/ARM64. This contract keeps
+the three roadmaps aligned without pretending that every Commons or fleet
+feature belongs in SAGE consensus.
+
+It distinguishes:
+
+1. behavior already available in v11.18.4;
+2. compatibility SAGE core must preserve and prove for v12;
+3. new SAGE-core dependencies that need their own implementation and evidence;
+4. Commons/Lantern work that stays outside SAGE core; and
+5. capabilities that remain unsupported and must not be implied by product copy.
+
+The hard constraints remain no chain reset, upgrade in place, exact identity and
+authorship preservation, local Root sovereignty, and no hidden widening of
+federation or fleet authority.
+
+## Long-horizon relationship
+
+SAGE Commons is not an accessory, downstream demo, or one-release consumer. It
+is SAGE's long-term community, public-knowledge, distribution, field, and
+hardware programme. SAGE core supplies the sovereign primitives; Commons turns
+those primitives into independently operated public and offline systems without
+absorbing personal-node authority into a foundation, fleet, or validator plane.
+
+The relationship is deliberately bidirectional:
+
+- SAGE core publishes stable capability, compatibility, migration, and evidence
+  contracts that Commons can plan against.
+- Commons and Lantern provide concrete field, ARM64, intermittent-network,
+  public-intake, distribution, and recovery requirements that shape future SAGE
+  planning.
+- A Commons requirement becomes a SAGE commitment only after ownership,
+  security, sovereignty, compatibility, migration, and—where applicable—BFT
+  replay and governed activation are accepted.
+- A SAGE deprecation or contract change that affects Commons requires impact
+  analysis, a supported transition, and acceptance evidence before removal.
+- Neither roadmap may claim the other programme's planned capability as shipped.
+
+This contract therefore continues after v12. Version-specific baselines and
+evidence will advance, while the ownership and joint-change-control model stays
+in force.
+
+## Product topology frozen for the beta
+
+- Every Lantern runs one full **personal SAGE** as its sovereign local memory
+  node when hardware measurements pass.
+- The Lantern's public role is a **query client and signed proposer**, not a
+  Commons validator.
+- Public proposals are queued as logical signed envelopes while offline. When
+  connected, the Lantern signs a fresh authenticated SAGE request under its
+  distinct public ordinary-agent identity.
+- Public query material and Commons Snapshot Packs live in a labelled,
+  replaceable **Lantern Cache**. They never become personal canonical memory by
+  copying files.
+- Stable, always-on servers validate and commit the public Commons chain.
+- Knowledge Points provide long-lived cache, synchronization, research, and
+  publishing services; possession of content does not grant validator power.
+- Data Donkey is an untrusted, content-addressed super-seed. It is independent
+  of SAGE consensus, state sync, full backup, and Federation Copy.
+
+An optional second public observer process stays disabled until SAGE has a
+documented long-lived non-validator product role and the ROCK hardware budget
+passes. A boot-time state-sync receiver is not repurposed as that observer.
+
+## Capability crosswalk
+
+| Capability | v11.18.4 baseline | v12/core obligation | Commons/Lantern obligation | Boundary |
+|---|---|---|---|---|
+| Personal sovereign node | Full app-v26 node, local Root, ordinary agents, recovery and upgrade-in-place | Preserve and acceptance-test on Linux/ARM64 without requiring the native shell | Package, supervise and measure it on Lantern hardware | Native app remains macOS/Windows; Linux daemon/browser/CLI stays supported |
+| Roles and collaboration | Root separate from Member/Manager/Admin; app-v26 local Access Groups | Preserve exact semantics and publish capability/version evidence | Map product roles to least-privilege local agents and separate fleet capabilities | Remote field operators never become local members, Admin, or Root |
+| Agent messaging | Canonical messages, exact identities, sender replies, passive status/history | Preserve SDK/MCP/REST compatibility and offline/restart evidence | Use messages only for untrusted coordination and workflow notices | Message delivery never delegates memory or device-mutation authority |
+| Public proposer | Ordinary-agent signed `MemorySubmit` enters the local/public chain lifecycle; the generic v11.18.4 submit route has no request-level idempotency contract | Preserve fresh nonce/timestamp signing, exact caller identity, and exact transaction/memory evidence | Maintain encrypted offline outbox, consent and public provenance; the Commons intake owns envelope-level idempotency and performs at most one SAGE submission | Federation remote Write remains unavailable; Root is not the proposer; generic-memory idempotency is a separate possible core enhancement, not a beta dependency |
+| Public intake | Direct submission and normal validator lifecycle exist | No implicit v12 promise of a new consensus schema | Build durable intake/quarantine, schema/privacy checks, human/governance review and receipts | Beta validation is an application boundary before `MemorySubmit` |
+| Hyperlocal content validation | No active app-v26 consensus gate for the proposed hyperlocal schema | Any consensus-enforced gate requires a separately governed app-version plan | Enforce the beta schema and locality/privacy policy in intake and clients | v12 product semver does not imply app-v27 |
+| Public query | Signed query/recall APIs and PUBLIC classification exist | Preserve bounded authenticated query and explicit source/lifecycle metadata | Build Commons query service, cache policy, stale/expired filtering and provenance UI | Never blend private and public recall without labels |
+| Commons Snapshot Pack export | No frozen public subset export/proof API | Define and acceptance-test a deterministic committed-PUBLIC export at a frozen checkpoint, with exact source/app/version metadata | Sign, catalogue, chunk, distribute and render staleness for derived packs | Export signature/root is off-chain attestation unless native inclusion proofs exist |
+| Federation | Trust plus explicit Read/Copy; Write reserved/501 | Preserve fail-closed identity/policy generation and no-write behavior | Use only where online Read/Copy semantics are actually desired | Federation Copy changes destination canonical author and is not pack transport |
+| State sync and backup | Authorized empty-node state sync; complete stopped-node backup/restore | Preserve both and keep their formats isolated | Use neither as Data Donkey or Lantern Cache formats | Full backup contains private node material; state sync is not public distribution |
+| Release/update evidence | Signed releases, exact version/source provenance, safe in-place recovery patterns | Expose a stable compatibility/evidence contract for embedded/headless consumers and prove Linux/ARM64 artifacts | Build TUF-style pack channels, fleet campaigns, local consent and device receipts | Field commands cannot bypass SAGE's own migration/recovery gates |
+| Fleet/device management | No remote fleet authority protocol | Preserve a narrow local API boundary; do not reinterpret Admin or messages as fleet control | Build signed offline capabilities, device agent, command sandbox, telemetry/privacy and execution receipts | Fleet Admin is a Commons role, never SAGE Admin |
+| Dual-home/multi-instance | Separate processes are mechanically possible with fully separate homes and identities; not first-class packaging | Either deliver a documented supported multi-instance profile or keep it explicitly out of v12 acceptance | Beta uses personal SAGE plus adapter/cache; do not require the optional observer | Never share homes, data roots, chain IDs, listeners, Root keys, or validator keys |
+| Validator topology | Stable server validators and governed roster/power operations | Preserve exact governance and recovery semantics | Operate independent always-on Commons validators and public transparency | Lanterns, Donkeys, and field laptops carry no validator key or voting power |
+
+## SAGE-core v12 release gates for Lantern and Commons
+
+The following evidence is required before claiming the v12 core is compatible
+with Lantern/Commons:
+
+1. **Linux/ARM64 headless lifecycle.** Clean install, first boot, ordinary-agent
+   enrollment, personal memory submit/recall, canonical messaging, restart,
+   stopped-node backup/restore, and signed upgrade all pass without the native
+   shell.
+2. **Version and capability evidence.** Lantern can determine the exact SAGE
+   release, source provenance, consensus app version, chain ID/role, and API
+   capability set without parsing human UI text or using a private database.
+3. **Public proposer path.** A distinct ordinary proposer can queue offline,
+   reconnect, obtain one envelope-idempotent Commons intake decision, create at
+   most one fresh authenticated SAGE submission, and observe exact transaction,
+   proposed/committed, or rejected evidence. Existing v11.18.4 generic memory
+   submission is not claimed to be request-idempotent; the beta resolves the
+   ambiguity at intake rather than resubmitting blindly.
+4. **No-authority regression.** A field, Donkey, message, linked reader, and
+   federated identity each fail to acquire local membership, Root/Admin,
+   validator/governance, remote Write, or personal-memory access.
+5. **Public export contract.** The exporter freezes one committed checkpoint,
+   emits only selected committed PUBLIC records, excludes private and
+   off-consensus state, binds deterministic counts/hashes and source metadata,
+   and states honestly whether per-record consensus inclusion proofs exist.
+6. **Private/public separation.** Public cache results remain labelled and
+   replaceable; importing one requires an explicit intake path and never changes
+   personal SAGE by filesystem copying.
+7. **Consensus compatibility.** Any new application behavior proves byte-identical
+   historical replay, governed activation, full upgrade/recovery evidence, and
+   no reset of existing app-v26 chains.
+
+## Commons/Lantern deliverables that do not block on new SAGE consensus
+
+These can proceed against the v11.18.4 baseline and should not wait for a v12
+native desktop shell:
+
+- Unit A local PTT loop and personal SAGE integration;
+- versioned MeshCore availability and bounded artifact exchange;
+- encrypted logical public-proposal outbox and fresh-request adapter;
+- durable intake/quarantine and review service;
+- public query/cache labelling and expiry policy;
+- Data Donkey pack, catalogue, trust, revocation, custody and swarm protocols;
+- Foundation, Field Operations, and Lantern user consoles;
+- fleet capability, command, consent, telemetry and receipt contracts; and
+- hardware inventory, resource, thermal, power and two-unit acceptance evidence.
+
+## Explicit non-promises
+
+Unless separately designed, implemented, reviewed, and accepted, neither v12 nor
+this contract promises:
+
+- app-v27 or a consensus-native hyperlocal schema;
+- remote federation Write;
+- a long-lived state-sync receiver as a public observer;
+- first-class multiple SAGE instances on one device;
+- per-record AppHash inclusion proofs for a derived public export;
+- remote SAGE Admin/Root operation from a field console;
+- validator participation by Lantern, Knowledge Point, or Data Donkey; or
+- automatic movement of private memories into Commons, packs, telemetry, or a
+  Return Pouch.
+
+## Change control
+
+Every Commons/Lantern roadmap item that names a SAGE capability must link to one
+of the crosswalk rows above and carry one state:
+
+- `available-v11.18.4`;
+- `required-sage-v12`;
+- `commons-lantern-owned`;
+- `future-consensus-proposal`; or
+- `unsupported-do-not-use`.
+
+Changing a row's owner or state requires review by both SAGE core and the
+Commons/Lantern product owner. Product copy may not promote `planned`,
+`future-consensus-proposal`, or `unsupported-do-not-use` into a shipped claim.
+
+## Joint roadmap operating cadence
+
+The two programmes maintain one rolling dependency register with three horizons:
+
+1. **Current compatibility:** exact released SAGE baseline, immutable evidence,
+   supported Commons/Lantern use, and known limitations.
+2. **Accepted delivery:** dependencies with an owner, target gate, interface or
+   RFC, migration plan, negative-authority tests, and acceptance evidence.
+3. **Research horizon:** candidate consensus, federation, proof, hardware, and
+   distribution capabilities that remain non-promises until promoted through
+   the normal review path.
+
+Review occurs at every SAGE release that changes a relied-upon contract, every
+Commons programme gate, and at least quarterly while either roadmap is active.
+The review records exact versions, capability-state changes, unresolved
+decisions, deprecations, security/sovereignty impact, and the next evidence
+owner. A failed or missing cross-programme review blocks the affected capability
+claim, not unrelated personal SAGE or Lantern work.

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.17. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.18. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -34,7 +34,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.17 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.18 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -205,7 +205,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.17)
+## Related docs (reconciled through v11.18.18)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.17.
+Status: implementation contract through SAGE v11.18.18.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.17 authorization layer is off-consensus and does not require
+The current v11.18.18 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.17 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.18 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.17/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.18/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.17. Legacy organization/federation sections retain
+Verified against SAGE v11.18.18. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.17. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.18. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.17**.
+and is **not in v11.18.18**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.17. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.18. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.17 code (2026-08-17). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.18 code (2026-08-17). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.17.
+Reconciled against internal/mcp for SAGE v11.18.18.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.17. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.18. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.17
+**Package:** `sage-agent-sdk` **Version:** 11.18.18
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.17. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.18. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.17 lineage implementation (2026-08-17). -->
+<!-- Verified against SAGE v11.18.18 lineage implementation (2026-08-17). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -334,8 +334,8 @@ test('connectome guidance is reachable without adding another floating panel', (
 test('connectome exposes persistent, keyboard-reachable agent identity details', () => {
   assert.match(mriSource, /<aside class="agent-inspector" aria-label="Connectome agent details" aria-hidden="true">/,
     'selected details must be a labelled nonmodal landmark');
-  assert.match(mriSource, /<select class="ai-select" aria-label="Browse agents">/,
-    'canvas-only neurons need a keyboard and touch selection path');
+  assert.match(mriSource, /<select class="ai-select" aria-label="Browse connected visible agents">/,
+    'connected visible neurons need a compact keyboard and touch selection path');
   assert.match(mriSource, /<button type="button" class="ai-close" aria-label="Close agent details">/,
     'persistent details need a real accessible close button');
   assert.match(mriSource, /class="tip" role="tooltip" aria-hidden="true"/,
@@ -346,6 +346,21 @@ test('connectome exposes persistent, keyboard-reachable agent identity details',
     'Escape must dismiss a selected agent');
   assert.match(mriSource, /subs\.push\(\(\)=>document\.removeEventListener\('keydown',onKeyDown\)\)/,
     'the global Escape listener must be cleaned up with the renderer');
+});
+
+test('connectome makes neuron clicks primary and keeps the fallback picker connection-scoped', () => {
+  assert.match(mriSource, /Click a neuron for details, or choose a connected visible agent/,
+    'the visible instruction must lead with direct neuron interaction');
+  assert.match(mriSource, /n\.isNeuron && n\.agent_id && \(\(n\._peers \|\| 0\) > 0 \|\| n\.agent_id === selectedAgentID\)/,
+    'the fallback picker must exclude dormant roster noise while preserving a selected isolated neuron');
+  assert.match(mriSource, /nodes\.sort\(\(a,b\)=>\(b\._w\|\|0\)-\(a\._w\|\|0\)\|\|agentName\(a\)\.localeCompare\(agentName\(b\)\)\)/,
+    'connected agents must be ordered by visible traffic before name');
+  assert.match(mriSource, /const nodeVal = n => n\.isNeuron\s*\? 3\.0 \+ \(n\._deg\|\|0\)\*7/,
+    'even dormant neurons need a practical minimum canvas click target');
+  assert.match(mriSource, /\.onNodeClick\([^\n]*selectNeuron\(n\)/,
+    'clicking the enlarged neuron must enter the persistent detail and relationship path');
+  assert.match(mriSource, /selectedAgentID = n\.agent_id; selectedAgentNode = n;[\s\S]{0,300}populateAgentPicker\(rendered\);[\s\S]{0,100}\$\('\.ai-select'\)\.value = selectedAgentID/,
+    'a clicked isolated neuron must be added to the picker before it becomes the keyboard return target');
 });
 
 test('directed-link inspection anchors the sender unless an endpoint is already selected', () => {

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -60,7 +60,7 @@ test('release-facing version metadata stays aligned', () => {
     ['deploy/federation-acceptance/README.md', `# v${version} federation Docker acceptance`],
     ['docs/FEDERATION.md', `Verified against SAGE v${version} federation behavior`],
     ['docs/reference/concepts/message-reply-lifecycle.md', `SAGE v${version} code`],
-    ['docs/UPGRADING.md', `| v${version} | Durable primary stdio claimant identity`],
+    ['docs/UPGRADING.md', `| v${version} | Byte-exact automatic Codex lifecycle-hook self-healing`],
     ['docs/ROADMAP.md', `## v${version} patch`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.17 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.18 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.17"
+version = "11.18.18"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.17"
+__version__ = "11.18.18"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.17",
+  "version": "11.18.18",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.17",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.18",
       "transport": {
         "type": "stdio"
       }

--- a/web/appv23_agent_lifecycle_test.go
+++ b/web/appv23_agent_lifecycle_test.go
@@ -23,6 +23,26 @@ import (
 	"github.com/l33tdawg/sage/internal/tx"
 )
 
+func TestAppV23RejectPendingRegistrationCannotReportHTTPConflictAsSuccess(t *testing.T) {
+	apiBytes, err := os.ReadFile("static/js/api.js")
+	require.NoError(t, err)
+	api := string(apiBytes)
+	start := strings.Index(api, "export async function removeAgent")
+	require.NotEqual(t, -1, start)
+	end := strings.Index(api[start:], "\n}\n")
+	require.NotEqual(t, -1, end)
+	removeAgentClient := api[start : start+end]
+
+	assert.Contains(t, removeAgentClient, "return appV23AccessRequest(")
+	assert.NotContains(t, removeAgentClient, "return res.json()")
+
+	appBytes, err := os.ReadFile("static/js/app.js")
+	require.NoError(t, err)
+	app := string(appBytes)
+	assert.Contains(t, app, "e.code === 'agent_has_memories'")
+	assert.Contains(t, app, "Deprecate them or transfer their domains before rejecting the identity.")
+}
+
 func TestAppV23RemoveCommitsDeactivationAndGroupCleanupBeforeSQLProjection(t *testing.T) {
 	fixture := newAppV23AccessFixture(t)
 	require.NoError(t, fixture.badger.MutateAppV23AccessGroup(

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -503,10 +503,9 @@ export async function updateAgent(id, data) {
 
 export async function removeAgent(id, force = false) {
     const q = force ? '?force=true' : '';
-    const res = await fetch(`${API_BASE}/v1/dashboard/network/agents/${id}${q}`, {
+    return appV23AccessRequest(`/v1/dashboard/network/agents/${encodeURIComponent(id)}${q}`, {
         method: 'DELETE',
     });
-    return res.json();
 }
 
 export async function downloadBundle(id) {

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.17';
+const SAGE_VERSION = 'v11.18.18';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace
@@ -9557,7 +9557,10 @@ function AppV23AccessControl() {
             await load();
             if (onDirectoryChanged) await onDirectoryChanged();
         } catch (e) {
-            showToast(e.message || 'The registration could not be rejected.', 'error', 9000);
+            const message = e.code === 'agent_has_memories'
+                ? 'This registration still owns historical memories. Deprecate them or transfer their domains before rejecting the identity.'
+                : e.message || 'The registration could not be rejected.';
+            showToast(message, 'error', 9000);
         } finally {
             setRejectBusy(false);
             endMutation(mutationKey);

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -181,6 +181,7 @@ const STYLE = `
 .mrib .tip .hint{margin-top:6px;color:#39d0ff;font-size:10px}
 .mrib .agent-browser{display:none;position:absolute;top:16px;right:16px;width:min(340px,calc(100% - 32px));z-index:8;padding:8px;background:rgba(10,16,28,.9);border:1px solid #15233b;border-radius:10px;backdrop-filter:blur(10px);box-shadow:0 8px 30px #0007}
 .mrib .agent-browser.visible{display:block}
+.mrib .agent-browser-hint{margin:0 0 6px;color:#9fb6d8;font-size:10px;letter-spacing:.35px}
 .mrib .agent-inspector{display:none;position:absolute;top:68px;right:16px;width:min(340px,calc(100% - 32px));max-height:calc(100% - 148px);overflow:auto;z-index:8;padding:14px;background:rgba(10,16,28,.92);border:1px solid #15233b;border-radius:12px;backdrop-filter:blur(10px);box-shadow:0 12px 44px #0009}
 .mrib .agent-inspector.visible{display:block}
 .mrib.with-domain-legend .agent-browser{left:16px;right:auto;top:82px}.mrib.with-domain-legend .agent-inspector{left:16px;right:auto;top:134px;max-height:calc(100% - 214px)}
@@ -398,7 +399,7 @@ export function mountMriBrain(container, opts = {}) {
       ${allowConnectome ? '<button type="button" class="btn b-mode" aria-label="Connectome view" aria-pressed="false">◉ connectome</button>' : ''}
       <label class="sld">skull <input class="b-op" type="range" min="0" max="60" value="8"></label>
     </div>
-    <div class="agent-browser" aria-hidden="true"><select class="ai-select" aria-label="Browse agents"><option value="">Browse agents…</option></select></div>
+    <div class="agent-browser" aria-hidden="true"><div class="agent-browser-hint">Click a neuron for details, or choose a connected visible agent</div><select class="ai-select" aria-label="Browse connected visible agents"><option value="">Connected visible agents…</option></select></div>
     <aside class="agent-inspector" aria-label="Connectome agent details" aria-hidden="true">
       <div class="ai-selected">
         <div class="ai-head"><span class="ai-neuron"></span><div class="ai-heading"><div class="ai-kicker">Selected agent</div><div class="ai-name"></div><div class="ai-role"></div><div class="ai-live">Snapshot</div></div><button type="button" class="ai-close" aria-label="Close agent details">×</button></div>
@@ -505,7 +506,7 @@ export function mountMriBrain(container, opts = {}) {
   // Memory nodes size by corroboration+confidence+freshness; neurons size by
   // degree (total traffic) so hubs read as large cells, plus a transient birth swell.
   const nodeVal = n => n.isNeuron
-    ? 1.6 + (n._deg||0)*7 + neuronBirthGlow(n)*4
+    ? 3.0 + (n._deg||0)*7 + neuronBirthGlow(n)*4
     : 1.4 + (n.corroboration_count||0)*1.1 + (n.confidence||0)*0.8 + (n._fresh||0)*2.2;
   function nodeColorRGBA(n){
     // Focus mode: everything outside the clicked node's neighbourhood fades back.
@@ -805,11 +806,17 @@ export function mountMriBrain(container, opts = {}) {
   }
   function populateAgentPicker(d){
     const select = $('.ai-select'); if (!select) return;
-    const nodes = (d && Array.isArray(d.nodes) ? d.nodes : []).filter(n => n.isNeuron && n.agent_id);
-    select.innerHTML = '<option value="">Browse agents…</option>';
-    nodes.sort((a,b)=>agentName(a).localeCompare(agentName(b))).forEach(n => {
+    // The graph itself remains the complete authorized neuron surface. The
+    // compact fallback picker is intentionally limited to agents with at least
+    // one visible retained connection, so a large roster of dormant/test
+    // identities does not become the primary navigation UI. Preserve an
+    // already-selected isolated neuron across live snapshot refreshes.
+    const nodes = (d && Array.isArray(d.nodes) ? d.nodes : []).filter(n =>
+      n.isNeuron && n.agent_id && ((n._peers || 0) > 0 || n.agent_id === selectedAgentID));
+    select.innerHTML = '<option value="">Connected visible agents…</option>';
+    nodes.sort((a,b)=>(b._w||0)-(a._w||0)||agentName(a).localeCompare(agentName(b))).forEach(n => {
       const option = document.createElement('option');
-      option.value = n.agent_id; option.textContent = `${agentName(n)} · ${n.agent_id}`;
+      option.value = n.agent_id; option.textContent = `${agentName(n)} · ${fmtN(n._peers)} peer${n._peers===1?'':'s'}`;
       select.appendChild(option);
     });
     select.value = selectedAgentID || '';
@@ -883,6 +890,10 @@ export function mountMriBrain(container, opts = {}) {
     inspector.setAttribute('aria-hidden', mode === 'connectome' && chosen ? 'false' : 'true');
     if (!chosen) return;
     selectedAgentID = n.agent_id; selectedAgentNode = n;
+    // A clicked isolated neuron is intentionally absent from the compact
+    // connected-agent picker until selected. Rebuild after selection so Close,
+    // Escape, and live refreshes still have a coherent keyboard return target.
+    populateAgentPicker(rendered);
     $('.ai-select').value = selectedAgentID;
     $('.ai-neuron').style.background = domainColor(n.domain);
     $('.ai-neuron').style.color = domainColor(n.domain);


### PR DESCRIPTION
## Summary
- make Codex MCP startup compare every installer-owned hook against the current fully rendered bytes, repairing stale no-op project hooks after an app upgrade
- make CEREBRUM agent removal surface consensus conflicts instead of reporting false success
- make Connectome neurons easier to click and scope the fallback picker to connected visible agents, with relationship details and docs
- align v11.18.18 release metadata and retain the reviewed security/Claude tooling cleanup

## Verification
- `node --test scripts/version-alignment.test.mjs scripts/connectome-mapping.test.mjs` (46 passed)
- `npm test -- --runInBand` (401 passed)
- `env GOCACHE=/private/tmp/sage-gocache go test ./cmd/sage-gui -run TestSelfHealCodex`
- `go vet ./cmd/sage-gui ./web`
- `git diff --check`
- focused CEREBRUM agent lifecycle regression passed as part of `./web`; the full package run reached one workspace-hygiene guard failure because tracked Claude worktrees under `.claude/worktrees` are scanned as duplicate production sources

## Release note
No App-v27 consensus bump is required; these are installer, UI, and release-contract changes.