### PR TITLE
chore(release): prepare v11.19.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 ## What's New in v11.19.6
 
 **Typed memory relationships are now readable through the public API and MCP.**
-`POST /v1/memory/links` accepts a bounded set of memory IDs and returns typed
+`POST /v1/memory/links` accepts up to 256 memory IDs and returns typed
 `supports`, `contradicts`, `supersedes`, and `refines` edges only when both
 endpoints are in that set and readable by the caller. The new `sage_get_links`
 MCP tool exposes the same projection, so an agent can recall memories and then

--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.19.6
+
+**Typed memory relationships are now readable through the public API and MCP.**
+`POST /v1/memory/links` accepts a bounded set of memory IDs and returns typed
+`supports`, `contradicts`, `supersedes`, and `refines` edges only when both
+endpoints are in that set and readable by the caller. The new `sage_get_links`
+MCP tool exposes the same projection, so an agent can recall memories and then
+reason over their explicit relationships without an N+1 query loop.
+
+The read path filters every requested memory through domain and record-level
+authorization before querying links. Unreadable endpoints—and therefore their
+existence—remain undisclosed. Authorization-policy storage failures are
+reported as unavailable instead of being flattened into a false complete empty
+graph. This is an off-consensus projection read: it changes no transaction,
+AppHash, fork target, or application version, and app-v27 remains the ceiling.
+
+Personal single-node upgrades remain one-click. The updater owns the canonical
+compatibility proof, recovery snapshot, coordinated shutdown, final stopped
+snapshot, atomic install, rollback, and restart. Manual stopped-node preflight
+is for quorum or externally managed governance, not the normal desktop flow.
+
+Container: `ghcr.io/l33tdawg/sage:11.19.6`. SDK 11.19.6.
+
 ## What's New in v11.19.5
 
 **Claim recovery and host wake coordination now survive real multi-transport
@@ -2295,7 +2318,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.19.5`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.19.6`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/SECURITY_FAQ.md
+++ b/SECURITY_FAQ.md
@@ -11,7 +11,7 @@ SAGE has two distinct deployment models with fundamentally different threat mode
 | **Who** | One user, one local operator | Multiple agents, teams, organizations |
 | **Trust model** | User IS the only validator | Byzantine fault tolerance across validators |
 | **Database** | Local BadgerDB/SQLite stores in `~/.sage/data/` | BadgerDB consensus state plus off-chain mirror |
-| **Release** | v11.19.5 personal-node surface | v11.19.5 quorum/federation surface |
+| **Release** | v11.19.6 personal-node surface | v11.19.6 quorum/federation surface |
 
 Many concerns raised about the enterprise codebase do not apply to SAGE Personal, and vice versa. Each item below is tagged with which deployment it affects.
 
@@ -108,7 +108,7 @@ The `make byzantine` target and GitHub Actions CI job spin up a 4-validator Dock
 
 The following boundaries describe the current v11 codebase:
 
-**SAGE Personal (sage-gui v11.19.5):**
+**SAGE Personal (sage-gui v11.19.6):**
 - Designed for one operator. The management dashboard/API remains a local surface; anyone with access to the operator session or machine should be treated as trusted.
 - Federation is an explicit network-facing feature, off by default. When enabled it uses a separate pinned-mTLS listener, active on-chain treaty checks, chain-qualified signed requests, and replay protection. That authenticated protocol now runs over libp2p NAT traversal and Circuit Relay v2; the relay sees encrypted traffic and connection metadata, not plaintext memories or federation keys.
 - SQLite database supports optional AES-256-GCM encryption at rest (Synaptic Ledger). Enable from CEREBRUM Settings → Security.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.19.5
+  version: 11.19.6
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.19.5-acceptance
+ARG VERSION=v11.19.6-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.19.5 federation Docker acceptance
+# v11.19.6 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -1,4 +1,4 @@
-name: sage-v111905-federation
+name: sage-v111906-federation
 
 services:
   relay:
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.19.5-acceptance
+        VERSION: v11.19.6-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.19.5"
+version = "11.19.6"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.19.5"
+version = "11.19.6"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.19.5",
+  "version": "11.19.6",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.19.5/app-v27. -->
+<!-- Reconciled through SAGE v11.19.6/app-v27. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.5 federation behavior. -->
+<!-- Verified against SAGE v11.19.6 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.19.5
+# sage-gui v11.19.6
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.19.5 advertises 33 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.19.6 advertises 34 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.19.5 is the current release.** It keeps the
+**Status (2026-08):** **v11.19.6 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -119,6 +119,12 @@ identity across stdio, Streamable HTTP, and SSE, and revision-fences every
 explicit claim handoff. Its separate payload-free inbox activity sequence lets
 host hooks notice fresh task assignments and replies without changing message
 wake or Stop semantics.
+v11.19.6 exposes typed memory relationships through one bounded REST projection
+and the `sage_get_links` MCP tool. It filters both endpoints through the
+caller's domain and record disclosure policy before querying the graph, and
+surfaces unavailable authorization state instead of returning a false complete
+empty graph. Personal-node upgrades remain automatic and updater-owned; manual
+stopped-node preflight is scoped to quorum or externally managed governance.
 v11.18.19 prevents Codex project-hook
 self-healing from ever targeting the user-global `~/.codex` scope and removes
 the Connectome's competing DOM/ForceGraph click paths while bounding raw access
@@ -129,6 +135,25 @@ ceiling is app-v27.
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.19.6 release
+
+`POST /v1/memory/links` accepts a bounded memory-ID set and returns only typed
+links whose two endpoints are both requested and readable by the caller. The
+new `sage_get_links` MCP tool exposes the same batched projection, allowing a
+recall result to be followed by explicit `supports`, `contradicts`,
+`supersedes`, and `refines` reasoning without N+1 reads.
+
+Domain and record-level authorization run before the link-store query, so an
+unreadable endpoint cannot leak through an edge. Malformed or unavailable
+legacy visibility policy is an explicit operational failure, never a false
+complete graph. The feature is read-only and off-consensus; app-v27 remains the
+ceiling.
+
+The personal desktop upgrade contract is explicitly one-click: SAGE performs
+the compatibility proof, recovery and stopped-state snapshots, coordinated
+shutdown, install, rollback on failure, and restart. Manual preflight remains
+an operator procedure for quorum or externally mutable governance only.
 
 ## v11.19.5 release
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -138,7 +138,7 @@ explicit, reviewed operator ceremony rather than a silent mutation.
 
 ## v11.19.6 release
 
-`POST /v1/memory/links` accepts a bounded memory-ID set and returns only typed
+`POST /v1/memory/links` accepts up to 256 memory IDs and returns only typed
 links whose two endpoints are both requested and readable by the caller. The
 new `sage_get_links` MCP tool exposes the same batched projection, allowing a
 recall result to be followed by explicit `supports`, `contradicts`,

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -169,6 +169,7 @@ Use this to work out how far your chain has to climb.
 | v11.19.3 | The normal updater performs the canonical compatibility check itself, carries supported in-flight governance through its verified recovery snapshot, and requires no user CLI or prompt; malformed or unsupported state still fails before executable mutation |
 | v11.19.4 | Replacement capability is read from the exact candidate binary, while governance validation plus committed height/AppHash capture remain under one uninterrupted runtime fence; fixes the v11.19.3 live-updater TOCTOU without changing app-v27 |
 | v11.19.5 | Exact-local receipt repair, durable transport-scoped claimant identities, revision-fenced explicit handoff with legacy REST revision-0 compatibility, and database-incarnation-fenced payload-free nonblocking task/reply activity wake; no consensus change and app-v27 remains the ceiling |
+| v11.19.6 | Typed memory-link reads over REST and `sage_get_links`, with both endpoints filtered through caller disclosure policy before graph lookup; personal-node upgrades remain automatic while stopped-node preflight is operator-only; no consensus change and app-v27 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.19.5. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.19.6. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -207,7 +207,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.19.5)
+## Related docs (reconciled through v11.19.6)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.19.5.
+Status: implementation contract through SAGE v11.19.6.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -425,7 +425,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.19.5 federation authorization layer is off-consensus and does
+The current v11.19.6 federation authorization layer is off-consensus and does
 not require a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/app-v27-lifecycle.md
+++ b/docs/reference/concepts/app-v27-lifecycle.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.5/app-v27 code (2026-08-26). -->
+<!-- Verified against SAGE v11.19.6/app-v27 code (2026-08-26). -->
 
 # App-v27 record lifecycle and task canonicalization
 

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.19.5 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.19.6 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.19.5/app-v27, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.19.6/app-v27, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.19.5. Legacy organization/federation sections retain
+Verified against SAGE v11.19.6. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.19.5. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.19.6. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.19.5**.
+and is **not in v11.19.6**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.5. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.19.6. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.5 code (2026-08-26). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.19.6 code (2026-08-26). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,8 +1,8 @@
-Reconciled against internal/mcp for SAGE v11.19.5.
+Reconciled against internal/mcp for SAGE v11.19.6.
 
 # SAGE MCP Tools Reference
 
-SAGE advertises exactly 33 MCP tools over JSON-RPC 2.0. Four deprecated
+SAGE advertises exactly 34 MCP tools over JSON-RPC 2.0. Four deprecated
 `sage_pipe*` compatibility names remain callable for one migration window but
 are intentionally absent from `tools/list`, so new clients learn the canonical
 Messages API. Stdio tools sign REST calls with

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.19.5. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.19.6. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.19.5
+**Package:** `sage-agent-sdk` **Version:** 11.19.6
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/reranker-and-setup.md
+++ b/docs/reference/reranker-and-setup.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.5. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.19.6. Cite file:line when behavior is non-obvious. -->
 
 # SAGE Local Engines and First-Run Setup Reference (v11)
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.5. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.19.6. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.5 lineage implementation (2026-08-26). -->
+<!-- Verified against SAGE v11.19.6 lineage implementation (2026-08-26). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -769,7 +769,7 @@ func TestAdvertisedToolsExactlyMatchReferenceHeadings(t *testing.T) {
 	doc, err := os.ReadFile(docPath)
 	require.NoError(t, err)
 	docText := string(doc)
-	assert.Contains(t, docText, "SAGE advertises exactly 33 MCP tools",
+	assert.Contains(t, docText, "SAGE advertises exactly 34 MCP tools",
 		"the human-readable inventory count must match tools/list")
 	assert.Contains(t, docText, "One call consumes at most one bounded peer page",
 		"sage_find_agent must document its advertised peer_cursor contract")

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -58,7 +58,7 @@ test('release-facing version metadata stays aligned', () => {
     ['docs/ADMIN_BOOTSTRAP.md', `Reconciled through SAGE v${version}/app-v27`],
     ['docs/GETTING_STARTED.md', 'From Source (Go 1.25.13+)'],
     ['docs/GETTING_STARTED.md', `# sage-gui v${version}`],
-    ['docs/GETTING_STARTED.md', `SAGE v${version} advertises 33 MCP tools`],
+    ['docs/GETTING_STARTED.md', `SAGE v${version} advertises 34 MCP tools`],
     ['docs/ARCHITECTURE.md', 'Go 1.25.13+ ABCI application'],
     ['docs/ARCHITECTURE.md', '| Go | 1.25.13+ |'],
     ['docs/reference/concepts/signer-nonce-fence.md', `Status: v${version}.`],
@@ -66,7 +66,7 @@ test('release-facing version metadata stays aligned', () => {
     ['deploy/federation-acceptance/README.md', `# v${version} federation Docker acceptance`],
     ['docs/FEDERATION.md', `Verified against SAGE v${version} federation behavior`],
     ['docs/reference/concepts/message-reply-lifecycle.md', `SAGE v${version} code`],
-    ['docs/UPGRADING.md', `| v${version} | Exact-local receipt repair, durable transport-scoped claimant identities`],
+    ['docs/UPGRADING.md', `| v${version} | Typed memory-link reads over REST and \`sage_get_links\``],
     ['docs/ROADMAP.md', `## v${version} release`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],
@@ -148,7 +148,7 @@ test('v11.18 user, recovery, federation, and SDK guides stay aligned', () => {
   assert.match(read('docs/FEDERATION.md'), /15 minutes/);
   assert.match(read('docs/UPGRADING.md'), /sage-gui upgrade lineage verify --json --manifest repair\.json/);
   assert.match(roadmap, /helper outside the replaceable bundle/);
-  assert.match(gettingStarted, /advertises 33 MCP tools/);
+  assert.match(gettingStarted, /advertises 34 MCP tools/);
   assert.match(gettingStarted, /Deprecated `sage_pipe\*`\s+compatibility/);
   assert.match(sdkReadme, /Compatibility pipeline/);
 });

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.19.5 SDK** | **TLS, app-v27 record-author lifecycle authority, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.19.6 SDK** | **TLS, app-v27 record-author lifecycle authority, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.19.5"
+version = "11.19.6"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.19.5"
+__version__ = "11.19.6"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.19.5",
+  "version": "11.19.6",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.19.5",
+      "identifier": "ghcr.io/l33tdawg/sage:11.19.6",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -76,7 +76,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.19.5';
+const SAGE_VERSION = 'v11.19.6';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
## Summary

- bump release-facing server, SDK, container, dashboard, OpenAPI, and native-shell metadata to v11.19.6
- document the new typed memory-link REST/MCP read path and its fail-closed endpoint authorization
- keep the personal-node one-click updater contract explicit and scope stopped-node preflight to operator-managed governance
- align the advertised MCP tool count at 34 and update release/reference documentation

## Verification

- `npm test` — 412/412 passing
- `node --test scripts/version-alignment.test.mjs scripts/doc-citations.test.mjs` — 19/19 passing
- `git diff --check`

## Included reviewed PRs

- #281 — merged green
- #278 — merged green after maintainer authorization/citation fixes
- #280 — excluded; blocking review reply posted