### PR TITLE
fix(pages): reliable package-download counter with cached fallback

### DIFF
--- a/download-counter.mjs
+++ b/download-counter.mjs
@@ -1,0 +1,110 @@
+// Count public release packages, not checksum files or unique installations.
+export const CACHE_KEY = 'sage_package_downloads_v1';
+const PACKAGE_FILE = /\.(?:dmg|exe|msi|pkg|deb|rpm|appimage|zip|tar\.gz|tgz|tar\.xz)$/i;
+const API = 'https://api.github.com/repos/l33tdawg/sage/releases';
+
+export function validSnapshot(value, now = Date.now()) {
+  return value?.version === 1 && Number.isSafeInteger(value.count) && value.count >= 0
+    && typeof value.updatedAt === 'string' && Number.isFinite(Date.parse(value.updatedAt))
+    && Date.parse(value.updatedAt) <= now + 60_000;
+}
+
+export function cachedSnapshot(storage, fallback, now = Date.now()) {
+  let cached;
+  try { cached = JSON.parse(storage?.getItem(CACHE_KEY) ?? 'null'); } catch { /* Storage may be disabled. */ }
+  const candidates = [fallback, cached].filter(value => validSnapshot(value, now));
+  return candidates.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))[0];
+}
+
+export async function fetchReleaseStats(fetchImpl, signal) {
+  const assets = new Map();
+  const seenReleases = new Set();
+  let latest;
+  for (let page = 1; page <= 100; page++) {
+    const response = await fetchImpl(`${API}?per_page=100&page=${page}`, { signal });
+    if (!response.ok) throw new Error(`GitHub HTTP ${response.status}`);
+    const releases = await response.json();
+    if (!Array.isArray(releases) || releases.length > 100) throw new Error('Invalid release page');
+    let newReleases = 0;
+    for (const release of releases) {
+      if (!Number.isSafeInteger(release.id) || release.id <= 0
+        || typeof release.draft !== 'boolean' || !Array.isArray(release.assets)) {
+        throw new Error('Invalid release record');
+      }
+      if (!seenReleases.has(release.id)) newReleases++;
+      seenReleases.add(release.id);
+      if (release.draft) continue;
+      if (!latest && release.prerelease === false && /^v\d+\.\d+\.\d+$/.test(release.tag_name)) {
+        latest = release.tag_name;
+      }
+      for (const asset of release.assets) {
+        if (typeof asset.name !== 'string') throw new Error('Invalid asset name');
+        if (!PACKAGE_FILE.test(asset.name)) continue;
+        if (!Number.isSafeInteger(asset.id) || asset.id <= 0
+          || !Number.isSafeInteger(asset.download_count) || asset.download_count < 0) {
+          throw new Error('Invalid package download count');
+        }
+        // Pagination can overlap when releases change while being fetched.
+        if (!assets.has(asset.id)) assets.set(asset.id, asset.download_count);
+      }
+    }
+    if (releases.length < 100) {
+      let count = 0;
+      for (const downloads of assets.values()) count += downloads;
+      if (!Number.isSafeInteger(count)) throw new Error('Download total overflow');
+      return { count, latest };
+    }
+    if (!newReleases) throw new Error('Repeated release page');
+  }
+  throw new Error('Release pagination limit exceeded');
+}
+
+export async function refreshCounter({ fetchImpl, storage, fallback, render, now = Date.now, timeoutMs = 20_000 }) {
+  const cached = cachedSnapshot(storage, fallback, now());
+  render(cached, 'checking');
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const result = await fetchReleaseStats(fetchImpl, controller.signal);
+    const snapshot = { version: 1, count: result.count, updatedAt: new Date(now()).toISOString() };
+    // Save only after every page succeeds. A lower fresh total replaces old data.
+    try { storage?.setItem(CACHE_KEY, JSON.stringify(snapshot)); } catch { /* The live result still works. */ }
+    render(snapshot, 'live', result.latest);
+    return snapshot;
+  } catch {
+    render(cached, 'cached');
+    return cached;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function startCounter(documentRef, fetchImpl, storage) {
+  const count = documentRef.getElementById('download-count');
+  const status = documentRef.getElementById('download-status');
+  if (!count || !status) return;
+  const fallback = { version: 1, count: Number(count.dataset.count), updatedAt: count.dataset.updatedAt };
+  return refreshCounter({
+    fetchImpl, storage, fallback,
+    render(snapshot, state, latest) {
+      count.textContent = snapshot ? snapshot.count.toLocaleString() : 'Unavailable';
+      if (snapshot) {
+        const date = new Date(snapshot.updatedAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+        status.textContent = state === 'live' ? `Updated ${date}`
+          : `Last known count · ${date}${state === 'cached' ? ' · GitHub unavailable' : ' · Checking for updates…'}`;
+      } else {
+        status.textContent = state === 'checking' ? 'Checking GitHub…' : 'GitHub unavailable · Try again later';
+      }
+      if (latest) {
+        const version = documentRef.getElementById('latest-version');
+        if (version) version.textContent = latest;
+      }
+    },
+  });
+}
+
+if (typeof document !== 'undefined') {
+  let storage;
+  try { storage = window.localStorage; } catch { /* Use the published snapshot when storage is disabled. */ }
+  void startCounter(document, window.fetch.bind(window), storage);
+}

--- a/index.html
+++ b/index.html
@@ -1074,10 +1074,12 @@ footer a:hover { text-decoration: underline; }
         <div class="latest-note">
           Latest: <strong id="latest-version">v11.19.19</strong> &mdash; signed release assets
         </div>
-        <div id="minds-freed" class="download-counter" style="display:none;">
+        <div id="minds-freed" class="download-counter">
           <span class="download-counter-pill">
-            Downloads: <strong id="download-count">0</strong>
+            Package downloads: <strong id="download-count" data-count="8312" data-updated-at="2026-09-10T01:26:26Z">8,312</strong>
           </span>
+          <div id="download-status" class="latest-note" aria-live="polite">Last known count · Sep 10, 2026, 01:26 UTC</div>
+          <div class="latest-note">Public release installers and archives, including prereleases. Counts repeat and automated downloads, not unique installs.</div>
         </div>
       </div>
     </div>
@@ -1699,63 +1701,6 @@ function copyPrompt(box) {
   });
 }
 
-// ─── Download Counter + Latest Version ───
-(function() {
-  // HWM_FLOOR: the highest total ever observed, committed to the repo.
-  // GitHub download counts reset when releases are re-tagged/deleted.
-  // This floor guarantees the counter NEVER drops below the known peak,
-  // regardless of browser, device, or localStorage state.
-  // To update: set HWM_FLOOR to the current displayed counter value and
-  // GITHUB_AT_FLOOR to what GitHub reports right now (the two COUNTs below),
-  // both at time of commit. Do this every release — re-tagged assets reset
-  // GitHub's per-asset download_count, which drops github_now below the old
-  // floor and freezes the displayed number (the localStorage clamp pins it).
-  // Last updated: 2026-08-13 (re-baselined at v11.18.9: githubNow=8187, displayed total=8560)
-  const HWM_FLOOR = 8560;
-
-  // GITHUB_AT_FLOOR: what GitHub reported when HWM_FLOOR was recorded.
-  // New downloads = github_now - GITHUB_AT_FLOOR (only if positive).
-  const GITHUB_AT_FLOOR = 8187;
-
-  async function fetchAllReleases() {
-    const all = [];
-    let page = 1;
-    while (true) {
-      const r = await fetch('https://api.github.com/repos/l33tdawg/sage/releases?per_page=100&page=' + page);
-      const data = await r.json();
-      if (!Array.isArray(data) || data.length === 0) break;
-      all.push(...data);
-      if (data.length < 100) break;
-      page++;
-    }
-    return all;
-  }
-
-  fetchAllReleases().then(releases => {
-    if (!releases.length) return;
-    let githubNow = 0;
-    for (const rel of releases) for (const asset of (rel.assets || [])) githubNow += asset.download_count || 0;
-    // New downloads since the floor was recorded (clamped to 0 — re-tags can make this negative)
-    const newDownloads = Math.max(0, githubNow - GITHUB_AT_FLOOR);
-    let total = HWM_FLOOR + newDownloads;
-    // localStorage HWM as a per-browser safety net (covers mid-session re-tags)
-    const hwmKey = 'sage_minds_freed_hwm';
-    const prevHWM = parseInt(localStorage.getItem(hwmKey) || '0', 10);
-    if (total > prevHWM) { localStorage.setItem(hwmKey, total); }
-    else if (prevHWM > total) { total = prevHWM; }
-    if (total > 0) {
-      document.getElementById('download-count').textContent = total.toLocaleString();
-      document.getElementById('minds-freed').style.display = 'block';
-    }
-    const latest = releases.find(r => !r.prerelease && !r.draft);
-    if (latest) {
-      const el = document.getElementById('latest-version'); if (el) el.textContent = latest.tag_name;
-      // Keep the curated release heading paired with its static notes.
-      // Only the download badge follows GitHub's latest published release.
-    }
-  }).catch(() => {});
-})();
-
 // ─── Screenshot Lightbox ───
 const lbImages = [
   { src: 'screen-brain.png', caption: 'CEREBRUM MRI brain — memory focus, related notes, and the train-of-thought view' },
@@ -1789,5 +1734,6 @@ document.addEventListener('keydown', (e) => {
   if (e.key === 'ArrowRight') lightboxNav(e, 1);
 });
 </script>
+<script type="module" src="download-counter.mjs"></script>
 </body>
 </html>

--- a/tests/download-counter.test.mjs
+++ b/tests/download-counter.test.mjs
@@ -1,0 +1,98 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { CACHE_KEY, cachedSnapshot, fetchReleaseStats, refreshCounter } from '../download-counter.mjs';
+
+const at = Date.parse('2026-09-10T02:00:00Z');
+const fallback = { version: 1, count: 8312, updatedAt: '2026-09-10T01:26:26Z' };
+const asset = (id, name, download_count) => ({ id, name, download_count });
+const release = (id, assets = [], extra = {}) => ({ id, assets, draft: false, prerelease: false, tag_name: `v1.0.${id}`, ...extra });
+const response = data => ({ ok: true, json: async () => data });
+function memoryStore(snapshot) {
+  const values = new Map(snapshot ? [[CACHE_KEY, JSON.stringify(snapshot)]] : []);
+  return { values, getItem: key => values.get(key), setItem: (key, value) => values.set(key, value) };
+}
+
+test('counts packages across stable and prerelease releases, excluding drafts and sidecars', async () => {
+  const result = await fetchReleaseStats(async () => response([
+    release(1, [asset(1, 'SAGE.dmg', 5), asset(2, 'SAGE.dmg.sha256', 8), asset(3, 'checksums.txt', 4), asset(4, 'notes.json', 3)]),
+    release(2, [asset(5, 'preview.tar.gz', 7)], { prerelease: true }),
+    release(3, [asset(6, 'private.exe', 99)], { draft: true }),
+    release(4, [asset(7, 'cli.zip', 2), asset(8, 'SAGE.AppImage', 1)]),
+  ]));
+  assert.deepEqual(result, { count: 15, latest: 'v1.0.1' });
+});
+
+test('paginates fully and counts overlapping asset IDs once', async () => {
+  const urls = [];
+  const first = Array.from({ length: 100 }, (_, i) => release(i + 1, [asset(i + 1, 'app.exe', 1)]));
+  const result = await fetchReleaseStats(async url => {
+    urls.push(url);
+    return response(urls.length === 1 ? first : [release(101, [asset(100, 'app.exe', 1), asset(101, 'app.dmg', 5)])]);
+  });
+  assert.equal(result.count, 105);
+  assert.equal(urls.length, 2);
+  assert.match(urls[1], /page=2$/);
+});
+
+test('partial pagination failure preserves last known good cache', async () => {
+  const cached = { version: 1, count: 8400, updatedAt: '2026-09-10T01:40:00Z' };
+  const storage = memoryStore(cached);
+  let calls = 0;
+  const rendered = [];
+  const result = await refreshCounter({ storage, fallback, now: () => at, render: (...args) => rendered.push(args),
+    fetchImpl: async () => ++calls === 1 ? response(Array.from({ length: 100 }, (_, i) => release(i + 1))) : { ok: false, status: 403 },
+  });
+  assert.deepEqual(result, cached);
+  assert.deepEqual(JSON.parse(storage.getItem(CACHE_KEY)), cached);
+  assert.deepEqual(rendered.map(x => x[1]), ['checking', 'cached']);
+});
+
+test('a lower fresh total replaces the cached maximum', async () => {
+  const storage = memoryStore({ version: 1, count: 9000, updatedAt: '2026-09-10T01:40:00Z' });
+  const result = await refreshCounter({ storage, fallback, now: () => at, render() {}, fetchImpl: async () => response([release(1, [asset(1, 'app.dmg', 4)])]) });
+  assert.equal(result.count, 4);
+  assert.equal(JSON.parse(storage.getItem(CACHE_KEY)).count, 4);
+});
+
+test('corrupt, future-dated, and older local caches fall back to published snapshot', () => {
+  assert.deepEqual(cachedSnapshot({ getItem: () => '{broken' }, fallback, at), fallback);
+  assert.deepEqual(cachedSnapshot(memoryStore({ ...fallback, count: -1 }), fallback, at), fallback);
+  assert.deepEqual(cachedSnapshot(memoryStore({ ...fallback, count: 99999, updatedAt: '2099-01-01' }), fallback, at), fallback);
+  assert.deepEqual(cachedSnapshot(memoryStore({ ...fallback, count: 99999, updatedAt: '2026-08-01' }), fallback, at), fallback);
+});
+
+test('blocked storage does not prevent fetching and displaying a live zero', async () => {
+  const storage = { getItem() { throw new Error('blocked'); }, setItem() { throw new Error('blocked'); } };
+  const rendered = [];
+  const result = await refreshCounter({ storage, fallback, now: () => at, render: (...args) => rendered.push(args), fetchImpl: async () => response([]) });
+  assert.equal(result.count, 0);
+  assert.equal(rendered.at(-1)[1], 'live');
+});
+
+test('a timed-out request preserves the published fallback', async () => {
+  const result = await refreshCounter({ fallback, now: () => at, timeoutMs: 10, render() {},
+    fetchImpl: (_url, { signal }) => new Promise((_resolve, reject) => signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true })),
+  });
+  assert.deepEqual(result, fallback);
+});
+
+test('HTTP errors, malformed JSON, invalid counts, and repeated pages never become totals', async () => {
+  for (const fetchImpl of [
+    async () => ({ ok: false, status: 429 }),
+    async () => response({ message: 'API error' }),
+    async () => ({ ok: true, json: async () => { throw new SyntaxError('bad JSON'); } }),
+    async () => response([release(1, [asset(1, 'app.exe', -1)])]),
+    async () => response([release(1, [asset(1, 'app.exe', '20')])]),
+    async () => response(Array.from({ length: 100 }, (_, i) => release(i + 1))),
+  ]) {
+    const storage = memoryStore(fallback);
+    const result = await refreshCounter({ storage, fallback, now: () => at, render() {}, fetchImpl });
+    assert.deepEqual(result, fallback);
+    assert.deepEqual(JSON.parse(storage.getItem(CACHE_KEY)), fallback);
+  }
+});
+
+test('without any valid cache a fetch failure returns unavailable, not zero', async () => {
+  const result = await refreshCounter({ now: () => at, render() {}, fetchImpl: async () => { throw new Error('offline'); } });
+  assert.equal(result, undefined);
+});


### PR DESCRIPTION
The site counted checksum/signature downloads, added a historical offset, and kept per-browser maximums that could go stale. Count public release installers and archives instead, excluding drafts and sidecars, and label the metric as package downloads (including repeat and automated downloads, not unique installs).

Cache only complete successful API results with their timestamp. On HTTP errors, timeouts, malformed data, or incomplete pagination, retain the last-known-good value and visibly mark it as cached. New visitors and browsers with blocked storage have a published 8,312-package snapshot as fallback. Fresh results replace cached values even when lower; duplicate asset IDs are counted once.

Validation: nine Node tests cover package filtering, pagination/deduplication, partial failure, lower totals, corrupt/future/older caches, unavailable storage, zero results, timeout, malformed responses, and no-cache failure. The production calculation matches an independently computed GitHub snapshot. Browser layout and the visible unavailable/cached state were verified.
