### PR TITLE
fix(ci): wait for exact Comet transaction index readiness

### DIFF
--- a/deploy/scripts/run-v11.9-chaos.sh
+++ b/deploy/scripts/run-v11.9-chaos.sh
@@ -402,9 +402,9 @@ rpc_tx_height() {
       return 1
       ;;
   esac
-  rpc_json "${port}" "/tx?hash=0x${hash}&prove=false" | python3 -c '
-import json, sys
-print(int(json.load(sys.stdin)["result"]["height"]))'
+  # Commit acknowledgement can precede the local asynchronous tx index.
+  # Wait only for exact-hash absence; preserve all other RPC/execution failures.
+  python3 deploy/scripts/wait-comet-tx.py "${port}" "${hash}"
 }
 
 rpc_commit_signers() {

--- a/deploy/scripts/test_wait_comet_tx.py
+++ b/deploy/scripts/test_wait_comet_tx.py
@@ -1,0 +1,75 @@
+import importlib.util
+import io
+import json
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+
+spec = importlib.util.spec_from_file_location("wait_tx", Path(__file__).with_name("wait-comet-tx.py"))
+helper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helper)
+HASH = "AB" * 32
+
+
+def ok(**overrides):
+    return {"result": {"hash": HASH, "height": "245", "tx_result": {"code": 0}, **overrides}}
+
+
+def missing(data=None):
+    return {"error": {"code": -32603, "message": "Internal error",
+                      "data": data or f"tx ({HASH}) not found"}}
+
+
+class Response(io.BytesIO):
+    status = 200
+
+
+class TxReadinessTests(unittest.TestCase):
+    def invoke(self, replies, timeout=30):
+        def request(url, timeout):
+            self.assertEqual(url, f"http://127.0.0.1:37757/tx?hash=0x{HASH}&prove=false")
+            self.assertGreater(timeout, 0)
+            reply = replies.pop(0)
+            if isinstance(reply, Exception):
+                raise reply
+            return Response(json.dumps(reply).encode())
+        with patch.object(helper, "urlopen", side_effect=request) as fetch:
+            result = helper.wait_tx(37757, HASH.lower(), timeout)
+            return result, fetch.call_count
+
+    def test_immediate_success(self):
+        self.assertEqual(self.invoke([ok()]), (245, 1))
+
+    def test_exact_http500_absence_then_success(self):
+        error = HTTPError("local", 500, "Internal error", {}, io.BytesIO(json.dumps(missing()).encode()))
+        self.assertEqual(self.invoke([error, ok()]), (245, 2))
+
+    def test_json_rpc_absence_then_success(self):
+        self.assertEqual(self.invoke([missing(), ok()]), (245, 2))
+
+    def test_timeout_retains_diagnostic(self):
+        with self.assertRaisesRegex(TimeoutError, "tx .* not found"):
+            self.invoke([missing()], timeout=0.01)
+
+    def test_nonretryable_errors(self):
+        cases = [missing("transaction indexing is disabled"), missing("tx (OTHER) not found"),
+                 ok(hash="CD" * 32), ok(height="0"), ok(height="-1"), ok(height=True),
+                 ok(tx_result={"code": 1}), ok(tx_result={}), [],
+                 HTTPError("local", 500, "Internal error", {}, io.BytesIO(b"upstream failure")),
+                 HTTPError("local", 503, "Unavailable", {}, io.BytesIO(json.dumps(missing()).encode())),
+                 URLError("connection refused")]
+        for response in cases:
+            with self.subTest(response=response):
+                with self.assertRaises((ValueError, URLError)):
+                    self.invoke([response])
+
+    def test_invalid_hash_no_request(self):
+        with patch.object(helper, "urlopen") as fetch:
+            with self.assertRaises(ValueError):
+                helper.wait_tx(37757, "BAD")
+            fetch.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/scripts/wait-comet-tx.py
+++ b/deploy/scripts/wait-comet-tx.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Read-only, bounded wait for an exact committed transaction's index entry."""
+import json
+import re
+import sys
+import time
+from urllib.error import HTTPError
+from urllib.request import urlopen
+
+
+def wait_tx(port, tx_hash, timeout=30):
+    if not re.fullmatch(r"[0-9A-Fa-f]{64}", tx_hash):
+        raise ValueError("expected an exact 32-byte transaction hash")
+    if not 1 <= int(port) <= 65535:
+        raise ValueError("invalid loopback RPC port")
+    tx_hash = tx_hash.upper()
+    url = f"http://127.0.0.1:{int(port)}/tx?hash=0x{tx_hash}&prove=false"
+    deadline = time.monotonic() + timeout
+    last = "no response"
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(url, timeout=min(3, deadline - time.monotonic())) as response:
+                status, raw = response.status, response.read(65537)
+        except HTTPError as error:
+            with error:
+                status, raw = error.code, error.read(65537)
+        # Transport failures deliberately propagate; only exact index absence retries.
+        if len(raw) > 65536:
+            raise ValueError("oversized transaction RPC response")
+        last = f"HTTP {status}: {raw.decode('utf-8', errors='replace')}"
+        try:
+            data = json.loads(raw)
+        except (ValueError, UnicodeError) as error:
+            raise ValueError(f"invalid transaction RPC JSON: {last}") from error
+        if not isinstance(data, dict):
+            raise ValueError(f"invalid transaction RPC envelope: {last}")
+        error = data.get("error")
+        if (status in (200, 500) and isinstance(error, dict)
+                and error.get("code") == -32603
+                and error.get("message") == "Internal error"
+                and error.get("data") == f"tx ({tx_hash}) not found"
+                and "result" not in data):
+            time.sleep(min(0.25, max(0, deadline - time.monotonic())))
+            continue
+        if status != 200 or error is not None:
+            raise ValueError(f"transaction RPC failed: {last}")
+        result = data.get("result")
+        if not isinstance(result, dict) or result.get("hash", "").upper() != tx_hash:
+            raise ValueError(f"transaction RPC hash mismatch: {last}")
+        height = result.get("height")
+        if not isinstance(height, str) or not re.fullmatch(r"[1-9][0-9]*", height):
+            raise ValueError(f"invalid committed transaction height: {last}")
+        tx_result = result.get("tx_result")
+        if not isinstance(tx_result, dict) or type(tx_result.get("code")) is not int or tx_result["code"] != 0:
+            raise ValueError(f"transaction execution failed: {last}")
+        return int(height)
+    raise TimeoutError(f"transaction index not ready after {timeout}s for {tx_hash}; {last}")
+
+
+if __name__ == "__main__":
+    try:
+        print(wait_tx(sys.argv[1], sys.argv[2]))
+    except Exception as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/governance-retry.test.mjs
+++ b/scripts/governance-retry.test.mjs
@@ -1,5 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+test('consensus fixture waits only for exact transaction index absence', () => {
+    const fixture = readFileSync(new URL('../deploy/scripts/run-v11.9-chaos.sh', import.meta.url), 'utf8');
+    assert.match(fixture, /python3 deploy\/scripts\/wait-comet-tx\.py "\$\{port\}" "\$\{hash\}"/);
+    const result = spawnSync('python3', ['-B', 'deploy/scripts/test_wait_comet_tx.py'], {
+        cwd: new URL('../', import.meta.url), encoding: 'utf8', timeout: 10000,
+    });
+    assert.equal(result.status, 0, result.stderr || String(result.error));
+});
 
 import {
     enqueueGovernedTransfer,


### PR DESCRIPTION
Repairs the release-blocking immediate transaction-index lookup in the real-process consensus gate. Adds a bounded read-only wait only for the exact requested hash not-found JSON-RPC diagnostic; all transport, malformed, unrelated HTTP/RPC, hash, height and execution-code errors fail closed with response evidence. Does not resubmit transactions or relax voting windows, AppHash or validator-set assertions. Tests cover immediate success, HTTP500 and JSON-RPC absence, timeout, wrong hash, disabled index, invalid height, rejected execution, malformed JSON and transport failures. Local npm suite 414 passed; focused tests and bash syntax/diff checks passed. Original protected-main failure: run33849778077 job100949697874. Index lag is a hypothesis because the old curl discarded the error body; new handling preserves diagnostics for any other cause. No runtime or consensus schema changes.