### PR TITLE
fix(sage-gui): skip bridge auto-heal when cwd is $HOME

### DIFF
--- a/cmd/sage-gui/mcp.go
+++ b/cmd/sage-gui/mcp.go
@@ -513,24 +513,34 @@ func sanitizeDirName(name string) string {
 // whichever project is open — so the hooks fail in every other project. Refuse
 // rather than write a guaranteed-broken install. Fails open when $HOME cannot be
 // resolved, so it never blocks a legitimate install.
-func errIfInstallTargetsHome(projectDir string) error {
+// installTargetsHome reports whether projectDir resolves to the user's home
+// directory — where a project-scoped .claude/.codex write would land in the
+// user-global config and its ${CLAUDE_PROJECT_DIR}-relative hooks would then break
+// in every project. Fails safe (false) when home cannot be resolved, so it never
+// blocks a legitimate install/heal.
+func installTargetsHome(projectDir string) bool {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return nil
+		return false
 	}
 	projectAbs, projectErr := filepath.Abs(projectDir)
 	homeAbs, homeErr := filepath.Abs(home)
 	if projectErr != nil || homeErr != nil {
+		return false
+	}
+	return filepath.Clean(projectAbs) == filepath.Clean(homeAbs)
+}
+
+func errIfInstallTargetsHome(projectDir string) error {
+	if !installTargetsHome(projectDir) {
 		return nil
 	}
-	if filepath.Clean(projectAbs) == filepath.Clean(homeAbs) {
-		return fmt.Errorf(
-			"refusing to install into the home directory (%s): install writes a "+
-				"project-scoped config whose hooks are ${CLAUDE_PROJECT_DIR}-relative, "+
-				"which would land in the user-global config and break in every project; "+
-				"cd into a project directory and run install there", homeAbs)
-	}
-	return nil
+	home, _ := os.UserHomeDir()
+	return fmt.Errorf(
+		"refusing to install into the home directory (%s): install writes a "+
+			"project-scoped config whose hooks are ${CLAUDE_PROJECT_DIR}-relative, "+
+			"which would land in the user-global config and break in every project; "+
+			"cd into a project directory and run install there", home)
 }
 
 // runMCPInstall creates a .mcp.json in the current directory so Claude Code
@@ -1317,6 +1327,18 @@ func claimAgentIdentity(sageHome, token, keyPath string) error {
 //     __SAGE_GUI_BIN__ path (e.g. user upgraded sage-gui to a new location)
 //     get re-templated.
 func selfHealProject(projectDir, sageHome string, active ...string) {
+	// The stdio bridge auto-heals a project's .claude/.codex hooks on every
+	// startup. Skip it only when projectDir == $HOME: there <cwd>/.claude IS the
+	// user-global config directory, so the ${CLAUDE_PROJECT_DIR}-relative hooks
+	// land in it and then break in every OTHER project (the same hazard
+	// errIfInstallTargetsHome guards for `install`). CLAUDE_CONFIG_DIR is NOT a
+	// reason to skip: it overrides the user config dir, not project config, so
+	// projectDir/.claude/settings.json remains the correct, cwd-discovered
+	// project scope regardless. The bridge only needs to sign requests; `mcp
+	// install` remains the explicit, directory-aware way to (re)install hooks.
+	if installTargetsHome(projectDir) {
+		return
+	}
 	activeProvider, activeIdentityPath := "", ""
 	if len(active) > 0 {
 		activeProvider = active[0]

--- a/cmd/sage-gui/selfheal_guard_test.go
+++ b/cmd/sage-gui/selfheal_guard_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// selfHealProject auto-heals a project's hooks on bridge startup. It must SKIP that
+// heal only when the working dir is $HOME — there the project-scoped
+// ${CLAUDE_PROJECT_DIR} hooks would land in the user-global config and break in
+// every other project. CLAUDE_CONFIG_DIR overrides the USER config dir, not
+// project config (projectDir/.claude/settings.json is still discovered from the
+// working directory), so a normal project must still heal when it is set.
+func TestSelfHealProject_SkipsHomeNotConfigDir(t *testing.T) {
+	// A project whose .claude/hooks already exists, so the heal WOULD fire.
+	seedProject := func(t *testing.T) string {
+		p := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(p, ".claude", "hooks"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	healed := func(dir string) bool {
+		_, err := os.Stat(filepath.Join(dir, ".claude", "hooks", "sage-stop.sh"))
+		return err == nil
+	}
+
+	t.Run("heals a normal project", func(t *testing.T) {
+		t.Setenv("CLAUDE_CONFIG_DIR", "")
+		p := seedProject(t)
+		selfHealProject(p, t.TempDir())
+		if !healed(p) {
+			t.Error("expected sage hooks healed into a normal project")
+		}
+	})
+
+	// Regression: CLAUDE_CONFIG_DIR must NOT disable project hook repair — it
+	// overrides the user config dir, not project config.
+	t.Run("heals a normal project even when CLAUDE_CONFIG_DIR is set", func(t *testing.T) {
+		t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+		p := seedProject(t)
+		selfHealProject(p, t.TempDir())
+		if !healed(p) {
+			t.Error("expected sage hooks healed into a normal project when CLAUDE_CONFIG_DIR is set (it overrides user config, not project config)")
+		}
+	})
+
+	t.Run("skips when the project dir is the user home", func(t *testing.T) {
+		t.Setenv("CLAUDE_CONFIG_DIR", "")
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		if err := os.MkdirAll(filepath.Join(home, ".claude", "hooks"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		selfHealProject(home, t.TempDir())
+		if healed(home) {
+			t.Error("must NOT heal into ~/.claude when projectDir == $HOME")
+		}
+	})
+}


### PR DESCRIPTION
## What

The `sage-gui mcp` stdio bridge no longer auto-heals hooks into the user-global
config directory. `selfHealProject` returns early when the project directory
resolves to `$HOME`. Normal project heal is unchanged.

## Why

The bridge (`runMCP`, `cmd/sage-gui/mcp.go`) calls `selfHealProject` on every
startup, creating `.claude/hooks/*.sh` and merging `${CLAUDE_PROJECT_DIR}`-
relative hook commands into `.claude/settings.json`. When the bridge's working
directory is `$HOME`, `<cwd>/.claude` *is* the user-global config dir. The
`${CLAUDE_PROJECT_DIR}`-relative hooks land there and then fail in every *other*
project with a missing-file error on `Stop`/`UserPromptSubmit`.

That is the same hazard #297 guards for the explicit `install` command; the
bridge's startup self-heal is a separate code path that did not share the guard.

## How

- Guard `selfHealProject` with an early return when `projectDir` resolves to
  `$HOME`. The bridge only needs to sign requests; `mcp install` remains the
  explicit, directory-aware way to (re)install hooks.
- Extract the `$HOME` check from `errIfInstallTargetsHome` (#297) into a reusable
  `installTargetsHome(projectDir string) bool`, which fails false when home is
  unresolvable. `errIfInstallTargetsHome` now calls it — no behaviour change to
  the install guard.
- Complements #297: that PR covered the explicit `install` command; this covers
  the bridge's startup self-heal.

## CLAUDE_CONFIG_DIR is deliberately not guarded

An earlier revision also returned early when `CLAUDE_CONFIG_DIR` was set. That
was wrong: `CLAUDE_CONFIG_DIR` overrides the *user* config directory, not project
config — `projectDir/.claude/settings.json` is still discovered from the working
directory and must still heal. Guarding on it disabled valid project hook repair
(and `selfHealCodex` + CLAUDE.md repair for Codex sessions that merely inherit
the variable). Only the `$HOME` case is a genuine pollution vector, and
`projectDir/.claude` can equal `~/.claude` only when `projectDir == $HOME`.

## ABCI determinism

Consensus path untouched. `cmd/sage-gui` only; no `internal/abci`,
`internal/store`, `internal/tx`, or FinalizeBlock code involved.

## Tests

- `go test ./cmd/sage-gui/` passes; `gofmt` clean.
- `golangci-lint run` clean at the CI-pinned version.
- `TestSelfHealProject_SkipsHomeNotConfigDir` in
  `cmd/sage-gui/selfheal_guard_test.go`: heals a normal project; **heals a normal
  project even when `CLAUDE_CONFIG_DIR` is set** (the requested regression); skips
  when `projectDir == $HOME`.
- existing `TestErrIfInstallTargetsHome` still passes (shared `installTargetsHome`
  helper).
