### PR TITLE
feat(sage-gui): flag a likely-alias embedding space so the guard's warning stays actionable

### DIFF
--- a/cmd/sage-gui/embedding_space_guard_test.go
+++ b/cmd/sage-gui/embedding_space_guard_test.go
@@ -101,3 +101,47 @@ func TestCheckEmbeddingSpaceConsistency_CountErrorLeavesUnchecked(t *testing.T) 
 	es := body["embedding_space"].(map[string]any)
 	assert.Equal(t, false, es["checked"], "a failed count leaves the check unrun, not a fabricated OK")
 }
+
+// fakeSemanticProvider is a minimal embedding.Provider (plus Named/Modeler) whose
+// SpaceID is a three-part name:model:dim id, so the alias classifier has a model
+// component to reason about — NewHashProvider only ever yields "hash"/"hash:N".
+type fakeSemanticProvider struct {
+	name, model string
+	dim         int
+}
+
+func (f fakeSemanticProvider) Embed(context.Context, string) ([]float32, error) { return nil, nil }
+func (f fakeSemanticProvider) Dimension() int                                   { return f.dim }
+func (f fakeSemanticProvider) Ready() bool                                      { return true }
+func (f fakeSemanticProvider) Semantic() bool                                   { return true }
+func (f fakeSemanticProvider) Name() string                                     { return f.name }
+func (f fakeSemanticProvider) Model() string                                    { return f.model }
+
+// A foreign space that is the ACTIVE model under a different name (the active
+// model carries an "Alibaba-NLP/" org prefix the stored rows lack) must be
+// reported as an alias, not lumped in with a genuinely different space — the
+// operator needs "re-embed, same model" rather than "wrong model."
+func TestCheckEmbeddingSpaceConsistency_ClassifiesLikelyAlias(t *testing.T) {
+	h := metrics.NewHealthChecker()
+	active := fakeSemanticProvider{name: "openai-compatible", model: "Alibaba-NLP/gte-Qwen2-1.5B-instruct", dim: 1536}
+	require.Equal(t, "openai-compatible:Alibaba-NLP/gte-Qwen2-1.5B-instruct:1536", embedding.SpaceID(active))
+
+	counter := fakeProviderCounter{counts: map[string]int{
+		"openai-compatible:Alibaba-NLP/gte-Qwen2-1.5B-instruct:1536": 1659, // active — reachable
+		"openai-compatible:gte-Qwen2-1.5B-instruct:1536":            12,    // same model, no org prefix — alias
+		"hash": 3, // genuinely different space — not an alias
+		"":     35, // repair queue — excluded
+	}}
+	checkEmbeddingSpaceConsistency(context.Background(), counter, active, h, zerolog.Nop())
+
+	code, body := readyBody(t, h, "/ready")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "degraded", body["status"])
+	es := body["embedding_space"].(map[string]any)
+	assert.EqualValues(t, 15, es["foreign_rows"], "12 alias + 3 hash; empty-provider excluded")
+	assert.EqualValues(t, 12, es["alias_rows"], "only the same-model-different-name rows")
+	aliases := es["alias_spaces"].(map[string]any)
+	assert.EqualValues(t, 12, aliases["openai-compatible:gte-Qwen2-1.5B-instruct:1536"])
+	_, hashAliased := aliases["hash"]
+	assert.False(t, hashAliased, "a genuinely different space is not an alias")
+}

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -3773,18 +3773,37 @@ func checkEmbeddingSpaceConsistency(
 		foreign[space] = n
 		total += n
 	}
+	// Classify the foreign spaces that are most likely the ACTIVE model under a
+	// different name (same model + dimension, differing only by an org prefix).
+	// Those are a re-embed, not a genuinely different model — telling them apart
+	// keeps the warning actionable instead of crying "foreign model" at a
+	// cosmetic label split an operator would then learn to ignore.
+	activeCanon := embedding.CanonicalSpaceID(active)
+	alias := make(map[string]int)
+	aliasTotal := 0
+	for space, n := range foreign {
+		if space != active && embedding.CanonicalSpaceID(space) == activeCanon {
+			alias[space] = n
+			aliasTotal += n
+		}
+	}
 	health.SetEmbeddingSpaceStatus(metrics.EmbeddingSpaceStatus{
 		OK:            total == 0,
 		ActiveSpace:   active,
 		ForeignRows:   total,
 		ForeignSpaces: foreign,
+		AliasRows:     aliasTotal,
+		AliasSpaces:   alias,
 	})
 	if total > 0 {
-		logger.Warn().
+		ev := logger.Warn().
 			Str("active_space", active).
 			Int("foreign_rows", total).
-			Interface("foreign_spaces", foreign).
-			Msg("embedding-space mismatch: the store holds committed vectors in a space the active embedder does not produce, so recall silently cannot see them. Re-embed to reconcile, or restart with the embedding config that wrote them. Serving in degraded mode (queryable at /ready).")
+			Interface("foreign_spaces", foreign)
+		if aliasTotal > 0 {
+			ev = ev.Int("alias_rows", aliasTotal).Interface("alias_spaces", alias)
+		}
+		ev.Msg("embedding-space mismatch: the store holds committed vectors in a space the active embedder does not produce, so recall silently cannot see them. Rows counted under alias_* are most likely your own model under a different name (same model and dimension) — a re-embed reconciles those. Re-embed to reconcile, or restart with the embedding config that wrote them. Serving in degraded mode (queryable at /ready).")
 	}
 }
 

--- a/internal/embedding/canonical_space_test.go
+++ b/internal/embedding/canonical_space_test.go
@@ -1,0 +1,43 @@
+package embedding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A model served under two spellings — with and without an organization prefix —
+// must canonicalize to one id, while a genuinely different model, provider, or
+// dimension must not.
+func TestCanonicalSpaceID(t *testing.T) {
+	// Same model, org-prefixed vs bare, collapse together.
+	assert.Equal(t,
+		CanonicalSpaceID("openai-compatible:gte-Qwen2-1.5B-instruct:1536"),
+		CanonicalSpaceID("openai-compatible:Alibaba-NLP/gte-Qwen2-1.5B-instruct:1536"),
+		"an org prefix on the model must not fork the space")
+	// The canonical form is the un-prefixed one.
+	assert.Equal(t, "openai-compatible:gte-Qwen2-1.5B-instruct:1536",
+		CanonicalSpaceID("openai-compatible:Alibaba-NLP/gte-Qwen2-1.5B-instruct:1536"))
+
+	// A different dimension must NOT collapse.
+	assert.NotEqual(t,
+		CanonicalSpaceID("openai-compatible:m:1536"),
+		CanonicalSpaceID("openai-compatible:m:768"))
+	// A different provider name must NOT collapse.
+	assert.NotEqual(t,
+		CanonicalSpaceID("openai-compatible:m:1536"),
+		CanonicalSpaceID("vllm:m:1536"))
+	// Two different models sharing an org prefix must NOT collapse.
+	assert.NotEqual(t,
+		CanonicalSpaceID("openai-compatible:org/a:1536"),
+		CanonicalSpaceID("openai-compatible:org/b:1536"))
+
+	// Legacy / no-model spaces are returned unchanged.
+	assert.Equal(t, "hash", CanonicalSpaceID("hash"))
+	assert.Equal(t, "ollama", CanonicalSpaceID("ollama"))
+	assert.Equal(t, "hash:512", CanonicalSpaceID("hash:512"))
+	assert.Equal(t, "", CanonicalSpaceID(""))
+
+	// Real default SpaceIDs round-trip cleanly (no model component to touch).
+	assert.Equal(t, "hash", CanonicalSpaceID(SpaceID(NewHashProvider(768))))
+}

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -110,3 +110,27 @@ func SpaceID(p Provider) string {
 	}
 	return fmt.Sprintf("%s:%s:%d", name, model, dimension)
 }
+
+// CanonicalSpaceID collapses a SpaceID to a form that ignores an organization
+// prefix on the MODEL name, so a model served under two spellings —
+// "openai-compatible:Alibaba-NLP/gte-Qwen2-1.5B-instruct:1536" and
+// "openai-compatible:gte-Qwen2-1.5B-instruct:1536" — map to the same canonical
+// id. Only a leading "org/" on the model component is stripped; the provider
+// name and dimension are left untouched, so two genuinely different models, or
+// the same model at a different dimension, never collapse together.
+//
+// This is a heuristic for TELLING an operator "this foreign space is most likely
+// your own model under another name," not a change to how recall partitions:
+// recall still compares the exact SpaceID, because two spellings could in
+// principle be different builds, and silently widening the match would be exactly
+// the cross-space cosine SpaceID exists to prevent.
+func CanonicalSpaceID(spaceID string) string {
+	parts := strings.Split(spaceID, ":")
+	if len(parts) != 3 {
+		return spaceID // "hash" / "ollama" / "name:dim" — no model component to canonicalize
+	}
+	if i := strings.LastIndex(parts[1], "/"); i >= 0 {
+		parts[1] = parts[1][i+1:]
+	}
+	return strings.Join(parts, ":")
+}

--- a/internal/metrics/health.go
+++ b/internal/metrics/health.go
@@ -100,6 +100,14 @@ type EmbeddingSpaceStatus struct {
 	ActiveSpace   string         `json:"active_space,omitempty"`   // SpaceID the node writes and queries now
 	ForeignRows   int            `json:"foreign_rows,omitempty"`   // committed rows the active space cannot see
 	ForeignSpaces map[string]int `json:"foreign_spaces,omitempty"` // foreign space id -> row count
+	// AliasRows / AliasSpaces are the subset of the foreign rows whose space is
+	// most likely the ACTIVE model under a different name — same model and
+	// dimension, differing only by an organization prefix on the model. They are
+	// invisible to recall for the same reason (an exact-string space filter), but
+	// the fix is a re-embed, not a config change, so distinguishing them keeps the
+	// warning trustworthy instead of crying "foreign model" at a cosmetic split.
+	AliasRows   int            `json:"alias_rows,omitempty"`
+	AliasSpaces map[string]int `json:"alias_spaces,omitempty"`
 }
 
 type HealthChecker struct {


### PR DESCRIPTION
## What
The boot embedding-space guard (v11.18.23) now distinguishes a foreign space that is **most likely the active model under a different name** — same model and dimension, differing only by an organization prefix — from a genuinely different space. The likely-alias rows are reported as `alias_rows` / `alias_spaces` in the `/ready` `embedding_space` status and named in the boot warning.

## Why
The guard reports committed vectors in a space the active embedder does not produce. A common cause is cosmetic: the *same* model served under two spellings — `openai-compatible:Alibaba-NLP/gte-Qwen2-1.5B-instruct:1536` vs `openai-compatible:gte-Qwen2-1.5B-instruct:1536` — forms two spaces under the exact-string filter, so the guard cries "foreign model" at what is really "your model, re-embed to reconcile." An operator who cannot tell those apart learns to ignore the warning, which defeats it. This is not hypothetical: a two-month store had 12 rows dark since July from the `Alibaba-NLP/` prefix difference alone, with nothing saying so.

## How
- `embedding.CanonicalSpaceID` collapses a `name:model:dim` SpaceID by stripping a leading `org/` on the model; the provider name and dimension are untouched, so two genuinely different models, providers, or dimensions never collapse together.
- `checkEmbeddingSpaceConsistency` classifies each foreign space whose canonical form equals the active space's canonical form as a likely alias, sets `AliasRows`/`AliasSpaces` on `EmbeddingSpaceStatus`, and names them in the warning ("rows counted under `alias_*` are most likely your own model under a different name; a re-embed reconciles those").
- **Recall behaviour is unchanged.** Recall still compares the exact SpaceID — two spellings could in principle be different builds, and silently widening the match is exactly the cross-space cosine SpaceID exists to prevent. This is display/advice only, so the operator points a re-embed at the right rows instead of ignoring the warning.

## ABCI / determinism
None. Boot-time observability plus one `/ready` health field; `CanonicalSpaceID` is a pure string heuristic used only for the warning, never for the recall partition. No consensus, storage, or memory-API change.

## Tests
- `CanonicalSpaceID`: org-prefixed and bare spellings collapse; a different dimension, provider, or two different models under the same org prefix do not; legacy `hash`/`ollama`/`name:dim` ids are unchanged.
- Guard: a foreign space that is the active model under an org-prefixed name is reported as `alias_rows`, while a genuinely different space (`hash`) is not; surfaced in `/ready`.
- Verified locally: `go build ./...`, `golangci-lint` (v2.12.2 CI pin) clean; `internal/embedding` and `internal/metrics` pass under `-race`, the changed `cmd/sage-gui` tests pass under `-race` and the full package passes non-race (its full `-race` sweep exceeds a local time budget, left to CI); full `npm test` 406 pass.
