### PR TITLE
fix(codex): prevent Stop hook exit 127

### DIFF
--- a/cmd/sage-gui/codex.go
+++ b/cmd/sage-gui/codex.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -102,7 +103,7 @@ func installCodexConfig(projectDir, sageHome, execPath string) ([]web.ConnectFil
 	// vars in hook commands, so we bake the absolute hook dir path in.
 	hooksPath := filepath.Join(codexDir, "hooks.json")
 	hooksAction := fileAction(hooksPath)
-	hooksConfig := map[string]any{"hooks": sageHooksConfig(hookDir)}
+	hooksConfig := map[string]any{"hooks": sageCodexHooksConfig(hookDir)}
 	hooksData, _ := json.MarshalIndent(hooksConfig, "", "  ")
 	if writeErr := safeWriteFile(hooksPath, append(hooksData, '\n'), 0600); writeErr != nil {
 		return files, fmt.Errorf("write hooks.json: %w", writeErr)
@@ -558,7 +559,10 @@ func selfHealCodex(projectDir, sageHome string, identityOverrides ...string) {
 	}
 
 	hooksJSONPath := filepath.Join(codexDir, "hooks.json")
-	if _, statErr := os.Stat(hooksJSONPath); os.IsNotExist(statErr) {
+	hooksConfig := map[string]any{"hooks": sageCodexHooksConfig(hookDir)}
+	hooksData, _ := json.MarshalIndent(hooksConfig, "", "  ")
+	hooksData = append(hooksData, '\n')
+	if currentHooks, readErr := os.ReadFile(hooksJSONPath); readErr != nil || !bytes.Equal(currentHooks, hooksData) {
 		needsRewrite = true
 	}
 
@@ -585,9 +589,7 @@ func selfHealCodex(projectDir, sageHome string, identityOverrides ...string) {
 		return
 	}
 
-	hooksConfig := map[string]any{"hooks": sageHooksConfig(hookDir)}
-	hooksData, _ := json.MarshalIndent(hooksConfig, "", "  ")
-	if writeErr := os.WriteFile(hooksJSONPath, append(hooksData, '\n'), 0600); writeErr != nil {
+	if writeErr := os.WriteFile(hooksJSONPath, hooksData, 0600); writeErr != nil {
 		fmt.Fprintf(os.Stderr, "SAGE: codex self-heal hooks.json: %v\n", writeErr)
 		return
 	}

--- a/cmd/sage-gui/codex.go
+++ b/cmd/sage-gui/codex.go
@@ -103,9 +103,15 @@ func installCodexConfig(projectDir, sageHome, execPath string) ([]web.ConnectFil
 	// vars in hook commands, so we bake the absolute hook dir path in.
 	hooksPath := filepath.Join(codexDir, "hooks.json")
 	hooksAction := fileAction(hooksPath)
-	hooksConfig := map[string]any{"hooks": sageCodexHooksConfig(hookDir)}
-	hooksData, _ := json.MarshalIndent(hooksConfig, "", "  ")
-	if writeErr := safeWriteFile(hooksPath, append(hooksData, '\n'), 0600); writeErr != nil {
+	existingHooks, readErr := os.ReadFile(hooksPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return files, fmt.Errorf("read hooks.json: %w", readErr)
+	}
+	hooksData, mergeErr := renderMergedCodexHooks(existingHooks, hookDir)
+	if mergeErr != nil {
+		return files, mergeErr
+	}
+	if writeErr := safeWriteFile(hooksPath, hooksData, 0600); writeErr != nil {
 		return files, fmt.Errorf("write hooks.json: %w", writeErr)
 	}
 	files = append(files, web.ConnectFile{Path: hooksPath, Action: hooksAction})
@@ -132,6 +138,25 @@ func installCodexConfig(projectDir, sageHome, execPath string) ([]web.ConnectFil
 	syncMemoryModeFlag(sageHome)
 
 	return files, nil
+}
+
+// renderMergedCodexHooks replaces only SAGE-owned hook entries. Users may
+// keep other lifecycle hooks and top-level settings in the same file.
+func renderMergedCodexHooks(existing []byte, hookDir string) ([]byte, error) {
+	document := make(map[string]any)
+	if len(bytes.TrimSpace(existing)) > 0 {
+		if err := json.Unmarshal(existing, &document); err != nil {
+			return nil, fmt.Errorf("existing Codex hooks.json is invalid JSON; fix it before connecting SAGE: %w", err)
+		}
+	}
+	currentHooks := document["hooks"]
+	shell := resolveCodexBash(installedSageHookShell(currentHooks, hookDir))
+	document["hooks"] = mergeSageHooksConfigWithShell(currentHooks, hookDir, shell)
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal hooks.json: %w", err)
+	}
+	return append(data, '\n'), nil
 }
 
 // codexConfigTemplate is the TOML written to .codex/config.toml. Codex
@@ -559,10 +584,17 @@ func selfHealCodex(projectDir, sageHome string, identityOverrides ...string) {
 	}
 
 	hooksJSONPath := filepath.Join(codexDir, "hooks.json")
-	hooksConfig := map[string]any{"hooks": sageCodexHooksConfig(hookDir)}
-	hooksData, _ := json.MarshalIndent(hooksConfig, "", "  ")
-	hooksData = append(hooksData, '\n')
-	if currentHooks, readErr := os.ReadFile(hooksJSONPath); readErr != nil || !bytes.Equal(currentHooks, hooksData) {
+	currentHooks, hooksReadErr := os.ReadFile(hooksJSONPath)
+	if hooksReadErr != nil && !os.IsNotExist(hooksReadErr) {
+		fmt.Fprintf(os.Stderr, "SAGE: codex self-heal read hooks.json: %v\n", hooksReadErr)
+		return
+	}
+	hooksData, hooksMergeErr := renderMergedCodexHooks(currentHooks, hookDir)
+	if hooksMergeErr != nil {
+		fmt.Fprintf(os.Stderr, "SAGE: codex self-heal hooks.json: %v\n", hooksMergeErr)
+		return
+	}
+	if hooksReadErr != nil || !bytes.Equal(currentHooks, hooksData) {
 		needsRewrite = true
 	}
 

--- a/cmd/sage-gui/codex_test.go
+++ b/cmd/sage-gui/codex_test.go
@@ -304,7 +304,7 @@ func TestCodexHookCommandRunsWithEmptyPATH(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "ran")
 	script := filepath.Join(hookDir, "sage-session-start.sh")
 	require.NoError(t, os.WriteFile(script, []byte("printf ok > \""+marker+"\"\n"), 0755))
-	hooks := sageCodexHooksConfigWithShell(hookDir, shell)
+	hooks := sageHooksConfigWithShell(hookDir, shell)
 	command := hookCommand(t, hooks, "SessionStart")
 	cmd := exec.Command("/bin/sh", "-c", command) //nolint:gosec // generated fixture command
 	cmd.Env = []string{"PATH="}
@@ -315,7 +315,7 @@ func TestCodexHookCommandRunsWithEmptyPATH(t *testing.T) {
 }
 
 func TestCodexHookCommandQuotesShellPathsWithSpaces(t *testing.T) {
-	hooks := sageCodexHooksConfigWithShell("C:/tmp/hooks", "C:/Program Files/Git/bin/bash.exe")
+	hooks := sageHooksConfigWithShell("C:/tmp/hooks", "C:/Program Files/Git/bin/bash.exe")
 	assert.Equal(t, `"C:/Program Files/Git/bin/bash.exe" "C:/tmp/hooks/sage-session-start.sh"`, hookCommand(t, hooks, "SessionStart"))
 }
 

--- a/cmd/sage-gui/codex_test.go
+++ b/cmd/sage-gui/codex_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -57,8 +59,11 @@ func TestRunCodexInstall_WritesAllArtifacts(t *testing.T) {
 	}
 	// Hook commands must use absolute paths (Codex doesn't expand env vars).
 	assert.Contains(t, string(hooksData), filepath.Join(projectDir, ".codex", "hooks"))
-	assert.Contains(t, string(hooksData), `/bin/bash \"`, "Codex hooks must not depend on launcher PATH")
-	assert.NotContains(t, string(hooksData), `"command": "bash `)
+	expectedShell := resolveCodexBash("")
+	assert.Contains(t, hookCommand(t, hooks, "SessionStart"), expectedShell, "Codex hooks must use the resolved shell")
+	if filepath.IsAbs(expectedShell) {
+		assert.NotContains(t, string(hooksData), `"command": "bash `, "Codex hooks must not depend on launcher PATH")
+	}
 	assert.NotContains(t, string(hooksData), "${CLAUDE_PROJECT_DIR}")
 
 	// 5 hook scripts present and templated.
@@ -231,16 +236,110 @@ func TestSelfHealCodex_RewritesPathDependentHooksJSON(t *testing.T) {
 	hooksJSONPath := filepath.Join(projectDir, ".codex", "hooks.json")
 	hooksData, err := os.ReadFile(hooksJSONPath)
 	require.NoError(t, err)
-	legacy := strings.ReplaceAll(string(hooksData), `/bin/bash \"`, `bash \"`)
-	require.NotEqual(t, string(hooksData), legacy)
-	require.NoError(t, os.WriteFile(hooksJSONPath, []byte(legacy), 0600))
+	var document map[string]any
+	require.NoError(t, json.Unmarshal(hooksData, &document))
+	hooks := document["hooks"].(map[string]any)
+	for _, event := range hooks {
+		entries, ok := event.([]any)
+		if !ok {
+			continue
+		}
+		for _, entryValue := range entries {
+			entry := entryValue.(map[string]any)
+			for _, hookValue := range entry["hooks"].([]any) {
+				hook := hookValue.(map[string]any)
+				command := hook["command"].(string)
+				if isInstalledSageHookCommand(command, filepath.Join(projectDir, ".codex", "hooks")) {
+					hook["command"] = "bash" + command[strings.Index(command, " "):]
+				}
+			}
+		}
+	}
+	customStop := map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "custom-tool", "timeout": float64(9)}}}
+	hooks["Stop"] = append(hooks["Stop"].([]any), customStop)
+	hooks["Notification"] = []any{map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "notify-tool"}}}}
+	document["customSetting"] = "keep-me"
+	legacy, err := json.MarshalIndent(document, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(hooksJSONPath, append(legacy, '\n'), 0600))
 
 	selfHealCodex(projectDir, sageHome)
 
 	healed, err := os.ReadFile(hooksJSONPath)
 	require.NoError(t, err)
-	assert.Contains(t, string(healed), `/bin/bash \"`)
-	assert.NotContains(t, string(healed), `"command": "bash `)
+	var healedDocument map[string]any
+	require.NoError(t, json.Unmarshal(healed, &healedDocument))
+	healedHooks := healedDocument["hooks"].(map[string]any)
+	assert.Equal(t, "keep-me", healedDocument["customSetting"])
+	assert.Contains(t, healedHooks, "Notification", "custom hook events must survive self-heal")
+	assert.Contains(t, string(healed), "custom-tool", "custom hooks under SAGE events must survive self-heal")
+	assert.Contains(t, hookCommand(t, healedHooks, "SessionStart"), resolveCodexBash(""))
+}
+
+func TestRunCodexInstall_PreservesExistingCustomHooks(t *testing.T) {
+	projectDir, _ := withCodexInstallEnv(t)
+	codexDir := filepath.Join(projectDir, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0755))
+	existing := `{"customSetting":true,"hooks":{"Stop":[{"hooks":[{"type":"command","command":"custom-tool"}]}],"Notification":[{"hooks":[{"type":"command","command":"notify-tool"}]}]}}`
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(existing), 0600))
+
+	require.NoError(t, runCodexInstall())
+
+	data, err := os.ReadFile(filepath.Join(codexDir, "hooks.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "custom-tool")
+	assert.Contains(t, string(data), "notify-tool")
+	assert.Contains(t, string(data), `"customSetting": true`)
+}
+
+func TestCodexHookCommandRunsWithEmptyPATH(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command execution assertion is Unix-specific")
+	}
+	shell := resolveCodexBash("")
+	if !filepath.IsAbs(shell) {
+		t.Skip("bash was not resolvable to an absolute path")
+	}
+	hookDir := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "ran")
+	script := filepath.Join(hookDir, "sage-session-start.sh")
+	require.NoError(t, os.WriteFile(script, []byte("printf ok > \""+marker+"\"\n"), 0755))
+	hooks := sageCodexHooksConfigWithShell(hookDir, shell)
+	command := hookCommand(t, hooks, "SessionStart")
+	cmd := exec.Command("/bin/sh", "-c", command) //nolint:gosec // generated fixture command
+	cmd.Env = []string{"PATH="}
+	require.NoError(t, cmd.Run())
+	data, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", string(data))
+}
+
+func TestCodexHookCommandQuotesShellPathsWithSpaces(t *testing.T) {
+	hooks := sageCodexHooksConfigWithShell("C:/tmp/hooks", "C:/Program Files/Git/bin/bash.exe")
+	assert.Equal(t, `"C:/Program Files/Git/bin/bash.exe" "C:/tmp/hooks/sage-session-start.sh"`, hookCommand(t, hooks, "SessionStart"))
+}
+
+func TestRenderMergedCodexHooksRejectsInvalidJSON(t *testing.T) {
+	_, err := renderMergedCodexHooks([]byte(`{"hooks":`), t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON")
+}
+
+func hookCommand(t *testing.T, hooks map[string]any, event string) string {
+	t.Helper()
+	entries, ok := hooks[event].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, entries)
+	entry, ok := entries[0].(map[string]any)
+	require.True(t, ok)
+	commands, ok := entry["hooks"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, commands)
+	hook, ok := commands[0].(map[string]any)
+	require.True(t, ok)
+	command, ok := hook["command"].(string)
+	require.True(t, ok)
+	return command
 }
 
 // expectExecutable returns the cleaned, symlink-resolved path of the test

--- a/cmd/sage-gui/codex_test.go
+++ b/cmd/sage-gui/codex_test.go
@@ -57,6 +57,8 @@ func TestRunCodexInstall_WritesAllArtifacts(t *testing.T) {
 	}
 	// Hook commands must use absolute paths (Codex doesn't expand env vars).
 	assert.Contains(t, string(hooksData), filepath.Join(projectDir, ".codex", "hooks"))
+	assert.Contains(t, string(hooksData), `/bin/bash \"`, "Codex hooks must not depend on launcher PATH")
+	assert.NotContains(t, string(hooksData), `"command": "bash `)
 	assert.NotContains(t, string(hooksData), "${CLAUDE_PROJECT_DIR}")
 
 	// 5 hook scripts present and templated.
@@ -220,6 +222,25 @@ func TestSelfHealCodex_RepairsMissingHooksJSON(t *testing.T) {
 
 	_, err := os.Stat(hooksJSONPath)
 	assert.NoError(t, err, "self-heal should repair missing hooks.json")
+}
+
+func TestSelfHealCodex_RewritesPathDependentHooksJSON(t *testing.T) {
+	projectDir, sageHome := withCodexInstallEnv(t)
+	require.NoError(t, runCodexInstall())
+
+	hooksJSONPath := filepath.Join(projectDir, ".codex", "hooks.json")
+	hooksData, err := os.ReadFile(hooksJSONPath)
+	require.NoError(t, err)
+	legacy := strings.ReplaceAll(string(hooksData), `/bin/bash \"`, `bash \"`)
+	require.NotEqual(t, string(hooksData), legacy)
+	require.NoError(t, os.WriteFile(hooksJSONPath, []byte(legacy), 0600))
+
+	selfHealCodex(projectDir, sageHome)
+
+	healed, err := os.ReadFile(hooksJSONPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(healed), `/bin/bash \"`)
+	assert.NotContains(t, string(healed), `"command": "bash `)
 }
 
 // expectExecutable returns the cleaned, symlink-resolved path of the test

--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -935,23 +935,10 @@ func installClaudeMD(projectDir string) error {
 // (the env var is expanded by Claude Code at hook firing time); Codex
 // installs pass the absolute path because Codex doesn't expand its own env
 // vars in hook commands.
-func sageHooksConfig(hookDirExpr string) map[string]any {
-	return sageHooksConfigWithShell(hookDirExpr, "bash")
-}
-
-// sageCodexHooksConfig resolves Bash while the installer still has its normal
-// environment. Codex CLI hook processes can inherit a restricted PATH from
-// their launcher, so persisting the absolute executable avoids exit 127. The
-// resolver retains a previously installed absolute shell when available,
-// which keeps non-FHS and Windows Git Bash installs stable during self-heal.
-func sageCodexHooksConfig(hookDirExpr string) map[string]any {
-	return sageCodexHooksConfigWithShell(hookDirExpr, resolveCodexBash(""))
-}
-
-func sageCodexHooksConfigWithShell(hookDirExpr, shell string) map[string]any {
-	return sageHooksConfigWithShell(hookDirExpr, shell)
-}
-
+// resolveCodexBash resolves Bash while the installer still has its normal
+// environment. Codex hook processes can inherit a restricted PATH, so the
+// absolute executable is persisted. A valid prior absolute path is retained
+// for stable non-FHS and Windows Git Bash self-healing.
 func resolveCodexBash(preferred string) string {
 	if filepath.IsAbs(preferred) {
 		if info, err := os.Stat(preferred); err == nil && !info.IsDir() {

--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -939,19 +939,91 @@ func sageHooksConfig(hookDirExpr string) map[string]any {
 	return sageHooksConfigWithShell(hookDirExpr, "bash")
 }
 
-// sageCodexHooksConfig uses an absolute shell path because Codex CLI hook
-// processes can inherit a restricted PATH from their launcher. A bare "bash"
-// then fails before the fail-open hook script starts, surfacing as exit 127.
+// sageCodexHooksConfig resolves Bash while the installer still has its normal
+// environment. Codex CLI hook processes can inherit a restricted PATH from
+// their launcher, so persisting the absolute executable avoids exit 127. The
+// resolver retains a previously installed absolute shell when available,
+// which keeps non-FHS and Windows Git Bash installs stable during self-heal.
 func sageCodexHooksConfig(hookDirExpr string) map[string]any {
-	return sageHooksConfigWithShell(hookDirExpr, "/bin/bash")
+	return sageCodexHooksConfigWithShell(hookDirExpr, resolveCodexBash(""))
+}
+
+func sageCodexHooksConfigWithShell(hookDirExpr, shell string) map[string]any {
+	return sageHooksConfigWithShell(hookDirExpr, shell)
+}
+
+func resolveCodexBash(preferred string) string {
+	if filepath.IsAbs(preferred) {
+		if info, err := os.Stat(preferred); err == nil && !info.IsDir() {
+			return preferred
+		}
+	}
+	if path, err := exec.LookPath("bash"); err == nil {
+		if absolute, absErr := filepath.Abs(path); absErr == nil {
+			return absolute
+		}
+		return path
+	}
+	for _, candidate := range []string{"/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash"} {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	// Preserve the historical fallback on platforms where Bash is supplied by
+	// the eventual host environment but cannot be resolved during installation.
+	return "bash"
+}
+
+func installedSageHookShell(existing any, hookDirExpr string) string {
+	events, ok := existing.(map[string]any)
+	if !ok {
+		return ""
+	}
+	for _, entriesValue := range events {
+		entries, ok := entriesValue.([]any)
+		if !ok {
+			continue
+		}
+		for _, entryValue := range entries {
+			entry, ok := entryValue.(map[string]any)
+			if !ok {
+				continue
+			}
+			hooks, ok := entry["hooks"].([]any)
+			if !ok {
+				continue
+			}
+			for _, hookValue := range hooks {
+				hook, ok := hookValue.(map[string]any)
+				if !ok {
+					continue
+				}
+				command, _ := hook["command"].(string)
+				if !isInstalledSageHookCommand(command, hookDirExpr) {
+					continue
+				}
+				for name := range hookScriptSet() {
+					suffix := ` "` + hookDirExpr + `/` + name + `"`
+					if strings.HasSuffix(command, suffix) {
+						return strings.Trim(strings.TrimSpace(strings.TrimSuffix(command, suffix)), `"`)
+					}
+				}
+			}
+		}
+	}
+	return ""
 }
 
 func sageHooksConfigWithShell(hookDirExpr, shell string) map[string]any {
+	shellCommand := shell
+	if strings.ContainsAny(shellCommand, " \t") {
+		shellCommand = `"` + strings.ReplaceAll(shellCommand, `"`, `\"`) + `"`
+	}
 	cmd := func(script string) []any {
 		return []any{
 			map[string]any{
 				"type":    "command",
-				"command": shell + " \"" + hookDirExpr + "/" + script + "\"",
+				"command": shellCommand + " \"" + hookDirExpr + "/" + script + "\"",
 				"timeout": 5,
 			},
 		}
@@ -996,13 +1068,17 @@ func sageHooksConfigWithShell(hookDirExpr, shell string) map[string]any {
 // mergeSageHooksConfig replaces only installer-owned SAGE hook entries and
 // preserves unrelated user hooks under the same Claude lifecycle events.
 func mergeSageHooksConfig(existing any, hookDirExpr string) map[string]any {
+	return mergeSageHooksConfigWithShell(existing, hookDirExpr, "bash")
+}
+
+func mergeSageHooksConfigWithShell(existing any, hookDirExpr, shell string) map[string]any {
 	merged := make(map[string]any)
 	if current, ok := existing.(map[string]any); ok {
 		for event, value := range current {
 			merged[event] = value
 		}
 	}
-	for event, desired := range sageHooksConfig(hookDirExpr) {
+	for event, desired := range sageHooksConfigWithShell(hookDirExpr, shell) {
 		var kept []any
 		if entries, ok := merged[event].([]any); ok {
 			for _, entry := range entries {
@@ -1044,12 +1120,12 @@ func mergeSageHooksConfig(existing any, hookDirExpr string) map[string]any {
 
 func isInstalledSageHookCommand(command, hookDirExpr string) bool {
 	for name := range hookScriptSet() {
-		if command == `bash "`+hookDirExpr+`/`+name+`"` {
+		if strings.HasSuffix(command, ` "`+hookDirExpr+`/`+name+`"`) {
 			return true
 		}
 	}
 	for _, name := range []string{legacyBootScriptName, legacyTurnScriptName} {
-		if command == `bash "`+hookDirExpr+`/`+name+`"` {
+		if strings.HasSuffix(command, ` "`+hookDirExpr+`/`+name+`"`) {
 			return true
 		}
 	}

--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -936,11 +936,22 @@ func installClaudeMD(projectDir string) error {
 // installs pass the absolute path because Codex doesn't expand its own env
 // vars in hook commands.
 func sageHooksConfig(hookDirExpr string) map[string]any {
+	return sageHooksConfigWithShell(hookDirExpr, "bash")
+}
+
+// sageCodexHooksConfig uses an absolute shell path because Codex CLI hook
+// processes can inherit a restricted PATH from their launcher. A bare "bash"
+// then fails before the fail-open hook script starts, surfacing as exit 127.
+func sageCodexHooksConfig(hookDirExpr string) map[string]any {
+	return sageHooksConfigWithShell(hookDirExpr, "/bin/bash")
+}
+
+func sageHooksConfigWithShell(hookDirExpr, shell string) map[string]any {
 	cmd := func(script string) []any {
 		return []any{
 			map[string]any{
 				"type":    "command",
-				"command": "bash \"" + hookDirExpr + "/" + script + "\"",
+				"command": shell + " \"" + hookDirExpr + "/" + script + "\"",
 				"timeout": 5,
 			},
 		}


### PR DESCRIPTION
## Summary
- resolve and persist the host Bash executable so restricted launcher PATHs cannot fail before the fail-open hook script starts
- preserve valid existing absolute shells for non-FHS and Windows Git Bash installations and quote paths containing spaces
- semantically merge installer-owned SAGE hooks while preserving custom hooks, events, and top-level JSON
- make Codex self-heal migrate stale hook commands without replacing the user-owned hooks file

## Verification
- full cmd/sage-gui test package passed
- generated hook command executed with PATH empty
- Windows cross-compile and go vet passed in independent exact-head review
- all required hosted checks passed at the reviewed pre-rebase head; the rebased patch series is byte-equivalent and hosted checks are rerunning