### PR TITLE
fix(rerankd): preflight the managed engine so an unloadable install fails with its real reason

### DIFF
--- a/docs/reference/reranker-and-setup.md
+++ b/docs/reference/reranker-and-setup.md
@@ -368,6 +368,17 @@ terminal. Routes are registered by `RegisterRerankerSetupRoutes`
 means the feature is unavailable on this node and every endpoint returns
 `{"available": false}` or HTTP 501.
 
+> **Host compatibility.** The managed engine is a prebuilt llama.cpp binary, and the
+> pinned `linux/arm64` asset is compiled on a newer base than the `amd64` one. On an
+> older-glibc arm64 host — notably a Jetson on JetPack 6 / Ubuntu 22.04 — that binary
+> downloads and sha256-verifies, but the dynamic loader cannot run it (`GLIBC_2.38` /
+> `GLIBCXX_3.4.32` not found). The install now **preflights the engine** after extraction:
+> on such a host it fails with the loader's own reason instead of reporting success over an
+> engine that never starts, and points at the bring-your-own path — run your own
+> `llama-server` and set `SAGE_RERANK_ENABLED=1`, `SAGE_RERANK_KIND=llamacpp`, and
+> `SAGE_RERANK_URL` (section 4). A non-loader failure (an unrecognized flag, a timeout) is
+> not treated as an incompatibility, so a good install is never blocked on an ambiguous signal.
+
 **Auth:** these routes carry `authMiddleware` **plus** a strict same-origin gate
 (`wizardSecurityGate`, `web/handler.go:1789-1802`, `web/handler.go:741`). Because setup
 downloads and `chmod`s a binary and spawns `llama-server` as a subprocess, the same

--- a/internal/rerankd/install.go
+++ b/internal/rerankd/install.go
@@ -12,9 +12,11 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // Managed engine install: SAGE downloads a pinned llama.cpp release build
@@ -106,7 +108,7 @@ func (m *Manager) EngineSizeBytes() int64 {
 // managed binary is already present.
 func (m *Manager) InstallEngine(ctx context.Context, progress func(done, total int64)) error {
 	if m.EngineInstalled() {
-		return nil
+		return m.preflightEngine(ctx)
 	}
 	// Guard against concurrent installs racing on the shared .part dir and
 	// rename (same pattern as Download). Without it, a second call's
@@ -198,13 +200,87 @@ func (m *Manager) InstallEngine(ctx context.Context, progress func(done, total i
 	// Belt-and-braces: if another install won the race while we were extracting,
 	// leave its engine in place rather than RemoveAll/Rename over it.
 	if m.EngineInstalled() {
-		return nil
+		return m.preflightEngine(ctx)
 	}
 	_ = os.RemoveAll(m.engineDir())
 	if err := os.Rename(tmpDir, m.engineDir()); err != nil {
 		return fmt.Errorf("install engine: %w", err)
 	}
+	return m.preflightEngine(ctx)
+}
+
+// EngineIncompatibleError means the managed engine downloaded and extracted
+// cleanly but cannot LOAD on this host: the dynamic loader rejected it because
+// the host's C/C++ runtime is older than the prebuilt asset requires. Distinct
+// from a download/extract failure — the bytes are correct, the host is too old
+// for this build. Callers should route the operator to a bring-your-own reranker
+// rather than retrying the managed install.
+type EngineIncompatibleError struct {
+	OS, Arch string
+	Detail   string // the loader's own message, e.g. "version `GLIBC_2.38' not found"
+}
+
+func (e *EngineIncompatibleError) Error() string {
+	return fmt.Sprintf(
+		"managed reranker engine cannot run on this host (%s/%s): %s. "+
+			"The prebuilt engine needs a newer C/C++ runtime than this host provides "+
+			"(the pinned linux/arm64 llama.cpp build is compiled on a newer base than the "+
+			"amd64 one, so an older-glibc arm64 host such as a Jetson on Ubuntu 22.04 hits this). "+
+			"Bring your own instead: run your own llama-server and set SAGE_RERANK_ENABLED=1, "+
+			"SAGE_RERANK_KIND=llamacpp, and SAGE_RERANK_URL to its address.",
+		e.OS, e.Arch, e.Detail)
+}
+
+// preflightEngine confirms the freshly-installed managed binary can actually
+// LOAD on this host, not merely that it downloaded and extracted. The install
+// verifies a sha256 and lands bytes on disk; that is silent about whether the
+// dynamic loader can satisfy the binary's C/C++ runtime requirements. On a host
+// with an older glibc than the build base (JetPack-6 / Ubuntu 22.04 on a Jetson,
+// against the Ubuntu-24.04-built arm64 asset) the engine never execs and the
+// operator sees only a dead engine with no cause. Running the binary with a
+// trivial flag surfaces the loader's own message so InstallEngine can fail with
+// the real reason instead of reporting success.
+func (m *Manager) preflightEngine(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, m.managedBinaryPath(), "--version")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if runErr := cmd.Run(); runErr != nil {
+		// Only convert a PROVEN dynamic-loader/libc version mismatch into an
+		// incompatibility. Any other non-zero exit (an unrecognized flag on some
+		// future build, a timeout) is not proof the host is too old, so it must
+		// not block an otherwise-good install on an ambiguous signal.
+		if isLoaderVersionFailure(stderr.String()) {
+			return &EngineIncompatibleError{
+				OS:     runtime.GOOS,
+				Arch:   effectiveArch(),
+				Detail: firstLine(stderr.String()),
+			}
+		}
+	}
 	return nil
+}
+
+// isLoaderVersionFailure recognizes the dynamic loader rejecting a binary because
+// the host's C/C++ runtime is too old. These tokens are emitted by ld.so and
+// libstdc++ themselves (e.g. "version `GLIBC_2.38' not found",
+// "`GLIBCXX_3.4.32' not found", "CXXABI_1.3.15 not found") and appear only in a
+// version-mismatch loader error, so matching them does not false-positive on
+// ordinary program output.
+func isLoaderVersionFailure(stderr string) bool {
+	s := strings.ToUpper(stderr)
+	return strings.Contains(s, "GLIBC_") ||
+		strings.Contains(s, "GLIBCXX_") ||
+		strings.Contains(s, "CXXABI_")
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
 }
 
 // extractTarGzFlat writes every regular file's BASENAME into dst. Flattening

--- a/internal/rerankd/install_preflight_test.go
+++ b/internal/rerankd/install_preflight_test.go
@@ -1,0 +1,50 @@
+//go:build unix
+
+package rerankd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeFakeEngine(t *testing.T, m *Manager, script string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(m.engineDir(), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(m.engineDir(), serverBinaryName()), []byte(script), 0o755))
+}
+
+// A managed engine that DOWNLOADED and extracted cleanly but cannot LOAD — the
+// dynamic loader rejecting it for an older host C/C++ runtime — must surface the
+// real reason, not report install success. This is the Jetson / JetPack-6 case:
+// the pinned arm64 asset needs a newer glibc than Ubuntu 22.04 provides.
+func TestPreflightEngineSurfacesLoaderVersionFailure(t *testing.T) {
+	m := New(t.TempDir())
+	writeFakeEngine(t, m, "#!/bin/sh\necho 'llama-server: /lib/aarch64-linux-gnu/libstdc++.so.6: version GLIBCXX_3.4.32 not found' 1>&2\nexit 1\n")
+
+	err := m.preflightEngine(context.Background())
+	require.Error(t, err)
+	var inc *EngineIncompatibleError
+	require.ErrorAs(t, err, &inc)
+	require.Contains(t, inc.Detail, "GLIBCXX_3.4.32", "the loader's own message is preserved verbatim")
+	require.Contains(t, err.Error(), "SAGE_RERANK_KIND=llamacpp", "the honest error points the operator at the bring-your-own path")
+}
+
+// A binary that loads and runs is not blocked.
+func TestPreflightEnginePassesWhenBinaryLoads(t *testing.T) {
+	m := New(t.TempDir())
+	writeFakeEngine(t, m, "#!/bin/sh\necho 'version: b9870'\nexit 0\n")
+	require.NoError(t, m.preflightEngine(context.Background()))
+}
+
+// A non-zero exit WITHOUT a loader version signature is not proof the host is too
+// old (an unrecognized flag on a future build, a timeout). It must not block an
+// otherwise-good install on an ambiguous signal.
+func TestPreflightEngineDoesNotBlockOnAmbiguousFailure(t *testing.T) {
+	m := New(t.TempDir())
+	writeFakeEngine(t, m, "#!/bin/sh\necho 'error: unknown option --version' 1>&2\nexit 2\n")
+	require.NoError(t, m.preflightEngine(context.Background()))
+}


### PR DESCRIPTION
## What
The managed reranker install now preflights the engine binary after extraction and, when the binary cannot load on this host, fails with the loader's own reason and points at the bring-your-own path — instead of reporting success over an engine that never starts.

## Why
`InstallEngine` downloads the pinned llama.cpp release, verifies its sha256, and extracts it, then returns success. That says nothing about whether the binary can LOAD. The pinned `linux/arm64` asset is built on a newer base than the `amd64` one, so on an older-glibc arm64 host — a Jetson on JetPack 6 / Ubuntu 22.04 — the engine downloads and verifies but the dynamic loader rejects it (`GLIBC_2.38` / `GLIBCXX_3.4.32` not found). Install "succeeds," the engine never execs, and the operator sees only a dead engine with no cause. The `amd64` asset loads fine on the same OS, so the asymmetry is invisible to anyone testing on x86. JetPack 6 ships Ubuntu 22.04 across the Orin line, so this is the most common arm64 Linux AI host.

## How
- `preflightEngine` runs the installed binary with `--version` and inspects the outcome; `InstallEngine` calls it on every success path (fresh install, already-installed, race branch).
- A proven dynamic-loader/libc version failure (`GLIBC_` / `GLIBCXX_` / `CXXABI_` in stderr) returns a typed `EngineIncompatibleError` carrying the loader's own message plus the bring-your-own path (`SAGE_RERANK_ENABLED=1`, `SAGE_RERANK_KIND=llamacpp`, `SAGE_RERANK_URL`), so the setup handler surfaces the real reason at the setup button.
- Any other non-zero exit (an unrecognized flag on a future build, a timeout) is not treated as an incompatibility — a good install is never blocked on an ambiguous signal.
- Documents the host-compatibility behavior in `docs/reference/reranker-and-setup.md`.

This does not repin the arm64 asset or change what is downloaded (a rebuilt asset can't be validated from here); it makes the existing failure honest and actionable, which is the cheapest fix and needs no new build infrastructure.

## ABCI / determinism
None. This is the local engine-setup sidecar path — no consensus, storage, or memory API involved; nothing enters `FinalizeBlock`.

## Tests
- `internal/rerankd/install_preflight_test.go`: a fake engine emitting a loader version error -> `EngineIncompatibleError` with the message preserved and the BYO pointer; a loading binary -> pass; a non-loader non-zero exit -> not blocked.
- Verified locally: `go build ./...`, `go test -race ./internal/rerankd/`, and `golangci-lint` (v2.12.2, CI pin) clean; full `npm test` 406 pass.
