### PR TITLE
fix(rbac): restore reserved shared-domain reads

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3843,7 +3843,10 @@ paths:
   /v1/domain/register:
     post:
       operationId: domainRegister
-      summary: Register a domain. Caller becomes owner.
+      summary: Register a non-shared domain. Caller becomes owner.
+      description: >-
+        Reserved static catch-alls and governance-promoted shared domains are
+        ownerless and reject registration with HTTP 403 / ABCI code 50.
       tags:
         - Domain
       requestBody:
@@ -3869,6 +3872,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalError"
 

--- a/api/rest/appv23_migration_read_compat_test.go
+++ b/api/rest/appv23_migration_read_compat_test.go
@@ -127,6 +127,43 @@ func TestAppV23LegacyReadCompatibilityRestrictsLocalRESTButNotPairwiseFederation
 	require.True(t, srv.appV23LegacyVisibilityRestricted(reader))
 }
 
+func TestAppV23LegacyStaticSharedWriteIsNotWriteOnly(t *testing.T) {
+	srv, _, badger, _ := newRBACTestServer(t)
+	srv.SetPostV22ForNextTxAccessor(func() bool { return true })
+	srv.SetPostV23ForNextTxAccessor(func() bool { return true })
+
+	root := fmt.Sprintf("%064x", 9051)
+	writer := fmt.Sprintf("%064x", 9052)
+	require.NoError(t, badger.RegisterAgentWithCapabilities(
+		root, "root", store.AppV23RoleAdmin, "", "", "", 1, 0,
+	))
+	require.NoError(t, badger.RegisterAgentWithCapabilities(
+		writer, "writer", store.AppV23RoleMember, "", "", "", 2, 0,
+	))
+	// Reproduce a stale historical owner row. Static shared-domain policy must
+	// ignore it rather than making the namespace private or treating this
+	// writer as a claimant.
+	require.NoError(t, badger.RegisterDomain("general", root, "", 3))
+	require.NoError(t, badger.EnsureAppV23Root("rest-static-shared-read", 100))
+
+	require.NoError(t, srv.checkDomainAccess(
+		context.Background(), writer, "general", "write",
+	), "an unchanged migrated Member retains the documented shared-domain write compatibility")
+	require.NoError(t, srv.checkDomainAccess(
+		context.Background(), writer, "general", "read",
+	), "a shared-domain writer must be able to dereference its accepted write")
+	allowed, err := srv.hasMemoryReadAccess(
+		"general", writer, 1, time.Unix(1000, 0),
+	)
+	require.NoError(t, err)
+	require.True(t, allowed)
+	allowed, err = srv.hasMemoryReadAccess(
+		"general", writer, 2, time.Unix(1000, 0),
+	)
+	require.NoError(t, err)
+	require.False(t, allowed, "shared Read remains bounded by current clearance")
+}
+
 func TestAppV23LegacyOrgMembershipClearanceSurvivesLocalRESTOnly(t *testing.T) {
 	srv, _, badger, _ := newRBACTestServer(t)
 	srv.SetPostV22ForNextTxAccessor(func() bool { return true })

--- a/api/rest/broadcast_error_test.go
+++ b/api/rest/broadcast_error_test.go
@@ -52,6 +52,11 @@ func TestBroadcastErrorPublic_DeprecationGate(t *testing.T) {
 			http.StatusForbidden,
 		},
 		{
+			"shared domain registration → 403",
+			"shared domain not ownable: general",
+			http.StatusForbidden,
+		},
+		{
 			"app-v17 wrong lifecycle state → 409",
 			"reinstate: memory abc is not challenged (status=committed)",
 			http.StatusConflict,

--- a/api/rest/memory_handler.go
+++ b/api/rest/memory_handler.go
@@ -3474,6 +3474,8 @@ func broadcastErrorPublic(err error) (int, string) {
 		return http.StatusForbidden, "access denied"
 	case strings.Contains(msg, "not in the validator set"):
 		return http.StatusForbidden, "access denied"
+	case strings.Contains(msg, "shared domain not ownable"):
+		return http.StatusForbidden, "shared domain not ownable"
 	case strings.Contains(msg, "agent identity verification failed"):
 		return http.StatusUnauthorized, "agent identity verification failed"
 	case strings.Contains(msg, "not registered"):

--- a/docs/reference/concepts/consensus-confidence-decay.md
+++ b/docs/reference/concepts/consensus-confidence-decay.md
@@ -160,7 +160,7 @@ PoE weights are computed at epoch boundaries and drive quorum vote weighting. Al
 const EpochInterval = 100  // blocks per epoch
 ```
 
-`IsEpochBoundary(height)` returns true when `height % 100 == 0 && height > 0`. At each boundary, `processEpoch` (`app.go:9554+`) recomputes weights for all validators.
+`IsEpochBoundary(height)` returns true when `height % 100 == 0 && height > 0`. At each boundary, `processEpoch` (`app.go:9563+`) recomputes weights for all validators.
 
 ### Weight Formula
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -103,7 +103,14 @@ Departments have their own `Clearance` field independent of the org-level member
 
 When an agent submits a memory to a domain that has no registered owner and is not a shared domain, `processMemorySubmit` calls `badgerStore.RegisterDomain(domain, agentID, "", height)` (check-and-set). The submitting agent becomes owner and receives a level-2 access grant automatically.
 
-**Shared domains** (never auto-registered, writable by any authenticated agent):
+**Shared domains** are ownerless and cannot be registered explicitly. The
+compile-time catch-alls are readable by every active local agent up to that
+agent's current clearance, even if historical chain state still contains an
+inert owner row. Their write policy remains separate: pre-app-v23 authenticated
+agents and unchanged migrated app-v23 principals retain compatibility Write,
+while fresh app-v23 principals need explicit shared Write authority. Dynamic
+governance-promoted shared domains retain explicit Read as well as Write policy.
+
 - Exact names: `general`, `self`, `meta` (`app.go:766-770`)
 - Prefix match: `sage-*` (`app.go:780-782`)
 - Any domain with on-chain `shared_domain:<name>` sentinel (set by `TxTypeDomainReassign` with `OpenToShared=true`)
@@ -336,7 +343,10 @@ whose canonical disposition is `member`, `legacy_restricted`, or
 when bit `2` is absent. It is strictly `Write`, never level-3 `Modify`; it
 requires the initial role and enrollment revisions and an exact match to the
 immutable migration baseline. Any explicit policy review ends it. Fresh
-app-v23 and direct-genesis agents always use normal explicit shared grants
+app-v23 and direct-genesis agents use normal explicit shared grants for Write
+or Modify. Compile-time catch-all Read remains automatic and
+classification-bounded; governance-promoted shared domains retain explicit
+Read policy
 (`internal/store/appv23_local_rbac.go`;
 `internal/abci/appv23_local_rbac.go`; `api/rest/memory_handler.go`).
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1128,7 +1128,14 @@ register_domain(
 
 `POST /v1/domain/register`
 
-Caller becomes domain owner. Current v11 chains also auto-register the first writer of an unowned, non-shared domain as owner and grant that owner level-2 access; shared domains (`general`, `self`, `meta`, `sage-*`, and domains opened by governance) remain writable by authenticated agents.
+Caller becomes domain owner. Current v11 chains also auto-register the first
+writer of an unowned, non-shared domain as owner and grant that owner level-2
+access. Reserved shared domains (`general`, `self`, `meta`, `sage-*`, and
+domains opened by governance) are ownerless and reject explicit registration
+with HTTP 403 / ABCI code 50 (`shared domain not ownable`). Compile-time
+catch-alls are readable by active local agents within their classification
+clearance; shared Write remains subject to the caller's current or migrated
+app-v23 policy.
 
 ---
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1198,7 +1198,11 @@ List active grants for an agent. Cross-checks BadgerDB (chain truth) against the
 
 ### `POST /v1/domain/register`
 
-Register a domain. Caller becomes owner. Broadcasts `TxTypeDomainRegister`.
+Register a non-shared domain. Caller becomes owner. Broadcasts
+`TxTypeDomainRegister`. Static catch-alls (`general`, `self`, `meta`, and
+`sage-*`) and governance-promoted shared domains are ownerless and return 403
+with `shared domain not ownable`; a historical owner row does not change that
+classification.
 
 **Request body:**
 
@@ -1209,6 +1213,8 @@ Register a domain. Caller becomes owner. Broadcasts `TxTypeDomainRegister`.
 | `parent` | string | no |
 
 **Response** (HTTP 201): `{"status": "registered", "tx_hash": "..."}`
+
+**Errors:** HTTP 403 / ABCI code 50 when `name` is a shared domain.
 
 ---
 

--- a/internal/abci/app.go
+++ b/internal/abci/app.go
@@ -8184,6 +8184,15 @@ func (app *SageApp) processDomainRegister(parsedTx *tx.ParsedTx, height int64, b
 	if err != nil {
 		return &abcitypes.ExecTxResult{Code: 40, Log: fmt.Sprintf("agent identity verification failed: %v", err)}
 	}
+	// Shared domains have no effective owner. Reject explicit registration at
+	// the same fork boundary as shared-domain grant rejection; otherwise a
+	// caller can receive a successful registration and an owned-domain index
+	// entry that confer no authority because every authorization resolver
+	// correctly treats the shared name as ownerless.
+	postSharedDomainRules := app.postV8Fork(height) || app.postAppV8Rules(height)
+	if postSharedDomainRules && app.isSharedDomain(reg.DomainName, height) {
+		return &abcitypes.ExecTxResult{Code: 50, Log: fmt.Sprintf("shared domain not ownable: %s", reg.DomainName)}
+	}
 	if app.postAppV23Rules(height) {
 		allowed, denialCode, decisionErr := app.appV23DomainDecision(
 			parsedTx, credentialID, reg.DomainName, store.AppV23VerbWrite, height, blockTime,

--- a/internal/abci/processaccessgrant_test.go
+++ b/internal/abci/processaccessgrant_test.go
@@ -134,6 +134,31 @@ func TestProcessAccessGrant_PostForkSharedPrefixReject(t *testing.T) {
 	assert.Error(t, err, "sage-debugging must remain unregistered")
 }
 
+func TestProcessDomainRegister_PostForkSharedReject(t *testing.T) {
+	app := setupTestApp(t)
+	app.v8AppliedHeight = 100
+	const height = int64(200)
+
+	registrant := newAgentKey(t)
+	require.NoError(t, app.badgerStore.SetSharedDomain("governed-open"))
+
+	for _, domain := range []string{"general", "self", "meta", "sage-debugging", "governed-open"} {
+		domain := domain
+		t.Run(domain, func(t *testing.T) {
+			parsed := makeDelegatedDomainRegisterTx(
+				t, registrant, registrant, []byte("register "+domain),
+				time.Unix(1_700_000_000, 0), domain, "", false,
+			)
+			result := app.processDomainRegister(parsed, height, time.Unix(1_700_000_000, 0))
+			require.Equal(t, uint32(50), result.Code, result.Log)
+			require.Contains(t, result.Log, "shared domain not ownable")
+
+			_, err := app.badgerStore.GetDomainOwner(domain)
+			require.Error(t, err, "shared domain %q must remain ownerless", domain)
+		})
+	}
+}
+
 // TestProcessAccessGrant_PostForkAncestorOwnedBlocksLeafClaim asserts
 // that if any ancestor of the grant domain has an owner, a different
 // agent CANNOT auto-claim the leaf — they would be writing under

--- a/internal/store/appv23_local_rbac.go
+++ b/internal/store/appv23_local_rbac.go
@@ -4657,6 +4657,16 @@ func (s *BadgerStore) authorizeAppV23LocalDomainPolicy(policyID, domain string, 
 		return AppV23Authorization{Allowed: true}, nil
 	}
 	if shared {
+		// Compile-time catch-all domains are ownerless common resources. Once an
+		// active local principal has passed the profile/enrollment checks above,
+		// Read is part of that reserved contract; per-record classification still
+		// applies at the disclosure layer. Requiring an exact grant here made
+		// legacy-compatible shared Write a write-only trap, because no effective
+		// owner exists to issue that grant. Governance-promoted shared domains
+		// retain their narrower explicit-read policy.
+		if verb == AppV23VerbRead && IsSharedDomainName(domain) {
+			return AppV23Authorization{Allowed: true}, nil
+		}
 		recoveredGroup, recoveredGroupErr :=
 			s.AuthorizeAppV25RecoveredGroupDomain(policyID, domain, verb)
 		if recoveredGroupErr != nil {


### PR DESCRIPTION
## Summary

- make compile-time shared domains (`general`, `self`, `meta`, and `sage-*`) readable by active local principals while preserving per-record classification enforcement
- reject attempts to register static or governance-promoted shared domains as ownable domains
- document and test the REST, Python SDK, RBAC, and consensus-facing behavior

## Validation

- `go test ./internal/store ./internal/abci ./api/rest`
- `node --test scripts/doc-citations.test.mjs scripts/appv23-api.test.mjs`
- `git diff --check`

Fixes #268