### PR TITLE
feat(sage-gui): checkEmbeddingSpaceConsistency — flag a foreign store space via /ready, never fail boot

### DIFF
--- a/cmd/sage-gui/embedding_space_guard_test.go
+++ b/cmd/sage-gui/embedding_space_guard_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/embedding"
+	"github.com/l33tdawg/sage/internal/metrics"
+)
+
+type fakeProviderCounter struct {
+	counts map[string]int
+	err    error
+}
+
+func (f fakeProviderCounter) CountMemoriesByProvider(_ context.Context) (map[string]int, error) {
+	return f.counts, f.err
+}
+
+// readyBody drives the readiness handler on an otherwise-healthy node so the
+// only thing that can move status is the embedding-space check under test.
+func readyBody(t *testing.T, h *metrics.HealthChecker, target string) (int, map[string]any) {
+	t.Helper()
+	h.SetPostgresHealth(true)
+	h.SetCometBFTHealth(true)
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	h.ReadinessHandler(rec, req)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	return rec.Code, body
+}
+
+// A store written in a vector space the active embedder does not produce must be
+// surfaced — loudly and queryably — but must NOT fail the boot: recall silently
+// partitions by space, a quality loss rather than an outage, and refusing to
+// start would brick a deliberate re-embed migration.
+func TestCheckEmbeddingSpaceConsistency_ForeignSpaceIsDegradedNotFatal(t *testing.T) {
+	h := metrics.NewHealthChecker()
+	// Active embedder is hash@768; the store is full of semantic vectors, with a
+	// handful of empty-provider rows (queued for re-embed — a different condition).
+	counter := fakeProviderCounter{counts: map[string]int{
+		"hash": 3,
+		"openai-compatible:gte-Qwen2-1.5B-instruct:1536": 1659,
+		"": 35,
+	}}
+	checkEmbeddingSpaceConsistency(context.Background(), counter, embedding.NewHashProvider(768), h, zerolog.Nop())
+
+	code, body := readyBody(t, h, "/ready")
+	assert.Equal(t, http.StatusOK, code, "a space mismatch is degraded, not an outage — the node still serves")
+	assert.Equal(t, "degraded", body["status"])
+
+	es, ok := body["embedding_space"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, es["checked"])
+	assert.Equal(t, false, es["ok"])
+	assert.Equal(t, "hash", es["active_space"])
+	assert.EqualValues(t, 1659, es["foreign_rows"], "empty-provider rows are excluded; only the foreign non-empty space counts")
+	foreign, ok := es["foreign_spaces"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 1659, foreign["openai-compatible:gte-Qwen2-1.5B-instruct:1536"])
+	_, hashCarried := foreign["hash"]
+	assert.False(t, hashCarried, "the active space is not foreign to itself")
+
+	// The disclosure is queryable, and strict readiness gates can act on it.
+	strictCode, _ := readyBody(t, h, "/ready?strict=1")
+	assert.Equal(t, http.StatusServiceUnavailable, strictCode)
+}
+
+// A store whose committed vectors all share the active space is healthy: no
+// warning, no degraded status.
+func TestCheckEmbeddingSpaceConsistency_MatchingSpaceIsOK(t *testing.T) {
+	h := metrics.NewHealthChecker()
+	counter := fakeProviderCounter{counts: map[string]int{"hash": 10, "": 2}}
+	checkEmbeddingSpaceConsistency(context.Background(), counter, embedding.NewHashProvider(768), h, zerolog.Nop())
+
+	code, body := readyBody(t, h, "/ready")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "ready", body["status"])
+	es := body["embedding_space"].(map[string]any)
+	assert.Equal(t, true, es["ok"])
+	assert.Nil(t, es["foreign_spaces"])
+}
+
+// If the count query itself fails the check must not fabricate a verdict: it
+// records nothing (status stays unchecked) rather than reporting a false OK or a
+// false mismatch, and it never blocks the boot.
+func TestCheckEmbeddingSpaceConsistency_CountErrorLeavesUnchecked(t *testing.T) {
+	h := metrics.NewHealthChecker()
+	counter := fakeProviderCounter{err: assert.AnError}
+	checkEmbeddingSpaceConsistency(context.Background(), counter, embedding.NewHashProvider(768), h, zerolog.Nop())
+
+	_, body := readyBody(t, h, "/ready")
+	es := body["embedding_space"].(map[string]any)
+	assert.Equal(t, false, es["checked"], "a failed count leaves the check unrun, not a fabricated OK")
+}

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -1125,6 +1125,13 @@ func runServe(startupProof string) (rerr error) {
 	})
 
 	embedProvider := createEmbeddingProvider(cfg, logger)
+	// Detect a store written in a different vector space than the active embedder
+	// — e.g. a bare `serve` with no embedding env starting over a store full of
+	// semantic vectors, silently downgrading to hash. Not fatal (the node serves),
+	// but recall filters by the active space, so foreign-space rows go invisible.
+	// Shout and record a queryable degraded status; never refuse to boot, because
+	// a deliberate re-embed migration is exactly this mismatch, transiently.
+	checkEmbeddingSpaceConsistency(ctx, sqliteStore, embedProvider, health, logger)
 	embedderReady := make(chan struct{}, 1)
 	trackDone(startEmbedderWatchdog(ctx, embedProvider, health, logger, func() {
 		select {
@@ -3726,6 +3733,59 @@ func applyEmbeddingProviderSelection(cfg *Config, provider string) {
 	cfg.Embedding.BaseURL = ""
 	cfg.Embedding.Model = ""
 	cfg.Embedding.Dimension = embedding.Dimension
+}
+
+// embeddingSpaceCounter is the slice of the store the boot space-check needs,
+// narrowed so the check is unit-testable with a fake.
+type embeddingSpaceCounter interface {
+	CountMemoriesByProvider(ctx context.Context) (map[string]int, error)
+}
+
+// checkEmbeddingSpaceConsistency compares the store's committed embedding spaces
+// against the space the active embedder produces, and records a queryable
+// degraded status (plus a loud log) when they disagree. It never fails the boot:
+// recall filtering by embedding_provider means a foreign-space row is a silent
+// quality loss, not an outage, and refusing to start would brick the legitimate
+// re-embed migration that transiently presents as exactly this mismatch.
+//
+// The empty-provider stamp ("") is deliberately excluded — those are rows queued
+// for re-embed after a store-time embedder outage, a different condition from a
+// space mismatch.
+func checkEmbeddingSpaceConsistency(
+	ctx context.Context,
+	counter embeddingSpaceCounter,
+	embedder embedding.Provider,
+	health *metrics.HealthChecker,
+	logger zerolog.Logger,
+) {
+	active := embedding.SpaceID(embedder)
+	counts, err := counter.CountMemoriesByProvider(ctx)
+	if err != nil {
+		logger.Warn().Err(err).Msg("embedding-space consistency check skipped: could not count memories by provider")
+		return
+	}
+	foreign := make(map[string]int)
+	total := 0
+	for space, n := range counts {
+		if n <= 0 || space == "" || space == active {
+			continue
+		}
+		foreign[space] = n
+		total += n
+	}
+	health.SetEmbeddingSpaceStatus(metrics.EmbeddingSpaceStatus{
+		OK:            total == 0,
+		ActiveSpace:   active,
+		ForeignRows:   total,
+		ForeignSpaces: foreign,
+	})
+	if total > 0 {
+		logger.Warn().
+			Str("active_space", active).
+			Int("foreign_rows", total).
+			Interface("foreign_spaces", foreign).
+			Msg("embedding-space mismatch: the store holds committed vectors in a space the active embedder does not produce, so recall silently cannot see them. Re-embed to reconcile, or restart with the embedding config that wrote them. Serving in degraded mode (queryable at /ready).")
+	}
 }
 
 // createEmbeddingProvider creates the configured embedding provider.

--- a/internal/metrics/health.go
+++ b/internal/metrics/health.go
@@ -87,16 +87,32 @@ type AppV25MaintenanceStatus struct {
 type appV25MaintenanceProvider func() AppV25MaintenanceStatus
 
 // HealthChecker tracks the health status of dependencies.
+// EmbeddingSpaceStatus reports whether the store's committed vectors all live in
+// the vector space the active embedder produces. A node booted configured for
+// one space over a store written in another does not error: recall filters by
+// embedding_provider = active space, so every row in a foreign space silently
+// becomes invisible. That is a quality loss, not an outage — so it surfaces as a
+// queryable degraded status and a loud boot log rather than a refusal to start,
+// which would brick a deliberate re-embed migration (the exact legitimate case).
+type EmbeddingSpaceStatus struct {
+	Checked       bool           `json:"checked"`                  // has the boot check run?
+	OK            bool           `json:"ok"`                       // no committed rows in a foreign non-empty space
+	ActiveSpace   string         `json:"active_space,omitempty"`   // SpaceID the node writes and queries now
+	ForeignRows   int            `json:"foreign_rows,omitempty"`   // committed rows the active space cannot see
+	ForeignSpaces map[string]int `json:"foreign_spaces,omitempty"` // foreign space id -> row count
+}
+
 type HealthChecker struct {
-	postgresOK  atomic.Bool
-	cometbftOK  atomic.Bool
-	embedder    atomic.Value // EmbedderStatus, set by SetEmbedderHealth
-	voter       atomic.Value // VoterStatus, set by SetVoterStatus
-	scoped      atomic.Value // ScopedProjectionStatus, set by recovery wiring
-	vendored    atomic.Value // VendoredAgentEnrollmentStatus, set by bootstrap/repair wiring
-	canonical   atomic.Value // canonicalMemoryProjectionProvider, wired after the final Badger store is selected
-	maintenance atomic.Value // appV25MaintenanceProvider, current-process migration proof
-	Version     string
+	postgresOK     atomic.Bool
+	cometbftOK     atomic.Bool
+	embedder       atomic.Value // EmbedderStatus, set by SetEmbedderHealth
+	embeddingSpace atomic.Value // EmbeddingSpaceStatus, set once at boot by the store-vs-config space check
+	voter          atomic.Value // VoterStatus, set by SetVoterStatus
+	scoped         atomic.Value // ScopedProjectionStatus, set by recovery wiring
+	vendored       atomic.Value // VendoredAgentEnrollmentStatus, set by bootstrap/repair wiring
+	canonical      atomic.Value // canonicalMemoryProjectionProvider, wired after the final Badger store is selected
+	maintenance    atomic.Value // appV25MaintenanceProvider, current-process migration proof
+	Version        string
 }
 
 // NewHealthChecker creates a new health checker.
@@ -116,6 +132,21 @@ func (h *HealthChecker) embedderStatus() EmbedderStatus {
 		return v
 	}
 	return EmbedderStatus{}
+}
+
+// SetEmbeddingSpaceStatus records the boot-time comparison of the store's
+// committed vector spaces against the active embedder's space. Called once at
+// startup; until then the check reads as not-yet-run.
+func (h *HealthChecker) SetEmbeddingSpaceStatus(s EmbeddingSpaceStatus) {
+	s.Checked = true
+	h.embeddingSpace.Store(s)
+}
+
+func (h *HealthChecker) embeddingSpaceStatus() EmbeddingSpaceStatus {
+	if v, ok := h.embeddingSpace.Load().(EmbeddingSpaceStatus); ok {
+		return v
+	}
+	return EmbeddingSpaceStatus{}
 }
 
 // SetVoterStatus records the memory auto-voter's latest self-report (called by
@@ -246,6 +277,7 @@ func (h *HealthChecker) ReadinessHandler(w http.ResponseWriter, r *http.Request)
 	vendored := h.vendoredAgentEnrollmentStatus()
 	canonical := h.canonicalMemoryProjectionStatus()
 	maintenance := h.appV25MaintenanceStatus()
+	embSpace := h.embeddingSpaceStatus()
 
 	status := "ready"
 	httpStatus := http.StatusOK
@@ -303,6 +335,16 @@ func (h *HealthChecker) ReadinessHandler(w http.ResponseWriter, r *http.Request)
 		if r.URL.Query().Get("strict") == "1" {
 			httpStatus = http.StatusServiceUnavailable
 		}
+	case embSpace.Checked && !embSpace.OK:
+		// The store holds committed vectors in a space the active embedder does not
+		// produce; recall filters by the active space, so those rows are silently
+		// invisible. The node still SERVES — this is a quality loss, not an outage —
+		// so report degraded (HTTP 200) with the mismatch visible for reconciliation
+		// (re-embed, or boot with the config that wrote them). ?strict=1 gates on it.
+		status = "degraded"
+		if r.URL.Query().Get("strict") == "1" {
+			httpStatus = http.StatusServiceUnavailable
+		}
 	case canonical.Required && canonical.Quarantined:
 		// Record-local projection faults are isolated and omitted from broad
 		// reads. Keep the node operational and advertise the degraded state
@@ -336,6 +378,7 @@ func (h *HealthChecker) ReadinessHandler(w http.ResponseWriter, r *http.Request)
 		"postgres":            pgOK,
 		"cometbft":            cmtOK,
 		"embedder":            emb,
+		"embedding_space":     embSpace,
 		"scoped_projection":   scoped,
 		"vendored_agent":      vendored,
 		"memory_projection":   canonical,


### PR DESCRIPTION
## What
Boot-time check that compares the active embedding space against the spaces already committed to the store. On mismatch it logs a loud warning and records a degraded status surfaced in `/ready` as `embedding_space`. The node keeps serving; it never refuses to boot.

## Why
`createEmbeddingProvider` builds the embedder from config+env (env overrides `config.yaml`) and never consults the store. A bare `sage-gui serve` with no embedding environment starts the default `hash@768` provider over a store whose committed vectors were written in a semantic space (e.g. `openai-compatible:...:1536`). Nothing errors — but `QuerySimilar` filters candidates by `embedding_provider = <active space>`, so every row in the foreign space silently disappears from recall. It is a quiet quality regression, not an outage, and the two populations are not comparable. Today the only symptom is degraded recall with no signal pointing at the cause.

## How
- `checkEmbeddingSpaceConsistency` in `cmd/sage-gui/node.go`, invoked directly after the embedder is built. Compares `embedding.SpaceID(activeEmbedder)` against the store's committed spaces via `CountMemoriesByProvider`.
- Foreign committed rows in a non-empty space → warn (active space + foreign spaces and counts) and set `metrics.EmbeddingSpaceStatus` on the `HealthChecker`.
- `/ready` exposes it as `embedding_space`: `degraded` returns HTTP 200 so the node stays in rotation; `?strict=1` gates it to 503 for readiness probes. This mirrors exactly how the existing semantic-embedder-down case behaves, so operators get one consistent contract.
- The empty-provider stamp (`""`) is excluded from the count: those rows are queued for re-embed after a store-time embedder outage — a different condition, not a space mismatch.
- Rejected alternative: fail-closed on mismatch. A legitimate re-embed migration transiently presents as exactly this state, so halting would brick the migration and convert a recoverable quality dip into an outage. Disclosure over outage.

## ABCI / determinism
Consensus path untouched. This is boot-time observability plus one `/ready` health field. No change to storage, the memory API, or any handler on the FinalizeBlock path; nothing new enters consensus.

## Tests
- `cmd/sage-gui/embedding_space_guard_test.go`: foreign space → `degraded`, not fatal, `?strict=1` gates to 503, empty-provider rows excluded; matching space → ready/200; `CountMemoriesByProvider` error → check left unrun (no fabricated verdict), boot never blocked.
- Verified locally: `go build ./...` clean; `go test -race ./internal/metrics/ ./cmd/sage-gui/` clean; `golangci-lint run` (v2.12.2, CI pin) 0 issues on the changed packages; full `npm test` 406 pass (doc-citation guard included, since `node.go`/`health.go` line numbers shifted).
