### PR TITLE
fix(cerebrum): keep verified MRI above inventory errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.21
+
+**A domain-summary refresh can no longer cover a verified MRI graph.** The MRI
+renderer is now the sole authority for the central unavailable overlay. Domain
+inventory failures stay localized to their own retrying panel, while genuine
+cold graph failures and unsafe mode switches remain fail-closed.
+
+This patch introduces no new consensus application version or state migration.
+The ceiling remains app-v26; **v11.18.21 introduces no app-v27**.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.21`. SDK 11.18.21.
+
 ## What's New in v11.18.20
 
 **A transient MRI refresh no longer hides a graph CEREBRUM has already
@@ -1994,7 +2006,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.20`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.21`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/SECURITY_FAQ.md
+++ b/SECURITY_FAQ.md
@@ -11,7 +11,7 @@ SAGE has two distinct deployment models with fundamentally different threat mode
 | **Who** | One user, one local operator | Multiple agents, teams, organizations |
 | **Trust model** | User IS the only validator | Byzantine fault tolerance across validators |
 | **Database** | Local BadgerDB/SQLite stores in `~/.sage/data/` | BadgerDB consensus state plus off-chain mirror |
-| **Release** | v11.18.20 personal-node surface | v11.18.20 quorum/federation surface |
+| **Release** | v11.18.21 personal-node surface | v11.18.21 quorum/federation surface |
 
 Many concerns raised about the enterprise codebase do not apply to SAGE Personal, and vice versa. Each item below is tagged with which deployment it affects.
 
@@ -108,7 +108,7 @@ The `make byzantine` target and GitHub Actions CI job spin up a 4-validator Dock
 
 The following boundaries describe the current v11 codebase:
 
-**SAGE Personal (sage-gui v11.18.20):**
+**SAGE Personal (sage-gui v11.18.21):**
 - Designed for one operator. The management dashboard/API remains a local surface; anyone with access to the operator session or machine should be treated as trusted.
 - Federation is an explicit network-facing feature, off by default. When enabled it uses a separate pinned-mTLS listener, active on-chain treaty checks, chain-qualified signed requests, and replay protection. That authenticated protocol now runs over libp2p NAT traversal and Circuit Relay v2; the relay sees encrypted traffic and connection metadata, not plaintext memories or federation keys.
 - SQLite database supports optional AES-256-GCM encryption at rest (Synaptic Ledger). Enable from CEREBRUM Settings → Security.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.20
+  version: 11.18.21
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.20-acceptance
+ARG VERSION=v11.18.21-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.20 federation Docker acceptance
+# v11.18.21 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.20-acceptance
+        VERSION: v11.18.21-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.20"
+version = "11.18.21"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.20"
+version = "11.18.21"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.20",
+  "version": "11.18.21",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.20/app-v26. -->
+<!-- Reconciled through SAGE v11.18.21/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.20 federation behavior. -->
+<!-- Verified against SAGE v11.18.21 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.20
+# sage-gui v11.18.21
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.20 advertises 33 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.21 advertises 33 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.20 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.21 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -72,16 +72,30 @@ runtimes remain independently fenced. v11.18.18 makes the Codex startup
 self-healer compare every fully rendered lifecycle hook and makes Connectome
 neurons the primary agent-detail navigation surface, with a compact
 relationship-only fallback selector. v11.18.20 also keeps a last verified MRI
-snapshot visible across a transient same-mode refresh failure. v11.18.19 prevents Codex project-hook
+snapshot visible across a transient same-mode refresh failure. v11.18.21 makes
+that renderer the sole authority for the central unavailable overlay, so an
+independent domain-inventory refresh failure cannot cover a verified graph.
+v11.18.19 prevents Codex project-hook
 self-healing from ever targeting the user-global `~/.codex` scope and removes
 the Connectome's competing DOM/ForceGraph click paths while bounding raw access
 metadata and making bloomed memories responsive. The supported consensus
-ceiling remains app-v26; **v11.18.20 does not introduce app-v27**.
+ceiling remains app-v26; **v11.18.21 does not introduce app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.21 patch
+
+The central MRI unavailable overlay now follows only the renderer's verified
+graph state. The independent domain inventory continues to report and retry its
+own failures locally, but can no longer cover a safe graph that is already on
+screen. Genuine cold graph failures and failed Memory/Connectome switches keep
+their existing fail-closed behavior.
+
+This patch introduces no new consensus application version or state migration:
+app-v26 remains the ceiling and v11.18.21 does not introduce app-v27.
 
 ## v11.18.20 patch
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -111,6 +111,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.18 | Byte-exact automatic Codex lifecycle-hook self-healing plus click-first CEREBRUM Connectome agent details, larger neuron targets, and a relationship-scoped fallback selector; no new app version; app-v26 remains the ceiling |
 | v11.18.19 | Global-scope Codex hook isolation, single-owner hit-tested Connectome clicks, bounded domain-access details, and responsive bloomed memory nodes; no new app version; app-v26 remains the ceiling |
 | v11.18.20 | Same-mode verified MRI snapshot retention across transient refresh failures, with cold and cross-mode failures still fail-closed; no new app version; app-v26 remains the ceiling |
+| v11.18.21 | MRI-renderer authority for the central unavailable overlay, with independent domain-inventory failures localized to their own retrying panel; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.20. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.21. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -34,7 +34,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.20 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.21 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -205,7 +205,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.20)
+## Related docs (reconciled through v11.18.21)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.20.
+Status: implementation contract through SAGE v11.18.21.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.20 authorization layer is off-consensus and does not require
+The current v11.18.21 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.20 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.21 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.20/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.21/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.20. Legacy organization/federation sections retain
+Verified against SAGE v11.18.21. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.20. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.21. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.20**.
+and is **not in v11.18.21**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.20. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.21. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.20 code (2026-08-17). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.21 code (2026-08-17). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.20.
+Reconciled against internal/mcp for SAGE v11.18.21.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.20. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.21. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.20
+**Package:** `sage-agent-sdk` **Version:** 11.18.21
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.20. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.21. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.20 lineage implementation (2026-08-17). -->
+<!-- Verified against SAGE v11.18.21 lineage implementation (2026-08-17). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -60,7 +60,7 @@ test('release-facing version metadata stays aligned', () => {
     ['deploy/federation-acceptance/README.md', `# v${version} federation Docker acceptance`],
     ['docs/FEDERATION.md', `Verified against SAGE v${version} federation behavior`],
     ['docs/reference/concepts/message-reply-lifecycle.md', `SAGE v${version} code`],
-    ['docs/UPGRADING.md', `| v${version} | Same-mode verified MRI snapshot retention`],
+    ['docs/UPGRADING.md', `| v${version} | MRI-renderer authority for the central unavailable overlay`],
     ['docs/ROADMAP.md', `## v${version} patch`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.20 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.21 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.20"
+version = "11.18.21"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.20"
+__version__ = "11.18.21"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.20",
+  "version": "11.18.21",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.20",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.21",
       "transport": {
         "type": "stdio"
       }

--- a/web/appv23_projection_cold_ui_test.go
+++ b/web/appv23_projection_cold_ui_test.go
@@ -69,6 +69,23 @@ func TestMRIRefreshFailureKeepsSameModeVerifiedSnapshotVisible(t *testing.T) {
 	assert.Contains(t, mri, "graphAvailabilityAfterFailure(")
 }
 
+func TestMRIOverlayAuthorityDoesNotFollowDomainInventoryFailure(t *testing.T) {
+	appBytes, err := os.ReadFile("static/js/app.js")
+	require.NoError(t, err)
+	app := string(appBytes)
+
+	mriStart := strings.Index(app, "function MriView")
+	require.NotEqual(t, -1, mriStart)
+	mriEnd := strings.Index(app[mriStart:], "\n// Global tooltips state")
+	require.NotEqual(t, -1, mriEnd)
+	mri := app[mriStart : mriStart+mriEnd]
+
+	assert.Contains(t, mri,
+		"const memoryViewUnavailable = graphAvailability === 'unavailable'")
+	assert.NotContains(t, mri,
+		"const memoryViewUnavailable = projectionAvailability === 'unavailable'")
+}
+
 func TestMemoryListClientCarriesOpaqueContinuation(t *testing.T) {
 	apiBytes, err := os.ReadFile("static/js/api.js")
 	require.NoError(t, err)

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1180,8 +1180,11 @@ function MriView({ sse }) {
     const noLocalMemories = inventory && inventory.localMemoryTotal === 0;
     const hasSharedDomains = inventory && inventory.sharedDomains.length > 0;
     const partialProjection = projectionAvailability === 'partial';
-    const memoryViewUnavailable = projectionAvailability === 'unavailable' ||
-        graphAvailability === 'unavailable';
+    // The MRI renderer is the authority for whether the central graph is safe
+    // to show. Domain inventory has its own localized unavailable panel; letting
+    // that independent stats request drive this overlay can cover a verified,
+    // already-rendered graph after a transient sidebar refresh failure.
+    const memoryViewUnavailable = graphAvailability === 'unavailable';
     const showingMemoryView = mriMode === 'memory';
     return html`<div class="mri-wrap">
         <div class="mri-stage" ref=${ref}></div>

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.20';
+const SAGE_VERSION = 'v11.18.21';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
## Summary
- make the MRI renderer the sole authority for the central unavailable overlay
- keep domain-inventory failures localized to the domain panel
- add a regression test preventing the sidebar availability signal from covering a verified graph

## Evidence
- reproduced in Chrome on v11.18.20: populated domain inventory and rendered MRI were covered by the hard unavailable overlay
- installed static assets are v11.18.20 and served with no-store, ruling out stale browser assets
- local `/ready` reports a record-local quarantined projection while broad verified serving remains allowed

## Tests
- `npm test` (405 passed)
- `env GOCACHE=/private/tmp/sage-gocache go test ./web`