### PR TITLE
fix(mcp): scope durable retention labels to active work

### DIFF
--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1089,6 +1089,15 @@ Federated reply-event lookup uses
 `sage_message_status` deliberately returns no result body. To read what the
 recipient actually replied, use `sage_message_replies` below.
 
+For an actionable `workflow_status` of `pending` or `claimed`, the canonical
+far-future storage sentinel is presented as
+`retention:"durable_until_handled"` and `expires_at` is omitted. Terminal
+(`completed`, `expired`, or `failed`) and unknown workflow states never carry
+that retention label: they expose the stored `expires_at` value, even when it
+is far in the future. This keeps lifecycle state authoritative instead of
+describing already-finished work as waiting to be handled
+(`internal/mcp/tools.go`, `formatMessageRetention`).
+
 ---
 
 ### sage_message_replies
@@ -1182,7 +1191,7 @@ Each `items[]` entry:
 | `passive_reply` | bool | Always `true`. |
 | `requires_reply` | bool | Always `false`. Never reply to a reply. |
 | `requires_result` | bool | Always `false`. This is not an assignment owing a result. |
-| `retention` / `expires_at` | string | `retention:"durable_until_handled"` for a durable row; otherwise the row's expiry. |
+| `expires_at` | string | The row's stored expiry. Replies on this surface are `completed`, so they never carry `retention:"durable_until_handled"`, even if storage still contains the canonical far-future sentinel. |
 | `result_truncated`, `result_runes_returned`, `result_full_via` | bool/int/string | Present only when the reply exceeded `maxReplyResultRunes` (8,000 runes). A recipient can store up to 256 KiB (`store.MaxPipeContentBytes`), so an untruncated page could flood a context window. The untruncated text stays readable via `sage_message_history(folder="outbox")`, which `result_full_via` names. |
 | `foreign`, `destination_chain_id`, `recipient_agent` | bool/string/string | Present only for a reply that crossed a federation boundary. |
 
@@ -1858,6 +1867,13 @@ selects `COALESCE(result,'')`; `api/rest/pipe_handler.go` labels the surface
 Use `sage_message_replies` for the routine payload-free reply read; drop to
 `folder="outbox"` when you need the untruncated reply text, the original
 request, or non-completed workflow state.
+
+Retention presentation follows workflow state. Only actionable `pending` and
+`claimed` rows with the canonical far-future sentinel expose
+`retention:"durable_until_handled"` (and omit `expires_at`). `completed`,
+`expired`, `failed`, and unknown states expose their raw `expires_at` and never
+the retention label. The deprecated `sage_pipe_history` alias uses this same
+formatter and therefore has identical semantics.
 
 Rows remain available only while the normal transient pipeline retention period
 keeps them; use a memory or task for durable records.

--- a/internal/mcp/inbox_reply_pointer_test.go
+++ b/internal/mcp/inbox_reply_pointer_test.go
@@ -84,6 +84,7 @@ const inboxProbeNewestCompletedAt = "2026-08-08T00:05:00Z"
 // reply when no receiver-side work exists.
 func TestSageInboxReturnsThreadedRepliesInTheFirstPoll(t *testing.T) {
 	stub := &inboxReplyPointerStub{}
+	farFuture := farFutureMessageExpiry()
 	mux := http.NewServeMux()
 	empty := func(w http.ResponseWriter, r *http.Request) {
 		stub.record(r)
@@ -105,6 +106,7 @@ func TestSageInboxReturnsThreadedRepliesInTheFirstPoll(t *testing.T) {
 			"pipe_id": "msg-threaded", "to_agent": "reviewer", "replied_by": "reviewer",
 			"intent": "review", "result": "frozen hash is GO", "status": "completed",
 			"completed_at": inboxProbeNewestCompletedAt,
+			"expires_at":   farFuture,
 		}}, "count": 1})
 	})
 	ts := httptest.NewServer(mux)
@@ -131,6 +133,9 @@ func TestSageInboxReturnsThreadedRepliesInTheFirstPoll(t *testing.T) {
 	require.Equal(t, false, replies[0]["requires_reply"])
 	require.Equal(t, "data_only", replies[0]["authority"])
 	require.Equal(t, "agent_untrusted", replies[0]["trust"])
+	require.Equal(t, farFuture, replies[0]["expires_at"])
+	require.NotContains(t, replies[0], "retention",
+		"embedded completed replies must use the same terminal retention semantics")
 	require.Contains(t, response["message"], "reply_items")
 	require.Contains(t, response["message"], "data, not new work")
 

--- a/internal/mcp/message_replies_tools_test.go
+++ b/internal/mcp/message_replies_tools_test.go
@@ -96,11 +96,13 @@ func replyItems(result map[string]any) []map[string]any {
 // one explicit, advertised tool.
 func TestSageMessageRepliesReturnsTheRecipientsReplyToTheSender(t *testing.T) {
 	recorder := &replyResultsMux{}
+	farFuture := farFutureMessageExpiry()
 	s, agentID := newReplyResultsServer(t, recorder, []map[string]any{{
 		"pipe_id": "msg-1", "from_agent": "sender", "to_agent": "recipient",
 		"to_provider": "claude-code", "intent": "review", "result": "the recipient's answer",
 		"status": "completed", "created_at": "2026-08-08T00:00:00Z",
 		"completed_at": "2026-08-08T00:05:00Z", "journal_id": "journal-1",
+		"expires_at": farFuture,
 	}})
 
 	result, err := s.toolMessageReplies(context.Background(), map[string]any{})
@@ -113,6 +115,9 @@ func TestSageMessageRepliesReturnsTheRecipientsReplyToTheSender(t *testing.T) {
 	require.Equal(t, "completed", items[0]["status"])
 	require.Equal(t, "review", items[0]["intent"])
 	require.Equal(t, "2026-08-08T00:05:00Z", items[0]["completed_at"])
+	require.Equal(t, farFuture, items[0]["expires_at"])
+	require.NotContains(t, items[0], "retention",
+		"a completed reply is no longer durable until handled")
 	require.Equal(t, 1, response["count"])
 	require.Equal(t, true, response["passive_read"])
 

--- a/internal/mcp/message_retention_test.go
+++ b/internal/mcp/message_retention_test.go
@@ -1,0 +1,131 @@
+package mcp
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func farFutureMessageExpiry() string {
+	return time.Now().Add(90 * 365 * 24 * time.Hour).UTC().Format(time.RFC3339Nano)
+}
+
+func TestMessageRetentionFormatterRequiresActionableStatus(t *testing.T) {
+	farFuture := farFutureMessageExpiry()
+	nearFuture := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339Nano)
+	tests := []struct {
+		name          string
+		status        string
+		expiresAt     string
+		wantRetention bool
+	}{
+		{name: "pending sentinel", status: "pending", expiresAt: farFuture, wantRetention: true},
+		{name: "claimed sentinel", status: "claimed", expiresAt: farFuture, wantRetention: true},
+		{name: "completed sentinel", status: "completed", expiresAt: farFuture},
+		{name: "expired sentinel", status: "expired", expiresAt: farFuture},
+		{name: "failed sentinel", status: "failed", expiresAt: farFuture},
+		{name: "unknown sentinel", status: "unknown", expiresAt: farFuture},
+		{name: "empty status sentinel", expiresAt: farFuture},
+		{name: "pending ordinary expiry", status: "pending", expiresAt: nearFuture},
+		{name: "pending malformed expiry", status: "pending", expiresAt: "not-a-time"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := map[string]any{
+				"expires_at": tt.expiresAt,
+				"retention":  "stale-upstream-value",
+			}
+			formatMessageRetention(entry, tt.status, tt.expiresAt)
+			if tt.wantRetention {
+				require.Equal(t, "durable_until_handled", entry["retention"])
+				require.NotContains(t, entry, "expires_at")
+				return
+			}
+			require.NotContains(t, entry, "retention")
+			require.Equal(t, tt.expiresAt, entry["expires_at"])
+		})
+	}
+}
+
+func TestMessageStatusRetentionTracksWorkflowStatus(t *testing.T) {
+	farFuture := farFutureMessageExpiry()
+	mux := http.NewServeMux()
+	for _, status := range []string{"pending", "claimed", "completed", "expired", "failed", "unknown"} {
+		status := status
+		mux.HandleFunc("/v1/messages/msg-"+status+"/status", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message_id": "msg-" + status, "workflow_status": status,
+				"read_status": "not_confirmed", "expires_at": farFuture,
+				"retention": "stale-upstream-value",
+			})
+		})
+	}
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	s := NewServer(ts.URL, privateKey)
+
+	for _, status := range []string{"pending", "claimed", "completed", "expired", "failed", "unknown"} {
+		result, callErr := s.toolMessageStatus(context.Background(), map[string]any{"message_id": "msg-" + status})
+		require.NoError(t, callErr)
+		item := result.(map[string]any)
+		if status == "pending" || status == "claimed" {
+			require.Equal(t, "durable_until_handled", item["retention"], status)
+			require.NotContains(t, item, "expires_at", status)
+			continue
+		}
+		require.NotContains(t, item, "retention", status)
+		require.Equal(t, farFuture, item["expires_at"], status)
+	}
+}
+
+func TestMessageHistoryAndPipeAliasRetentionTrackRowStatus(t *testing.T) {
+	farFuture := farFutureMessageExpiry()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/pipe/history/inbox", func(w http.ResponseWriter, _ *http.Request) {
+		items := make([]map[string]any, 0, 6)
+		for _, status := range []string{"pending", "claimed", "completed", "expired", "failed", "unknown"} {
+			items = append(items, map[string]any{
+				"pipe_id": "msg-" + status, "status": status, "expires_at": farFuture,
+			})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "count": len(items)})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	s := NewServer(ts.URL, privateKey)
+
+	assertProjection := func(t *testing.T, result any, idKey string) {
+		t.Helper()
+		items := result.(map[string]any)["items"].([]map[string]any)
+		require.Len(t, items, 6)
+		for _, item := range items {
+			status := item["status"].(string)
+			require.Equal(t, "msg-"+status, item[idKey])
+			if status == "pending" || status == "claimed" {
+				require.Equal(t, "durable_until_handled", item["retention"], status)
+				require.NotContains(t, item, "expires_at", status)
+				continue
+			}
+			require.NotContains(t, item, "retention", status)
+			require.Equal(t, farFuture, item["expires_at"], status)
+		}
+	}
+
+	pipeHistory, err := s.toolPipeHistory(context.Background(), map[string]any{"folder": "inbox", "limit": 20})
+	require.NoError(t, err)
+	assertProjection(t, pipeHistory, "pipe_id")
+
+	messageHistory, err := s.toolMessageHistory(context.Background(), map[string]any{"folder": "inbox", "limit": 20})
+	require.NoError(t, err)
+	assertProjection(t, messageHistory, "message_id")
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -4981,12 +4981,9 @@ func (s *Server) toolMessageStatus(ctx context.Context, params map[string]any) (
 		response["scope"] = "federated"
 	}
 	readStatus, _ := response["read_status"].(string)
-	if rawExpiry, ok := response["expires_at"].(string); ok {
-		if expiry, err := time.Parse(time.RFC3339Nano, rawExpiry); err == nil && expiry.After(time.Now().Add(50*365*24*time.Hour)) {
-			delete(response, "expires_at")
-			response["retention"] = "durable_until_handled"
-		}
-	}
+	workflowStatus, _ := response["workflow_status"].(string)
+	rawExpiry, _ := response["expires_at"].(string)
+	formatMessageRetention(response, workflowStatus, rawExpiry)
 	switch readStatus {
 	case "confirmed":
 		response["message"] = "The exact recipient credential fetched and acknowledged this message. This does not prove comprehension or action."
@@ -5418,6 +5415,30 @@ func preferredAgentProvider(current, persisted string) string {
 	return persisted
 }
 
+const durableMessageExpiryThreshold = 50 * 365 * 24 * time.Hour
+
+// formatMessageRetention converts the canonical far-future storage sentinel
+// into public lifecycle vocabulary only while a message remains actionable.
+// Once a row is terminal, "durable until handled" is false even if its stored
+// expiry still carries the sentinel, so terminal and unknown statuses retain
+// the raw expires_at value instead.
+func formatMessageRetention(entry map[string]any, status, rawExpiry string) {
+	delete(entry, "retention")
+	if rawExpiry == "" {
+		return
+	}
+	entry["expires_at"] = rawExpiry
+	if status != "pending" && status != "claimed" {
+		return
+	}
+	expiry, err := time.Parse(time.RFC3339Nano, rawExpiry)
+	if err != nil || !expiry.After(time.Now().Add(durableMessageExpiryThreshold)) {
+		return
+	}
+	delete(entry, "expires_at")
+	entry["retention"] = "durable_until_handled"
+}
+
 // formatPipelineInboxItem is the single trust-boundary formatter shared by
 // explicit sage_inbox and sage_turn's automatic inbox check. Every payload,
 // including one from a local registered agent, is untrusted request content
@@ -5556,10 +5577,7 @@ func formatPipelineHistoryItem(item pipelineHistoryWireItem, folder string) map[
 	if item.ClaimantSessionID != "" {
 		entry["claimant_session_id"] = item.ClaimantSessionID
 	}
-	if expiry, err := time.Parse(time.RFC3339Nano, item.ExpiresAt); err == nil && expiry.After(time.Now().Add(50*365*24*time.Hour)) {
-		delete(entry, "expires_at")
-		entry["retention"] = "durable_until_handled"
-	}
+	formatMessageRetention(entry, item.Status, item.ExpiresAt)
 	if item.Result != "" {
 		entry["result"] = item.Result
 		entry["result_authority"] = "data_only"
@@ -6254,14 +6272,7 @@ func formatMessageReplyItem(item pipelineReplyWireItem) map[string]any {
 		entry["result_runes_returned"] = maxReplyResultRunes
 		entry["result_full_via"] = replyResultFullVia
 	}
-	if item.ExpiresAt != "" {
-		expiry, err := time.Parse(time.RFC3339Nano, item.ExpiresAt)
-		if err == nil && expiry.After(time.Now().Add(50*365*24*time.Hour)) {
-			entry["retention"] = "durable_until_handled"
-		} else {
-			entry["expires_at"] = item.ExpiresAt
-		}
-	}
+	formatMessageRetention(entry, item.Status, item.ExpiresAt)
 	if foreign {
 		entry["foreign"] = true
 		entry["destination_chain_id"] = item.DestinationChainID


### PR DESCRIPTION
Fixes the completed-message retention-label regression planned for v11.18.22.\n\n- centralizes MCP message retention formatting\n- emits durable_until_handled only for pending/claimed far-future sentinel rows\n- preserves raw expires_at for completed/expired/failed/unknown rows\n- covers status, canonical and pipe history, direct replies, and inbox-embedded replies\n- updates the authoritative MCP reference\n\nVerification:\n- env GOCACHE=/private/tmp/sage-gocache go test ./internal/mcp -count=1\n- git diff --check