### PR TITLE
fix(memory): re-linking a pair updates its type instead of silently dropping it

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -673,6 +673,11 @@ Link two memories. Off-chain relation, no tx.
 
 **Response** (HTTP 200): `{"source_id": "...", "target_id": "...", "link_type": "..."}`
 
+A `(source_id, target_id)` pair holds a single relationship. Re-linking an existing
+pair **updates** its `link_type` (idempotent, last-write-wins), so a relationship can
+be re-typed (for example `related` → `supersedes`). The reverse direction
+(`target_id` → `source_id`) is an independent link.
+
 ---
 
 ### `POST /v1/memory/links`
@@ -2369,7 +2374,7 @@ address resolved from a bounded legacy-status offline cache can be accepted
 locally while the peer is down. Delivery waits for that peer to return and pass
 the fresh live authorization preflight above.
 
-**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:771-777`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6525` declaration, `:6527` payload, `:6530` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:792-794`) to 413.
+**Size caps → HTTP 413.** `payload` is capped at 256 KiB and `intent` at 8 KiB (`MaxPipeContentBytes`/`MaxPipeIntentBytes`, `internal/store/store.go:771-777`). The REST handler fast-fails an over-cap request with **413** before the store write; the store enforces the same caps at the `InsertPipeline` chokepoint (`internal/store/sqlite.go:6531` declaration, `:6533` payload, `:6536` intent) as defense in depth, mapping `ErrPipePayloadTooLarge`/`ErrPipeIntentTooLarge` (`store.go:792-794`) to 413.
 
 **Open-pipe quota → HTTP 429 + `Retry-After`.** A single verified agent identity may hold at most 256 non-terminal (pending or claimed) pipes open at once, and a node caps 10000 across all requesters (`MaxOpenPipesPerAgent`/`MaxOpenPipesGlobal`). An index-backed COUNT and its INSERT run under the same write critical section, so parallel sends cannot race past either cap. Over-quota inserts are rejected as **429 with `Retry-After`** (`ErrPipeQuotaPerAgent`/`ErrPipeQuotaGlobal`), keyed on the Ed25519-verified `from_agent`, not the spoofable rate-limit header. This mirrors the mempool-full recipe (see `GET /v1/chain/backpressure` below): treat it as backpressure and retry after the hinted interval, not as a per-agent rate-limit breach.
 
@@ -2606,7 +2611,7 @@ the result over the original agreement-bound return route
 | `source_chain_id` | string | for foreign work | Exact local reply-source chain returned as `reply_source_chain_id` by the pipe status preflight; prevents another node relabeling the signed result |
 | `claimant_session_id` | string | for foreign work; recommended for provider-addressed compatibility work | Opaque 1–128-byte session currently holding the claim. A provider-addressed row claimed by an older sessionless caller is fenced as `legacy`, and an omitted result session selects only that exact fence; it cannot bypass a named sibling session. |
 
-`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:775`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6791`, mapping `ErrPipeResultTooLarge` at `:6793-6794`).
+`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:775`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6797`, mapping `ErrPipeResultTooLarge` at `:6799-6800`).
 
 **Response** (HTTP 200):
 `{"status":"completed","journal_id":"<memory_id or empty>","journaled":true|false}`.

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -2719,8 +2719,11 @@ var _ TaskAssignmentStore = (*PostgresStore)(nil)
 
 // LinkMemories creates a link between two memories.
 func (s *PostgresStore) LinkMemories(ctx context.Context, sourceID, targetID, linkType string) error {
+	// Re-linking an existing pair UPDATES its type rather than silently dropping the
+	// new type (see SQLiteStore.LinkMemories). Idempotent, last-write-wins upsert.
 	_, err := s.db.Exec(ctx,
-		`INSERT INTO memory_links (source_id, target_id, link_type) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+		`INSERT INTO memory_links (source_id, target_id, link_type) VALUES ($1, $2, $3)
+		 ON CONFLICT (source_id, target_id) DO UPDATE SET link_type = excluded.link_type`,
 		sourceID, targetID, linkType)
 	if err != nil {
 		return fmt.Errorf("link memories: %w", err)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -5475,8 +5475,14 @@ func (s *SQLiteStore) UpdateTaskStatus(ctx context.Context, memoryID string, tas
 
 // LinkMemories creates a link between two memories.
 func (s *SQLiteStore) LinkMemories(ctx context.Context, sourceID, targetID, linkType string) error {
+	// A pair (source, target) holds one relationship (that is the primary key).
+	// Re-linking an existing pair UPDATES its type rather than silently dropping the
+	// new type: `ON CONFLICT DO NOTHING` discarded the second write with no error, so
+	// re-typing a relationship (e.g. related -> supersedes) vanished. This is an
+	// authorization-gated, idempotent upsert — last write wins.
 	_, err := s.writeExecContext(ctx,
-		`INSERT INTO memory_links (source_id, target_id, link_type) VALUES (?, ?, ?) ON CONFLICT DO NOTHING`,
+		`INSERT INTO memory_links (source_id, target_id, link_type) VALUES (?, ?, ?)
+		 ON CONFLICT(source_id, target_id) DO UPDATE SET link_type = excluded.link_type`,
 		sourceID, targetID, linkType)
 	if err != nil {
 		return fmt.Errorf("link memories: %w", err)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -409,6 +409,39 @@ func TestGetEvidenceCountsAndLinksAmong(t *testing.T) {
 	assert.Empty(t, el)
 }
 
+func TestLinkMemoriesRetypeUpdatesInPlace(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	for _, id := range []string{"m1", "m2"} {
+		require.NoError(t, s.InsertMemory(ctx, testMemory(id, "agent1", "content "+id, "general")))
+	}
+
+	// First link: m1 -> m2 as 'related' (e.g. auto-created alongside a capture).
+	require.NoError(t, s.LinkMemories(ctx, "m1", "m2", "related"))
+	// Re-link the SAME pair with a stronger type. This must UPDATE the type in place,
+	// not be silently discarded — the previous `ON CONFLICT DO NOTHING` dropped it, so
+	// a related->supersedes upgrade vanished with no error.
+	require.NoError(t, s.LinkMemories(ctx, "m1", "m2", "supersedes"))
+
+	links, err := s.GetLinksAmong(ctx, []string{"m1", "m2"})
+	require.NoError(t, err)
+	require.Len(t, links, 1, "a pair still holds exactly one link (PK is source+target)")
+	assert.Equal(t, "supersedes", links[0].LinkType, "re-linking a pair updates its type; last write wins")
+
+	// Re-asserting the same type is an idempotent no-op: still one row, same type.
+	require.NoError(t, s.LinkMemories(ctx, "m1", "m2", "supersedes"))
+	links, err = s.GetLinksAmong(ctx, []string{"m1", "m2"})
+	require.NoError(t, err)
+	require.Len(t, links, 1)
+	assert.Equal(t, "supersedes", links[0].LinkType)
+
+	// The reverse direction is a distinct pair and is unaffected by the upsert.
+	require.NoError(t, s.LinkMemories(ctx, "m2", "m1", "refines"))
+	links, err = s.GetLinksAmong(ctx, []string{"m1", "m2"})
+	require.NoError(t, err)
+	assert.Len(t, links, 2, "m1->m2 and m2->m1 are independent links")
+}
+
 func TestEvidenceProjectionCompletenessIsOneWayAndDefaultsComplete(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## The bug

`memory_links` has `PRIMARY KEY (source_id, target_id)`, and `LinkMemories`
inserted with `ON CONFLICT DO NOTHING`. Because `link_type` is not part of the key,
re-linking an existing pair with a **different** type is silently discarded — no
error, no update. Concretely:

- `POST /v1/memory/link` for a pair that already has a link returns `200` but does
  nothing.
- Upgrading an auto-created `related` link to `supersedes`, or re-typing
  `contradicts` → `supersedes`, simply vanishes.

## The fix

An idempotent, last-write-wins upsert on both store backends:

```sql
ON CONFLICT (source_id, target_id) DO UPDATE SET link_type = excluded.link_type
```

- A pair still holds exactly one relationship (the reverse direction,
  `target → source`, remains an independent link).
- Re-asserting the same type stays a no-op.

## Safety — no consensus impact

`memory_links` is off-chain and node-local: a single REST-to-store writer
(`handleLinkMemories` → `store.LinkMemories`), not part of the ABCI app hash. The
REST reference already documents `POST /v1/memory/link` as an "off-chain relation,
no tx". So this is a local behaviour change with **no consensus, determinism, or
migration impact** — the primary key is unchanged, so existing databases need no
migration.

## Tests

- New store regression `TestLinkMemoriesRetypeUpdatesInPlace`: re-type updates in
  place, idempotent re-assert is a no-op, and the reverse pair is independent.
- `gofmt` / `go vet` / `go build ./...` / the full `internal/store` package /
  `doc-citations` all green.
- Documents the upsert behaviour in `docs/reference/rest-api.md`.
