### PR TITLE
fix: discover transferred Access Group domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,28 +51,26 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
-## What's New in v11.19.7
+## What's New in v11.19.8
 
-**Recall-backed compaction can now preserve a Claude thread verbatim in governed
-SAGE memory and restore it when that same thread resumes.** The feature is
-default-off and requires an explicit, versioned acknowledgment (or the managed
-`SAGE_NEVERCOMPACT=1` setting). Capture is byte-exact, bounded, thread-scoped,
-idempotent across ambiguous network outcomes, and advances its durable cursor
-only after every chunk—or visible gap marker—is committed. Transcript path,
-ownership, session identity, and file-descriptor authority are validated before
-content leaves the host. Governed deprecation is available through
-`sage-gui nevercompact purge`; SAGE does not claim hard deletion.
+**Access Groups now discover transferred historical domains, not only each
+member's enrollment-time home domain.** CEREBRUM's bounded caller-domain
+projection consults the consensus-maintained current-owner index for the caller
+and active local group peers. A transferred `user-*` domain therefore appears
+as a usable exact recall or write target even when its current owner never
+authored a memory there.
 
-CEREBRUM's memory MRI gains a `◈ links` view that isolates sparse typed
-reasoning relationships from domain and lineage scaffolding, with first-class
-styling for `supersedes` and `duplicates`. Re-linking an existing memory pair
-now updates its type instead of silently retaining the old relationship.
+Every discovered candidate is still re-authorized against current ownership,
+group authority, profile restrictions, and hard denies before it is returned.
+Per-record classification checks remain on the memory disclosure path. The
+result remains bounded and explicitly reports truncation; it does
+not expose a global domain roster, change ownership, copy grants, or weaken
+shared-domain and foreign-write restrictions.
 
-The Go dependency baseline and pinned GitHub Actions have also been refreshed.
-All changes are off-consensus: there is no transaction, AppHash, fork-target, or
-application-version change, and app-v27 remains the ceiling.
+This patch changes no transaction, AppHash input, key encoding, fork target, or
+application version. Existing app-v27 chains replay byte-identically.
 
-Container: `ghcr.io/l33tdawg/sage:11.19.7`. SDK 11.19.7.
+Container: `ghcr.io/l33tdawg/sage:11.19.8`. SDK 11.19.8.
 
 ## What's New in v11.19.5
 
@@ -2318,7 +2316,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.19.7`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.19.8`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/SECURITY_FAQ.md
+++ b/SECURITY_FAQ.md
@@ -11,7 +11,7 @@ SAGE has two distinct deployment models with fundamentally different threat mode
 | **Who** | One user, one local operator | Multiple agents, teams, organizations |
 | **Trust model** | User IS the only validator | Byzantine fault tolerance across validators |
 | **Database** | Local BadgerDB/SQLite stores in `~/.sage/data/` | BadgerDB consensus state plus off-chain mirror |
-| **Release** | v11.19.7 personal-node surface | v11.19.7 quorum/federation surface |
+| **Release** | v11.19.8 personal-node surface | v11.19.8 quorum/federation surface |
 
 Many concerns raised about the enterprise codebase do not apply to SAGE Personal, and vice versa. Each item below is tagged with which deployment it affects.
 
@@ -108,7 +108,7 @@ The `make byzantine` target and GitHub Actions CI job spin up a 4-validator Dock
 
 The following boundaries describe the current v11 codebase:
 
-**SAGE Personal (sage-gui v11.19.7):**
+**SAGE Personal (sage-gui v11.19.8):**
 - Designed for one operator. The management dashboard/API remains a local surface; anyone with access to the operator session or machine should be treated as trusted.
 - Federation is an explicit network-facing feature, off by default. When enabled it uses a separate pinned-mTLS listener, active on-chain treaty checks, chain-qualified signed requests, and replay protection. That authenticated protocol now runs over libp2p NAT traversal and Circuit Relay v2; the relay sees encrypted traffic and connection metadata, not plaintext memories or federation keys.
 - SQLite database supports optional AES-256-GCM encryption at rest (Synaptic Ledger). Enable from CEREBRUM Settings → Security.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.19.7
+  version: 11.19.8
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.
@@ -3580,10 +3580,13 @@ paths:
       summary: Retrieve bounded readable domains for the authenticated agent.
       description: >-
         Returns only current caller-authorized domain identifiers derived from
-        the caller's own home/provenance, direct grants, and local Access
-        Groups. Candidates are re-authorized against live policy. The result is
-        bounded and may be truncated; it is not a global domain roster or a
-        complete expansion of read-all/ancestor authority.
+        the caller's current owned-domain index and home/provenance, direct
+        grants, and the bounded current owned-domain indexes of active local
+        Access Group peers. This includes transferred domains that were never
+        authored by their current owner. Candidates are re-authorized against
+        live policy. The result is bounded and may be truncated; it is not a
+        global domain roster or a complete expansion of read-all/ancestor
+        authority.
       tags:
         - Agent
       responses:

--- a/api/rest/agent_domains_handler.go
+++ b/api/rest/agent_domains_handler.go
@@ -129,6 +129,24 @@ func (s *Server) handleGetAgentReadableDomains(w http.ResponseWriter, r *http.Re
 		candidates[domain] = struct{}{}
 	}
 	add(enrollment.HomeDomain)
+	// The reverse owner index is the authoritative source for domains that the
+	// caller acquired after enrollment. In particular, a transferred historical
+	// domain may never have been authored by its current owner and therefore
+	// cannot be recovered from the SQL provenance hint below.
+	indexedOwned, indexedOwnedMore, indexedOwnedErr := s.badgerStore.ListOwnedDomainsPage(
+		agentID, "", callerReadableDomainLimit,
+	)
+	ownedFromIndex := indexedOwnedErr == nil
+	if indexedOwnedErr != nil {
+		truncated = true
+	} else {
+		for _, domain := range indexedOwned {
+			add(domain)
+		}
+		if indexedOwnedMore {
+			truncated = true
+		}
+	}
 	now := time.Now()
 	queryCtx, cancel := context.WithTimeout(r.Context(), callerAuthoredDomainQueryBudget)
 	defer cancel()
@@ -181,12 +199,24 @@ func (s *Server) handleGetAgentReadableDomains(w http.ResponseWriter, r *http.Re
 		truncated = true
 	}
 	if groups, groupsErr := s.badgerStore.ListAppV23AgentGroups(agentID); groupsErr == nil {
+		seenMembers := map[string]struct{}{agentID: {}}
+		scannedMembers := 0
+	groupScan:
 		for _, group := range groups {
 			for _, memberID := range group.Members {
 				if len(candidates) >= callerReadableDomainCandidateScan {
 					truncated = true
-					break
+					break groupScan
 				}
+				if _, seen := seenMembers[memberID]; seen {
+					continue
+				}
+				seenMembers[memberID] = struct{}{}
+				if scannedMembers == callerReadableDomainCandidateScan {
+					truncated = true
+					break groupScan
+				}
+				scannedMembers++
 				member, memberErr := s.badgerStore.GetAppV23Enrollment(memberID)
 				if memberErr != nil {
 					truncated = true
@@ -194,10 +224,26 @@ func (s *Server) handleGetAgentReadableDomains(w http.ResponseWriter, r *http.Re
 				}
 				if member != nil && member.Active {
 					add(member.HomeDomain)
+					remaining := callerReadableDomainCandidateScan - len(candidates)
+					if remaining == 0 {
+						truncated = true
+						break groupScan
+					}
+					pageLimit := min(remaining, callerReadableDomainLimit)
+					ownedDomains, more, ownedErr := s.badgerStore.ListOwnedDomainsPage(
+						memberID, "", pageLimit,
+					)
+					if ownedErr != nil {
+						truncated = true
+						continue
+					}
+					for _, domain := range ownedDomains {
+						add(domain)
+					}
+					if more {
+						truncated = true
+					}
 				}
-			}
-			if len(candidates) >= callerReadableDomainCandidateScan {
-				break
 			}
 		}
 	} else {
@@ -242,13 +288,8 @@ func (s *Server) handleGetAgentReadableDomains(w http.ResponseWriter, r *http.Re
 	sort.Strings(remaining)
 	ordered = append(ordered, remaining...)
 	owned := make([]string, 0, min(len(ordered), callerReadableDomainLimit))
-	ownedFromIndex := false
-	if indexed, more, indexErr := s.badgerStore.ListOwnedDomainsPage(agentID, "", callerReadableDomainLimit); indexErr == nil {
-		owned = indexed
-		ownedFromIndex = true
-		if more {
-			truncated = true
-		}
+	if ownedFromIndex {
+		owned = indexedOwned
 	}
 	readable := make([]string, 0, min(len(ordered), callerReadableDomainLimit))
 	writable := make([]string, 0, min(len(ordered), callerReadableDomainLimit))

--- a/api/rest/agent_domains_handler_test.go
+++ b/api/rest/agent_domains_handler_test.go
@@ -220,4 +220,35 @@ func TestOwnedDomainPageDiscoversTransferredNeverAuthoredDomain(t *testing.T) {
 	var readable callerReadableDomainsResponse
 	require.NoError(t, json.Unmarshal(readableRec.Body.Bytes(), &readable))
 	require.Contains(t, readable.OwnedDomains, "transferred.unseen")
+	require.Contains(t, readable.ReadableDomains, "transferred.unseen")
+	require.Contains(t, readable.WritableDomains, "transferred.unseen")
+}
+
+func TestAppV26ReadableDomainsDiscoverGroupPeerTransferredDomain(t *testing.T) {
+	srv, badgerStore, memberID, ownerID, outsiderID := setupAppV23RESTAccess(t)
+	require.NoError(t, badgerStore.RegisterDomain("user-historical", outsiderID, "", 30))
+	require.NoError(t, badgerStore.MigrateAppV26AccessGroupAuthorities(31))
+	_, err := badgerStore.TransferDomainAppV26CAS(
+		"user-historical", ownerID, "", outsiderID,
+		"proposal-user-historical", 32, false, 256,
+	)
+	require.NoError(t, err)
+	root, err := badgerStore.GetAppV23Root()
+	require.NoError(t, err)
+	require.NotNil(t, root)
+	require.NoError(t, badgerStore.MutateAppV26AccessGroup(
+		root.PrincipalID, "local-team", "Local team", []string{memberID, ownerID},
+		store.AppV26GroupAuthorityReadWrite, 1, false, 33,
+	))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agent/me/domains", nil)
+	req = req.WithContext(middleware.WithAgentID(context.Background(), memberID))
+	rec := httptest.NewRecorder()
+	srv.handleGetAgentReadableDomains(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var response callerReadableDomainsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Contains(t, response.ReadableDomains, "user-historical")
+	require.Contains(t, response.WritableDomains, "user-historical")
+	require.NotContains(t, response.OwnedDomains, "user-historical")
 }

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.19.7-acceptance
+ARG VERSION=v11.19.8-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.19.7 federation Docker acceptance
+# v11.19.8 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -1,4 +1,4 @@
-name: sage-v111907-federation
+name: sage-v111908-federation
 
 services:
   relay:
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.19.7-acceptance
+        VERSION: v11.19.8-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.19.7"
+version = "11.19.8"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.19.7"
+version = "11.19.8"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.19.7",
+  "version": "11.19.8",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.19.7/app-v27. -->
+<!-- Reconciled through SAGE v11.19.8/app-v27. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.7 federation behavior. -->
+<!-- Verified against SAGE v11.19.8 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.19.7
+# sage-gui v11.19.8
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.19.7 advertises 34 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.19.8 advertises 34 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.19.7 is the current release.** It keeps the
+**Status (2026-08):** **v11.19.8 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -141,6 +141,20 @@ ceiling is app-v27.
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.19.8 release
+
+The bounded caller-domain projection now consults the authoritative current
+owner index for both the caller and active local Access Group peers. This makes
+transferred historical domains discoverable even when their current owner never
+authored a memory there, while preserving the existing 64-result output bound,
+candidate and peer-scan caps, truncation signal, and exact live-policy
+reauthorization. Access Group authority remains dynamic and ownership-based;
+the projection does not copy grants or disclose a global domain roster.
+
+This is an off-consensus REST/MCP discovery correction. It changes no
+transaction, AppHash, key encoding, fork target, or application version;
+app-v27 remains the ceiling.
 
 ## v11.19.7 release
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -171,6 +171,7 @@ Use this to work out how far your chain has to climb.
 | v11.19.5 | Exact-local receipt repair, durable transport-scoped claimant identities, revision-fenced explicit handoff with legacy REST revision-0 compatibility, and database-incarnation-fenced payload-free nonblocking task/reply activity wake; no consensus change and app-v27 remains the ceiling |
 | v11.19.6 | Typed memory-link reads over REST and `sage_get_links`, with both endpoints filtered through caller disclosure policy before graph lookup; personal-node upgrades remain automatic while stopped-node preflight is operator-only; no consensus change and app-v27 remains the ceiling |
 | v11.19.7 | Default-off consent-gated recall-backed compaction with commit-backed byte-exact capture, visible gaps, complete same-thread restoration, and governed purge; isolated typed-link MRI rendering and correct last-write-wins memory re-typing; refreshed Go modules and CI actions; no consensus change and app-v27 remains the ceiling |
+| v11.19.8 | Bounded caller-domain discovery now includes re-authorized current-owned domains of active local Access Group peers, so transferred historical domains remain discoverable without a global roster or grant copying; no consensus change and app-v27 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.19.7. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.19.8. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -208,7 +208,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.19.7)
+## Related docs (reconciled through v11.19.8)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.19.7.
+Status: implementation contract through SAGE v11.19.8.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -425,7 +425,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.19.7 federation authorization layer is off-consensus and does
+The current v11.19.8 federation authorization layer is off-consensus and does
 not require a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/app-v27-lifecycle.md
+++ b/docs/reference/concepts/app-v27-lifecycle.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.7/app-v27 code (2026-08-28). -->
+<!-- Verified against SAGE v11.19.8/app-v27 code (2026-08-28). -->
 
 # App-v27 record lifecycle and task canonicalization
 

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.19.7 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.19.8 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.19.7/app-v27, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.19.8/app-v27, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.19.7. Legacy organization/federation sections retain
+Verified against SAGE v11.19.8. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.19.7. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.19.8. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.19.7**.
+and is **not in v11.19.8**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.7. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.19.8. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.7 code (2026-08-28). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.19.8 code (2026-08-28). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.19.7.
+Reconciled against internal/mcp for SAGE v11.19.8.
 
 # SAGE MCP Tools Reference
 
@@ -720,9 +720,12 @@ are bounded caller-only samples: owned identifies domains whose current owning
 ancestor is the caller, readable identifies scoped recall targets, and writable
 identifies candidates that pass current effective write policy. The readable-domain list is a bounded sample of
 currently authorized targets derived from the caller's own home/provenance,
-direct grants, and local Access Groups; every candidate is checked against
-live policy before it is returned. It is not a global domain roster and does
-not claim to enumerate every domain a read-all or ancestor grant can reach.
+current owned-domain index, direct grants, and the bounded current owned-domain
+indexes of active local Access Group peers; every candidate is checked against
+live policy before it is returned. This lets transferred domains appear even
+when their current owner never authored a memory there. It is not a global
+domain roster and does not claim to enumerate every domain a read-all or
+ancestor grant can reach.
 The access booleans are explicitly scoped to `home_domain`. A
 pending or inactive caller receives this standing with
 `memory_access_available:false` and SAGE does not probe a forbidden memory

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.19.7. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.19.8. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.19.7
+**Package:** `sage-agent-sdk` **Version:** 11.19.8
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash
@@ -684,8 +684,11 @@ domain_access_sample() -> AgentDomainAccessSample
 
 Signed `GET /v1/agent/me/domains`. Returns bounded `owned_domains`,
 `readable_domains`, and `writable_domains` policy samples plus `truncated`.
-Use it to choose an exact recall/write scope cheaply; use `owned_domains()`
-when the authoritative complete ownership set is required.
+The readable/write samples include re-authorized candidates from the bounded
+current owned-domain indexes of active local Access Group peers, including
+transferred domains that the peer never authored. Use it to choose an exact
+recall/write scope cheaply; use `owned_domains()` when the authoritative
+complete ownership set is required.
 
 ---
 

--- a/docs/reference/reranker-and-setup.md
+++ b/docs/reference/reranker-and-setup.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.7. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.19.8. Cite file:line when behavior is non-obvious. -->
 
 # SAGE Local Engines and First-Run Setup Reference (v11)
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.7. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.19.8. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 
@@ -945,7 +945,11 @@ Signed caller-only bounded policy projection. `domains` and
 `owned_domains` is a bounded ownership sample. `truncated:true` means at least
 one sample is incomplete. These arrays deliberately avoid a global roster or
 memory scan and are suitable for choosing an exact scope, not proving complete
-ownership.
+ownership. Candidate discovery includes the caller's current owned-domain index
+and the bounded current owned-domain indexes of active local Access Group peers,
+so a transferred historical domain can appear even when its current owner never
+authored a memory there. Every candidate is re-authorized against live policy;
+group membership never turns the peer's domain into caller ownership.
 
 ### `GET /v1/agent/me/domains/owned`
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.7 lineage implementation (2026-08-28). -->
+<!-- Verified against SAGE v11.19.8 lineage implementation (2026-08-28). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -66,7 +66,7 @@ test('release-facing version metadata stays aligned', () => {
     ['deploy/federation-acceptance/README.md', `# v${version} federation Docker acceptance`],
     ['docs/FEDERATION.md', `Verified against SAGE v${version} federation behavior`],
     ['docs/reference/concepts/message-reply-lifecycle.md', `SAGE v${version} code`],
-    ['docs/UPGRADING.md', `| v${version} | Default-off consent-gated recall-backed compaction`],
+    ['docs/UPGRADING.md', `| v${version} | Bounded caller-domain discovery`],
     ['docs/ROADMAP.md', `## v${version} release`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.19.7 SDK** | **TLS, app-v27 record-author lifecycle authority, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.19.8 SDK** | **TLS, app-v27 record-author lifecycle authority, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.19.7"
+version = "11.19.8"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.19.7"
+__version__ = "11.19.8"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.19.7",
+  "version": "11.19.8",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.19.7",
+      "identifier": "ghcr.io/l33tdawg/sage:11.19.8",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -76,7 +76,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.19.7';
+const SAGE_VERSION = 'v11.19.8';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
## Summary
- include caller-owned and active Access Group peer-owned domains in bounded domain discovery
- re-authorize every candidate against current policy and preserve ownership, candidate, peer, and output bounds
- prove transferred never-authored domains remain discoverable for owners and read/write group peers
- align release metadata and public contracts for v11.19.8

## Verification
- focused REST regression suite
- api/rest, internal/store, and internal/mcp suites
- full npm test (413 tests)
- Python SDK local-source suite (174 tests)
- locked native-shell cargo check
- version-alignment and release-workflow contract suites
- full go test ./... (running locally; protected CI repeats the complete release gates)

No consensus, AppHash, transaction, key-encoding, fork-target, or application-version change.