### PR TITLE
fix: reject root-scoped MCP identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ The dashboard also includes agent management, domain permissions, key rotation, 
 
 ---
 
+## What's New in v11.19.9
+
+**Codex workspace identity resolution now fails closed at the filesystem
+root.** A user-level Codex MCP process launched from `/` can no longer reuse the
+retired `global-codex` signer or auto-register the synthetic name `codex//`.
+SAGE rejects that broad, untrustworthy boundary before Git discovery,
+project-config lookup, key loading, or key generation. Real project and linked
+worktree roots continue to resolve to their stable workspace identities;
+operators who intentionally need a non-workspace shared identity must pin it
+explicitly with `SAGE_IDENTITY_PATH`.
+
+This patch changes no transaction, AppHash input, key encoding, fork target, or
+application version. Existing app-v27 chains replay byte-identically.
+
+Container: `ghcr.io/l33tdawg/sage:11.19.9`. SDK 11.19.9.
+
 ## What's New in v11.19.8
 
 **Access Groups now discover transferred historical domains, not only each
@@ -2316,7 +2332,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.19.8`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.19.9`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:

--- a/SECURITY_FAQ.md
+++ b/SECURITY_FAQ.md
@@ -11,7 +11,7 @@ SAGE has two distinct deployment models with fundamentally different threat mode
 | **Who** | One user, one local operator | Multiple agents, teams, organizations |
 | **Trust model** | User IS the only validator | Byzantine fault tolerance across validators |
 | **Database** | Local BadgerDB/SQLite stores in `~/.sage/data/` | BadgerDB consensus state plus off-chain mirror |
-| **Release** | v11.19.8 personal-node surface | v11.19.8 quorum/federation surface |
+| **Release** | v11.19.9 personal-node surface | v11.19.9 quorum/federation surface |
 
 Many concerns raised about the enterprise codebase do not apply to SAGE Personal, and vice versa. Each item below is tagged with which deployment it affects.
 
@@ -108,7 +108,7 @@ The `make byzantine` target and GitHub Actions CI job spin up a 4-validator Dock
 
 The following boundaries describe the current v11 codebase:
 
-**SAGE Personal (sage-gui v11.19.8):**
+**SAGE Personal (sage-gui v11.19.9):**
 - Designed for one operator. The management dashboard/API remains a local surface; anyone with access to the operator session or machine should be treated as trusted.
 - Federation is an explicit network-facing feature, off by default. When enabled it uses a separate pinned-mTLS listener, active on-chain treaty checks, chain-qualified signed requests, and replay protection. That authenticated protocol now runs over libp2p NAT traversal and Circuit Relay v2; the relay sees encrypted traffic and connection metadata, not plaintext memories or federation keys.
 - SQLite database supports optional AES-256-GCM encryption at rest (Synaptic Ledger). Enable from CEREBRUM Settings → Security.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.19.8
+  version: 11.19.9
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -271,6 +271,14 @@ func canonicalWorkspaceRootWithProbe(projectDir string, probe func(context.Conte
 	if err != nil {
 		return "", err
 	}
+	// A filesystem root is not a project boundary. In particular, the Codex
+	// desktop app-server itself runs from `/`; accepting that cwd would reuse
+	// the retired global-codex signer and auto-register the misleading name
+	// `codex//` instead of the task's actual workspace identity. Fail before
+	// probing Git, reading project config, or generating any key material.
+	if filepath.Dir(clean) == clean {
+		return "", fmt.Errorf("refusing broad workspace identity root")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	out, gitErr := probe(ctx, clean)

--- a/cmd/sage-gui/mcp_key_test.go
+++ b/cmd/sage-gui/mcp_key_test.go
@@ -94,6 +94,31 @@ func TestCanonicalWorkspaceRootFailsClosedWhenGitProbeTimesOut(t *testing.T) {
 		"identity resolution must fail closed promptly when Git stalls")
 }
 
+func TestCanonicalWorkspaceRootRejectsFilesystemRootWithoutGit(t *testing.T) {
+	root := string(filepath.Separator)
+	probed := false
+
+	resolved, err := canonicalWorkspaceRootWithProbe(root, func(context.Context, string) ([]byte, error) {
+		probed = true
+		return nil, exec.ErrNotFound
+	})
+
+	require.ErrorContains(t, err, "refusing broad workspace identity root")
+	require.Empty(t, resolved)
+	require.False(t, probed, "a filesystem-root workspace must fail before Git probing or identity generation")
+}
+
+func TestResolveImplicitWorkspaceIdentityRejectsFilesystemRoot(t *testing.T) {
+	keyPath, provider, project, err := resolveImplicitWorkspaceIdentity(
+		t.TempDir(), string(filepath.Separator), "codex", "",
+	)
+
+	require.ErrorContains(t, err, "refusing broad workspace identity root")
+	require.Empty(t, keyPath)
+	require.Equal(t, "codex", provider)
+	require.Empty(t, project)
+}
+
 func TestPrimaryWorkspaceMCPEnvPreservesPinnedProviderIdentity(t *testing.T) {
 	root := t.TempDir()
 	key := filepath.Join(t.TempDir(), "agent.key")

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.19.8-acceptance
+ARG VERSION=v11.19.9-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.19.8 federation Docker acceptance
+# v11.19.9 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -1,4 +1,4 @@
-name: sage-v111908-federation
+name: sage-v111909-federation
 
 services:
   relay:
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.19.8-acceptance
+        VERSION: v11.19.9-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.19.8"
+version = "11.19.9"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.19.8"
+version = "11.19.9"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.19.8",
+  "version": "11.19.9",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.19.8/app-v27. -->
+<!-- Reconciled through SAGE v11.19.9/app-v27. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.8 federation behavior. -->
+<!-- Verified against SAGE v11.19.9 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.19.8
+# sage-gui v11.19.9
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.19.8 advertises 34 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.19.9 advertises 34 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-08):** **v11.19.8 is the current release.** It keeps the
+**Status (2026-08):** **v11.19.9 is the current release.** It keeps the
 pairwise exported-agent federation model, safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
 JOIN route discovery, complete stopped-node backup/restore/preflight tooling,
@@ -141,6 +141,20 @@ ceiling is app-v27.
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.19.9 release
+
+Unpinned Codex MCP identity resolution now rejects the filesystem root before
+probing Git, reading workspace configuration, or generating a signer. This
+prevents the desktop app-server's `/` working directory from resurrecting the
+retired `global-codex` identity and registering the misleading `codex//`
+principal. Real repository and worktree roots retain their existing stable
+identity derivation, and explicit `SAGE_IDENTITY_PATH` pins remain available
+for intentional non-workspace identities.
+
+This is an off-consensus client identity-boundary correction. It changes no
+transaction, AppHash, key encoding, fork target, or application version;
+app-v27 remains the ceiling.
 
 ## v11.19.8 release
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -172,6 +172,7 @@ Use this to work out how far your chain has to climb.
 | v11.19.6 | Typed memory-link reads over REST and `sage_get_links`, with both endpoints filtered through caller disclosure policy before graph lookup; personal-node upgrades remain automatic while stopped-node preflight is operator-only; no consensus change and app-v27 remains the ceiling |
 | v11.19.7 | Default-off consent-gated recall-backed compaction with commit-backed byte-exact capture, visible gaps, complete same-thread restoration, and governed purge; isolated typed-link MRI rendering and correct last-write-wins memory re-typing; refreshed Go modules and CI actions; no consensus change and app-v27 remains the ceiling |
 | v11.19.8 | Bounded caller-domain discovery now includes re-authorized current-owned domains of active local Access Group peers, so transferred historical domains remain discoverable without a global roster or grant copying; no consensus change and app-v27 remains the ceiling |
+| v11.19.9 | Unpinned Codex MCP sessions reject filesystem-root workspace resolution before key loading or generation, preventing retired `global-codex` reuse and synthetic `codex//` registration; no consensus change and app-v27 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.19.8. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.19.9. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -208,7 +208,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.19.8)
+## Related docs (reconciled through v11.19.9)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.19.8.
+Status: implementation contract through SAGE v11.19.9.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -425,7 +425,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.19.8 federation authorization layer is off-consensus and does
+The current v11.19.9 federation authorization layer is off-consensus and does
 not require a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/app-v27-lifecycle.md
+++ b/docs/reference/concepts/app-v27-lifecycle.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.8/app-v27 code (2026-08-28). -->
+<!-- Verified against SAGE v11.19.9/app-v27 code (2026-08-29). -->
 
 # App-v27 record lifecycle and task canonicalization
 

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.19.8 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.19.9 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.19.8/app-v27, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.19.9/app-v27, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.19.8. Legacy organization/federation sections retain
+Verified against SAGE v11.19.9. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.19.8. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.19.9. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.19.8**.
+and is **not in v11.19.9**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.8. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.19.9. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.8 code (2026-08-28). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.19.9 code (2026-08-29). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.19.8.
+Reconciled against internal/mcp for SAGE v11.19.9.
 
 # SAGE MCP Tools Reference
 
@@ -131,6 +131,15 @@ CEREBRUM operator-only `/v1/dashboard/stats` surface.
 `GET /v1/dashboard/settings/boot-instructions`,
 `GET /v1/dashboard/settings/memory-mode`, `POST /v1/embed`,
 `POST /v1/memory/submit`
+
+For an unpinned user-level Codex MCP registration, the MCP process working
+directory must resolve to a real workspace boundary. A filesystem-root working
+directory is rejected before Git discovery, project-config lookup, key loading,
+or key generation; it never falls back to the retired `global-codex` signer and
+cannot auto-register a synthetic `codex//` identity. Start the task in its
+intended workspace, or deliberately configure `SAGE_IDENTITY_PATH` when a
+non-workspace, explicitly shared identity is required (`cmd/sage-gui/mcp.go`,
+`canonicalWorkspaceRootWithProbe`).
 
 **When to call:** First action of every new conversation. No exceptions —
 not even for greetings. Since v11.18.1, a compliant MCP session runs the

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.19.8. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.19.9. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.19.8
+**Package:** `sage-agent-sdk` **Version:** 11.19.9
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/reranker-and-setup.md
+++ b/docs/reference/reranker-and-setup.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.8. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.19.9. Cite file:line when behavior is non-obvious. -->
 
 # SAGE Local Engines and First-Run Setup Reference (v11)
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.8. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.19.9. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.8 lineage implementation (2026-08-28). -->
+<!-- Verified against SAGE v11.19.9 lineage implementation (2026-08-29). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -66,7 +66,7 @@ test('release-facing version metadata stays aligned', () => {
     ['deploy/federation-acceptance/README.md', `# v${version} federation Docker acceptance`],
     ['docs/FEDERATION.md', `Verified against SAGE v${version} federation behavior`],
     ['docs/reference/concepts/message-reply-lifecycle.md', `SAGE v${version} code`],
-    ['docs/UPGRADING.md', `| v${version} | Bounded caller-domain discovery`],
+    ['docs/UPGRADING.md', `| v${version} | Unpinned Codex MCP sessions reject filesystem-root workspace resolution`],
     ['docs/ROADMAP.md', `## v${version} release`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.19.8 SDK** | **TLS, app-v27 record-author lifecycle authority, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.19.9 SDK** | **TLS, app-v27 record-author lifecycle authority, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.19.8"
+version = "11.19.9"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.19.8"
+__version__ = "11.19.9"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.19.8",
+  "version": "11.19.9",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.19.8",
+      "identifier": "ghcr.io/l33tdawg/sage:11.19.9",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -76,7 +76,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.19.8';
+const SAGE_VERSION = 'v11.19.9';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace


### PR DESCRIPTION
## Summary
- reject filesystem-root cwd for implicit Codex MCP workspace identities
- prevent retired global-codex signer reuse and synthetic codex// registrations
- add regression coverage and document the fail-closed boundary
- align release metadata for v11.19.9

## Verification
- npm test (413 passed)
- PYTHONPATH=src python3 -m pytest -q (174 passed)
- GOCACHE=/private/tmp/sage-gocache go test ./cmd/sage-gui -count=1
- git diff --check

## Release
Off-consensus patch; app-v27 remains unchanged.