### PR TITLE
v11.18.19: isolate global hooks and fix Connectome clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.19
+
+**Codex project hooks stay inside their project.** The v11.18.18 byte-exact
+self-healer could mistake Codex's user-global `~/.codex` configuration directory
+for a project and generate a global `hooks.json`. That made an unrelated Codex
+task receive SAGE inbox Stop nudges for the shared agent identity. The healer now
+refuses the user-home/global scope; project-local hooks continue to self-repair.
+
+**Connectome clicks now have one hit-tested owner.** The redundant DOM click
+fallback that raced ForceGraph's deferred node click is gone. Small pointer
+wobble is handled by one explicit tolerance, background dismissal uses the
+graph's raycast result, and clicking a second neuron no longer closes the
+inspector and starts a competing zoom-out first. Raw domain-access metadata is
+summarized behind a bounded disclosure below traffic, relationships, and memory
+details; bloomed memory nodes now expose hover and accessible click feedback.
+
+This patch introduces no new consensus application version or state migration.
+The ceiling remains app-v26; **v11.18.19 introduces no app-v27**.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.19`. SDK 11.18.19.
+
 ## What's New in v11.18.18
 
 **Codex upgrades now repair stale SAGE lifecycle hooks automatically.** On
@@ -1959,7 +1980,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.18`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.19`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/SECURITY_FAQ.md
+++ b/SECURITY_FAQ.md
@@ -11,7 +11,7 @@ SAGE has two distinct deployment models with fundamentally different threat mode
 | **Who** | One user, one local operator | Multiple agents, teams, organizations |
 | **Trust model** | User IS the only validator | Byzantine fault tolerance across validators |
 | **Database** | Local BadgerDB/SQLite stores in `~/.sage/data/` | BadgerDB consensus state plus off-chain mirror |
-| **Release** | v11.18.18 personal-node surface | v11.18.18 quorum/federation surface |
+| **Release** | v11.18.19 personal-node surface | v11.18.19 quorum/federation surface |
 
 Many concerns raised about the enterprise codebase do not apply to SAGE Personal, and vice versa. Each item below is tagged with which deployment it affects.
 
@@ -108,7 +108,7 @@ The `make byzantine` target and GitHub Actions CI job spin up a 4-validator Dock
 
 The following boundaries describe the current v11 codebase:
 
-**SAGE Personal (sage-gui v11.18.18):**
+**SAGE Personal (sage-gui v11.18.19):**
 - Designed for one operator. The management dashboard/API remains a local surface; anyone with access to the operator session or machine should be treated as trusted.
 - Federation is an explicit network-facing feature, off by default. When enabled it uses a separate pinned-mTLS listener, active on-chain treaty checks, chain-qualified signed requests, and replay protection. That authenticated protocol now runs over libp2p NAT traversal and Circuit Relay v2; the relay sees encrypted traffic and connection metadata, not plaintext memories or federation keys.
 - SQLite database supports optional AES-256-GCM encryption at rest (Synaptic Ledger). Enable from CEREBRUM Settings → Security.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.18
+  version: 11.18.19
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/cmd/sage-gui/codex.go
+++ b/cmd/sage-gui/codex.go
@@ -501,6 +501,15 @@ func installAgentsMD(projectDir string) error {
 //   - .codex/config.toml references a stale binary path
 //   - .codex/hooks.json missing (legacy installs predate it)
 func selfHealCodex(projectDir, sageHome string, identityOverrides ...string) {
+	// ~/.codex is Codex's user-global configuration directory, not a project
+	// install. Treating $HOME as a workspace makes hooks.json global, so a SAGE
+	// Stop hook created while one task happens to run from $HOME is then applied
+	// to every unrelated Codex task. Project hooks must never be self-healed into
+	// that scope. The global MCP registration remains valid; only project-side
+	// lifecycle artifacts are excluded here.
+	if userHome, err := os.UserHomeDir(); err == nil && sameFilesystemPath(projectDir, userHome) {
+		return
+	}
 	identityOverride := ""
 	if len(identityOverrides) > 0 {
 		identityOverride = identityOverrides[0]

--- a/cmd/sage-gui/codex_test.go
+++ b/cmd/sage-gui/codex_test.go
@@ -187,6 +187,27 @@ func TestSelfHealCodex_NoOpWhenNoCodexDir(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "self-heal must not create .codex/ when it doesn't exist")
 }
 
+func TestSelfHealCodex_NeverCreatesGlobalHooksUnderUserHome(t *testing.T) {
+	userHome := t.TempDir()
+	sageHome := t.TempDir()
+	t.Setenv("HOME", userHome)
+
+	// A normal global Codex installation already has ~/.codex/config.toml.
+	// Its presence must not be mistaken for evidence of a project-local SAGE
+	// install, because ~/.codex/hooks.json is loaded by every unrelated task.
+	codexDir := filepath.Join(userHome, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "config.toml"),
+		[]byte("[mcp_servers.sage]\ncommand = \"sage-gui\"\n"), 0600))
+
+	selfHealCodex(userHome, sageHome)
+
+	_, hooksErr := os.Stat(filepath.Join(codexDir, "hooks.json"))
+	assert.True(t, os.IsNotExist(hooksErr), "self-heal must never create global Codex hooks")
+	_, scriptsErr := os.Stat(filepath.Join(codexDir, "hooks"))
+	assert.True(t, os.IsNotExist(scriptsErr), "self-heal must never create global hook scripts")
+}
+
 func TestSelfHealCodex_RepairsMissingHooksJSON(t *testing.T) {
 	projectDir, sageHome := withCodexInstallEnv(t)
 	require.NoError(t, runCodexInstall())

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.18-acceptance
+ARG VERSION=v11.18.19-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.18 federation Docker acceptance
+# v11.18.19 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.18-acceptance
+        VERSION: v11.18.19-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.18"
+version = "11.18.19"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.18"
+version = "11.18.19"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.18",
+  "version": "11.18.19",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.18/app-v26. -->
+<!-- Reconciled through SAGE v11.18.19/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.18 federation behavior. -->
+<!-- Verified against SAGE v11.18.19 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.18
+# sage-gui v11.18.19
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.18 advertises 33 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.19 advertises 33 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.18 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.19 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -71,13 +71,33 @@ after an OS liveness lock proves the prior runtime is gone, while concurrent
 runtimes remain independently fenced. v11.18.18 makes the Codex startup
 self-healer compare every fully rendered lifecycle hook and makes Connectome
 neurons the primary agent-detail navigation surface, with a compact
-relationship-only fallback selector. The supported consensus ceiling remains
-app-v26; **v11.18.18 does not introduce app-v27**.
+relationship-only fallback selector. v11.18.19 prevents Codex project-hook
+self-healing from ever targeting the user-global `~/.codex` scope and removes
+the Connectome's competing DOM/ForceGraph click paths while bounding raw access
+metadata and making bloomed memories responsive. The supported consensus
+ceiling remains app-v26; **v11.18.19 does not introduce app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.19 patch
+
+Codex self-healing now rejects the user-home/global configuration scope before
+inspecting or creating lifecycle artifacts. A normal global MCP registration
+therefore cannot grow a global Stop hook that injects one project's durable
+inbox work into unrelated tasks. Existing project-local byte-exact repair is
+unchanged.
+
+The Connectome now routes node, link, and background clicks through the graph
+library's raycast result with one explicit six-pixel pointer tolerance. The
+hit-test-free DOM fallback and its stale timing heuristic are removed. Primary
+traffic, connection, and memory details render before domain-access metadata;
+large raw values remain available inside a bounded disclosure, tooltips are
+clamped, and bloomed memory nodes provide hover and accessible click feedback.
+This patch introduces no new consensus application version or state migration:
+app-v26 remains the ceiling and v11.18.19 does not introduce app-v27.
 
 ## v11.18.18 patch
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -109,6 +109,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.16 | Unfinished-message wake and passive exact-session claim visibility in `sage_inbox`, payload-free hook parity for claimed work, and fail-soft compatibility when that additive projection is unavailable; no automatic ownership transfer; no new app version; app-v26 remains the ceiling |
 | v11.18.17 | Durable primary stdio claimant identity scoped by exact agent/provider/project, OS-lock liveness fencing across ordinary restarts, distinct concurrent-session ownership, and installed-runtime identity carry-forward; pre-v11.18.17 claims still require explicit CAS handoff; no new app version; app-v26 remains the ceiling |
 | v11.18.18 | Byte-exact automatic Codex lifecycle-hook self-healing plus click-first CEREBRUM Connectome agent details, larger neuron targets, and a relationship-scoped fallback selector; no new app version; app-v26 remains the ceiling |
+| v11.18.19 | Global-scope Codex hook isolation, single-owner hit-tested Connectome clicks, bounded domain-access details, and responsive bloomed memory nodes; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.18. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.19. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -34,7 +34,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.18 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.19 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -205,7 +205,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.18)
+## Related docs (reconciled through v11.18.19)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.18.
+Status: implementation contract through SAGE v11.18.19.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.18 authorization layer is off-consensus and does not require
+The current v11.18.19 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.18 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.19 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.18/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.19/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.18. Legacy organization/federation sections retain
+Verified against SAGE v11.18.19. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.18. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.19. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.18**.
+and is **not in v11.18.19**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.18. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.19. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.18 code (2026-08-17). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.19 code (2026-08-17). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.18.
+Reconciled against internal/mcp for SAGE v11.18.19.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.18. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.19. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.18
+**Package:** `sage-agent-sdk` **Version:** 11.18.19
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.18. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.19. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.18 lineage implementation (2026-08-17). -->
+<!-- Verified against SAGE v11.18.19 lineage implementation (2026-08-17). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/scripts/connectome-engrams.test.mjs
+++ b/scripts/connectome-engrams.test.mjs
@@ -276,12 +276,16 @@ test('the 50ms deep-link bloom timer is tracked and cleared on dispose', () => {
     'the deep-link timer must be cleared in cleanup');
 });
 
-test('only a NEURON click blooms engrams — clicking a bloomed engram does not re-bloom', () => {
+test('only a NEURON click blooms engrams while a bloomed engram responds without re-blooming', () => {
   // clicking an engram (a memory node) must not re-run bloomEngrams with a memory
   // id as ?agent, which would strip the lobe and leave a focus ring on a removed
   // node. Guard: connectome click blooms only when n.isNeuron.
-  assert.match(mriSource, /mode==='connectome'\)\s*\{\s*if \(n\.isNeuron\) selectNeuron\(n\); \}\s*else exploreNode\(n\)/,
-    'connectome click must select only neurons; selectNeuron owns the single bloom while memory mode keeps exploreNode');
+  assert.match(mriSource, /mode==='connectome'\)\s*\{\s*if \(n\.isNeuron\) selectNeuron\(n\); else if\(n\._engram\) announceEngram\(n\); \}\s*else exploreNode\(n\)/,
+    'connectome click must select only neurons while engrams acknowledge the click without triggering another bloom');
+  assert.match(mriSource, /if \(n\._engram\) \{[\s\S]{0,500}Memory in the selected agent’s visible lobe/,
+    'bloomed memories must expose a visible hover response');
+  assert.match(mriSource, /function announceEngram\(n\)[\s\S]{0,250}status\.textContent=/,
+    'bloomed memory clicks must produce an accessible response');
   const selectBody = functionBody(mriSource, 'selectNeuron');
   assert.match(selectBody, /bloomEngrams\(n\)/, 'one selection must preserve the existing engram bloom');
 });

--- a/scripts/connectome-mapping.test.mjs
+++ b/scripts/connectome-mapping.test.mjs
@@ -363,6 +363,34 @@ test('connectome makes neuron clicks primary and keeps the fallback picker conne
     'a clicked isolated neuron must be added to the picker before it becomes the keyboard return target');
 });
 
+test('connectome click dispatch has one hit-tested owner and tolerates small pointer drift', () => {
+  assert.doesNotMatch(mriSource, /root\.addEventListener\('click'/,
+    'a DOM click fallback races ForceGraph deferred hit-testing and must not dismiss a real node click');
+  assert.match(mriSource, /\.clickAfterDrag\(true\)/,
+    'ForceGraph must deliver the candidate click so the renderer can apply its explicit tolerance');
+  const body = bracedBlock(mriSource, 'function graphClickWithinTolerance').body;
+  const withinTolerance = new Function('e', 'graphPointerDown', body);
+  assert.equal(withinTolerance({ clientX:102, clientY:101 }, { x:100, y:100 }), true,
+    'a two-pixel mouse wobble must still select the neuron');
+  assert.equal(withinTolerance({ clientX:110, clientY:100 }, { x:100, y:100 }), false,
+    'a real orbit drag must not become a click');
+  assert.match(mriSource, /\.onBackgroundClick\(e=>\{ if\(graphClickWithinTolerance\(e\)\) exitFocus\(\); \}\)/,
+    'only the graph library raycast may classify a background click');
+});
+
+test('connectome bounds domain metadata and keeps traffic ahead of optional raw policy', () => {
+  const traffic = mriSource.indexOf('<div class="ai-label">Visible retained traffic</div>');
+  const domain = mriSource.indexOf('<div class="ai-label">Domain access metadata</div>');
+  assert.ok(traffic !== -1 && domain > traffic,
+    'raw access metadata must not bury the primary traffic and relationship details');
+  assert.match(mriSource, /<details class="ai-domain-details"><summary class="ai-domain"><\/summary><pre class="ai-domain-full"><\/pre><\/details>/,
+    'the full access value must remain available behind an explicit bounded disclosure');
+  assert.match(mriSource, /\.ai-domain-full\{max-height:180px;overflow:auto/,
+    'expanded policy metadata must scroll inside a bounded region');
+  assert.match(mriSource, /agentDomainSummary\(n\)/,
+    'the inspector and hover path must use the bounded domain summary');
+});
+
 test('directed-link inspection anchors the sender unless an endpoint is already selected', () => {
   const body = bracedBlock(mriSource, 'function selectDirectedLink').body;
   const inspect = new Function(
@@ -514,7 +542,8 @@ test('agent tooltip is clamped, escaped, and includes identity plus visible traf
   const show = mriSource.slice(showStart, showEnd);
   assert.match(show, /escapeHtml\(agentName\(n\)\)/);
   assert.match(show, /escapeHtml\(agentRole\(n\)\)/);
-  assert.match(show, /escapeHtml\(agentDomain\(n\)\)/);
+  assert.match(show, /escapeHtml\(agentDomainSummary\(n\)\)/,
+    'the tooltip must never render unbounded raw access metadata');
   assert.match(show, /escapeHtml\(id\)/, 'canonical agent identity must be escaped');
   assert.match(show, /n\._incoming/); assert.match(show, /n\._outgoing/); assert.match(show, /n\._peers/);
   const positionStart = mriSource.indexOf('function positionTip(');

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -60,7 +60,7 @@ test('release-facing version metadata stays aligned', () => {
     ['deploy/federation-acceptance/README.md', `# v${version} federation Docker acceptance`],
     ['docs/FEDERATION.md', `Verified against SAGE v${version} federation behavior`],
     ['docs/reference/concepts/message-reply-lifecycle.md', `SAGE v${version} code`],
-    ['docs/UPGRADING.md', `| v${version} | Byte-exact automatic Codex lifecycle-hook self-healing`],
+    ['docs/UPGRADING.md', `| v${version} | Global-scope Codex hook isolation`],
     ['docs/ROADMAP.md', `## v${version} patch`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.18 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.19 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.18"
+version = "11.18.19"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.18"
+__version__ = "11.18.19"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.18",
+  "version": "11.18.19",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.18",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.19",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.18';
+const SAGE_VERSION = 'v11.18.19';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace

--- a/web/static/js/mri-brain.js
+++ b/web/static/js/mri-brain.js
@@ -174,7 +174,7 @@ const STYLE = `
 .mrib .scan{position:absolute;top:16px;left:16px;padding:10px 14px}
 .mrib .scan b{color:#eaf4ff;font-size:14px;letter-spacing:.5px}
 .mrib .scan .s{color:#39d0ff;font-size:11px;letter-spacing:2px;margin-top:4px}
-.mrib .tip{position:absolute;pointer-events:none;display:none;max-width:280px;padding:8px 11px;background:rgba(6,11,20,.96);border:1px solid #15233b;border-radius:9px;z-index:9;font-size:12px}
+.mrib .tip{position:absolute;pointer-events:none;display:none;max-width:280px;max-height:min(320px,calc(100% - 16px));overflow:hidden;padding:8px 11px;background:rgba(6,11,20,.96);border:1px solid #15233b;border-radius:9px;z-index:9;font-size:12px}
 .mrib .tip .h{color:#eaf4ff;font-weight:700;margin-bottom:2px}
 .mrib .tip .m{color:#5d7395;font-size:11px}
 .mrib .tip .chip{font-size:10px;padding:1px 6px;border-radius:6px;background:#0e1b30;color:#aecbf0;margin-right:4px}
@@ -191,6 +191,7 @@ const STYLE = `
 .mrib .ai-close{width:40px;height:40px;margin:-8px -8px 0 0;border:0;border-radius:9px;background:transparent;color:#9fb6d8;cursor:pointer;font:20px/1 sans-serif}.mrib .ai-close:hover{background:#0e1b30;color:#eaf4ff}
 .mrib .ai-select{min-width:0;width:100%;padding:8px 10px;color:#dceaff;background:#081221;border:1px solid #203455;border-radius:8px;font:12px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
 .mrib .ai-section{border-top:1px solid #15233b;padding-top:10px;margin-top:10px}.mrib .ai-label{color:#5d7395;font-size:10px;letter-spacing:1.2px;text-transform:uppercase;margin-bottom:3px}.mrib .ai-value{color:#dceaff;font-size:12px;overflow-wrap:anywhere}.mrib .ai-id-row{display:flex;gap:8px;align-items:flex-start}.mrib .ai-id{flex:1;color:#aecbf0;font-size:11px;word-break:break-all}.mrib .ai-copy,.mrib .ai-retry{border:1px solid #203455;border-radius:7px;background:transparent;color:#39d0ff;cursor:pointer;font:10px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;padding:4px 7px}.mrib .ai-copy:hover,.mrib .ai-retry:hover{background:#0e1b30}
+.mrib .ai-domain-details summary{cursor:pointer;color:#dceaff;font-size:12px;overflow-wrap:anywhere}.mrib .ai-domain-full{max-height:180px;overflow:auto;white-space:pre-wrap;word-break:break-word;padding:8px;border-radius:7px;background:#081221;color:#9fb6d8;font-size:10px}
 .mrib .ai-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;margin-top:8px}.mrib .ai-stat{padding:8px;border-radius:8px;background:rgba(14,27,48,.62)}.mrib .ai-stat b{display:block;color:#eaf4ff;font-size:14px}.mrib .ai-stat span{color:#5d7395;font-size:9px;letter-spacing:.8px;text-transform:uppercase}.mrib .ai-memory{color:#9fb6d8;font-size:11px}.mrib .ai-memory.error{color:#ff9aa5}.mrib .ai-memory-title{color:#dceaff;font-size:11px;margin:6px 0 2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.mrib .ai-empty{color:#5d7395;font-size:11px}
 .mrib .ai-live{display:inline-flex;align-items:center;gap:5px;color:#5ee2a0;font-size:10px;margin-top:5px}.mrib .ai-live:before{content:'';width:6px;height:6px;border-radius:50%;background:currentColor;box-shadow:0 0 8px currentColor}.mrib .ai-live.updating{color:#f6c85f}.mrib .ai-live.unavailable{color:#ff9aa5}
 .mrib .ai-connections{display:grid;gap:6px}.mrib .ai-connection{width:100%;display:grid;grid-template-columns:minmax(0,1fr) auto;gap:3px 8px;text-align:left;padding:8px;border:1px solid #15233b;border-radius:8px;background:rgba(14,27,48,.48);color:#dceaff;cursor:pointer;font:11px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}.mrib .ai-connection:hover,.mrib .ai-connection.selected{background:#0e2943;border-color:#39d0ff}.mrib .ai-connection .peer{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:600}.mrib .ai-connection .counts{color:#aecbf0;white-space:nowrap}.mrib .ai-connection .last{grid-column:1/-1;color:#5d7395;font-size:10px}.mrib .ai-connections-empty{color:#5d7395;font-size:11px}
@@ -404,10 +405,11 @@ export function mountMriBrain(container, opts = {}) {
       <div class="ai-selected">
         <div class="ai-head"><span class="ai-neuron"></span><div class="ai-heading"><div class="ai-kicker">Selected agent</div><div class="ai-name"></div><div class="ai-role"></div><div class="ai-live">Snapshot</div></div><button type="button" class="ai-close" aria-label="Close agent details">×</button></div>
         <div class="ai-section"><div class="ai-label">Agent ID</div><div class="ai-id-row"><code class="ai-id"></code><button type="button" class="ai-copy">Copy</button></div></div>
-        <div class="ai-section"><div class="ai-label">Domain</div><div class="ai-value ai-domain"></div><div class="ai-label" style="margin-top:8px">Last retained message activity</div><div class="ai-value ai-activity"></div></div>
+        <div class="ai-section"><div class="ai-label">Last retained message activity</div><div class="ai-value ai-activity"></div></div>
         <div class="ai-section"><div class="ai-label">Visible retained traffic</div><div class="ai-grid"><div class="ai-stat"><b class="ai-in">0</b><span>Incoming</span></div><div class="ai-stat"><b class="ai-out">0</b><span>Outgoing</span></div><div class="ai-stat"><b class="ai-total">0</b><span>Total</span></div><div class="ai-stat"><b class="ai-peers">0</b><span>Connected agents</span></div></div><div class="ai-value ai-strongest" style="margin-top:8px"></div></div>
         <div class="ai-section"><div class="ai-label">Visible retained connections</div><div class="ai-connections"></div></div>
         <div class="ai-section"><div class="ai-label">Visible memory lobe</div><div class="ai-memory"></div></div>
+        <div class="ai-section"><div class="ai-label">Domain access metadata</div><details class="ai-domain-details"><summary class="ai-domain"></summary><pre class="ai-domain-full"></pre></details></div>
       </div>
     </aside>
     <div class="tip" role="tooltip" aria-hidden="true"></div>
@@ -749,7 +751,7 @@ export function mountMriBrain(container, opts = {}) {
 
   const reduceMotion = !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
   let Graph = null, controls = null, disposed = false, flow = !reduceMotion, scanning = !reduceMotion;
-  let lastNodeClickAt = 0, graphPointerDown = null;
+  let graphPointerDown = null;
   let selectedAgentID = null, selectedAgentNode = null;
   let selectedConnectionPeerID = null, selectedSnapshotAt = 0;
   let selectedMemoryState = null;
@@ -786,6 +788,11 @@ export function mountMriBrain(container, opts = {}) {
   const agentName = n => String((n && (n.label || n.agent_id)) || 'Unknown agent');
   const agentRole = n => String((n && n.role) || 'Unknown role');
   const agentDomain = n => String((n && n.agent_domain) || 'No domain');
+  function agentDomainSummary(n){
+    const raw=agentDomain(n);
+    if(raw.length<=120) return raw;
+    return `${raw.slice(0,117)}… · ${raw.length.toLocaleString()} characters`;
+  }
   function activityLabel(value){
     if (!value) return 'No recorded retained activity';
     const at = new Date(value);
@@ -898,7 +905,9 @@ export function mountMriBrain(container, opts = {}) {
     $('.ai-neuron').style.background = domainColor(n.domain);
     $('.ai-neuron').style.color = domainColor(n.domain);
     $('.ai-name').textContent = agentName(n); $('.ai-role').textContent = agentRole(n);
-    $('.ai-id').textContent = n.agent_id; $('.ai-domain').textContent = agentDomain(n);
+    const domain=agentDomain(n);
+    $('.ai-id').textContent = n.agent_id; $('.ai-domain').textContent = agentDomainSummary(n);
+    $('.ai-domain-full').textContent = domain;
     $('.ai-activity').textContent = activityLabel(n._activity);
     $('.ai-in').textContent = fmtN(n._incoming); $('.ai-out').textContent = fmtN(n._outgoing);
     $('.ai-total').textContent = fmtN(n._w); $('.ai-peers').textContent = fmtN(n._peers);
@@ -1436,9 +1445,10 @@ export function mountMriBrain(container, opts = {}) {
       .warmupTicks(1).cooldownTicks(6)
       .onNodeHover(showTip)
       .onLinkHover(showLinkTip)
-      .onNodeClick(n=>{ lastNodeClickAt = performance.now(); hideTip(); if (mode==='connectome') { if (n.isNeuron) selectNeuron(n); } else exploreNode(n); })
-      .onLinkClick(l=>{ lastNodeClickAt=performance.now(); hideTip(); if(mode==='connectome') selectDirectedLink(l); })
-      .onBackgroundClick(()=>{ exitFocus(); });
+      .clickAfterDrag(true)
+      .onNodeClick((n,e)=>{ if(!graphClickWithinTolerance(e)) return; hideTip(); if (mode==='connectome') { if (n.isNeuron) selectNeuron(n); else if(n._engram) announceEngram(n); } else exploreNode(n); })
+      .onLinkClick((l,e)=>{ if(!graphClickWithinTolerance(e)) return; hideTip(); if(mode==='connectome') selectDirectedLink(l); })
+      .onBackgroundClick(e=>{ if(graphClickWithinTolerance(e)) exitFocus(); });
 
     // Positions are pinned by placeNodes() (fx/fy/fz), so disable the force
     // simulation entirely — zero per-tick cost regardless of node count.
@@ -1710,10 +1720,15 @@ export function mountMriBrain(container, opts = {}) {
       tip.innerHTML=`<div class="h">${escapeHtml((n.label||'').slice(0,90))}</div><div class="m">${escapeHtml(n.domain)} · ${escapeHtml(n.memory_type||'—')} · ${escapeHtml(n.status)}</div><div style="margin-top:5px"><span class="chip">conf ${(+n.confidence).toFixed(2)}</span><span class="chip">corroborated ×${n.corroboration_count|0}</span></div>`;
       positionTip(); return;
     }
+    if (n._engram) {
+      tip.style.display='block'; tip.setAttribute('aria-hidden','false');
+      tip.innerHTML=`<div class="h">${escapeHtml((n.label||n.memory_id||'Visible memory').slice(0,90))}</div><div class="m">Memory · ${escapeHtml(n.domain||'unknown')} · ${escapeHtml(n.memory_type||n.status||'committed')}</div><div class="hint">Memory in the selected agent’s visible lobe</div>`;
+      positionTip(); return;
+    }
     if (!n.isNeuron) { hideTip(); return; }
     const id=String(n.agent_id||'Unknown agent'), short=id.length>30?id.slice(0,14)+'…'+id.slice(-10):id;
     tip.style.display='block'; tip.setAttribute('aria-hidden','false');
-    tip.innerHTML=`<div class="h"><span class="dot" style="width:8px;height:8px;background:${domainColor(n.domain)};margin-right:7px"></span>${escapeHtml(agentName(n))}</div><div class="m">Agent · ${escapeHtml(agentRole(n))} · ${escapeHtml(agentDomain(n))}</div><div class="m" title="${escapeHtml(id)}">${escapeHtml(short)}</div>
+    tip.innerHTML=`<div class="h"><span class="dot" style="width:8px;height:8px;background:${domainColor(n.domain)};margin-right:7px"></span>${escapeHtml(agentName(n))}</div><div class="m">Agent · ${escapeHtml(agentRole(n))} · ${escapeHtml(agentDomainSummary(n))}</div><div class="m" title="${escapeHtml(id)}">${escapeHtml(short)}</div>
       <div style="margin-top:5px"><span class="chip">in ${fmtN(n._incoming)}</span><span class="chip">out ${fmtN(n._outgoing)}</span><span class="chip">${fmtN(n._peers)} peers</span></div><div class="m" style="margin-top:5px">${escapeHtml(activityLabel(n._activity))}</div><div class="hint">Click for agent details</div>`;
     positionTip();
   }
@@ -1744,15 +1759,15 @@ export function mountMriBrain(container, opts = {}) {
     hideTip();
     graphPointerDown = { x: e.clientX, y: e.clientY };
   }
-  function onGraphClick(e){
-    if (!focusId || isPanelTarget(e.target)) return;
-    if (performance.now() - lastNodeClickAt < 350) return;
-    if (graphPointerDown && Math.hypot(e.clientX - graphPointerDown.x, e.clientY - graphPointerDown.y) > 6) return;
-    exitFocus();
+  function graphClickWithinTolerance(e){
+    return !graphPointerDown || !e || Math.hypot(e.clientX-graphPointerDown.x,e.clientY-graphPointerDown.y)<=6;
+  }
+  function announceEngram(n){
+    const status=$('.sr-status');
+    if(status) status.textContent=`Visible memory ${n.label||n.memory_id||'without a title'} in ${agentName(selectedAgentNode)}’s lobe.`;
   }
   root.addEventListener('pointermove', onMove, true);
   root.addEventListener('pointerdown', onGraphPointerDown);
-  root.addEventListener('click', onGraphClick);
   // Relabel the stat panel and expose mode-specific guidance through the
   // existing reading panel. Mode changes are announced without placing another
   // visible panel over the graph.
@@ -1840,7 +1855,6 @@ export function mountMriBrain(container, opts = {}) {
     subs.forEach(u => { try { u && u(); } catch(e){ /* noop */ } });
     root.removeEventListener('pointermove', onMove, true);
     root.removeEventListener('pointerdown', onGraphPointerDown);
-    root.removeEventListener('click', onGraphClick);
     try {
       if (focusMarker && focusMarker.parent) focusMarker.parent.remove(focusMarker);
       if (focusMarker && focusMarker.material) focusMarker.material.dispose();


### PR DESCRIPTION
## Summary
- prevent Codex self-healing from generating SAGE lifecycle hooks under the user-global `~/.codex` scope
- remove the Connectome DOM click race and use one ForceGraph hit-tested path with bounded pointer tolerance
- bound raw domain-access metadata, prioritize relationships, and make bloomed memories responsive
- align v11.18.19 release metadata and notes

## Validation
- `env GOCACHE=/private/tmp/sage-gocache go test ./cmd/sage-gui -count=1`
- `npm test` (403/403)
- focused Connectome suite (108/108)
- `git diff --check`

## Live cleanup
The mistakenly generated global `~/.codex/hooks.json` and its SAGE-only script directory were quarantined locally under `~/.codex/sage-global-hooks-quarantine-v11.18.18/`; the project-local hooks remain active.