### PR TITLE
fix(mcp): sage_turn recall block — carry corroboration_count and status like sage_recall

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3073,9 +3073,15 @@ func appendTurnRecallResult(result map[string]any, recall recallResp, domain str
 			"confidence":  r.ConfidenceScore,
 			"type":        r.MemoryType,
 			"created_at":  r.CreatedAt,
-			"source_kind": r.SourceKind,
-			"foreign":     r.Foreign,
-			"trust":       r.Trust,
+			// Weighting a recalled memory needs its corroboration and lifecycle:
+			// sage_recall carries both, and a caller reading the turn block cannot
+			// tell it is a subset. Omitting them here silently drops the trust
+			// signal and hides a deprecated row behind a plain recall.
+			"corroboration_count": r.CorroborationCount,
+			"status":              r.Status,
+			"source_kind":         r.SourceKind,
+			"foreign":             r.Foreign,
+			"trust":               r.Trust,
 		}
 		if r.SourceChainID != "" {
 			entry["source_chain_id"] = r.SourceChainID

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -2874,6 +2874,37 @@ func TestSageTurnScopesKeywordRecallToExactDomain(t *testing.T) {
 	require.Equal(t, "tii-sage", recalled[0]["domain"])
 }
 
+// The turn recall block is a curated subset of sage_recall's fields, and a
+// caller reading it cannot tell it is a subset. It must still carry the two
+// fields needed to weight a recalled memory — corroboration_count (trust) and
+// status (lifecycle) — or it silently under-informs the decision and hides a
+// deprecated row behind a plain recall.
+func TestSageTurnRecallCarriesCorroborationAndStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/embed/info", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"semantic": false, "ready": true})
+	})
+	mux.HandleFunc("/v1/memory/search", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"results": []map[string]any{
+			{"memory_id": "m1", "content": "ctx", "domain_tag": "tii-sage",
+				"confidence_score": 0.9, "memory_type": "fact",
+				"corroboration_count": 7, "status": "committed"},
+		}})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	t.Setenv("SAGE_RECALL_HYBRID", "0")
+	_, priv, _ := ed25519.GenerateKey(nil)
+	s := NewServer(ts.URL, priv)
+	result, err := s.toolTurn(context.Background(), map[string]any{"topic": "current work", "domain": "tii-sage"})
+	require.NoError(t, err)
+	recalled := result.(map[string]any)["recalled"].([]map[string]any)
+	require.Len(t, recalled, 1)
+	assert.Equal(t, 7, recalled[0]["corroboration_count"], "turn recall must carry the corroboration trust signal, like sage_recall")
+	assert.Equal(t, "committed", recalled[0]["status"], "turn recall must carry lifecycle status, like sage_recall")
+}
+
 func TestSageTurnFirstWritableDomainDoesNotReportBogusReadDenial(t *testing.T) {
 	var queryCalls, submitCalls int
 	mux := http.NewServeMux()


### PR DESCRIPTION
## What
The `sage_turn` recall block emits a curated subset of the fields `sage_recall` returns for the same memory. It carried `source_kind`/`foreign`/`trust` (and the conditional origin/disputed fields) but dropped `corroboration_count` (the corroboration/trust signal used to weight a memory) and `status` (lifecycle — committed/deprecated). This carries both onto the turn entry so the two surfaces agree.

## Why
A caller reading the turn block has no way to tell it is a subset of `sage_recall`. Omitting `corroboration_count` silently under-informs how it weights a recalled memory; omitting `status` can hide a DEPRECATED row behind a plain-looking recall. `recallResp` already parses both fields — they were simply not copied into the emitted entry map in `appendTurnRecallResult`, so the two surfaces disagreed for the same underlying memory.

## How
- `appendTurnRecallResult` (`internal/mcp/tools.go`) copies `corroboration_count` and `status` from the parsed `recallResp` result onto the turn recall entry.
- Additive only: no existing field is renamed or dropped, so consumers that ignore the new keys are unaffected.

## ABCI / determinism
Consensus path untouched. MCP recall output shape only — additive fields on the tool result. No change to storage, the recall query, or the FinalizeBlock path.

## Tests
- `TestSageTurnRecallCarriesCorroborationAndStatus` — manufactures a matching-domain recall row carrying both fields and asserts the turn block discloses them.
- Verified locally: `go build ./...` clean; `go test -race ./internal/mcp/` clean; `golangci-lint run ./internal/mcp/` clean at the CI pin (v2.12.2); full `npm test` 406 pass (doc-citation guard included, since `tools.go` line numbers shifted).
