### PR TITLE
release: SAGE v11.18.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.18.23
+
+**Turn-time recall now carries the same trust and lifecycle evidence as explicit
+recall.** `sage_turn` includes each recalled memory's `corroboration_count` and
+`status`, so the every-turn path no longer hides corroboration weight or whether
+a recalled row is committed or currently challenged.
+
+**Embedding-space drift is visible before it silently empties semantic recall.**
+At boot, SAGE compares the active embedder with the non-deprecated vector spaces
+already in the local store. A mismatch produces a loud warning and a structured
+`embedding_space` block in `/ready`; the node remains available by default while
+strict readiness returns 503, allowing an intentional re-embed migration to
+finish instead of turning a quality warning into an outage.
+
+**Managed reranker setup now diagnoses incompatible prebuilt engines.** After a
+verified install, SAGE preflights `llama-server`. Proven GLIBC, GLIBCXX, or CXXABI
+loader failures preserve the loader's real error and point operators to the
+bring-your-own reranker path instead of reporting a successful unusable install.
+
+This patch introduces no new consensus application version or state migration.
+The ceiling remains app-v26; **v11.18.23 introduces no app-v27**.
+
+Container: `ghcr.io/l33tdawg/sage:11.18.23`. SDK 11.18.23.
+
 ## What's New in v11.18.22
 
 **A missing optional ForceGraph API can no longer strand CEREBRUM after the
@@ -2020,7 +2044,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.22`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.18.23`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/SECURITY_FAQ.md
+++ b/SECURITY_FAQ.md
@@ -11,7 +11,7 @@ SAGE has two distinct deployment models with fundamentally different threat mode
 | **Who** | One user, one local operator | Multiple agents, teams, organizations |
 | **Trust model** | User IS the only validator | Byzantine fault tolerance across validators |
 | **Database** | Local BadgerDB/SQLite stores in `~/.sage/data/` | BadgerDB consensus state plus off-chain mirror |
-| **Release** | v11.18.22 personal-node surface | v11.18.22 quorum/federation surface |
+| **Release** | v11.18.23 personal-node surface | v11.18.23 quorum/federation surface |
 
 Many concerns raised about the enterprise codebase do not apply to SAGE Personal, and vice versa. Each item below is tagged with which deployment it affects.
 
@@ -108,7 +108,7 @@ The `make byzantine` target and GitHub Actions CI job spin up a 4-validator Dock
 
 The following boundaries describe the current v11 codebase:
 
-**SAGE Personal (sage-gui v11.18.22):**
+**SAGE Personal (sage-gui v11.18.23):**
 - Designed for one operator. The management dashboard/API remains a local surface; anyone with access to the operator session or machine should be treated as trusted.
 - Federation is an explicit network-facing feature, off by default. When enabled it uses a separate pinned-mTLS listener, active on-chain treaty checks, chain-qualified signed requests, and replay protection. That authenticated protocol now runs over libp2p NAT traversal and Circuit Relay v2; the relay sees encrypted traffic and connection metadata, not plaintext memories or federation keys.
 - SQLite database supports optional AES-256-GCM encryption at rest (Synaptic Ledger). Enable from CEREBRUM Settings → Security.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.18.22
+  version: 11.18.23
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/cmd/sage-gui/embedding_space_guard_test.go
+++ b/cmd/sage-gui/embedding_space_guard_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/l33tdawg/sage/internal/embedding"
+	"github.com/l33tdawg/sage/internal/metrics"
+)
+
+type fakeProviderCounter struct {
+	counts map[string]int
+	err    error
+}
+
+func (f fakeProviderCounter) CountMemoriesByProvider(_ context.Context) (map[string]int, error) {
+	return f.counts, f.err
+}
+
+// readyBody drives the readiness handler on an otherwise-healthy node so the
+// only thing that can move status is the embedding-space check under test.
+func readyBody(t *testing.T, h *metrics.HealthChecker, target string) (int, map[string]any) {
+	t.Helper()
+	h.SetPostgresHealth(true)
+	h.SetCometBFTHealth(true)
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	h.ReadinessHandler(rec, req)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	return rec.Code, body
+}
+
+// A store written in a vector space the active embedder does not produce must be
+// surfaced — loudly and queryably — but must NOT fail the boot: recall silently
+// partitions by space, a quality loss rather than an outage, and refusing to
+// start would brick a deliberate re-embed migration.
+func TestCheckEmbeddingSpaceConsistency_ForeignSpaceIsDegradedNotFatal(t *testing.T) {
+	h := metrics.NewHealthChecker()
+	// Active embedder is hash@768; the store is full of semantic vectors, with a
+	// handful of empty-provider rows (queued for re-embed — a different condition).
+	counter := fakeProviderCounter{counts: map[string]int{
+		"hash": 3,
+		"openai-compatible:gte-Qwen2-1.5B-instruct:1536": 1659,
+		"": 35,
+	}}
+	checkEmbeddingSpaceConsistency(context.Background(), counter, embedding.NewHashProvider(768), h, zerolog.Nop())
+
+	code, body := readyBody(t, h, "/ready")
+	assert.Equal(t, http.StatusOK, code, "a space mismatch is degraded, not an outage — the node still serves")
+	assert.Equal(t, "degraded", body["status"])
+
+	es, ok := body["embedding_space"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, es["checked"])
+	assert.Equal(t, false, es["ok"])
+	assert.Equal(t, "hash", es["active_space"])
+	assert.EqualValues(t, 1659, es["foreign_rows"], "empty-provider rows are excluded; only the foreign non-empty space counts")
+	foreign, ok := es["foreign_spaces"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 1659, foreign["openai-compatible:gte-Qwen2-1.5B-instruct:1536"])
+	_, hashCarried := foreign["hash"]
+	assert.False(t, hashCarried, "the active space is not foreign to itself")
+
+	// The disclosure is queryable, and strict readiness gates can act on it.
+	strictCode, _ := readyBody(t, h, "/ready?strict=1")
+	assert.Equal(t, http.StatusServiceUnavailable, strictCode)
+}
+
+// A store whose committed vectors all share the active space is healthy: no
+// warning, no degraded status.
+func TestCheckEmbeddingSpaceConsistency_MatchingSpaceIsOK(t *testing.T) {
+	h := metrics.NewHealthChecker()
+	counter := fakeProviderCounter{counts: map[string]int{"hash": 10, "": 2}}
+	checkEmbeddingSpaceConsistency(context.Background(), counter, embedding.NewHashProvider(768), h, zerolog.Nop())
+
+	code, body := readyBody(t, h, "/ready")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "ready", body["status"])
+	es := body["embedding_space"].(map[string]any)
+	assert.Equal(t, true, es["ok"])
+	assert.Nil(t, es["foreign_spaces"])
+}
+
+// If the count query itself fails the check must not fabricate a verdict: it
+// records nothing (status stays unchecked) rather than reporting a false OK or a
+// false mismatch, and it never blocks the boot.
+func TestCheckEmbeddingSpaceConsistency_CountErrorLeavesUnchecked(t *testing.T) {
+	h := metrics.NewHealthChecker()
+	counter := fakeProviderCounter{err: assert.AnError}
+	checkEmbeddingSpaceConsistency(context.Background(), counter, embedding.NewHashProvider(768), h, zerolog.Nop())
+
+	_, body := readyBody(t, h, "/ready")
+	es := body["embedding_space"].(map[string]any)
+	assert.Equal(t, false, es["checked"], "a failed count leaves the check unrun, not a fabricated OK")
+}

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -1125,6 +1125,13 @@ func runServe(startupProof string) (rerr error) {
 	})
 
 	embedProvider := createEmbeddingProvider(cfg, logger)
+	// Detect a store written in a different vector space than the active embedder
+	// — e.g. a bare `serve` with no embedding env starting over a store full of
+	// semantic vectors, silently downgrading to hash. Not fatal (the node serves),
+	// but recall filters by the active space, so foreign-space rows go invisible.
+	// Shout and record a queryable degraded status; never refuse to boot, because
+	// a deliberate re-embed migration is exactly this mismatch, transiently.
+	checkEmbeddingSpaceConsistency(ctx, sqliteStore, embedProvider, health, logger)
 	embedderReady := make(chan struct{}, 1)
 	trackDone(startEmbedderWatchdog(ctx, embedProvider, health, logger, func() {
 		select {
@@ -3726,6 +3733,59 @@ func applyEmbeddingProviderSelection(cfg *Config, provider string) {
 	cfg.Embedding.BaseURL = ""
 	cfg.Embedding.Model = ""
 	cfg.Embedding.Dimension = embedding.Dimension
+}
+
+// embeddingSpaceCounter is the slice of the store the boot space-check needs,
+// narrowed so the check is unit-testable with a fake.
+type embeddingSpaceCounter interface {
+	CountMemoriesByProvider(ctx context.Context) (map[string]int, error)
+}
+
+// checkEmbeddingSpaceConsistency compares the store's committed embedding spaces
+// against the space the active embedder produces, and records a queryable
+// degraded status (plus a loud log) when they disagree. It never fails the boot:
+// recall filtering by embedding_provider means a foreign-space row is a silent
+// quality loss, not an outage, and refusing to start would brick the legitimate
+// re-embed migration that transiently presents as exactly this mismatch.
+//
+// The empty-provider stamp ("") is deliberately excluded — those are rows queued
+// for re-embed after a store-time embedder outage, a different condition from a
+// space mismatch.
+func checkEmbeddingSpaceConsistency(
+	ctx context.Context,
+	counter embeddingSpaceCounter,
+	embedder embedding.Provider,
+	health *metrics.HealthChecker,
+	logger zerolog.Logger,
+) {
+	active := embedding.SpaceID(embedder)
+	counts, err := counter.CountMemoriesByProvider(ctx)
+	if err != nil {
+		logger.Warn().Err(err).Msg("embedding-space consistency check skipped: could not count memories by provider")
+		return
+	}
+	foreign := make(map[string]int)
+	total := 0
+	for space, n := range counts {
+		if n <= 0 || space == "" || space == active {
+			continue
+		}
+		foreign[space] = n
+		total += n
+	}
+	health.SetEmbeddingSpaceStatus(metrics.EmbeddingSpaceStatus{
+		OK:            total == 0,
+		ActiveSpace:   active,
+		ForeignRows:   total,
+		ForeignSpaces: foreign,
+	})
+	if total > 0 {
+		logger.Warn().
+			Str("active_space", active).
+			Int("foreign_rows", total).
+			Interface("foreign_spaces", foreign).
+			Msg("embedding-space mismatch: the store holds committed vectors in a space the active embedder does not produce, so recall silently cannot see them. Re-embed to reconcile, or restart with the embedding config that wrote them. Serving in degraded mode (queryable at /ready).")
+	}
 }
 
 // createEmbeddingProvider creates the configured embedding provider.

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.18.22-acceptance
+ARG VERSION=v11.18.23-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.18.22 federation Docker acceptance
+# v11.18.23 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.18.22-acceptance
+        VERSION: v11.18.23-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.18.22"
+version = "11.18.23"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.18.22"
+version = "11.18.23"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.18.22",
+  "version": "11.18.23",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.18.22/app-v26. -->
+<!-- Reconciled through SAGE v11.18.23/app-v26. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.22 federation behavior. -->
+<!-- Verified against SAGE v11.18.23 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.18.22
+# sage-gui v11.18.23
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.18.22 advertises 33 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.18.23 advertises 33 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.18.22 is the current release.** It keeps the
+**Status (2026-08):** **v11.18.23 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -78,16 +78,34 @@ independent domain-inventory refresh failure cannot cover a verified graph.
 v11.18.22 publishes verified MRI core readiness before optional renderer setup
 and feature-gates the bundled runtime's absent `clickAfterDrag` helper, keeping
 the anatomical hull, controls, and auto-rotation alive after the graph paints.
+v11.18.23 restores trust and lifecycle parity between `sage_turn` and
+`sage_recall`, discloses active/store embedding-space mismatches through
+readiness without blocking intentional re-embedding, and makes managed reranker
+setup surface proven host-loader incompatibilities with bring-your-own guidance.
 v11.18.19 prevents Codex project-hook
 self-healing from ever targeting the user-global `~/.codex` scope and removes
 the Connectome's competing DOM/ForceGraph click paths while bounding raw access
 metadata and making bloomed memories responsive. The supported consensus
-ceiling remains app-v26; **v11.18.22 does not introduce app-v27**.
+ceiling remains app-v26; **v11.18.23 does not introduce app-v27**.
 
 **Hard constraint driving the whole plan:** no chain reset. Existing chains must
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.18.23 patch
+
+The every-turn recall block now carries `corroboration_count` and lifecycle
+`status`, matching the decision-relevant evidence already exposed by explicit
+`sage_recall`. Boot also compares the active embedding space with vector spaces
+already present in the non-deprecated local store. Mismatches are logged and
+reported under `/ready` as degraded, while ordinary serving remains available
+and strict readiness can gate reconciliation. Managed reranker installation now
+preflights the verified engine binary and reports proven GLIBC, GLIBCXX, and
+CXXABI loader failures with the operator-controlled external-engine path.
+
+This patch introduces no new consensus application version or state migration:
+app-v26 remains the ceiling and v11.18.23 does not introduce app-v27.
 
 ## v11.18.22 patch
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -113,6 +113,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.20 | Same-mode verified MRI snapshot retention across transient refresh failures, with cold and cross-mode failures still fail-closed; no new app version; app-v26 remains the ceiling |
 | v11.18.21 | MRI-renderer authority for the central unavailable overlay, with independent domain-inventory failures localized to their own retrying panel; no new app version; app-v26 remains the ceiling |
 | v11.18.22 | Post-render MRI initialization hardening, verified-core readiness before optional renderer setup, and feature-gated `clickAfterDrag` support for bundled ForceGraph runtimes; no new app version; app-v26 remains the ceiling |
+| v11.18.23 | Turn-recall trust/lifecycle parity, non-fatal boot-time embedding-space mismatch disclosure, and managed-reranker loader incompatibility diagnosis with bring-your-own guidance; no new app version; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.18.22. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.18.23. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -34,7 +34,7 @@ or `api/openapi.yaml`, **trust this reference** — those two have known drift (
 | [`concepts/consensus-confidence-decay.md`](concepts/consensus-confidence-decay.md) | CometBFT BFT path, "CometBFT-committed" vs "SAGE-committed", quorum, PoE weights, epochs. |
 | [`concepts/block-production-and-idle.md`](concepts/block-production-and-idle.md) | Why an idle chain mints **no** blocks (SAGE has no heartbeat), when a block *is* minted, and how to tell healthy-idle from actually-stuck. Read this before alarming on a frozen block height. |
 | [`concepts/voter-operations.md`](concepts/voter-operations.md) | How `proposed` memories become `committed` (the per-node auto-voter), how to *guarantee* auto-commit (`--require-voter` / `voter:` config), the stuck-memory alarm + triage, key safety, and the honest REST-vote caveat. |
-| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.22 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
+| [`concepts/signer-nonce-fence.md`](concepts/signer-nonce-fence.md) | Per-signing-key nonce ordering, the signer fence, and **the cross-restart residual v11.18.23 does not close**. Why only a proven fate lifts a fence, why re-submitting byte-identical bytes is the reconciliation engine, why a restart does **not** safely clear a fence (and vetoes itself while one is held), what is logged and what is deliberately never logged, and how to triage `ErrSignerFenced`. Read this if a signing key stops signing, or before claiming nonce inversion is "fixed". |
 | [`concepts/content-validation-gate.md`](concepts/content-validation-gate.md) | The optional Layer-2 content-validation gate (`outcome_class`-keyed reject hook) and the deployment **arming seam** — both the stateless `contentvalidator.SetProvider` and the context-aware `SetProviderWithContext` (exposes the on-chain `RoleResolver` for signer-authority checks) — enabling it without patching the cmd entrypoints. |
 | [`federation-and-brain-api.md`](federation-and-brain-api.md) | The v11 HTTP surface: trust-only JOIN over direct HTTPS or libp2p relay/NAT traversal; explicit pairwise agent exports with default borrowed Read of their owned trees and receiver-side narrowing; independent manual Read/Copy grants; receiver-controlled Copy subscriptions; authenticated agent messaging; and `/fed/v1/pipe/event`. Transport, peer policy, contacts, and pipeline work are off-consensus; tx-33/34 preserves agreement compatibility. The Write field/route remains reserved and fails closed. |
 | [`reranker-and-setup.md`](reranker-and-setup.md) | The v11 local-engine and setup surface: create-or-join/private-or-shared onboarding, Synaptic Ledger recovery acknowledgement, portable memory-backup boundaries, recall-tuning clamps, managed semantic memory setup (`/v1/dashboard/embeddings/*`, pinned Ollama runtime + readiness-gated model pull), the reranker config endpoint (`kind` field + verify-on-enable), the managed llama.cpp sidecar (`/v1/dashboard/reranker/setup/*`, pinned assets + sha256 + adopt-not-respawn), the TEI vs llama.cpp rerank dialects, and `embedding_provider` stamped at insert. Mostly off-consensus; imported memories re-enter the normal consensus lifecycle. |
@@ -205,7 +205,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.18.22)
+## Related docs (reconciled through v11.18.23)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.18.22.
+Status: implementation contract through SAGE v11.18.23.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -421,7 +421,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.18.22 authorization layer is off-consensus and does not require
+The current v11.18.23 authorization layer is off-consensus and does not require
 a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.18.22 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.18.23 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.18.22/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.18.23/app-v26, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.18.22. Legacy organization/federation sections retain
+Verified against SAGE v11.18.23. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.18.22. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.18.23. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.18.22**.
+and is **not in v11.18.23**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.22. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.18.23. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.22 code (2026-08-18). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.18.23 code (2026-08-18). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.18.22.
+Reconciled against internal/mcp for SAGE v11.18.23.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.18.22. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.18.23. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.18.22
+**Package:** `sage-agent-sdk` **Version:** 11.18.23
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/reranker-and-setup.md
+++ b/docs/reference/reranker-and-setup.md
@@ -1,4 +1,4 @@
-<!-- Verified against code during SAGE v11.12 development. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.23. Cite file:line when behavior is non-obvious. -->
 
 # SAGE Local Engines and First-Run Setup Reference (v11)
 

--- a/docs/reference/reranker-and-setup.md
+++ b/docs/reference/reranker-and-setup.md
@@ -368,6 +368,17 @@ terminal. Routes are registered by `RegisterRerankerSetupRoutes`
 means the feature is unavailable on this node and every endpoint returns
 `{"available": false}` or HTTP 501.
 
+> **Host compatibility.** The managed engine is a prebuilt llama.cpp binary, and the
+> pinned `linux/arm64` asset is compiled on a newer base than the `amd64` one. On an
+> older-glibc arm64 host — notably a Jetson on JetPack 6 / Ubuntu 22.04 — that binary
+> downloads and sha256-verifies, but the dynamic loader cannot run it (`GLIBC_2.38` /
+> `GLIBCXX_3.4.32` not found). The install now **preflights the engine** after extraction:
+> on such a host it fails with the loader's own reason instead of reporting success over an
+> engine that never starts, and points at the bring-your-own path — run your own
+> `llama-server` and set `SAGE_RERANK_ENABLED=1`, `SAGE_RERANK_KIND=llamacpp`, and
+> `SAGE_RERANK_URL` (section 4). A non-loader failure (an unrecognized flag, a timeout) is
+> not treated as an incompatibility, so a good install is never blocked on an ambiguous signal.
+
 **Auth:** these routes carry `authMiddleware` **plus** a strict same-origin gate
 (`wizardSecurityGate`, `web/handler.go:1789-1802`, `web/handler.go:741`). Because setup
 downloads and `chmod`s a binary and spawns `llama-server` as a subprocess, the same

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.18.22. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.18.23. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.18.22 lineage implementation (2026-08-18). -->
+<!-- Verified against SAGE v11.18.23 lineage implementation (2026-08-18). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3073,9 +3073,15 @@ func appendTurnRecallResult(result map[string]any, recall recallResp, domain str
 			"confidence":  r.ConfidenceScore,
 			"type":        r.MemoryType,
 			"created_at":  r.CreatedAt,
-			"source_kind": r.SourceKind,
-			"foreign":     r.Foreign,
-			"trust":       r.Trust,
+			// Weighting a recalled memory needs its corroboration and lifecycle:
+			// sage_recall carries both, and a caller reading the turn block cannot
+			// tell it is a subset. Omitting them here silently drops the trust
+			// signal and hides a deprecated row behind a plain recall.
+			"corroboration_count": r.CorroborationCount,
+			"status":              r.Status,
+			"source_kind":         r.SourceKind,
+			"foreign":             r.Foreign,
+			"trust":               r.Trust,
 		}
 		if r.SourceChainID != "" {
 			entry["source_chain_id"] = r.SourceChainID

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -2874,6 +2874,37 @@ func TestSageTurnScopesKeywordRecallToExactDomain(t *testing.T) {
 	require.Equal(t, "tii-sage", recalled[0]["domain"])
 }
 
+// The turn recall block is a curated subset of sage_recall's fields, and a
+// caller reading it cannot tell it is a subset. It must still carry the two
+// fields needed to weight a recalled memory — corroboration_count (trust) and
+// status (lifecycle) — or it silently under-informs the decision and hides a
+// deprecated row behind a plain recall.
+func TestSageTurnRecallCarriesCorroborationAndStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/embed/info", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"semantic": false, "ready": true})
+	})
+	mux.HandleFunc("/v1/memory/search", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"results": []map[string]any{
+			{"memory_id": "m1", "content": "ctx", "domain_tag": "tii-sage",
+				"confidence_score": 0.9, "memory_type": "fact",
+				"corroboration_count": 7, "status": "committed"},
+		}})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	t.Setenv("SAGE_RECALL_HYBRID", "0")
+	_, priv, _ := ed25519.GenerateKey(nil)
+	s := NewServer(ts.URL, priv)
+	result, err := s.toolTurn(context.Background(), map[string]any{"topic": "current work", "domain": "tii-sage"})
+	require.NoError(t, err)
+	recalled := result.(map[string]any)["recalled"].([]map[string]any)
+	require.Len(t, recalled, 1)
+	assert.Equal(t, 7, recalled[0]["corroboration_count"], "turn recall must carry the corroboration trust signal, like sage_recall")
+	assert.Equal(t, "committed", recalled[0]["status"], "turn recall must carry lifecycle status, like sage_recall")
+}
+
 func TestSageTurnFirstWritableDomainDoesNotReportBogusReadDenial(t *testing.T) {
 	var queryCalls, submitCalls int
 	mux := http.NewServeMux()

--- a/internal/metrics/health.go
+++ b/internal/metrics/health.go
@@ -87,16 +87,32 @@ type AppV25MaintenanceStatus struct {
 type appV25MaintenanceProvider func() AppV25MaintenanceStatus
 
 // HealthChecker tracks the health status of dependencies.
+// EmbeddingSpaceStatus reports whether the store's committed vectors all live in
+// the vector space the active embedder produces. A node booted configured for
+// one space over a store written in another does not error: recall filters by
+// embedding_provider = active space, so every row in a foreign space silently
+// becomes invisible. That is a quality loss, not an outage — so it surfaces as a
+// queryable degraded status and a loud boot log rather than a refusal to start,
+// which would brick a deliberate re-embed migration (the exact legitimate case).
+type EmbeddingSpaceStatus struct {
+	Checked       bool           `json:"checked"`                  // has the boot check run?
+	OK            bool           `json:"ok"`                       // no committed rows in a foreign non-empty space
+	ActiveSpace   string         `json:"active_space,omitempty"`   // SpaceID the node writes and queries now
+	ForeignRows   int            `json:"foreign_rows,omitempty"`   // committed rows the active space cannot see
+	ForeignSpaces map[string]int `json:"foreign_spaces,omitempty"` // foreign space id -> row count
+}
+
 type HealthChecker struct {
-	postgresOK  atomic.Bool
-	cometbftOK  atomic.Bool
-	embedder    atomic.Value // EmbedderStatus, set by SetEmbedderHealth
-	voter       atomic.Value // VoterStatus, set by SetVoterStatus
-	scoped      atomic.Value // ScopedProjectionStatus, set by recovery wiring
-	vendored    atomic.Value // VendoredAgentEnrollmentStatus, set by bootstrap/repair wiring
-	canonical   atomic.Value // canonicalMemoryProjectionProvider, wired after the final Badger store is selected
-	maintenance atomic.Value // appV25MaintenanceProvider, current-process migration proof
-	Version     string
+	postgresOK     atomic.Bool
+	cometbftOK     atomic.Bool
+	embedder       atomic.Value // EmbedderStatus, set by SetEmbedderHealth
+	embeddingSpace atomic.Value // EmbeddingSpaceStatus, set once at boot by the store-vs-config space check
+	voter          atomic.Value // VoterStatus, set by SetVoterStatus
+	scoped         atomic.Value // ScopedProjectionStatus, set by recovery wiring
+	vendored       atomic.Value // VendoredAgentEnrollmentStatus, set by bootstrap/repair wiring
+	canonical      atomic.Value // canonicalMemoryProjectionProvider, wired after the final Badger store is selected
+	maintenance    atomic.Value // appV25MaintenanceProvider, current-process migration proof
+	Version        string
 }
 
 // NewHealthChecker creates a new health checker.
@@ -116,6 +132,21 @@ func (h *HealthChecker) embedderStatus() EmbedderStatus {
 		return v
 	}
 	return EmbedderStatus{}
+}
+
+// SetEmbeddingSpaceStatus records the boot-time comparison of the store's
+// committed vector spaces against the active embedder's space. Called once at
+// startup; until then the check reads as not-yet-run.
+func (h *HealthChecker) SetEmbeddingSpaceStatus(s EmbeddingSpaceStatus) {
+	s.Checked = true
+	h.embeddingSpace.Store(s)
+}
+
+func (h *HealthChecker) embeddingSpaceStatus() EmbeddingSpaceStatus {
+	if v, ok := h.embeddingSpace.Load().(EmbeddingSpaceStatus); ok {
+		return v
+	}
+	return EmbeddingSpaceStatus{}
 }
 
 // SetVoterStatus records the memory auto-voter's latest self-report (called by
@@ -246,6 +277,7 @@ func (h *HealthChecker) ReadinessHandler(w http.ResponseWriter, r *http.Request)
 	vendored := h.vendoredAgentEnrollmentStatus()
 	canonical := h.canonicalMemoryProjectionStatus()
 	maintenance := h.appV25MaintenanceStatus()
+	embSpace := h.embeddingSpaceStatus()
 
 	status := "ready"
 	httpStatus := http.StatusOK
@@ -303,6 +335,16 @@ func (h *HealthChecker) ReadinessHandler(w http.ResponseWriter, r *http.Request)
 		if r.URL.Query().Get("strict") == "1" {
 			httpStatus = http.StatusServiceUnavailable
 		}
+	case embSpace.Checked && !embSpace.OK:
+		// The store holds committed vectors in a space the active embedder does not
+		// produce; recall filters by the active space, so those rows are silently
+		// invisible. The node still SERVES — this is a quality loss, not an outage —
+		// so report degraded (HTTP 200) with the mismatch visible for reconciliation
+		// (re-embed, or boot with the config that wrote them). ?strict=1 gates on it.
+		status = "degraded"
+		if r.URL.Query().Get("strict") == "1" {
+			httpStatus = http.StatusServiceUnavailable
+		}
 	case canonical.Required && canonical.Quarantined:
 		// Record-local projection faults are isolated and omitted from broad
 		// reads. Keep the node operational and advertise the degraded state
@@ -336,6 +378,7 @@ func (h *HealthChecker) ReadinessHandler(w http.ResponseWriter, r *http.Request)
 		"postgres":            pgOK,
 		"cometbft":            cmtOK,
 		"embedder":            emb,
+		"embedding_space":     embSpace,
 		"scoped_projection":   scoped,
 		"vendored_agent":      vendored,
 		"memory_projection":   canonical,

--- a/internal/rerankd/install.go
+++ b/internal/rerankd/install.go
@@ -12,9 +12,11 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // Managed engine install: SAGE downloads a pinned llama.cpp release build
@@ -106,7 +108,7 @@ func (m *Manager) EngineSizeBytes() int64 {
 // managed binary is already present.
 func (m *Manager) InstallEngine(ctx context.Context, progress func(done, total int64)) error {
 	if m.EngineInstalled() {
-		return nil
+		return m.preflightEngine(ctx)
 	}
 	// Guard against concurrent installs racing on the shared .part dir and
 	// rename (same pattern as Download). Without it, a second call's
@@ -198,13 +200,87 @@ func (m *Manager) InstallEngine(ctx context.Context, progress func(done, total i
 	// Belt-and-braces: if another install won the race while we were extracting,
 	// leave its engine in place rather than RemoveAll/Rename over it.
 	if m.EngineInstalled() {
-		return nil
+		return m.preflightEngine(ctx)
 	}
 	_ = os.RemoveAll(m.engineDir())
 	if err := os.Rename(tmpDir, m.engineDir()); err != nil {
 		return fmt.Errorf("install engine: %w", err)
 	}
+	return m.preflightEngine(ctx)
+}
+
+// EngineIncompatibleError means the managed engine downloaded and extracted
+// cleanly but cannot LOAD on this host: the dynamic loader rejected it because
+// the host's C/C++ runtime is older than the prebuilt asset requires. Distinct
+// from a download/extract failure — the bytes are correct, the host is too old
+// for this build. Callers should route the operator to a bring-your-own reranker
+// rather than retrying the managed install.
+type EngineIncompatibleError struct {
+	OS, Arch string
+	Detail   string // the loader's own message, e.g. "version `GLIBC_2.38' not found"
+}
+
+func (e *EngineIncompatibleError) Error() string {
+	return fmt.Sprintf(
+		"managed reranker engine cannot run on this host (%s/%s): %s. "+
+			"The prebuilt engine needs a newer C/C++ runtime than this host provides "+
+			"(the pinned linux/arm64 llama.cpp build is compiled on a newer base than the "+
+			"amd64 one, so an older-glibc arm64 host such as a Jetson on Ubuntu 22.04 hits this). "+
+			"Bring your own instead: run your own llama-server and set SAGE_RERANK_ENABLED=1, "+
+			"SAGE_RERANK_KIND=llamacpp, and SAGE_RERANK_URL to its address.",
+		e.OS, e.Arch, e.Detail)
+}
+
+// preflightEngine confirms the freshly-installed managed binary can actually
+// LOAD on this host, not merely that it downloaded and extracted. The install
+// verifies a sha256 and lands bytes on disk; that is silent about whether the
+// dynamic loader can satisfy the binary's C/C++ runtime requirements. On a host
+// with an older glibc than the build base (JetPack-6 / Ubuntu 22.04 on a Jetson,
+// against the Ubuntu-24.04-built arm64 asset) the engine never execs and the
+// operator sees only a dead engine with no cause. Running the binary with a
+// trivial flag surfaces the loader's own message so InstallEngine can fail with
+// the real reason instead of reporting success.
+func (m *Manager) preflightEngine(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, m.managedBinaryPath(), "--version")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if runErr := cmd.Run(); runErr != nil {
+		// Only convert a PROVEN dynamic-loader/libc version mismatch into an
+		// incompatibility. Any other non-zero exit (an unrecognized flag on some
+		// future build, a timeout) is not proof the host is too old, so it must
+		// not block an otherwise-good install on an ambiguous signal.
+		if isLoaderVersionFailure(stderr.String()) {
+			return &EngineIncompatibleError{
+				OS:     runtime.GOOS,
+				Arch:   effectiveArch(),
+				Detail: firstLine(stderr.String()),
+			}
+		}
+	}
 	return nil
+}
+
+// isLoaderVersionFailure recognizes the dynamic loader rejecting a binary because
+// the host's C/C++ runtime is too old. These tokens are emitted by ld.so and
+// libstdc++ themselves (e.g. "version `GLIBC_2.38' not found",
+// "`GLIBCXX_3.4.32' not found", "CXXABI_1.3.15 not found") and appear only in a
+// version-mismatch loader error, so matching them does not false-positive on
+// ordinary program output.
+func isLoaderVersionFailure(stderr string) bool {
+	s := strings.ToUpper(stderr)
+	return strings.Contains(s, "GLIBC_") ||
+		strings.Contains(s, "GLIBCXX_") ||
+		strings.Contains(s, "CXXABI_")
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
 }
 
 // extractTarGzFlat writes every regular file's BASENAME into dst. Flattening

--- a/internal/rerankd/install_preflight_test.go
+++ b/internal/rerankd/install_preflight_test.go
@@ -1,0 +1,50 @@
+//go:build unix
+
+package rerankd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeFakeEngine(t *testing.T, m *Manager, script string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(m.engineDir(), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(m.engineDir(), serverBinaryName()), []byte(script), 0o755))
+}
+
+// A managed engine that DOWNLOADED and extracted cleanly but cannot LOAD — the
+// dynamic loader rejecting it for an older host C/C++ runtime — must surface the
+// real reason, not report install success. This is the Jetson / JetPack-6 case:
+// the pinned arm64 asset needs a newer glibc than Ubuntu 22.04 provides.
+func TestPreflightEngineSurfacesLoaderVersionFailure(t *testing.T) {
+	m := New(t.TempDir())
+	writeFakeEngine(t, m, "#!/bin/sh\necho 'llama-server: /lib/aarch64-linux-gnu/libstdc++.so.6: version GLIBCXX_3.4.32 not found' 1>&2\nexit 1\n")
+
+	err := m.preflightEngine(context.Background())
+	require.Error(t, err)
+	var inc *EngineIncompatibleError
+	require.ErrorAs(t, err, &inc)
+	require.Contains(t, inc.Detail, "GLIBCXX_3.4.32", "the loader's own message is preserved verbatim")
+	require.Contains(t, err.Error(), "SAGE_RERANK_KIND=llamacpp", "the honest error points the operator at the bring-your-own path")
+}
+
+// A binary that loads and runs is not blocked.
+func TestPreflightEnginePassesWhenBinaryLoads(t *testing.T) {
+	m := New(t.TempDir())
+	writeFakeEngine(t, m, "#!/bin/sh\necho 'version: b9870'\nexit 0\n")
+	require.NoError(t, m.preflightEngine(context.Background()))
+}
+
+// A non-zero exit WITHOUT a loader version signature is not proof the host is too
+// old (an unrecognized flag on a future build, a timeout). It must not block an
+// otherwise-good install on an ambiguous signal.
+func TestPreflightEngineDoesNotBlockOnAmbiguousFailure(t *testing.T) {
+	m := New(t.TempDir())
+	writeFakeEngine(t, m, "#!/bin/sh\necho 'error: unknown option --version' 1>&2\nexit 2\n")
+	require.NoError(t, m.preflightEngine(context.Background()))
+}

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -60,7 +60,7 @@ test('release-facing version metadata stays aligned', () => {
     ['deploy/federation-acceptance/README.md', `# v${version} federation Docker acceptance`],
     ['docs/FEDERATION.md', `Verified against SAGE v${version} federation behavior`],
     ['docs/reference/concepts/message-reply-lifecycle.md', `SAGE v${version} code`],
-    ['docs/UPGRADING.md', `| v${version} | Post-render MRI initialization hardening`],
+    ['docs/UPGRADING.md', `| v${version} | Turn-recall trust/lifecycle parity`],
     ['docs/ROADMAP.md', `## v${version} patch`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.18.22 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.18.23 SDK** | **TLS, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.18.22"
+version = "11.18.23"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.18.22"
+__version__ = "11.18.23"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.18.22",
+  "version": "11.18.23",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.18.22",
+      "identifier": "ghcr.io/l33tdawg/sage:11.18.23",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -75,7 +75,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.18.22';
+const SAGE_VERSION = 'v11.18.23';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
## What

Release SAGE v11.18.23 with the three review-green Hubanov fixes:

- #253: carry corroboration_count and lifecycle status through sage_turn recall
- #254: disclose active/store embedding-space mismatch through non-fatal readiness
- #256: preflight managed reranker binaries and surface proven loader incompatibility

## Safety

No consensus application change or state migration. App-v26 remains the ceiling.

PR #255 is deliberately excluded: its whole-domain completeness/count disclosure does not preserve caller-specific record visibility, and composition also drops index_status from empty sage_turn recall. It remains open for an authorization-aware redesign.

## Verification

- go test -timeout 20m ./...
- go vet ./...
- focused race suites for MCP, metrics, GUI, REST, store, and rerankd
- npm test: 406/406
- version alignment and release workflow contracts
- git diff --check