### PR TITLE
fix(sage-gui): mcp-token create --help must not mint a token

### DIFF
--- a/cmd/sage-gui/mcp_token.go
+++ b/cmd/sage-gui/mcp_token.go
@@ -77,11 +77,22 @@ func runMCPTokenCreate() error {
 			}
 			name = args[i+1]
 			i++
+		case "--help", "-h", "help":
+			// `create` mints a real, irreversible credential, so an unrecognized
+			// arg must never be silently swallowed and fall through to the mint.
+			// Handle help here — the outer dispatcher only sees `--help` at the
+			// subcommand position, so `mcp-token create --help` reached this parser
+			// and used to mint a token instead of printing usage.
+			printMCPTokenUsage()
+			return nil
 		default:
-			if strings.HasPrefix(args[i], "--agent=") {
+			switch {
+			case strings.HasPrefix(args[i], "--agent="):
 				agentID = strings.TrimPrefix(args[i], "--agent=")
-			} else if strings.HasPrefix(args[i], "--name=") {
+			case strings.HasPrefix(args[i], "--name="):
 				name = strings.TrimPrefix(args[i], "--name=")
+			default:
+				return fmt.Errorf("unknown argument %q for 'mcp-token create'; run 'sage-gui mcp-token create --help'", args[i])
 			}
 		}
 	}

--- a/cmd/sage-gui/mcp_token_help_test.go
+++ b/cmd/sage-gui/mcp_token_help_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// `mcp-token create` mints a real, irreversible credential. `create --help` must
+// print usage and return WITHOUT minting — the bug was that the parser's default
+// branch silently swallowed --help and fell through to the mint (the outer
+// dispatcher only handles --help at the subcommand position). Returning here
+// before mcpTokenSigningIdentity/mcpTokenAPICall proves no token is issued: on
+// the old code path --help reached the signing/API step and could not return nil.
+func TestMCPTokenCreateHelpDoesNotMint(t *testing.T) {
+	orig := os.Args
+	t.Cleanup(func() { os.Args = orig })
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	os.Args = []string{"sage-gui", "mcp-token", "create", "--help"}
+	err := runMCPTokenCreate()
+	_ = w.Close()
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+
+	require.NoError(t, err, "--help must print usage and return, never fall through to minting")
+	assert.Contains(t, string(out), "sage-gui mcp-token create", "usage was printed")
+}
+
+// An unrecognized flag must ERROR rather than be silently ignored, because
+// silently swallowing an unknown flag on a command with irreversible side
+// effects is its own trap.
+func TestMCPTokenCreateRejectsUnknownFlag(t *testing.T) {
+	orig := os.Args
+	t.Cleanup(func() { os.Args = orig })
+	os.Args = []string{"sage-gui", "mcp-token", "create", "--bogus"}
+	err := runMCPTokenCreate()
+	require.Error(t, err, "an unknown flag must not be swallowed on a command that mints a credential")
+	assert.Contains(t, err.Error(), "unknown argument")
+}


### PR DESCRIPTION
## What
`mcp-token create --help` now prints usage and returns instead of minting a real bearer token, and an unrecognized argument errors instead of being silently ignored.

## Why
`mcp-token create` mints a real, irreversible credential (a keyed MCP bearer). Its hand-rolled arg parser recognized only `--agent`/`--name`; the `default` branch silently ignored everything else. `--help` is handled by the outer dispatcher only at the subcommand position (`os.Args[2]`), so `mcp-token create --help` reached the create parser, fell through the default, and proceeded to mint — a flag that conventionally does nothing produces a live credential.

## How
- `--help`/`-h`/`help` inside the create parser prints `printMCPTokenUsage()` and returns before `mcpTokenSigningIdentity()` or the `/v1/mcp/tokens` POST, so no token is issued.
- An unrecognized argument returns an error rather than being ignored, because silently swallowing an unknown flag on a command with irreversible side effects is its own trap.

## ABCI / determinism
None. CLI arg handling for a local admin command; no consensus, storage, or memory-API path.

## Tests
- `create --help` returns without reaching the signing/mint step (no-error proves it did not fall through — the old path could not return nil) and prints usage; an unknown flag errors.
- `go build` / `go vet` / `golangci-lint` (v2.12.2 CI pin) clean; full `cmd/sage-gui` package test green.
