### PR TITLE
ci: guard natter from invalid libp2p updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,13 @@ updates:
       natter-go-deps:
         patterns:
           - "*"
+    ignore:
+      # Natter uses the same pre-v1 go-libp2p module as the root graph. Avoid
+      # Dependabot's unrelated legacy v6.0.23+incompatible line while keeping
+      # real v0.x updates visible.
+      - dependency-name: github.com/libp2p/go-libp2p
+        versions:
+          - ">= 1.0.0"
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
## Summary
- apply the existing root-module go-libp2p legacy-major guard to the nested /natter Go module
- keep valid v0.x updates, including the current v0.49.0 update, visible to Dependabot

## Verification
- parsed .github/dependabot.yml and asserted both gomod entries carry the guard
- env GOCACHE=/private/tmp/sage-natter-gocache go mod tidy -diff (clean)
- git diff --check