### PR TITLE
fix(sage-gui): errIfInstallTargetsHome — refuse mcp/codex install into $HOME

### DIFF
--- a/cmd/sage-gui/codex.go
+++ b/cmd/sage-gui/codex.go
@@ -31,6 +31,9 @@ func runCodexInstall() error {
 	if err != nil {
 		return fmt.Errorf("get working directory: %w", err)
 	}
+	if guardErr := errIfInstallTargetsHome(projectDir); guardErr != nil {
+		return guardErr
+	}
 
 	binPath, err := os.Executable()
 	if err != nil {

--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -505,6 +505,34 @@ func sanitizeDirName(name string) string {
 	return name
 }
 
+// errIfInstallTargetsHome refuses a project-scoped install that would land in the
+// user's home directory. runMCPInstall and runCodexInstall write their config under
+// the working directory (.claude/ or .codex/) and register hook commands with
+// ${CLAUDE_PROJECT_DIR}-relative paths. Run from $HOME, that config lands in the
+// user-global config directory, where ${CLAUDE_PROJECT_DIR} later resolves to
+// whichever project is open — so the hooks fail in every other project. Refuse
+// rather than write a guaranteed-broken install. Fails open when $HOME cannot be
+// resolved, so it never blocks a legitimate install.
+func errIfInstallTargetsHome(projectDir string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	projectAbs, projectErr := filepath.Abs(projectDir)
+	homeAbs, homeErr := filepath.Abs(home)
+	if projectErr != nil || homeErr != nil {
+		return nil
+	}
+	if filepath.Clean(projectAbs) == filepath.Clean(homeAbs) {
+		return fmt.Errorf(
+			"refusing to install into the home directory (%s): install writes a "+
+				"project-scoped config whose hooks are ${CLAUDE_PROJECT_DIR}-relative, "+
+				"which would land in the user-global config and break in every project; "+
+				"cd into a project directory and run install there", homeAbs)
+	}
+	return nil
+}
+
 // runMCPInstall creates a .mcp.json in the current directory so Claude Code
 // (or any MCP-compatible client) can connect to SAGE automatically.
 //
@@ -536,6 +564,9 @@ func runMCPInstall() error {
 	projectDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("get working directory: %w", err)
+	}
+	if guardErr := errIfInstallTargetsHome(projectDir); guardErr != nil {
+		return guardErr
 	}
 
 	// Determine SAGE_HOME

--- a/cmd/sage-gui/mcp_test.go
+++ b/cmd/sage-gui/mcp_test.go
@@ -36,6 +36,24 @@ func TestClaudeChannelRequiresExplicitCapableHostOptIn(t *testing.T) {
 	}
 }
 
+func TestErrIfInstallTargetsHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Refuses when the install target is the home directory itself: a
+	// project-scoped install there pollutes the user-global config with
+	// ${CLAUDE_PROJECT_DIR}-relative hooks that break in every project.
+	err := errIfInstallTargetsHome(home)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "home directory")
+
+	// Refuses regardless of a trailing separator or otherwise uncleaned path.
+	assert.Error(t, errIfInstallTargetsHome(home+string(os.PathSeparator)))
+
+	// Allows a normal project directory.
+	assert.NoError(t, errIfInstallTargetsHome(t.TempDir()))
+}
+
 func TestInstallClaudeMD_CreateNew(t *testing.T) {
 	projectDir := t.TempDir()
 	err := installClaudeMD(projectDir)


### PR DESCRIPTION
## What
`sage-gui mcp install` and `sage-gui codex install` now refuse to run when
the current directory is the user's home directory. Installs from any real
project directory are unchanged, for both Claude Code and Codex.

## Why
Both installers are project-scoped. `projectDir` comes from `os.Getwd()`,
and the install writes `<cwd>/.claude/` (or `.codex/`) plus a settings/hooks
config that registers each hook command as
`${CLAUDE_PROJECT_DIR}/.claude/hooks/sage-*.sh` — project-relative.

Run from `$HOME`, `<cwd>/.claude/` *is* the user-global Claude Code config
dir (`~/.claude`). The hook scripts get written into the host-global config,
but the registration stays `${CLAUDE_PROJECT_DIR}`-relative, which at runtime
resolves against whatever project is currently open — never home. So every
subsequent session in any *other* project tries to exec
`<that-project>/.claude/hooks/sage-*.sh`, which doesn't exist.

The hooks fail open, so the breakage is silent — except the Stop hook, which
surfaces a visible "No such file or directory" error, and it does so in a
project unrelated to where the install was ever run. A home-directory install
therefore has no working outcome: it produces a config guaranteed broken in
every project and pollutes the user-global host config in the process.

## How
- add `errIfInstallTargetsHome(projectDir string) error` in
  `cmd/sage-gui/mcp.go`, called right after `os.Getwd()` in `runMCPInstall`
  and in `runCodexInstall` (`cmd/sage-gui/codex.go`)
- compare `filepath.Clean(filepath.Abs(projectDir))` against
  `filepath.Clean(filepath.Abs($HOME))`; on match, return an error whose
  message explains the `${CLAUDE_PROJECT_DIR}` mismatch and tells the user to
  `cd` into a project directory first
- fail open (`return nil`) if `os.UserHomeDir()` or either `Abs()` can't be
  resolved, so the guard can never block a legitimate install on a platform
  where home isn't resolvable

### Why hard-refuse rather than warn-and-proceed
A home-directory install can only ever produce a broken, hard-to-diagnose
config: silent everywhere except the Stop hook, and surfacing in a different
project than the one it was installed from. Aborting up front is strictly
more helpful than writing that config and leaving the user to later hunt down
and hand-remove the scripts from their host-global `~/.claude`. It also keeps
the user-global config from being polluted at all. This mirrors the existing
refuse-on-invalid-target posture in `fix: reject root-scoped MCP identities`
(#294).

That said, this is a UX judgment call, and the final call is yours. A
warn-and-proceed variant — print the same explanation, then continue — is a
reasonable alternative if you'd rather not hard-block. The guard is a one-line
swap either way (return the error vs. log it and fall through). Happy to change
it to whichever you prefer.

## ABCI determinism
No consensus-path code touched — the change is confined to the `cmd/sage-gui`
install commands.

## Tests
- `TestErrIfInstallTargetsHome` — refuses when target == home (including the
  trailing-slash form), allows a normal project dir
- `go test ./cmd/sage-gui/` passes; `gofmt` clean
- `golangci-lint run` clean at the CI-pinned v2.12.2
