### PR TITLE
fix(mcp): bind tokens to approved managed identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ updates already exercised by the full repository gate.
 current revisions.** CodeQL runs with the updated action bundle and the native
 shell cache action is updated, without changing SAGE runtime behavior.
 
+**HTTP MCP tokens now bind to existing approved managed identities.** On
+app-v23 nodes, token creation no longer generates an unapprovable pending
+principal: Root/Admin selects an active ordinary agent already managed by the
+node, and issuance fails closed if its exact key is unavailable. The CLI also
+handles `mcp-token create --help` without minting a credential and rejects
+unknown creation flags.
+
 This patch introduces no new consensus application version or state migration.
 The ceiling remains app-v26; **v11.18.26 introduces no app-v27**.
 
@@ -1689,7 +1696,7 @@ SDK 11.8.3.
 
 **Synchronization groups — human-verified, signed memory sharing between separate SAGE brains.** A synchronization group coordinates memory sharing off-consensus through a partitioned, hash-chained, ed25519-signed audit journal: a roster sub-chain replicated to every member and independent per-domain sub-chains replicated only to the members who share that domain, so a node never learns of a domain it does not share. Group items are origin-signed, so a relaying peer can back-fill the mesh without being able to forge or mis-attribute them. Adding a shared domain is a two-party action — the owning member and the group controller both sign — members express selective-sync consent over the subset of domains they receive, and controller epoch rotation, member removal, and rejoin are all explicit signed roster events reconciled between peers by anti-entropy exchange.
 
-Each MCP bearer token now mints and registers its own signing identity, so a delegated agent action is attributable to exactly one token and one token can never act as another. This release also hardens group authorization: a controller epoch rotation now re-attests the shared domain set under the incoming controller, so rotating control away from a node revokes that node's ability to admit or re-widen shared domains with its old key; and a removed or departed member cannot be silently re-activated with stale entitlements — re-entry requires a fresh, co-signed invitation. The v11.8 consensus fork gate is present but dormant.
+At the time of v11.8.2, each MCP bearer minted and registered its own signing identity. Current app-v23 behavior supersedes that design: v11.18.26 binds new bearers to existing approved locally managed agents so token creation cannot strand an unapprovable identity. This release also hardens group authorization: a controller epoch rotation now re-attests the shared domain set under the incoming controller, so rotating control away from a node revokes that node's ability to admit or re-widen shared domains with its old key; and a removed or departed member cannot be silently re-activated with stale entitlements — re-entry requires a fresh, co-signed invitation. The v11.8 consensus fork gate is present but dormant.
 
 The CEREBRUM MRI now renders a 2,500-memory representative sample instead of stopping at 500, filling large brains with a denser view while preserving a bounded GPU and API workload. The dashboard and fullscreen MRI share one limit, and operators can still tune the server ceiling with `SAGE_GRAPH_MAX_NODES`.
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2258,7 +2258,11 @@ components:
           description: Human label, e.g. "chatgpt-laptop".
         agent_id:
           type: string
-          description: 64-char hex Ed25519 pubkey to mint for.
+          description: >-
+            App-v23: 64-char hex Ed25519 pubkey of an existing active approved
+            ordinary agent whose exact key is locally managed. The bearer
+            executes with that identity's existing permissions. Pre-v23: the
+            node operator identity.
 
     MCPTokenIssueResponse:
       type: object
@@ -4839,8 +4843,10 @@ paths:
       operationId: issueMCPToken
       summary: Issue a bearer token for MCP clients that cannot sign Ed25519 requests.
       description: >-
-        Ed25519 auth required (admin use). Token plaintext shown ONCE — not
-        stored, only SHA-256 digest persisted.
+        Ed25519 auth required (current Root/Admin under app-v23). Token
+        plaintext is shown ONCE; only its SHA-256 digest is persisted. App-v23
+        binds the bearer to the requested existing active locally managed agent
+        and never creates a new pending principal.
       tags:
         - MCP Tokens
       requestBody:

--- a/api/rest/federation_identity_adversary_test.go
+++ b/api/rest/federation_identity_adversary_test.go
@@ -2,6 +2,9 @@ package rest
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,7 +18,9 @@ import (
 // still mint local MCP identities while the replacement Root is locked out.
 func TestAdversaryRootHandoverSeparatesMCPControlFromFederationTransportIdentity(t *testing.T) {
 	srv, _ := newTokenServer(t)
-	companionID := appV23RESTAgentID("22")
+	companionPub, companionKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	companionID := hex.EncodeToString(companionPub)
 	currentRootID := appV23RESTAgentID("33")
 	badger, err := store.NewBadgerStore(t.TempDir())
 	require.NoError(t, err)
@@ -29,6 +34,18 @@ func TestAdversaryRootHandoverSeparatesMCPControlFromFederationTransportIdentity
 	require.NoError(t, badger.RotateAppV23RootCredential(1, currentRootID, 2))
 	srv.badgerStore = badger
 	srv.SetPostV23ForNextTxAccessor(func() bool { return true })
+	tokenStore := srv.store.(*store.SQLiteStore)
+	tokenStore.SetMCPTokenKeyedIdentityRequirement(func() bool { return true })
+	tokenStore.SetMCPTokenIdentityResolver(func(id string) (ed25519.PrivateKey, bool) {
+		if id != companionID {
+			return nil, false
+		}
+		return companionKey, true
+	})
+	t.Cleanup(func() {
+		tokenStore.SetMCPTokenKeyedIdentityRequirement(nil)
+		tokenStore.SetMCPTokenIdentityResolver(nil)
+	})
 
 	for _, tc := range []struct {
 		name       string
@@ -45,7 +62,7 @@ func TestAdversaryRootHandoverSeparatesMCPControlFromFederationTransportIdentity
 		{
 			name:       "current Root can mint",
 			callerID:   currentRootID,
-			requestID:  currentRootID,
+			requestID:  companionID,
 			wantStatus: http.StatusCreated,
 		},
 	} {

--- a/api/rest/mcp_tokens_handler.go
+++ b/api/rest/mcp_tokens_handler.go
@@ -6,8 +6,8 @@ package rest
 // the bearer-token auth that gates the actual MCP transport). The flow is:
 //
 //  1. Current Root/Admin (or the pre-v23 node operator during upgrade) calls
-//     POST /v1/mcp/tokens. Under app-v23 the authorizer is only the issuer:
-//     the bearer receives a distinct restricted Member identity.
+//     POST /v1/mcp/tokens. Under app-v23 agent_id selects an already-enrolled
+//     local identity whose managed key is held by this node.
 //     The server returns a one-shot token string + token ID.
 //   2. External MCP client (ChatGPT, Cursor, etc.) sends that token in
 //      Authorization: Bearer <token> on every /v1/mcp/sse or
@@ -54,7 +54,7 @@ func (s *Server) ConfigureMCPTokenIdentityRegistrar(ts *store.SQLiteStore) {
 // MCPTokenIssueRequest is the JSON body for POST /v1/mcp/tokens.
 type MCPTokenIssueRequest struct {
 	Name    string `json:"name"`     // human label, e.g. "chatgpt-laptop"
-	AgentID string `json:"agent_id"` // hex-encoded ed25519 pubkey of the agent identity to mint for
+	AgentID string `json:"agent_id"` // exact existing managed identity the bearer executes as
 }
 
 // MCPTokenIssueResponse is what the client sees ONCE and only once.
@@ -75,6 +75,20 @@ type MCPTokenSummary struct {
 	CreatedAt  time.Time `json:"created_at"`
 	LastUsedAt time.Time `json:"last_used_at,omitempty"`
 	RevokedAt  time.Time `json:"revoked_at,omitempty"`
+}
+
+// ValidateMCPTokenTarget verifies the consensus half of app-v23 bind-to-
+// existing issuance. The store separately proves that the exact private key is
+// present in the node's managed inventory before it writes a token row.
+func (s *Server) ValidateMCPTokenTarget(_ context.Context, agentID string) error {
+	active, err := s.appV23ActiveOrdinaryAgent(agentID)
+	if err != nil {
+		return err
+	}
+	if !active {
+		return errors.New("agent_id must identify an active approved ordinary agent")
+	}
+	return nil
 }
 
 // handleMCPTokenIssue mints a new bearer token. The plaintext token is shown
@@ -118,11 +132,15 @@ func (s *Server) handleMCPTokenIssue(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusForbidden, "MCP token issuance requires the current CEREBRUM Root or a current local Admin")
 			return
 		}
-		if req.AgentID != callerID {
-			writeJSONError(w, http.StatusBadRequest, "agent_id must match the authorizing Root or Admin")
+		if targetErr := s.ValidateMCPTokenTarget(r.Context(), req.AgentID); targetErr != nil {
+			if strings.Contains(targetErr.Error(), "active approved") {
+				writeJSONError(w, http.StatusBadRequest, targetErr.Error())
+				return
+			}
+			writeJSONError(w, http.StatusServiceUnavailable, "MCP token target enrollment is unavailable")
 			return
 		}
-		legacyAgentID = callerID
+		legacyAgentID = req.AgentID
 	} else {
 		if s.nodeOperatorID == "" {
 			writeJSONError(w, http.StatusServiceUnavailable, "node operator identity unavailable — MCP tokens cannot be issued")
@@ -152,7 +170,7 @@ func (s *Server) handleMCPTokenIssue(w http.ResponseWriter, r *http.Request) {
 		AgentID:   issued.AgentID,
 		Token:     issued.Token,
 		CreatedAt: issued.CreatedAt,
-		UseHint:   "Set Authorization: Bearer <token> on requests to /v1/mcp/sse or /v1/mcp/streamable. Vault-backed tokens sign as their own on-chain identity. SAVE THIS TOKEN NOW — it is never shown again.",
+		UseHint:   "Set Authorization: Bearer <token> on requests to /v1/mcp/sse or /v1/mcp/streamable. This token executes exactly as the selected existing agent identity. SAVE THIS TOKEN NOW — it is never shown again.",
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/api/rest/mcp_tokens_handler_test.go
+++ b/api/rest/mcp_tokens_handler_test.go
@@ -3,6 +3,9 @@ package rest
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/l33tdawg/sage/api/rest/middleware"
+	"github.com/l33tdawg/sage/internal/auth"
 	"github.com/l33tdawg/sage/internal/store"
 )
 
@@ -94,6 +98,52 @@ func TestMCPTokenIssue_BadAgentID(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rr.Code, "body=%s", c.body)
 		assert.Contains(t, rr.Body.String(), c.want, "body=%s", c.body)
 	}
+}
+
+func TestAppV23MCPTokenIssueBindsToExistingApprovedManagedAgent(t *testing.T) {
+	s, _ := newTokenServer(t)
+	badgerStore, err := store.NewBadgerStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = badgerStore.CloseBadger() })
+	s.badgerStore = badgerStore
+	s.SetPostV23ForNextTxAccessor(func() bool { return true })
+
+	targetPub, targetPriv, err := auth.GenerateKeypair()
+	require.NoError(t, err)
+	targetID := auth.PublicKeyToAgentID(targetPub)
+	require.NoError(t, badgerStore.BootstrapAppV23Genesis(store.AppV23GenesisBootstrap{
+		RootID: tokenOperatorID, Scope: "mcp-token-bind-test",
+		AgentID: targetID, Profile: store.AppV23ProfileStandard,
+		HomeDomain: "managed.home", Clearance: 2,
+		Height: 1, BootstrapDigest: "mcp-token-bind-test",
+	}))
+	tokenStore := s.store.(*store.SQLiteStore)
+	tokenStore.SetMCPTokenKeyedIdentityRequirement(func() bool { return true })
+	t.Cleanup(func() { tokenStore.SetMCPTokenKeyedIdentityRequirement(nil) })
+	tokenStore.SetMCPTokenIdentityResolver(func(id string) (ed25519.PrivateKey, bool) {
+		if id != targetID {
+			return nil, false
+		}
+		return targetPriv, true
+	})
+	t.Cleanup(func() { tokenStore.SetMCPTokenIdentityResolver(nil) })
+
+	body := []byte(`{"agent_id":"` + targetID + `","name":"chatgpt"}`)
+	rr := httptest.NewRecorder()
+	tokenRouterAs(s, tokenOperatorID).ServeHTTP(rr,
+		httptest.NewRequest(http.MethodPost, "/v1/mcp/tokens", bytes.NewReader(body)))
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	var response MCPTokenIssueResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&response))
+	require.Equal(t, targetID, response.AgentID)
+
+	digest := sha256.Sum256([]byte(response.Token))
+	boundID, signer, lookupErr := tokenStore.LookupMCPTokenSignerWithBearer(
+		context.Background(), response.Token, hex.EncodeToString(digest[:]),
+	)
+	require.NoError(t, lookupErr)
+	require.Equal(t, targetID, boundID)
+	require.Equal(t, targetID, hex.EncodeToString(signer.Public().(ed25519.PublicKey)))
 }
 
 func TestMCPTokenList_EmptyThenPopulated(t *testing.T) {

--- a/api/rest/oauth_appv23_controlplane_adversary_test.go
+++ b/api/rest/oauth_appv23_controlplane_adversary_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -242,7 +243,7 @@ func oauthHiddenInput(t *testing.T, body, name string) string {
 	return value[:end]
 }
 
-func TestOAuthLocalApprovalBridgeMintsDistinctPendingAgentEncryptionOnAndOff(t *testing.T) {
+func TestOAuthLocalApprovalBridgeBindsExistingManagedAgentEncryptionOnAndOff(t *testing.T) {
 	for _, encrypted := range []bool{false, true} {
 		t.Run(map[bool]string{false: "unencrypted", true: "vault-encrypted"}[encrypted], func(t *testing.T) {
 			h, router, tokenStore := newOAuthRouter(t, false, "")
@@ -256,19 +257,23 @@ func TestOAuthLocalApprovalBridgeMintsDistinctPendingAgentEncryptionOnAndOff(t *
 			}
 			tokenStore.SetMCPTokenKeyedIdentityRequirement(func() bool { return true })
 			t.Cleanup(func() { tokenStore.SetMCPTokenKeyedIdentityRequirement(nil) })
-			var registeredID, registeredProvider string
-			tokenStore.SetMCPTokenIdentityRegistrar(func(
-				_ context.Context,
-				pub ed25519.PublicKey,
-				priv ed25519.PrivateKey,
-				_, provider string,
-			) error {
-				require.True(t, priv.Public().(ed25519.PublicKey).Equal(pub))
-				registeredID = hex.EncodeToString(pub)
-				registeredProvider = provider
-				return nil
+			targetPub, targetPriv, keyErr := ed25519.GenerateKey(rand.Reader)
+			require.NoError(t, keyErr)
+			targetID := hex.EncodeToString(targetPub)
+			tokenStore.SetMCPTokenIdentityResolver(func(id string) (ed25519.PrivateKey, bool) {
+				if id != targetID {
+					return nil, false
+				}
+				return targetPriv, true
 			})
-			t.Cleanup(func() { tokenStore.SetMCPTokenIdentityRegistrar(nil) })
+			t.Cleanup(func() { tokenStore.SetMCPTokenIdentityResolver(nil) })
+			h.ManagedTokenTargetsRequired = func() bool { return true }
+			h.ValidateTokenTarget = func(_ context.Context, id string) error {
+				if id != targetID {
+					return errors.New("not an approved target")
+				}
+				return nil
+			}
 
 			approverID := strings.Repeat("7", 64)
 			h.ResolveControlActor = func(r *http.Request) (string, bool) {
@@ -326,12 +331,13 @@ func TestOAuthLocalApprovalBridgeMintsDistinctPendingAgentEncryptionOnAndOff(t *
 			require.NoError(t, err)
 			require.NoError(t, getResp.Body.Close())
 			csrf := oauthHiddenInput(t, string(getBody), "csrf_nonce")
-			require.Contains(t, string(getBody), "distinct pending-review MCP agent")
+			require.Contains(t, string(getBody), "selected existing active agent")
 
 			form := url.Values{
 				"handoff":    {handoff},
 				"csrf_nonce": {csrf},
 				"token_name": {"bridge-client"},
+				"agent_id":   {targetID},
 			}
 			postReq := httptest.NewRequest(
 				http.MethodPost, approvalURL.RequestURI(), strings.NewReader(form.Encode()),
@@ -356,9 +362,8 @@ func TestOAuthLocalApprovalBridgeMintsDistinctPendingAgentEncryptionOnAndOff(t *
 			require.NoError(t, err)
 			require.Len(t, rows, 1)
 			require.Equal(t, approverID, rows[0].IssuerID)
-			require.Equal(t, registeredID, rows[0].AgentID)
+			require.Equal(t, targetID, rows[0].AgentID)
 			require.NotEqual(t, approverID, rows[0].AgentID)
-			require.Equal(t, "oauth-mcp-token", registeredProvider)
 
 			tokenForm := url.Values{
 				"grant_type": {"authorization_code"}, "code": {code},
@@ -386,8 +391,8 @@ func TestOAuthLocalApprovalBridgeMintsDistinctPendingAgentEncryptionOnAndOff(t *
 				hex.EncodeToString(tokenDigest[:]),
 			)
 			require.NoError(t, err)
-			require.Equal(t, registeredID, agentID)
-			require.Equal(t, registeredID, hex.EncodeToString(signer.Public().(ed25519.PublicKey)))
+			require.Equal(t, targetID, agentID)
+			require.Equal(t, targetID, hex.EncodeToString(signer.Public().(ed25519.PublicKey)))
 
 			// The same approval handle cannot mint a second token.
 			replayReq := httptest.NewRequest(

--- a/api/rest/oauth_handlers.go
+++ b/api/rest/oauth_handlers.go
@@ -142,8 +142,8 @@ type OAuthDashboardSession func(r *http.Request) bool
 // OAuthControlActorResolver resolves the exact current local CEREBRUM
 // authority for this request. Production wires the dashboard's app-v23-aware
 // resolver, which accepts only the current committed Root or an active
-// current-generation same-machine Admin. The returned identity is the issuer
-// for a distinct pending-review MCP agent; it never becomes the token actor.
+// current-generation same-machine Admin. The returned identity owns the token;
+// app-v23 selects a separate existing managed ordinary agent as its actor.
 type OAuthControlActorResolver func(r *http.Request) (agentID string, ok bool)
 
 // OAuthLocalityChecker is the localhost control-plane boundary used by the
@@ -168,14 +168,16 @@ type oauthApprovalHandoff struct {
 // screen rather than letting the user pick an agent that the bearer will
 // not actually act as.
 type OAuthHandler struct {
-	Store                OAuthStore
-	IsAuthed             OAuthSessionChecker
-	HasDashboardCookie   OAuthDashboardSession
-	ResolveControlActor  OAuthControlActorResolver
-	IsLocalApproval      OAuthLocalityChecker
-	IssuerBaseURL        func(r *http.Request) string // e.g. "https://host:8443" — derived per request
-	LocalApprovalBaseURL string                       // e.g. "http://127.0.0.1:8080"
-	NodeOperatorAgentID  string
+	Store                       OAuthStore
+	IsAuthed                    OAuthSessionChecker
+	HasDashboardCookie          OAuthDashboardSession
+	ResolveControlActor         OAuthControlActorResolver
+	IsLocalApproval             OAuthLocalityChecker
+	IssuerBaseURL               func(r *http.Request) string // e.g. "https://host:8443" — derived per request
+	LocalApprovalBaseURL        string                       // e.g. "http://127.0.0.1:8080"
+	NodeOperatorAgentID         string
+	ManagedTokenTargetsRequired func() bool
+	ValidateTokenTarget         func(context.Context, string) error
 
 	csrfKey        []byte // process-lifetime random for HMAC-signing consent + approval handles
 	dcrLimits      *ipRateLimiter
@@ -994,14 +996,19 @@ var consentTemplate = template.Must(template.New("consent").Parse(`<!doctype htm
     <h2 style="font-size: 1.1em;">Mint a new bearer for this client</h2>
     <p class="meta">A new <code>mcp_tokens</code> row is created for this connection — you can revoke it at any time from <code>sage-gui mcp-token revoke &lt;id&gt;</code> or the dashboard.</p>
     <p>
+      {{if .BindExisting}}<label>Existing managed agent ID<br>
+        <input type="text" name="agent_id" value="" required style="width: 100%; box-sizing: border-box;" placeholder="64-char Ed25519 public key">
+      </label>{{end}}
       <label>Token name (optional, e.g. "chatgpt-laptop")<br>
         <input type="text" name="token_name" value="" style="width: 100%; box-sizing: border-box;">
       </label>
     </p>
-    <div class="card" style="background:#fff;border-color:#cfd8dc;">
+    {{if .BindExisting}}<div class="card" style="background:#fff;border-color:#cfd8dc;">
+      <p style="margin:0;"><strong>Identity:</strong> the selected existing active agent</p>
+      <p class="meta" style="margin:0.5em 0 0;">The node must already hold this agent's managed key. The bearer receives exactly that agent's existing permissions; token creation never creates a pending identity.</p>
+    </div>{{else}}<div class="card" style="background:#fff;border-color:#cfd8dc;">
       <p style="margin:0;"><strong>Identity:</strong> a distinct pending-review MCP agent</p>
-      <p class="meta" style="margin:0.5em 0 0;">This connection receives its own signing key and starts as a restricted Member pending CEREBRUM review. It never inherits Root or Admin authority from the person approving it.</p>
-    </div>
+    </div>{{end}}
     <p style="margin-top:1em;"><button type="submit">Authorize</button></p>
   </form>
 
@@ -1045,6 +1052,7 @@ func (h *OAuthHandler) renderConsent(
 		CSRFNonce           string
 		ApprovalHandoff     string
 		Action              string
+		BindExisting        bool
 	}{
 		ClientID:            p.ClientID,
 		RedirectURI:         p.RedirectURI,
@@ -1057,6 +1065,7 @@ func (h *OAuthHandler) renderConsent(
 		CSRFNonce:           csrfNonce,
 		ApprovalHandoff:     p.ApprovalHandoff,
 		Action:              action,
+		BindExisting:        h.ManagedTokenTargetsRequired != nil && h.ManagedTokenTargetsRequired(),
 	}
 	_ = actorID // authority is deliberately not rendered into the consent page
 	if err := consentTemplate.Execute(w, data); err != nil {
@@ -1101,18 +1110,36 @@ func (h *OAuthHandler) processConsent(
 		tokenName = "oauth-" + p.ClientID
 	}
 
-	// actorID is resolved from live local CEREBRUM state on this exact POST.
-	// It owns the token record but never becomes the token's acting identity:
-	// IssuePendingMCPToken generates and synchronously registers a distinct
-	// restricted Member key.
-	agentID := strings.TrimSpace(actorID)
-	if len(agentID) != 64 {
+	// actorID is the authorizing Root/Admin and remains the token owner. The
+	// bearer acts only as the separately selected existing managed identity.
+	issuerID := strings.TrimSpace(actorID)
+	if len(issuerID) != 64 {
 		h.renderConsent(w, r, p, actorID, "current CEREBRUM authority unavailable — bearers cannot be issued", r.URL.Path)
 		return
 	}
-	if _, decErr := hex.DecodeString(agentID); decErr != nil {
+	if _, decErr := hex.DecodeString(issuerID); decErr != nil {
 		h.renderConsent(w, r, p, actorID, "current CEREBRUM authority is invalid — server misconfiguration", r.URL.Path)
 		return
+	}
+	targetID := issuerID
+	if h.ManagedTokenTargetsRequired != nil && h.ManagedTokenTargetsRequired() {
+		targetID = strings.TrimSpace(r.FormValue("agent_id"))
+		if len(targetID) != 64 {
+			h.renderConsent(w, r, p, actorID, "select an existing managed agent identity", r.URL.Path)
+			return
+		}
+		if _, decErr := hex.DecodeString(targetID); decErr != nil {
+			h.renderConsent(w, r, p, actorID, "selected agent identity is invalid", r.URL.Path)
+			return
+		}
+		if h.ValidateTokenTarget == nil {
+			h.renderConsent(w, r, p, actorID, "agent enrollment validation is unavailable", r.URL.Path)
+			return
+		}
+		if targetErr := h.ValidateTokenTarget(r.Context(), targetID); targetErr != nil {
+			h.renderConsent(w, r, p, actorID, "selected agent is not an active approved local identity", r.URL.Path)
+			return
+		}
 	}
 	// Validate the redirect sink before creating either secret. The normal
 	// HandleAuthorize validation is intentionally repeated here because this is
@@ -1128,9 +1155,9 @@ func (h *OAuthHandler) processConsent(
 	}
 
 	// 1. Mint via the exact shared issuer used by /v1/mcp/tokens and the
-	// wizard. On vault-active nodes this creates/registers a distinct keyed
-	// identity and records the operator as issuer/owner.
-	issued, err := h.Store.IssuePendingMCPToken(r.Context(), tokenName, agentID, agentID, "oauth-mcp-token")
+	// wizard. App-v23 binds the bearer to targetID while recording the live
+	// Root/Admin as its issuer/owner.
+	issued, err := h.Store.IssuePendingMCPToken(r.Context(), tokenName, issuerID, targetID, "oauth-mcp-token")
 	if err != nil {
 		http.Error(w, "failed to persist token: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/api/rest/oauth_handlers.go
+++ b/api/rest/oauth_handlers.go
@@ -1008,6 +1008,7 @@ var consentTemplate = template.Must(template.New("consent").Parse(`<!doctype htm
       <p class="meta" style="margin:0.5em 0 0;">The node must already hold this agent's managed key. The bearer receives exactly that agent's existing permissions; token creation never creates a pending identity.</p>
     </div>{{else}}<div class="card" style="background:#fff;border-color:#cfd8dc;">
       <p style="margin:0;"><strong>Identity:</strong> a distinct pending-review MCP agent</p>
+      <p class="meta" style="margin:0.5em 0 0;">It never inherits Root or Admin authority from the person approving it.</p>
     </div>{{end}}
     <p style="margin-top:1em;"><button type="submit">Authorize</button></p>
   </form>

--- a/cmd/sage-gui/mcp_token.go
+++ b/cmd/sage-gui/mcp_token.go
@@ -3,7 +3,7 @@ package main
 // CLI for managing HTTP MCP bearer tokens.
 //
 // Usage:
-//   sage-gui mcp-token create [--name <label>]
+//   sage-gui mcp-token create [--agent <existing-agent-id>] [--name <label>]
 //   sage-gui mcp-token list
 //   sage-gui mcp-token revoke <id>
 //
@@ -50,12 +50,12 @@ func printMCPTokenUsage() {
 	fmt.Println(`Manage HTTP MCP bearer tokens.
 
 Usage:
-  sage-gui mcp-token create [--name <label>]
+  sage-gui mcp-token create [--agent <existing-agent-id>] [--name <label>]
   sage-gui mcp-token list
   sage-gui mcp-token revoke <id>
 
 Examples:
-  sage-gui mcp-token create --name chatgpt-laptop
+  sage-gui mcp-token create --agent <existing-agent-id> --name chatgpt-laptop
   sage-gui mcp-token list
   sage-gui mcp-token revoke 6c5e9f8a-b21d-4d52-89c4-1a3a4d9e7c5a`)
 }
@@ -77,11 +77,19 @@ func runMCPTokenCreate() error {
 			}
 			name = args[i+1]
 			i++
+		case "--help", "-h", "help":
+			// create mints a real credential, so help must return before any
+			// signing-key lookup or API call can issue one.
+			printMCPTokenUsage()
+			return nil
 		default:
-			if strings.HasPrefix(args[i], "--agent=") {
+			switch {
+			case strings.HasPrefix(args[i], "--agent="):
 				agentID = strings.TrimPrefix(args[i], "--agent=")
-			} else if strings.HasPrefix(args[i], "--name=") {
+			case strings.HasPrefix(args[i], "--name="):
 				name = strings.TrimPrefix(args[i], "--name=")
+			default:
+				return fmt.Errorf("unknown argument %q for 'mcp-token create'; run 'sage-gui mcp-token create --help'", args[i])
 			}
 		}
 	}
@@ -89,10 +97,9 @@ func runMCPTokenCreate() error {
 	if identityErr != nil {
 		return identityErr
 	}
-	if agentID != "" && agentID != operatorID {
-		return fmt.Errorf("HTTP MCP tokens execute as this node's operator (%s); remove --agent or use that identity", operatorID)
+	if agentID == "" {
+		agentID = operatorID
 	}
-	agentID = operatorID
 
 	body, _ := json.Marshal(map[string]string{
 		"agent_id": agentID,

--- a/cmd/sage-gui/mcp_token_help_test.go
+++ b/cmd/sage-gui/mcp_token_help_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPTokenCreateHelpDoesNotMint(t *testing.T) {
+	orig := os.Args
+	t.Cleanup(func() { os.Args = orig })
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = oldStdout })
+	os.Args = []string{"sage-gui", "mcp-token", "create", "--help"}
+	require.NoError(t, runMCPTokenCreate())
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "sage-gui mcp-token create")
+}
+
+func TestMCPTokenCreateRejectsUnknownFlag(t *testing.T) {
+	orig := os.Args
+	t.Cleanup(func() { os.Args = orig })
+	os.Args = []string{"sage-gui", "mcp-token", "create", "--bogus"}
+	err := runMCPTokenCreate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown argument")
+}

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -1260,6 +1260,11 @@ func runServe(startupProof string) (rerr error) {
 	// federation transport role unchanged. Gate issuance and lookup synchronously
 	// on the live app version, then durably revoke those rows at boot/activation.
 	sqliteStore.SetMCPTokenKeyedIdentityRequirement(app.IsAppV23ActiveForNextTx)
+	// App-v23 bearer issuance binds only to an existing approved identity whose
+	// exact key is already in the node's managed inventory. This is the same
+	// resolver used by consent and Root recovery, so token creation cannot mint
+	// an unapprovable principal with orphaned key material.
+	sqliteStore.SetMCPTokenIdentityResolver(resolveLocalAgentKey)
 	revokeLegacyMCPBearers := func() bool {
 		revoked, err := sqliteStore.RevokeAppV23LegacyMCPBearers(ctx)
 		if err != nil {
@@ -1767,6 +1772,8 @@ func runServe(startupProof string) (rerr error) {
 	// it is never consulted after Root handover.
 	oauthHandler.IsLocalApproval = dashboard.IsLocalCEREBRUMRequest
 	oauthHandler.ResolveControlActor = dashboard.ResolveOAuthControlActor
+	oauthHandler.ManagedTokenTargetsRequired = app.IsAppV23ActiveForNextTx
+	oauthHandler.ValidateTokenTarget = restServer.ValidateMCPTokenTarget
 	oauthHandler.LocalApprovalBaseURL = oauthLocalApprovalBaseURL(cfg.RESTAddr)
 	oauthHandler.NodeOperatorAgentID = operatorAgentID
 	rest.MountOAuthRoutes(r, oauthHandler)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -106,8 +106,10 @@ explicit, reviewed operator ceremony rather than a silent mutation.
 
 This maintenance patch updates the validated Go dependency baseline (`testify`
 1.12.0, `x/crypto` 0.55.0, and `x/tools` 0.49.0) and the pinned CodeQL and
-native-shell CI actions. It does not change a SAGE runtime, REST, MCP, or
-consensus contract.
+native-shell CI actions. It also binds new app-v23 HTTP MCP bearers to existing
+approved locally managed agent identities, instead of creating structurally
+unapprovable pending principals, and makes the token-create CLI help path
+side-effect free.
 
 This patch introduces no new consensus application version or state migration:
 app-v26 remains the ceiling and v11.18.26 does not introduce app-v27.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -116,7 +116,7 @@ Use this to work out how far your chain has to climb.
 | v11.18.23 | Turn-recall trust/lifecycle parity, non-fatal boot-time embedding-space mismatch disclosure, and managed-reranker loader incompatibility diagnosis with bring-your-own guidance; no new app version; app-v26 remains the ceiling |
 | v11.18.24 | Session-fenced federated claim recovery and idempotent reply events, MCP boot-guidance result isolation, actionable-only retention labels, and qualified-versus-bare embedding alias diagnosis; no new app version; app-v26 remains the ceiling |
 | v11.18.25 | Generation-fenced CEREBRUM task refreshes with fail-closed reconciliation, plus portable merge-preserving Codex hook shell migration; no new app version; app-v26 remains the ceiling |
-| v11.18.26 | Validated Go dependency refresh plus pinned CodeQL and native-shell CI action updates; no runtime, API, or consensus contract change; app-v26 remains the ceiling |
+| v11.18.26 | Validated Go dependency refresh plus pinned CI action updates; app-v23 MCP bearer issuance binds to existing approved locally managed agents; token-create help is side-effect free; no consensus change; app-v26 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 
@@ -689,7 +689,7 @@ every legacy keyless bearer:
 
 ```bash
 sage-gui mcp-token list      # revoked entries show here
-sage-gui mcp-token create    # issue a replacement per client
+sage-gui mcp-token create --agent <existing-agent-id>  # bind a replacement to an approved locally managed agent
 ```
 
 ---

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1834,16 +1834,18 @@ must be the exact current committed CEREBRUM Root or an active
 current-generation local Admin; the historical `agent.key` transport identity
 does not retain issuance authority after Root handover.
 
-The token plaintext is shown **once only**. Every app-v23 bearer mints and
-synchronously self-registers a distinct restricted Member identity pending
-CEREBRUM review; it never acts as Root/Admin or falls back to the issuer's key.
-Its private key is AES-256-GCM sealed under an HKDF-SHA256 key derived from the
-bearer plaintext and a per-row random salt, whether optional ledger encryption
-is on or off. This keeps the credential stable through ledger enable/disable,
-lock/unlock, and passphrase changes. SQLite stores the bearer SHA-256 only as
-its lookup/fingerprint value; that digest cannot decrypt the signing key.
-Authentication presents the plaintext transiently to unlock only its own row,
-then downstream REST calls sign as the token's distinct agent. Existing
+The token plaintext is shown **once only**. Under app-v23, `agent_id` selects an
+existing active approved ordinary agent whose exact private key is already in
+the node's managed key inventory. Issuance fails without writing a token row if
+either the consensus enrollment or local key is unavailable. It never creates
+a new pending principal. The selected private key is AES-256-GCM sealed under
+an HKDF-SHA256 key derived from the bearer plaintext and a per-row random salt,
+whether optional ledger encryption is on or off. The bearer therefore executes
+with exactly the selected agent's existing permissions; the authorizing
+Root/Admin remains only the token owner/issuer. SQLite stores the bearer SHA-256
+only as its lookup/fingerprint value; that digest cannot decrypt the signing
+key. Authentication presents the plaintext transiently to unlock only its own
+row, then downstream REST calls sign as the selected agent. Existing
 vault-sealed keyed rows remain compatible: while unlocked, their next valid
 bearer authentication atomically rewraps them into the transition-stable
 bearer envelope. Until that one-time migration, a locked vault fails them
@@ -1854,7 +1856,7 @@ closed rather than falling back to Root.
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `name` | string | no | Human label, e.g. `chatgpt-laptop` |
-| `agent_id` | string | yes | The authorizing current Root/Admin's 64-char hex Ed25519 pubkey. The response `agent_id` is the newly minted distinct MCP agent. |
+| `agent_id` | string | yes | App-v23: the existing active approved ordinary agent to bind, whose exact key must be locally managed. Pre-v23: the node operator identity. |
 
 **Response** (HTTP 201):
 
@@ -1902,7 +1904,7 @@ not public: `/oauth/approve` is a localhost-only CEREBRUM route.
 | `GET` | `/oauth/authorize` | Validate the DCR/PKCE request and redirect to an absolute loopback approval URL carrying only an opaque signed five-minute handoff |
 | `POST` | `/oauth/authorize` | Compatibility entry; remote requests still receive only the loopback handoff and cannot submit consent |
 | `GET` | `/oauth/approve` | Localhost-only consent page; resolves live Root/Admin authority and requires an unlocked CEREBRUM session when encryption is enabled |
-| `POST` | `/oauth/approve` | Localhost-only, CSRF-bound, single-use approval; re-resolves live authority, synchronously registers a distinct pending-review agent, then issues the authorization code |
+| `POST` | `/oauth/approve` | Localhost-only, CSRF-bound, single-use approval; re-resolves live authority, binds the bearer to the selected existing active locally managed agent, then issues the authorization code |
 | `POST` | `/oauth/token` | Exchange auth code for bearer (`grant_type=authorization_code` only) |
 
 The `access_token` returned by `/oauth/token` is the same bearer accepted by `Authorization: Bearer <token>` on `/v1/mcp/sse` and `/v1/mcp/streamable`. Token lifetime is controlled by revocation (`DELETE /v1/mcp/tokens/{id}`), not expiry — `expires_in: 0` in the token response.

--- a/internal/store/mcp_tokens.go
+++ b/internal/store/mcp_tokens.go
@@ -92,6 +92,14 @@ type MCPTokenIdentityRegistrar func(ctx context.Context, pub ed25519.PublicKey, 
 
 var mcpTokenRegistrars sync.Map // map[*SQLiteStore]MCPTokenIdentityRegistrar
 
+// MCPTokenIdentityResolver returns private key material already managed by
+// this node for an exact enrolled agent identity. App-v23 bearer issuance is
+// allowed to bind only to such an existing identity; it must never mint a new
+// pending principal that cannot complete the target-consent flow.
+type MCPTokenIdentityResolver func(agentID string) (ed25519.PrivateKey, bool)
+
+var mcpTokenIdentityResolvers sync.Map // map[*SQLiteStore]MCPTokenIdentityResolver
+
 // mcpTokenKeyedRequirements is process-local policy wiring. The callback is
 // evaluated for every issuance and lookup so the activation edge fails closed
 // immediately, before the durable revocation reconciler has to observe it.
@@ -120,6 +128,17 @@ func (s *SQLiteStore) SetMCPTokenIdentityRegistrar(reg MCPTokenIdentityRegistrar
 		return
 	}
 	mcpTokenRegistrars.Store(s, reg)
+}
+
+// SetMCPTokenIdentityResolver wires the local managed-key inventory used by
+// app-v23 token issuance. The resolver never exposes key material to callers;
+// the store seals the exact key under the one-shot bearer before persistence.
+func (s *SQLiteStore) SetMCPTokenIdentityResolver(resolve MCPTokenIdentityResolver) {
+	if resolve == nil {
+		mcpTokenIdentityResolvers.Delete(s)
+		return
+	}
+	mcpTokenIdentityResolvers.Store(s, resolve)
 }
 
 // SetMCPTokenKeyedIdentityRequirement wires the app-version gate used by all
@@ -381,6 +400,7 @@ func (s *SQLiteStore) insertMCPTokenWithBearerIdentity(
 	id, name, agentID, issuerID, tokenSHA256, tokenPubHex string,
 	tokenPriv ed25519.PrivateKey,
 	bearerPlaintext, provider string,
+	registrationState string,
 	cleanupPending bool,
 ) error {
 	if id == "" || agentID == "" || issuerID == "" || tokenSHA256 == "" ||
@@ -397,6 +417,9 @@ func (s *SQLiteStore) insertMCPTokenWithBearerIdentity(
 	if provider == "" {
 		provider = "mcp-token"
 	}
+	if registrationState != "pending" && registrationState != "confirmed" {
+		return fmt.Errorf("invalid token registration state %q", registrationState)
+	}
 	salt := make([]byte, mcpTokenBearerSealSaltSize)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
 		return fmt.Errorf("generate bearer envelope salt: %w", err)
@@ -412,9 +435,9 @@ func (s *SQLiteStore) insertMCPTokenWithBearerIdentity(
 			id, name, agent_id, issuer_id, token_sha256, token_pubkey,
 			token_privkey_sealed, token_privkey_seal, token_privkey_salt,
 			registration_state, identity_provider, cleanup_pending
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)`,
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, name, agentID, issuerID, tokenSHA256, tokenPubHex, sealed,
-		mcpTokenPrivateKeySealBearerV1, salt, provider, boolToInt(cleanupPending))
+		mcpTokenPrivateKeySealBearerV1, salt, registrationState, provider, boolToInt(cleanupPending))
 	if err != nil {
 		return fmt.Errorf("insert bearer-sealed mcp token identity: %w", err)
 	}
@@ -497,10 +520,9 @@ func openMCPTokenPrivateKeyWithBearer(
 }
 
 // IssueMCPToken is the single issuance primitive shared by direct REST, OAuth,
-// and the setup wizard. Vault-active nodes seal a distinct signing identity
-// with the vault. App-v23 nodes without a vault seal that identity under the
-// bearer itself, so an unencrypted personal node never falls back to Root.
-// Legacy keyless issuance remains only for unencrypted pre-v23 nodes.
+// and the setup wizard. App-v23 binds the bearer to an existing locally managed
+// identity; it never creates a pending principal. Older nodes retain their
+// historical distinct-identity/vault behavior for compatibility.
 func (s *SQLiteStore) IssueMCPToken(ctx context.Context, name, issuerID, legacyAgentID, provider string) (*MCPTokenIssue, error) {
 	return s.issueMCPToken(ctx, name, issuerID, legacyAgentID, provider, false)
 }
@@ -517,7 +539,7 @@ func (s *SQLiteStore) issueMCPToken(ctx context.Context, name, issuerID, legacyA
 		return nil, fmt.Errorf("issuer_id and legacy agent_id are required")
 	}
 	requireKeyed := s.mcpTokenKeyedIdentityRequired()
-	if s.VaultLocked() {
+	if !requireKeyed && s.VaultLocked() {
 		return nil, fmt.Errorf("keyed MCP token issuance unavailable: vault is locked")
 	}
 	raw := make([]byte, 32)
@@ -528,6 +550,30 @@ func (s *SQLiteStore) issueMCPToken(ctx context.Context, name, issuerID, legacyA
 	digest := sha256.Sum256([]byte(plain))
 	digestHex := hex.EncodeToString(digest[:])
 	issued := &MCPTokenIssue{ID: uuid.NewString(), Name: name, IssuerID: issuerID, Token: plain, CreatedAt: time.Now().UTC()}
+
+	if requireKeyed {
+		resolverAny, ok := mcpTokenIdentityResolvers.Load(s)
+		if !ok {
+			return nil, fmt.Errorf("MCP token issuance unavailable: managed identity resolver is not configured")
+		}
+		resolver := resolverAny.(MCPTokenIdentityResolver)
+		priv, found := resolver(legacyAgentID)
+		if !found || len(priv) != ed25519.PrivateKeySize {
+			return nil, fmt.Errorf("MCP token target %s is not a locally managed identity", legacyAgentID)
+		}
+		pub, ok := priv.Public().(ed25519.PublicKey)
+		if !ok || hex.EncodeToString(pub) != legacyAgentID {
+			return nil, fmt.Errorf("managed key does not match MCP token target %s", legacyAgentID)
+		}
+		issued.AgentID = legacyAgentID
+		if err := s.insertMCPTokenWithBearerIdentity(
+			ctx, issued.ID, name, issued.AgentID, issuerID, digestHex,
+			issued.AgentID, priv, plain, provider, "confirmed", cleanupPending,
+		); err != nil {
+			return nil, err
+		}
+		return issued, nil
+	}
 
 	if !s.VaultActive() && !requireKeyed {
 		issued.AgentID = legacyAgentID
@@ -547,24 +593,14 @@ func (s *SQLiteStore) issueMCPToken(ctx context.Context, name, issuerID, legacyA
 		return nil, fmt.Errorf("generate token identity: %w", err)
 	}
 	issued.AgentID = hex.EncodeToString(pub)
-	if requireKeyed {
-		// App-v23 uses the bearer envelope regardless of memory-vault state.
-		// This keeps the credential stable across optional ledger
-		// enable/disable, lock/unlock, and passphrase-change transitions.
-		if err := s.insertMCPTokenWithBearerIdentity(
-			ctx, issued.ID, name, issued.AgentID, issuerID, digestHex,
-			issued.AgentID, priv, plain, provider, cleanupPending,
-		); err != nil {
-			return nil, err
-		}
-	} else if s.VaultActive() {
+	if s.VaultActive() {
 		if err := s.insertMCPTokenWithIdentity(ctx, issued.ID, name, issued.AgentID, issuerID, digestHex, issued.AgentID, priv, provider, cleanupPending); err != nil {
 			return nil, err
 		}
 	} else {
 		if err := s.insertMCPTokenWithBearerIdentity(
 			ctx, issued.ID, name, issued.AgentID, issuerID, digestHex,
-			issued.AgentID, priv, plain, provider, cleanupPending,
+			issued.AgentID, priv, plain, provider, "pending", cleanupPending,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/mcp_tokens_test.go
+++ b/internal/store/mcp_tokens_test.go
@@ -59,6 +59,21 @@ func mkDigest(token string) string {
 	return hex.EncodeToString(d[:])
 }
 
+func setManagedMCPTokenIdentity(t *testing.T, s *SQLiteStore) (string, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	agentID := hex.EncodeToString(pub)
+	s.SetMCPTokenIdentityResolver(func(requested string) (ed25519.PrivateKey, bool) {
+		if requested != agentID {
+			return nil, false
+		}
+		return priv, true
+	})
+	t.Cleanup(func() { s.SetMCPTokenIdentityResolver(nil) })
+	return agentID, priv
+}
+
 func TestMCPTokens_InsertAndLookup(t *testing.T) {
 	s := newTokenStore(t)
 	ctx := context.Background()
@@ -216,30 +231,27 @@ func TestMCPTokenIssue_LegacyTokenPreservesDistinctIssuer(t *testing.T) {
 	require.Equal(t, "operator-owner", rows[0].IssuerID)
 }
 
-func TestAppV23MCPTokenPolicyMintsBearerSealedIdentityWithoutVault(t *testing.T) {
+func TestAppV23MCPTokenPolicyBindsBearerToManagedIdentityWithoutVault(t *testing.T) {
 	s := newTokenStore(t)
 	s.SetMCPTokenKeyedIdentityRequirement(func() bool { return true })
 	t.Cleanup(func() { s.SetMCPTokenKeyedIdentityRequirement(nil) })
-	var registeredID string
+	targetID, _ := setManagedMCPTokenIdentity(t, s)
+	registrarCalled := false
 	s.SetMCPTokenIdentityRegistrar(func(
-		_ context.Context,
-		pub ed25519.PublicKey,
-		_ ed25519.PrivateKey,
-		_, _ string,
+		context.Context, ed25519.PublicKey, ed25519.PrivateKey, string, string,
 	) error {
-		registeredID = hex.EncodeToString(pub)
-		return nil
+		registrarCalled = true
+		return errors.New("app-v23 bind-to-existing must not register a new principal")
 	})
 	t.Cleanup(func() { s.SetMCPTokenIdentityRegistrar(nil) })
 
 	issued, err := s.IssueMCPToken(
-		context.Background(), "must-be-keyed", "root-principal", "root-credential", "test",
+		context.Background(), "must-be-keyed", "root-principal", targetID, "test",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, issued)
-	require.Equal(t, issued.AgentID, registeredID)
-	require.NotEqual(t, "root-principal", issued.AgentID)
-	require.NotEqual(t, "root-credential", issued.AgentID)
+	require.Equal(t, targetID, issued.AgentID)
+	require.False(t, registrarCalled)
 
 	rows, listErr := s.ListMCPTokens(context.Background())
 	require.NoError(t, listErr)
@@ -257,22 +269,30 @@ func TestAppV23MCPTokenPolicyMintsBearerSealedIdentityWithoutVault(t *testing.T)
 		"the database digest alone must not decrypt an unencrypted-node token identity")
 }
 
+func TestAppV23MCPTokenPolicyRefusesUnmanagedIdentityWithoutWritingRow(t *testing.T) {
+	s := newTokenStore(t)
+	s.SetMCPTokenKeyedIdentityRequirement(func() bool { return true })
+	t.Cleanup(func() { s.SetMCPTokenKeyedIdentityRequirement(nil) })
+	targetID := strings.Repeat("a", 64)
+
+	issued, err := s.IssueMCPToken(
+		context.Background(), "unmanaged", "root-principal", targetID, "test",
+	)
+	require.Nil(t, issued)
+	require.ErrorContains(t, err, "managed identity resolver is not configured")
+	rows, listErr := s.ListMCPTokens(context.Background())
+	require.NoError(t, listErr)
+	require.Empty(t, rows, "failed bind-to-existing issuance must not create a token row")
+}
+
 func TestAppV23BearerSealedIdentitySurvivesRestartAndDBDigestCannotDecrypt(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "bearer-envelope-restart.db")
 	s, err := NewSQLiteStore(ctx, dbPath)
 	require.NoError(t, err)
 	s.SetMCPTokenKeyedIdentityRequirement(func() bool { return true })
-	s.SetMCPTokenIdentityRegistrar(func(
-		context.Context,
-		ed25519.PublicKey,
-		ed25519.PrivateKey,
-		string,
-		string,
-	) error {
-		return nil
-	})
-	issued, err := s.IssueMCPToken(ctx, "restart", "current-root", "current-root", "test")
+	targetID, _ := setManagedMCPTokenIdentity(t, s)
+	issued, err := s.IssueMCPToken(ctx, "restart", "current-root", targetID, "test")
 	require.NoError(t, err)
 	digest := mkDigest(issued.Token)
 
@@ -294,7 +314,6 @@ func TestAppV23BearerSealedIdentitySurvivesRestartAndDBDigestCannotDecrypt(t *te
 	)
 	require.Error(t, err, "the SHA-256 value stored in SQLite is not an envelope key")
 
-	s.SetMCPTokenIdentityRegistrar(nil)
 	s.SetMCPTokenKeyedIdentityRequirement(nil)
 	require.NoError(t, s.Close())
 
@@ -388,17 +407,8 @@ func TestMCPTokenBearerSealSurvivesLedgerEnableAndPassphraseChange(t *testing.T)
 	t.Cleanup(func() { _ = s.Close() })
 	s.SetMCPTokenKeyedIdentityRequirement(func() bool { return true })
 	t.Cleanup(func() { s.SetMCPTokenKeyedIdentityRequirement(nil) })
-	s.SetMCPTokenIdentityRegistrar(func(
-		context.Context,
-		ed25519.PublicKey,
-		ed25519.PrivateKey,
-		string,
-		string,
-	) error {
-		return nil
-	})
-	t.Cleanup(func() { s.SetMCPTokenIdentityRegistrar(nil) })
-	issued, err := s.IssueMCPToken(ctx, "bearer-first", "issuer", "operator", "test")
+	targetID, _ := setManagedMCPTokenIdentity(t, s)
+	issued, err := s.IssueMCPToken(ctx, "bearer-first", "issuer", targetID, "test")
 	require.NoError(t, err)
 	digest := mkDigest(issued.Token)
 
@@ -525,28 +535,19 @@ func TestAppV23LegacyMCPBearerActivationRevokesDurablyAcrossReopen(t *testing.T)
 		"app-v23 revocation must survive process restart")
 }
 
-func TestAppV23MCPTokenPolicyKeepsDistinctKeyedIdentity(t *testing.T) {
+func TestAppV23MCPTokenPolicyUsesExactManagedIdentityWithVault(t *testing.T) {
 	s := newTokenStore(t)
 	attachTokenVault(t, s)
 	s.SetMCPTokenKeyedIdentityRequirement(func() bool { return true })
 	t.Cleanup(func() { s.SetMCPTokenKeyedIdentityRequirement(nil) })
-	s.SetMCPTokenIdentityRegistrar(func(
-		_ context.Context,
-		_ ed25519.PublicKey,
-		_ ed25519.PrivateKey,
-		_, _ string,
-	) error {
-		return nil
-	})
-	t.Cleanup(func() { s.SetMCPTokenIdentityRegistrar(nil) })
+	targetID, _ := setManagedMCPTokenIdentity(t, s)
 
 	issued, err := s.IssueMCPToken(
-		context.Background(), "keyed", "root-principal", "root-credential", "test",
+		context.Background(), "keyed", "root-principal", targetID, "test",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, issued)
-	require.NotEqual(t, "root-principal", issued.AgentID)
-	require.NotEqual(t, "root-credential", issued.AgentID)
+	require.Equal(t, targetID, issued.AgentID)
 
 	agentID, signer, err := s.LookupMCPTokenSignerWithBearer(
 		context.Background(), issued.Token, mkDigest(issued.Token),

--- a/scripts/cerebrum-shell.test.mjs
+++ b/scripts/cerebrum-shell.test.mjs
@@ -587,11 +587,11 @@ test('agent removal leaves the confirmation usable if the server rejects it', ()
         'the progress copy must not promise a redeployment that app-v23 removal does not perform');
 });
 
-test('MCP setup copy describes the app-v23 restricted identity instead of obsolete Root inheritance', () => {
+test('MCP setup copy binds app-v23 bearers to an approved managed agent instead of Root', () => {
     assert.doesNotMatch(appSource, /bearer (?:runs as|is) (?:an? )?(?:the )?local node operator/i);
     assert.doesNotMatch(appSource, /node-operator access|administrator credential for this SAGE node/i);
-    assert.match(appSource, /separate restricted Member identity/);
-    assert.match(appSource, /never inherits the approving Root or Admin key/);
+    assert.match(appSource, /selected existing approved agent/);
+    assert.match(appSource, /exact key (?:is already|must already be) managed by this node/);
 });
 
 test('historical Root authors are labelled without becoming selectable graph agents', () => {

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -13188,6 +13188,13 @@ ${runCommand}`;
     `;
 }
 
+function managedBearerAgents(agents) {
+    return (agents || []).filter(agent =>
+        agent && agent.agent_id && agent.local_key_available &&
+        agent.enrollment_active && !agent.needs_approval && !agent.needs_reauthorization
+    );
+}
+
 // RemoteAccessWizard — guided flow that gives SAGE a public URL via cloudflared
 // so a tool on another computer (or a hosted chat like ChatGPT) can reach it.
 // Steps 1-6 are generic tunnel setup (install → login → hostname → create →
@@ -13236,6 +13243,8 @@ function RemoteAccessWizard({ agents, onClose, target }) {
 
     // Step 6: token mint
     const [tokenName, setTokenName] = useState(forChatGPT ? 'chatgpt' : 'remote');
+    const tokenAgents = managedBearerAgents(agents);
+    const [tokenAgentID, setTokenAgentID] = useState(tokenAgents[0]?.agent_id || '');
     const [mintedToken, setMintedToken] = useState(null);
     const [minting, setMinting] = useState(false);
 
@@ -13344,7 +13353,7 @@ function RemoteAccessWizard({ agents, onClose, target }) {
         setMinting(true);
         setError(null);
         try {
-            const r = await wizardMintToken('', tokenName);
+            const r = await wizardMintToken(tokenAgentID, tokenName);
             if (r.error) { setError(r.error); }
             else { setMintedToken(r); setStep(7); }
         } catch (e) { setError('mint token failed: ' + e.message); }
@@ -13513,12 +13522,19 @@ function RemoteAccessWizard({ agents, onClose, target }) {
                     ${step === 6 && html`
                         <div style="line-height:1.55;">
                             <h3 style="margin-top:0;">Mint a bearer token</h3>
-                            <p>CEREBRUM creates a separate restricted Member identity for this bearer. It starts pending review and never inherits the approving Root or Admin key.</p>
+                            <p>This bearer runs as an existing approved agent whose exact key is already managed by this node.</p>
+                            <div class="wizard-field">
+                                <label>Agent identity</label>
+                                <select class="wizard-input" value=${tokenAgentID} onChange=${e => setTokenAgentID(e.target.value)}>
+                                    <option value="">Select an active managed agent</option>
+                                    ${tokenAgents.map(agent => html`<option value=${agent.agent_id}>${agent.name || agent.registered_name || agent.agent_id.slice(0, 12)} — ${agent.agent_id.slice(0, 12)}…</option>`)}
+                                </select>
+                            </div>
                             <div class="wizard-field">
                                 <label>Token name</label>
                                 <input class="wizard-input" value=${tokenName} onInput=${e => setTokenName(e.target.value)} placeholder=${forChatGPT ? 'chatgpt' : 'remote'} />
                             </div>
-                            <button class="btn btn-primary" onClick=${startMintToken} disabled=${minting}>
+                            <button class="btn btn-primary" onClick=${startMintToken} disabled=${minting || !tokenAgentID}>
                                 ${minting ? 'Minting…' : 'Mint bearer'}
                             </button>
                         </div>
@@ -13606,6 +13622,8 @@ function ChatGPTCopyField({ label, value, sensitive, multiline }) {
 // option: zero external surface area.
 function CursorSetupPanel({ agents, onClose }) {
     const [tokenName, setTokenName] = useState('cursor');
+    const tokenAgents = managedBearerAgents(agents);
+    const [tokenAgentID, setTokenAgentID] = useState(tokenAgents[0]?.agent_id || '');
     const [mintedToken, setMintedToken] = useState(null);
     const [minting, setMinting] = useState(false);
     const [error, setError] = useState(null);
@@ -13614,7 +13632,7 @@ function CursorSetupPanel({ agents, onClose }) {
         setMinting(true);
         setError(null);
         try {
-            const r = await wizardMintToken('', tokenName);
+            const r = await wizardMintToken(tokenAgentID, tokenName);
             if (r.error) setError(r.error);
             else setMintedToken(r);
         } catch (e) { setError('mint failed: ' + e.message); }
@@ -13641,12 +13659,19 @@ function CursorSetupPanel({ agents, onClose }) {
 
                     ${!mintedToken && html`
                         <h3 style="margin-top:18px;">1. Mint a bearer</h3>
-                        <p style="font-size:12px;color:var(--text-muted);">This bearer receives its own restricted Member identity pending review; it never runs as CEREBRUM Root or the approving Admin. Keep it private and revoke it when the connection is no longer needed.</p>
+                        <p style="font-size:12px;color:var(--text-muted);">This bearer runs as the selected existing approved agent. Its exact key must already be managed by this node. Keep it private and revoke it when the connection is no longer needed.</p>
+                        <div class="wizard-field">
+                            <label>Agent identity</label>
+                            <select class="wizard-input" value=${tokenAgentID} onChange=${e => setTokenAgentID(e.target.value)}>
+                                <option value="">Select an active managed agent</option>
+                                ${tokenAgents.map(agent => html`<option value=${agent.agent_id}>${agent.name || agent.registered_name || agent.agent_id.slice(0, 12)} — ${agent.agent_id.slice(0, 12)}…</option>`)}
+                            </select>
+                        </div>
                         <div class="wizard-field">
                             <label>Token name</label>
                             <input class="wizard-input" value=${tokenName} onInput=${e => setTokenName(e.target.value)} placeholder="cursor" />
                         </div>
-                        <button class="btn btn-primary" onClick=${onMint} disabled=${minting}>
+                        <button class="btn btn-primary" onClick=${onMint} disabled=${minting || !tokenAgentID}>
                             ${minting ? 'Minting…' : 'Mint bearer'}
                         </button>
                     `}
@@ -13768,6 +13793,8 @@ function RemoteConnectPanel({ agents, onOpenChatGPT }) {
     const [base, setBase] = useState('');           // 'tunnel' | 'lan'
     const [lanIdx, setLanIdx] = useState(0);        // which lan_candidates entry the operator picked
     const [tokenName, setTokenName] = useState('remote');
+    const tokenAgents = managedBearerAgents(agents);
+    const [tokenAgentID, setTokenAgentID] = useState(tokenAgents[0]?.agent_id || '');
     const [minting, setMinting] = useState(false);
     const [minted, setMinted] = useState(null);
     const [mintErr, setMintErr] = useState(null);
@@ -13795,7 +13822,7 @@ function RemoteConnectPanel({ agents, onOpenChatGPT }) {
         setMinting(true);
         setMintErr(null);
         try {
-            const r = await wizardMintToken('', tokenName || 'remote');
+            const r = await wizardMintToken(tokenAgentID, tokenName || 'remote');
             if (r.error) setMintErr(r.error);
             else setMinted(r);
         } catch (e) { setMintErr('mint failed: ' + (e.message || e)); }
@@ -13944,12 +13971,19 @@ function RemoteConnectPanel({ agents, onOpenChatGPT }) {
                     : html`
                         ${!minted && html`
                             <h4 style="margin:14px 0 8px;">Mint a bearer for the other computer</h4>
-                            <p style="font-size:12px;color:var(--text-muted);">The bearer receives its own restricted Member identity pending review; it never inherits CEREBRUM Root or Admin authority.</p>
+                            <p style="font-size:12px;color:var(--text-muted);">The bearer runs as the selected existing approved agent whose exact key is managed by this node.</p>
+                                    <div class="wizard-field">
+                                        <label>Agent identity</label>
+                                        <select class="wizard-input" value=${tokenAgentID} onChange=${e => setTokenAgentID(e.target.value)}>
+                                            <option value="">Select an active managed agent</option>
+                                            ${tokenAgents.map(agent => html`<option value=${agent.agent_id}>${agent.name || agent.registered_name || agent.agent_id.slice(0, 12)} — ${agent.agent_id.slice(0, 12)}…</option>`)}
+                                        </select>
+                                    </div>
                                     <div class="wizard-field">
                                         <label>Token name</label>
                                         <input class="wizard-input" value=${tokenName} onInput=${e => setTokenName(e.target.value)} placeholder="remote" />
                                     </div>
-                                    <button class="btn btn-primary" onClick=${onMint} disabled=${minting}>
+                                    <button class="btn btn-primary" onClick=${onMint} disabled=${minting || !tokenAgentID}>
                                         ${minting ? 'Minting…' : 'Mint bearer'}
                                     </button>
                         `}

--- a/web/wizard_chatgpt.go
+++ b/web/wizard_chatgpt.go
@@ -1132,9 +1132,46 @@ func (h *DashboardHandler) handleWizardMintToken(w http.ResponseWriter, r *http.
 		writeError(w, http.StatusServiceUnavailable, "current CEREBRUM authority unavailable — MCP tokens cannot be issued")
 		return
 	}
-	if req.AgentID != "" && req.AgentID != issuerID {
-		writeError(w, http.StatusBadRequest, "agent_id must match the current authorizing Root or Admin")
-		return
+	targetID := req.AgentID
+	if h.appV23IsActive() {
+		if targetID == "" {
+			writeError(w, http.StatusBadRequest, "agent_id must identify an existing managed agent")
+			return
+		}
+		if h.appV23IsRootIdentity(targetID) || h.BadgerStore == nil {
+			writeError(w, http.StatusBadRequest, "agent_id must identify an active approved ordinary agent")
+			return
+		}
+		enrollment, enrollmentErr := h.BadgerStore.GetAppV23Enrollment(targetID)
+		role, roleErr := h.BadgerStore.GetAppV23Role(targetID)
+		root, rootErr := h.BadgerStore.GetAppV23Root()
+		validPolicy := enrollment != nil && role != nil &&
+			store.ValidateAppV23Policy(
+				role.Role, enrollment.Profile, enrollment.Capabilities, enrollment.Clearance,
+			) == nil
+		currentAdmin := role != nil && enrollment != nil && root != nil &&
+			(role.Role != store.AppV23RoleAdmin || enrollment.RootGeneration == root.Generation)
+		if enrollmentErr != nil || roleErr != nil || rootErr != nil || root == nil ||
+			enrollment == nil || role == nil || !enrollment.Active ||
+			enrollment.AgentID != targetID || role.AgentID != targetID ||
+			enrollment.Profile == store.AppV23ProfileRoot || !validPolicy || !currentAdmin {
+			writeError(w, http.StatusBadRequest, "agent_id must identify an active approved ordinary agent")
+			return
+		}
+		if h.ResolveAgentKeyFn == nil {
+			writeError(w, http.StatusServiceUnavailable, "managed agent key resolver unavailable")
+			return
+		}
+		if _, ok := h.ResolveAgentKeyFn(targetID); !ok {
+			writeError(w, http.StatusBadRequest, "agent_id key is not managed by this node")
+			return
+		}
+	} else {
+		if targetID != "" && targetID != issuerID {
+			writeError(w, http.StatusBadRequest, "agent_id must match the node operator before app-v23")
+			return
+		}
+		targetID = issuerID
 	}
 
 	ts, ok := h.store.(mcpWizardTokenStore)
@@ -1144,7 +1181,7 @@ func (h *DashboardHandler) handleWizardMintToken(w http.ResponseWriter, r *http.
 	}
 
 	// Mint the token using the same primitives as the api/rest handler.
-	token, id, actingAgentID, createdAt, err := mintMCPTokenForWizard(r.Context(), ts, issuerID, req.TokenName)
+	token, id, actingAgentID, createdAt, err := mintMCPTokenForWizard(r.Context(), ts, issuerID, targetID, req.TokenName)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "mint token: "+err.Error())
 		return

--- a/web/wizard_chatgpt_test.go
+++ b/web/wizard_chatgpt_test.go
@@ -428,6 +428,8 @@ func TestWizard_MintTokenV23UsesLiveLocalAuthorityAfterRootHandover(t *testing.T
 	h.NodeOperatorAgentID = fixture.rootID
 	h.ResolveAgentKeyFn = func(agentID string) (ed25519.PrivateKey, bool) {
 		switch agentID {
+		case fixture.agentID:
+			return fixture.agentKey, true
 		case fixture.rootID:
 			return fixture.rootKey, true
 		case currentRootID:
@@ -438,11 +440,17 @@ func TestWizard_MintTokenV23UsesLiveLocalAuthorityAfterRootHandover(t *testing.T
 			return nil, false
 		}
 	}
+	tokenStore.SetMCPTokenKeyedIdentityRequirement(func() bool { return true })
+	t.Cleanup(func() { tokenStore.SetMCPTokenKeyedIdentityRequirement(nil) })
+	tokenStore.SetMCPTokenIdentityResolver(h.ResolveAgentKeyFn)
+	t.Cleanup(func() { tokenStore.SetMCPTokenIdentityResolver(nil) })
 	router := testRouter(h)
 
 	mint := func(t *testing.T, name string, signer ed25519.PrivateKey, localBrowser bool) int {
 		t.Helper()
-		body, marshalErr := json.Marshal(map[string]string{"token_name": name})
+		body, marshalErr := json.Marshal(map[string]string{
+			"agent_id": fixture.agentID, "token_name": name,
+		})
 		require.NoError(t, marshalErr)
 		req := httptest.NewRequest(
 			http.MethodPost, "/v1/wizard/chatgpt/mint-token", bytes.NewReader(body),
@@ -474,6 +482,7 @@ func TestWizard_MintTokenV23UsesLiveLocalAuthorityAfterRootHandover(t *testing.T
 	issuers := map[string]bool{}
 	for _, row := range rows {
 		issuers[row.IssuerID] = true
+		require.Equal(t, fixture.agentID, row.AgentID)
 	}
 	require.True(t, issuers[currentRootID], "unencrypted local SPA must issue as current Root")
 	require.True(t, issuers[adminID], "current local Admin must issue under its own authority")

--- a/web/wizard_chatgpt_token.go
+++ b/web/wizard_chatgpt_token.go
@@ -15,8 +15,8 @@ import (
 // mintMCPTokenForWizard issues a fresh bearer for the given agent. Returns
 // (plainTextToken, tokenID, actingAgentID, createdAt, err). plainTextToken is shown ONCE
 // to the wizard UI and never again.
-func mintMCPTokenForWizard(ctx context.Context, ts mcpWizardTokenStore, agentID, name string) (string, string, string, time.Time, error) {
-	issued, err := ts.IssueMCPToken(ctx, name, agentID, agentID, "wizard-mcp-token")
+func mintMCPTokenForWizard(ctx context.Context, ts mcpWizardTokenStore, issuerID, targetID, name string) (string, string, string, time.Time, error) {
+	issued, err := ts.IssueMCPToken(ctx, name, issuerID, targetID, "wizard-mcp-token")
 	if err != nil {
 		return "", "", "", time.Time{}, err
 	}


### PR DESCRIPTION
## Summary

- bind app-v23 HTTP MCP bearers to an existing active approved locally managed agent instead of minting an unapprovable pending principal
- apply the same issuer/target split to direct REST, OAuth, the dashboard wizard, and CLI flows while preserving pre-v23 compatibility
- make `sage-gui mcp-token create --help` side-effect free and reject unknown create arguments, incorporating the fix proposed in #265
- document the v11.18.26 behavior without introducing an application-version or consensus migration

Closes #264

## Validation

- `go test ./internal/store ./api/rest ./web ./cmd/sage-gui -run 'MCPToken|OAuthLocalApproval|Wizard_MintToken' -count=1`
- `go test ./cmd/sage-gui -run '^TestHookStopCheckConcurrentSameSessionWritesStayReadable$' -count=5`
- `node scripts/check-static-js.mjs`
- release JavaScript/documentation suite: 412 passed, 0 failed
- full `go test ./...`: affected packages passed; one pre-existing concurrent marker-lock test timed out once and then passed 5/5 in isolation
