### PR TITLE
fix: visible federation motion and reliable interaction resume (v11.19.18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker run -d --name sage \
   ghcr.io/l33tdawg/sage:latest
 ```
 
-Pin a specific version with `ghcr.io/l33tdawg/sage:11.19.17`.
+Pin a specific version with `ghcr.io/l33tdawg/sage:11.19.18`.
 
 The SAGE server stays in that container. To give a local MCP client a stdio
 bridge, start a second process **inside the same running container**:
@@ -207,6 +207,12 @@ software updates, and encryption controls. Ordinary agent identity replacement
 uses re-enrollment; historical memory authorship is preserved.
 
 ---
+
+## What's New in v11.19.18
+
+Federation agents now visibly orbit their nodes. Motion continues over empty map space and resumes after pointer selection; hovering an agent, keyboard inspection, and dragging keep targets steady. Pause motion and reduced-motion preferences remain supported.
+
+Container: `ghcr.io/l33tdawg/sage:11.19.18`. SDK 11.19.18.
 
 ## What's New in v11.19.17
 

--- a/SECURITY_FAQ.md
+++ b/SECURITY_FAQ.md
@@ -11,7 +11,7 @@ SAGE has two distinct deployment models with fundamentally different threat mode
 | **Who** | One user, one local operator | Multiple agents, teams, organizations |
 | **Trust model** | User IS the only validator | Byzantine fault tolerance across validators |
 | **Database** | Local BadgerDB/SQLite stores in `~/.sage/data/` | BadgerDB consensus state plus off-chain mirror |
-| **Release** | v11.19.17 personal-node surface | v11.19.17 quorum/federation surface |
+| **Release** | v11.19.18 personal-node surface | v11.19.18 quorum/federation surface |
 
 Many concerns raised about the enterprise codebase do not apply to SAGE Personal, and vice versa. Each item below is tagged with which deployment it affects.
 
@@ -108,7 +108,7 @@ The `make byzantine` target and GitHub Actions CI job spin up a 4-validator Dock
 
 The following boundaries describe the current v11 codebase:
 
-**SAGE Personal (sage-gui v11.19.17):**
+**SAGE Personal (sage-gui v11.19.18):**
 - Designed for one operator. The management dashboard/API remains a local surface; anyone with access to the operator session or machine should be treated as trusted.
 - Federation is an explicit network-facing feature, off by default. When enabled it uses a separate pinned-mTLS listener, active on-chain treaty checks, chain-qualified signed requests, and replay protection. That authenticated protocol now runs over libp2p NAT traversal and Circuit Relay v2; the relay sees encrypted traffic and connection metadata, not plaintext memories or federation keys.
 - SQLite database supports optional AES-256-GCM encryption at rest (Synaptic Ledger). Enable from CEREBRUM Settings → Security.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: (S)AGE API
-  version: 11.19.17
+  version: 11.19.18
   description: |-
     (Sovereign) Agent Governed Experience — network REST API for memory
     submission, validation, and query.

--- a/deploy/federation-acceptance/Dockerfile.node
+++ b/deploy/federation-acceptance/Dockerfile.node
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 COPY third_party/cometbft/go.mod third_party/cometbft/go.sum ./third_party/cometbft/
 RUN go mod download
 COPY . .
-ARG VERSION=v11.19.17-acceptance
+ARG VERSION=v11.19.18-acceptance
 ARG COMMIT=docker-acceptance
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \

--- a/deploy/federation-acceptance/README.md
+++ b/deploy/federation-acceptance/README.md
@@ -1,4 +1,4 @@
-# v11.19.17 federation Docker acceptance
+# v11.19.18 federation Docker acceptance
 
 This harness gives two SAGE personal nodes separate persisted homes, separate
 Docker edge networks, and one self-hosted natter relay. A temporary third

--- a/deploy/federation-acceptance/docker-compose.yml
+++ b/deploy/federation-acceptance/docker-compose.yml
@@ -1,4 +1,4 @@
-name: sage-v111917-federation
+name: sage-v111918-federation
 
 services:
   relay:
@@ -27,7 +27,7 @@ services:
       context: ../..
       dockerfile: deploy/federation-acceptance/Dockerfile.node
       args:
-        VERSION: v11.19.17-acceptance
+        VERSION: v11.19.18-acceptance
         COMMIT: docker-acceptance
     environment:
       SAGE_HOME: /root/.sage

--- a/desktop/sage-shell/Cargo.lock
+++ b/desktop/sage-shell/Cargo.lock
@@ -2770,7 +2770,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sage-shell"
-version = "11.19.17"
+version = "11.19.18"
 dependencies = [
  "getrandom 0.3.4",
  "serde",

--- a/desktop/sage-shell/Cargo.toml
+++ b/desktop/sage-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-shell"
-version = "11.19.17"
+version = "11.19.18"
 description = "Additive native CEREBRUM shell"
 authors = ["Dhillon Andrew Kannabhiran"]
 edition = "2024"

--- a/desktop/sage-shell/tauri.conf.json
+++ b/desktop/sage-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SAGE Native Preview",
-  "version": "11.19.17",
+  "version": "11.19.18",
   "identifier": "com.sage.native-preview",
   "build": {
     "frontendDist": "ui"

--- a/docs/ADMIN_BOOTSTRAP.md
+++ b/docs/ADMIN_BOOTSTRAP.md
@@ -1,6 +1,6 @@
 # CEREBRUM Root and agent approval
 
-<!-- Reconciled through SAGE v11.19.17/app-v27. -->
+<!-- Reconciled through SAGE v11.19.18/app-v27. -->
 
 This guide covers the current governed bootstrap and recovery workflow. The
 pre-app-v23 self-promotion and per-field permission APIs are retired and must

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.17 federation behavior. -->
+<!-- Verified against SAGE v11.19.18 federation behavior. -->
 
 # Connect your SAGE to another network
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -27,7 +27,7 @@ sudo mv sage-gui /usr/local/bin/  # or add to your PATH
 
 ```bash
 sage-gui version
-# sage-gui v11.19.17
+# sage-gui v11.19.18
 ```
 
 ---
@@ -197,7 +197,7 @@ sage-gui setup
 
 ### 3. Start using it
 
-Just chat normally. SAGE v11.19.17 advertises 34 MCP tools. The core workflow is:
+Just chat normally. SAGE v11.19.18 advertises 34 MCP tools. The core workflow is:
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # SAGE Roadmap
 
-**Status (2026-09):** **v11.19.17 is the current release.** CEREBRUM adds a federation connectome, live metadata activity, clearer pairing steps, and explicit memory-sharing drafts. Trusted paired nodes now discover and
+**Status (2026-09):** **v11.19.18 is the current release.** CEREBRUM adds a federation connectome, live metadata activity, clearer pairing steps, and explicit memory-sharing drafts. Trusted paired nodes now discover and
 message eligible ordinary agents automatically, with memory sharing separately
 configured. It keeps safe registered-name addressing and
 reply-event visibility, the three-tab Access Controls redesign, five-minute
@@ -158,6 +158,10 @@ ceiling is app-v27.
 upgrade in place across all future releases. Routine personal-node upgrades
 remain automatic; the exceptional legacy-lineage repair is deliberately an
 explicit, reviewed operator ceremony rather than a silent mutation.
+
+## v11.19.18 release
+
+Federation agent motion is visibly continuous, with pauses limited to inspecting an agent or dragging. Browser regression checks measure screen displacement and verify pointer and keyboard resume behavior.
 
 ## v11.19.17 release
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -181,6 +181,7 @@ Use this to work out how far your chain has to climb.
 | v11.19.15 | Consensus-safe memory cleanup with uncapped full-inventory previews, durable exact-byte recovery, and honest progress counts; automatic cleanup requires fresh current-Root opt-in after upgrade, open tasks/internal records stay protected, and audit history remains; no consensus change and app-v27 remains the ceiling |
 | v11.19.16 | Automatic trusted-node agent discovery and messaging when both peers are upgraded; memory sharing remains explicit and existing approved grants remain; searchable CEREBRUM directory and bulk/drag-and-drop Read/Copy drafts; no consensus change and app-v27 remains the ceiling |
 | v11.19.17 | Federation connectome, operator-only metadata activity stream, explicit viewed-node names, clearer pairing onboarding, and Read/Copy/removal drafts; existing trust and permissions preserved; no consensus change and app-v27 remains the ceiling |
+| v11.19.18 | Visible federation agent orbits and reliable interaction pause/resume; no consensus change and app-v27 remains the ceiling |
 
 ### v11.18.3 — the signer fence, and what it does *not* cover
 

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,4 +1,4 @@
-<!-- Reference index reconciled for SAGE v11.19.17. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
+<!-- Reference index reconciled for SAGE v11.19.18. Core REST, MCP, concepts, Python SDK, federation/brain graph, reranker, and environment references are current-facing for v11. -->
 
 
 # SAGE Reference — Agent Integration Index
@@ -209,7 +209,7 @@ are recorded here because agents may have cached them.
   `sage_message_replies`, or `sage_message_history(folder="outbox")` for the
   untruncated text.
 
-## Related docs (reconciled through v11.19.17)
+## Related docs (reconciled through v11.19.18)
 
 These were stale earlier in v8 and have now been reconciled against the code. Where any of them still disagrees with this reference, this reference wins.
 

--- a/docs/reference/app-v23-access-control-design.md
+++ b/docs/reference/app-v23-access-control-design.md
@@ -1,6 +1,6 @@
 # App-v23 Access Control and Federation Design
 
-Status: implementation contract through SAGE v11.19.17.
+Status: implementation contract through SAGE v11.19.18.
 
 This document fixes the security and product invariants for app-v23. It is not
 permission to weaken an invariant to preserve app-v22 runtime behavior.
@@ -425,7 +425,7 @@ Runtime federation after app-v23 has no pre-v23 compatibility fallback.
 Negotiation rejects peers that do not support the v23 agent-delegated query
 protocol.
 
-The current v11.19.17 federation authorization layer is off-consensus and does
+The current v11.19.18 federation authorization layer is off-consensus and does
 not require a new application protocol. Every active trusted node connection is itself a
 pairwise federation group. Each operator explicitly exports the local ordinary
 agents that join that federation; the other SAGE does not create a matching

--- a/docs/reference/concepts/app-v27-lifecycle.md
+++ b/docs/reference/concepts/app-v27-lifecycle.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.17/app-v27 code (2026-09-02). -->
+<!-- Verified against SAGE v11.19.18/app-v27 code (2026-09-02). -->
 
 # App-v27 record lifecycle and task canonicalization
 

--- a/docs/reference/concepts/message-reply-lifecycle.md
+++ b/docs/reference/concepts/message-reply-lifecycle.md
@@ -1,4 +1,4 @@
-Reconciled against SAGE v11.19.17 code. Cite file:line or file + symbol when behavior is non-obvious.
+Reconciled against SAGE v11.19.18 code. Cite file:line or file + symbol when behavior is non-obvious.
 
 # Message and Reply Lifecycle — who can see a reply, and where
 

--- a/docs/reference/concepts/rbac-orgs-federation.md
+++ b/docs/reference/concepts/rbac-orgs-federation.md
@@ -1,8 +1,8 @@
-<!-- Core document reconciled through SAGE v11.19.17/app-v27, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
+<!-- Core document reconciled through SAGE v11.19.18/app-v27, including consensus-backed Access Group authority, Root continuity, linked federated readers, and the quorum/state-sync/governance-gateway sections. -->
 
 # RBAC, Organizations, and Federation
 
-Verified against SAGE v11.19.17. Legacy organization/federation sections retain
+Verified against SAGE v11.19.18. Legacy organization/federation sections retain
 their historical context; app-v23 roles, Root, Access Groups, and app-v25
 historical writer continuity are the current local-control model.
 

--- a/docs/reference/concepts/signer-nonce-fence.md
+++ b/docs/reference/concepts/signer-nonce-fence.md
@@ -1,6 +1,6 @@
 # The signer fence — same-key nonce ordering, and the hole that is still open
 
-**Status: v11.19.17. This document states a KNOWN RESIDUAL that this release does
+**Status: v11.19.18. This document states a KNOWN RESIDUAL that this release does
 not close. Read the "What is still broken" section before you rely on anything
 here.**
 
@@ -171,7 +171,7 @@ A `kill -9`, a power cut, or a crash during the original RPC can still lose the
 fence. **Closing that needs durable pre-broadcast intent** — the exact bytes and
 hash recorded *before* the send, cleared only on a proven fate, reloaded and
 reconciled *before* any nonce is allocated on startup. That is persistence work
-and is **not in v11.19.17**.
+and is **not in v11.19.18**.
 
 The residual is covered by an executable test:
 `TestRestartWhileFencedLosesTheTransaction` in

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.17. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
+<!-- Reconciled through SAGE v11.19.18. Every variable below was located at the cited file:line via `os.Getenv` or the local env helper. When the code changes, re-verify and bump this header. -->
 
 # SAGE Reference — Environment Variables
 

--- a/docs/reference/federation-and-brain-api.md
+++ b/docs/reference/federation-and-brain-api.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.17 code (2026-09-02). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
+<!-- Verified against SAGE v11.19.18 code (2026-09-02). Cite file:line when behavior is non-obvious. This doc covers the v11 federation and brain graph surface; rest-api.md governs the core /v1/* endpoints. -->
 
 # SAGE Federation and Brain HTTP API Reference (v11)
 
@@ -1047,7 +1047,7 @@ Sources: `internal/federation/node_contacts.go` (`buildNodeContactPage`,
 `api/rest/federation_handler.go` (`handleFederationAvailable`);
 `internal/store/pipeline_transport.go` (transport mode persistence).
 
-### Federation connectome and operator activity (v11.19.17)
+### Federation connectome and operator activity (v11.19.18)
 
 The Federation landing page provides a connectome and a text-equivalent List
 view. Each cluster is one trusted SAGE; agents are loaded through the existing

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,4 +1,4 @@
-Reconciled against internal/mcp for SAGE v11.19.17.
+Reconciled against internal/mcp for SAGE v11.19.18.
 
 # SAGE MCP Tools Reference
 

--- a/docs/reference/python-sdk.md
+++ b/docs/reference/python-sdk.md
@@ -1,8 +1,8 @@
-Verified against SDK source for SAGE v11.19.17. Package: sage-agent-sdk.
+Verified against SDK source for SAGE v11.19.18. Package: sage-agent-sdk.
 
 # SAGE Python SDK Reference
 
-**Package:** `sage-agent-sdk` **Version:** 11.19.17
+**Package:** `sage-agent-sdk` **Version:** 11.19.18
 **Requires:** Python 3.10+ | httpx ≥ 0.25 | pydantic ≥ 2.0 | PyNaCl ≥ 1.5
 
 ```bash

--- a/docs/reference/reranker-and-setup.md
+++ b/docs/reference/reranker-and-setup.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.17. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.19.18. Cite file:line when behavior is non-obvious. -->
 
 # SAGE Local Engines and First-Run Setup Reference (v11)
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,4 +1,4 @@
-<!-- Reconciled through SAGE v11.19.17. Cite file:line when behavior is non-obvious. -->
+<!-- Reconciled through SAGE v11.19.18. Cite file:line when behavior is non-obvious. -->
 
 # SAGE REST API Reference
 

--- a/docs/reference/upgrade-lineage-repair.md
+++ b/docs/reference/upgrade-lineage-repair.md
@@ -1,4 +1,4 @@
-<!-- Verified against SAGE v11.19.17 lineage implementation (2026-09-02). -->
+<!-- Verified against SAGE v11.19.18 lineage implementation (2026-09-02). -->
 
 # Legacy upgrade-lineage repair (app-v21 → app-v22)
 

--- a/e2e/federation-connectome.spec.js
+++ b/e2e/federation-connectome.spec.js
@@ -76,3 +76,36 @@ test('ambient agents drift, pause for interaction and respect reduced motion',as
  await page.waitForTimeout(250);
  expect(await dot.getAttribute('cx')).toBe(reduced);
 });
+
+
+test('motion is visible over empty map space and resumes after inspecting an agent',async({page})=>{
+ await openMap(page);
+ const map=page.locator('.fc-map');
+ await map.hover({position:{x:30,y:30}});
+ const dot=page.locator('.fc-agent-core').first();
+ const position=()=>dot.evaluate(el=>{const r=el.getBoundingClientRect();return {x:r.x,y:r.y}});
+ const initial=await position();
+ await expect.poll(async()=>{const p=await position();return Math.hypot(p.x-initial.x,p.y-initial.y)},{timeout:4000}).toBeGreaterThan(8);
+ await page.locator('[data-entity="agent"]').first().hover();
+ await expect(map).toHaveClass(/fc-ambient-paused/);
+ const paused=await position();
+ await page.waitForTimeout(300);
+ expect(await position()).toEqual(paused);
+ await map.hover({position:{x:30,y:30}});
+ await expect(map).toHaveClass(/fc-ambient-running/);
+ await expect.poll(async()=>{const p=await position();return Math.hypot(p.x-paused.x,p.y-paused.y)},{timeout:4000}).toBeGreaterThan(8);
+});
+
+
+test('pointer selection releases motion and keyboard inspection holds targets steady',async({page})=>{
+ await openMap(page);
+ const map=page.locator('.fc-map');
+ const agent=page.locator('[data-entity="agent"]').first();
+ await agent.click();
+ await map.hover({position:{x:30,y:30}});
+ await expect(map).toHaveClass(/fc-ambient-running/);
+ await page.keyboard.press('Tab');
+ await expect(map).toHaveClass(/fc-ambient-paused/);
+ await page.getByRole('button',{name:'Pause motion',exact:true}).focus();
+ await expect(map).toHaveClass(/fc-ambient-running/);
+});

--- a/scripts/federation-connectome.test.mjs
+++ b/scripts/federation-connectome.test.mjs
@@ -50,7 +50,7 @@ test('ambient drift is bounded, deterministic and preserves message identities',
  assert.notEqual(drift[0].agents[0].x,initial[0].agents[0].x);
  for(const seconds of [0,10,100,1000]) {
   const point=driftConstellation(initial,seconds)[0].agents[0],base=initial[0].agents[0];
-  assert.ok(Math.hypot(point.x-base.x,point.y-base.y)<22);
+  assert.ok(Math.abs(Math.hypot(point.x-initial[0].x,point.y-initial[0].y)-Math.hypot(base.x-initial[0].x,base.y-initial[0].y))<7);
  }
  assert.deepEqual(drift,driftConstellation(initial,10));
 });

--- a/scripts/version-alignment.test.mjs
+++ b/scripts/version-alignment.test.mjs
@@ -73,7 +73,7 @@ test('release-facing version metadata stays aligned', () => {
     ['docs/UPGRADING.md', '| v11.19.13 | Stdio MCP startup skips automatic Claude project-hook repair'],
     ['docs/UPGRADING.md', '| v11.19.14 | gRPC-Go v1.83.1'],
     ['docs/UPGRADING.md', '| v11.19.15 | Consensus-safe memory cleanup'],
-    ['docs/UPGRADING.md', `| v${version} | Federation connectome, operator-only metadata activity stream`],
+    ['docs/UPGRADING.md', `| v${version} | Visible federation agent orbits`],
     ['docs/ROADMAP.md', `## v${version} release`],
     ['docs/UPGRADING.md', 'The recovery commands in this guide require SAGE v11.18.0 or later.'],
     ['docs/UPGRADING.md', '`backup --full`, `restore --from`,'],

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for the SAGE (Sovereign Agent Governed Experience) protocol -- a governed, verifiable institutional memory layer for multi-agent systems.
 
-**Requires Python 3.10+** | **SAGE v11.19.17 SDK** | **TLS, app-v27 record-author lifecycle authority, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
+**Requires Python 3.10+** | **SAGE v11.19.18 SDK** | **TLS, app-v27 record-author lifecycle authority, app-v26 explicit Access Group authority, app-v24 memory integrity, app-v25 immutable envelopes and historical continuity recovery, canonical local and federated Messages with read receipts, read-only federation, scoped governance, and per-record `classification` supported**
 
 ## Installation
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sage-agent-sdk"
-version = "11.19.17"
+version = "11.19.18"
 description = "Python SDK for SAGE — Sovereign Agent Governed Experience. Persistent, consensus-validated memory for AI agents."
 readme = "README.md"
 authors = [{name = "Dhillon Andrew Kannabhiran", email = "dhillon@levelupctf.com"}]

--- a/sdk/python/src/sage_sdk/__init__.py
+++ b/sdk/python/src/sage_sdk/__init__.py
@@ -4,5 +4,5 @@ from sage_sdk.auth import AgentIdentity
 from sage_sdk.async_client import AsyncSageClient
 from sage_sdk.client import SageClient
 
-__version__ = "11.19.17"
+__version__ = "11.19.18"
 __all__ = ["SageClient", "AsyncSageClient", "AgentIdentity"]

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/l33tdawg/sage",
     "source": "github"
   },
-  "version": "11.19.17",
+  "version": "11.19.18",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/l33tdawg/sage:11.19.17",
+      "identifier": "ghcr.io/l33tdawg/sage:11.19.18",
       "transport": {
         "type": "stdio"
       }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -78,7 +78,7 @@ const html = window.html;
 // `go build` dev binary where main.version is "dev"). Keep in sync with the
 // release being built; stamped release builds override this via the live
 // /health read below.
-const SAGE_VERSION = 'v11.19.17';
+const SAGE_VERSION = 'v11.19.18';
 
 // Promise-based, themed replacement for the browser's blocking confirmation API.
 // Requests are immutable and serialized so independent actions cannot replace

--- a/web/static/js/federation-connectome.js
+++ b/web/static/js/federation-connectome.js
@@ -34,7 +34,7 @@ export function driftConstellation(nodes, seconds) {
     return nodes.map(node => ({ ...node, agents: node.agents.map((agent, index) => {
         const phase = index * 2.399963;
         const dx = agent.x - node.x, dy = agent.y - node.y;
-        const angle = Math.atan2(dy, dx) + (Math.sin(seconds / 13 + phase) - Math.sin(phase)) * .065;
+        const angle = Math.atan2(dy, dx) + seconds * .045 + (Math.sin(seconds / 7 + phase) - Math.sin(phase)) * .025;
         const radius = Math.hypot(dx, dy) + (Math.sin(seconds / 5 + phase) - Math.sin(phase)) * 3;
         return { ...agent, x: node.x + Math.cos(angle) * radius, y: node.y + Math.sin(angle) * radius };
     }) }));
@@ -63,11 +63,12 @@ export function FederationConnectome({ connections, statuses, localChain, localN
     const [cursors, setCursors] = useState({});
     const [motionOn, setMotionOn] = useState(true);
     const [reducedMotion, setReducedMotion] = useState(() => window.matchMedia('(prefers-reduced-motion: reduce)').matches);
-    const [mapHovered, setMapHovered] = useState(false);
+    const [agentHovered, setAgentHovered] = useState(false);
+    const [mapDragging, setMapDragging] = useState(false);
     const [mapFocused, setMapFocused] = useState(false);
     const [ambientTime, setAmbientTime] = useState(0);
     const ambientClock = useRef(0);
-    const ambientRunning = motionOn && !reducedMotion && enabled && view === 'graph' && !mapHovered && !mapFocused;
+    const ambientRunning = motionOn && !reducedMotion && enabled && view === 'graph' && !agentHovered && !mapFocused && !mapDragging;
     useEffect(() => {
         const media = window.matchMedia('(prefers-reduced-motion: reduce)');
         const changed = () => setReducedMotion(media.matches);
@@ -224,11 +225,11 @@ export function FederationConnectome({ connections, statuses, localChain, localN
         </div>
         <div class="fc-workspace"><div class="fc-map-area">
         ${view === 'graph' ? html`<div class=${`fc-map ${ambientRunning ? 'fc-ambient-running' : 'fc-ambient-paused'}`}
-            onMouseEnter=${() => setMapHovered(true)} onMouseLeave=${() => setMapHovered(false)}
-            onFocusCapture=${event => setMapFocused(!!event.target.closest('[data-entity]'))} onBlurCapture=${event => { if (!event.currentTarget.contains(event.relatedTarget)) setMapFocused(false); }}><svg ref=${svgRef} viewBox=${mapViewBox} aria-label="Interactive federation map. Tab to a node or agent and press Enter for details."
-            onPointerDown=${event => { if (event.target.closest('[data-entity]')) return; drag.current = { ...point(event), camera }; event.currentTarget.setPointerCapture(event.pointerId); }}
+            onMouseMove=${event => setAgentHovered(!!event.target.closest('[data-entity="agent"]'))} onMouseLeave=${() => setAgentHovered(false)}
+            onFocusCapture=${event => setMapFocused(!!event.target.closest('[data-entity]') && event.target.matches(':focus-visible'))} onBlurCapture=${event => { setMapFocused(false); }}><svg ref=${svgRef} viewBox=${mapViewBox} aria-label="Interactive federation map. Tab to a node or agent and press Enter for details."
+            onPointerDown=${event => { if (event.target.closest('[data-entity]')) return; setMapDragging(true); drag.current = { ...point(event), camera }; event.currentTarget.setPointerCapture(event.pointerId); }}
             onPointerMove=${event => { if (!drag.current) return; const p = point(event); setCamera({ ...drag.current.camera, x: drag.current.camera.x + p.x - drag.current.x, y: drag.current.camera.y + p.y - drag.current.y }); }}
-            onPointerUp=${() => { drag.current = null; }} onPointerCancel=${() => { drag.current = null; }}>
+            onPointerUp=${() => { drag.current = null; setMapDragging(false); }} onPointerCancel=${() => { drag.current = null; setMapDragging(false); }}>
             <defs><radialGradient id="fc-halo"><stop offset="0" stop-color="#42d7c4" stop-opacity=".15"/><stop offset="1" stop-color="#42d7c4" stop-opacity="0"/></radialGradient></defs>
             <g transform=${`translate(${camera.x} ${camera.y}) translate(600 380) scale(${camera.zoom}) translate(-600 -380)`}>
             ${nodes.slice(1).map(node => html`<g key=${node.id} class=${`fc-trust ${node.state === 'Reachable' ? 'is-reachable' : ''}`}>
@@ -253,7 +254,7 @@ export function FederationConnectome({ connections, statuses, localChain, localN
                 </g>
             </g>`)}
             ${pulses.map(item => { const endpoints = activityNodes(item); if (!endpoints) return null; return html`<g key=${item.key} class=${`fc-pulse fc-pulse-${item.state}`} aria-hidden="true"><path pathLength="1" d=${`M ${endpoints.source.x} ${endpoints.source.y} L ${endpoints.target.x} ${endpoints.target.y}`} /></g>`; })}
-            </g></svg><div class="fc-map-tools"><button class="btn" aria-pressed=${motionOn && !reducedMotion} disabled=${reducedMotion} title="Decorative movement; pauses while you interact. It does not indicate agent presence." onClick=${() => setMotionOn(value => !value)}>${reducedMotion ? 'Reduced motion' : motionOn ? 'Pause motion' : 'Resume motion'}</button><button class="btn" aria-label="Zoom in" onClick=${() => setCamera(c => ({ ...c, zoom: Math.min(2.5,c.zoom + .2) }))}>+</button><button class="btn" aria-label="Zoom out" onClick=${() => setCamera(c => ({ ...c, zoom: Math.max(.5,c.zoom - .2) }))}>−</button><button class="btn" onClick=${() => setCamera({ x:0,y:0,zoom:1 })}>Fit view</button></div><div class="fc-map-hint">Drag space to pan · select a dot to inspect an agent</div></div>` : html`<div class="fc-list">${nodes.filter(nodeVisible).map(node => html`<section key=${node.id}><button class="fc-list-node" onClick=${() => select(node)}>${node.name}<small>${node.state}</small></button>${filterFederationAgents(node.loadedAgents,nodeMatches(node) ? '' : query).map(agent => html`<button class="fc-list-agent" key=${agent.agent_id} onClick=${() => select(node,agent)}><strong>${agentLabel(agent)}</strong><small>${access(node,agent)}</small></button>`)}</section>`)}</div>`}
+            </g></svg><div class="fc-map-tools"><button class="btn" aria-pressed=${motionOn && !reducedMotion} disabled=${reducedMotion} title="Decorative movement; pauses over an agent, during keyboard inspection, or while dragging. It does not indicate agent presence." onClick=${() => setMotionOn(value => !value)}>${reducedMotion ? 'Reduced motion' : motionOn ? 'Pause motion' : 'Resume motion'}</button><button class="btn" aria-label="Zoom in" onClick=${() => setCamera(c => ({ ...c, zoom: Math.min(2.5,c.zoom + .2) }))}>+</button><button class="btn" aria-label="Zoom out" onClick=${() => setCamera(c => ({ ...c, zoom: Math.max(.5,c.zoom - .2) }))}>−</button><button class="btn" onClick=${() => setCamera({ x:0,y:0,zoom:1 })}>Fit view</button></div><div class="fc-map-hint">Drag space to pan · select a dot to inspect an agent</div></div>` : html`<div class="fc-list">${nodes.filter(nodeVisible).map(node => html`<section key=${node.id}><button class="fc-list-node" onClick=${() => select(node)}>${node.name}<small>${node.state}</small></button>${filterFederationAgents(node.loadedAgents,nodeMatches(node) ? '' : query).map(agent => html`<button class="fc-list-agent" key=${agent.agent_id} onClick=${() => select(node,agent)}><strong>${agentLabel(agent)}</strong><small>${access(node,agent)}</small></button>`)}</section>`)}</div>`}
         <div class="fc-legend"><span>● Agent</span><span>─ Trusted connection</span><span>┄ Allowed messaging on selection</span><span>Pulse = message status update</span><span>Gentle drift is decorative</span></div>
         <div class="fc-pagination">${nodes.filter(n => n.grant?.next_cursor || (n.local ? cursors[localSourceChain]?.local : cursors[n.id]?.remote)).map(n => html`<div key=${n.id}><span>${n.name}</span><button class="btn btn-sm" onClick=${() => navigate(n,n.local ? 'local':'remote','')}>First agents</button>${n.grant?.next_cursor && html`<button class="btn btn-sm" onClick=${() => navigate(n,n.local ? 'local':'remote',n.grant.next_cursor)}>Next agents</button>`}</div>`)}
             ${connections.length > pageSize && html`<button class="btn" disabled=${activePage === 0} onClick=${() => { setPage(activePage-1);setSelection(null); }}>Previous nodes</button><span>Node page ${activePage+1}</span><button class="btn" disabled=${(activePage+1)*pageSize>=connections.length} onClick=${() => {setPage(activePage+1);setSelection(null);}}>Next nodes</button>`}</div>


### PR DESCRIPTION
Federation agents appeared stationary: the drift was barely perceptible, hovering anywhere in the map paused it, and pointer selection could retain the keyboard-focus pause after the pointer left.

Agents now orbit visibly. Empty map space keeps moving; agent hover, keyboard inspection, and panning hold targets steady, then resume. Explicit pause, reduced motion, hidden-tab suspension, and real-message-only pulses are preserved.

Validation: 424 JavaScript checks and 10 isolated browser tests (five each in Chrome and Firefox) pass, including measured screen displacement, empty-space hover, agent hover/resume, pointer selection, keyboard focus, and reduced motion. Release metadata is aligned for v11.19.18; app-v27 remains unchanged.
