### PR TITLE
fix(voter): make dedup rejection sticky without the self-match

### DIFF
--- a/api/rest/handlers_test.go
+++ b/api/rest/handlers_test.go
@@ -487,7 +487,7 @@ func (m *mockMemoryStore) ListAllTags(_ context.Context) ([]store.TagCount, erro
 func (m *mockMemoryStore) ListMemoriesByTag(_ context.Context, _ string, _, _ int) ([]*memory.MemoryRecord, int, error) {
 	return nil, 0, nil
 }
-func (m *mockMemoryStore) FindByContentHash(_ context.Context, _ string) (bool, error) {
+func (m *mockMemoryStore) FindByContentHash(_ context.Context, _, _ string) (bool, error) {
 	return false, nil
 }
 func (m *mockMemoryStore) RepairSelfDupRejected(_ context.Context, _ string, _ func(memoryID string) error) (int, error) {

--- a/cmd/sage-gui/node.go
+++ b/cmd/sage-gui/node.go
@@ -1709,7 +1709,9 @@ func runServe(startupProof string) (rerr error) {
 	// Wire pre-validate function into both dashboard and REST API. This is the
 	// advisory pre-vote display; it delegates to voter.DecideVerbose so it shows the
 	// EXACT named checks (dedup/quality/consistency) the node's real vote applies —
-	// one rule set, no second drifting copy.
+	// one rule set, no second drifting copy. No candidate row exists yet at
+	// pre-validate time, so no memory id is excluded: any committed, challenged,
+	// or rejected row with this hash reports duplicate.
 	preValidate := func(content, contentHash, domain, memType string, confidence float64) []web.PreValidateVote {
 		_, checks := voter.DecideVerbose(ctx, sqliteStore, voter.MemoryInput{
 			Content: content, ContentHash: contentHash, Domain: domain, MemType: memType, Confidence: confidence,

--- a/deploy/init.sql
+++ b/deploy/init.sql
@@ -538,8 +538,10 @@ CREATE INDEX IF NOT EXISTS idx_memories_domain_live_status
 CREATE INDEX IF NOT EXISTS idx_memories_assignee ON memories (assignee) WHERE assignee != '';
 CREATE INDEX IF NOT EXISTS idx_memories_task_picked_up_by ON memories (task_picked_up_by) WHERE task_picked_up_by != '';
 -- Serves FindByContentHash, which voter.Run evaluates per pending memory on a
--- 2s poll. Partial predicate matches the dedup query exactly.
-CREATE INDEX IF NOT EXISTS idx_memories_content_hash ON memories (content_hash) WHERE status = 'committed';
+-- 2s poll. NOT partial: the dedup predicate spans every non-proposed status
+-- (existing databases migrate via DROP INDEX idx_memories_content_hash +
+-- CREATE INDEX idx_memories_content_hash_dedup in postgresTaskAssignmentSchema).
+CREATE INDEX IF NOT EXISTS idx_memories_content_hash_dedup ON memories (content_hash);
 
 -- HNSW index for vector similarity search
 CREATE INDEX idx_memories_embedding_hnsw ON memories

--- a/docs/reference/concepts/voter-operations.md
+++ b/docs/reference/concepts/voter-operations.md
@@ -135,3 +135,12 @@ disclosure one. If no replacement is needed, the removal path is
 `sage_remember(replaces_memory_id=...)`: it verifies the replacement is
 committed before challenging the old memory, so an interrupted correction may
 leave both records but never neither.
+
+The `dedup` check matches any **other** memory that has left `proposed` (validated,
+committed, challenged, or deprecated) carrying the same content hash. The candidate's
+own row is always excluded, and other still-`proposed` rows are ignored so two in-flight
+identical submissions cannot reject each other. Consequences: identical bytes are
+rejected again after a rejection or deprecation (sticky rejection — the removal path is
+`sage_forget`, and a corrected body must actually change the content to pass dedup), and
+a correction submitted via `sage_remember(replaces_memory_id=...)` therefore carries a
+new content hash.

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -2618,7 +2618,7 @@ the result over the original agreement-bound return route
 | `source_chain_id` | string | for foreign work | Exact local reply-source chain returned as `reply_source_chain_id` by the pipe status preflight; prevents another node relabeling the signed result |
 | `claimant_session_id` | string | for foreign work; recommended for provider-addressed compatibility work | Opaque 1–128-byte session currently holding the claim. A provider-addressed row claimed by an older sessionless caller is fenced as `legacy`, and an omitted result session selects only that exact fence; it cannot bypass a named sibling session. |
 
-`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:775`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6743`, mapping `ErrPipeResultTooLarge` at `:6743-6744`).
+`result` is capped at 256 KiB (`MaxPipeContentBytes`, `store.go:775`); an over-cap submission is rejected **HTTP 413**, enforced both at the handler and at the `CompletePipeline` store chokepoint (`sqlite.go:6765`, mapping `ErrPipeResultTooLarge` at `:6767-6768`).
 
 **Response** (HTTP 200):
 `{"status":"completed","journal_id":"<memory_id or empty>","journaled":true|false}`.

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -466,9 +466,12 @@ var postgresTaskAssignmentSchema = []string{
 	// FindByContentHash became a live query in v11.11 (it previously returned a
 	// constant false), and voter.Run evaluates it per pending memory on a 2s
 	// poll. Without this index that is a sequential scan of a table carrying
-	// content TEXT plus a 768-dimension vector. Partial on status='committed'
-	// because that is exactly the predicate the dedup query uses.
-	`CREATE INDEX IF NOT EXISTS idx_memories_content_hash ON memories (content_hash) WHERE status = 'committed'`,
+	// content TEXT plus a 768-dimension vector. The dedup predicate is no
+	// longer committed-only, so the legacy partial index must go: DROP IF
+	// EXISTS is a catalog no-op once migrated and nothing recreates that name;
+	// the replacement covers content_hash unconditionally.
+	`DROP INDEX IF EXISTS idx_memories_content_hash`,
+	`CREATE INDEX IF NOT EXISTS idx_memories_content_hash_dedup ON memories (content_hash)`,
 	`CREATE TABLE IF NOT EXISTS agent_notifications (
 		notification_id TEXT PRIMARY KEY,
 		agent_id TEXT NOT NULL,
@@ -3128,20 +3131,25 @@ func (s *PostgresStore) ListMemoriesByTag(ctx context.Context, tag string, limit
 	return s.ListMemories(ctx, ListOptions{Tag: tag, Limit: limit, Offset: offset})
 }
 
-// FindByContentHash checks the same committed-only dedup predicate as SQLite.
-// The voter runs while its candidate is still proposed, so including proposed
-// rows would make every new memory look like a duplicate of itself.
-func (s *PostgresStore) FindByContentHash(ctx context.Context, contentHash string) (bool, error) {
+// FindByContentHash checks the same dedup predicate as SQLite: a DIFFERENT
+// memory that has left status='proposed' carries this content hash. The
+// candidate's own row is excluded (the voter runs while its candidate is still
+// proposed, so including that row would make every new memory look like a
+// duplicate of itself) and so are other proposed rows (two concurrent identical
+// submissions must not reject each other). Deprecated rows DO match, so
+// rejected bytes cannot re-enter through a fresh memory id.
+func (s *PostgresStore) FindByContentHash(ctx context.Context, contentHash, excludeMemoryID string) (bool, error) {
 	hashBytes, err := hex.DecodeString(contentHash)
 	if err != nil {
 		return false, fmt.Errorf("decode content hash: %w", err)
 	}
 	var exists bool
 	if err := s.db.QueryRow(ctx,
-		`SELECT EXISTS(SELECT 1 FROM memories WHERE content_hash = $1 AND status = 'committed')`,
-		hashBytes,
+		`SELECT EXISTS(SELECT 1 FROM memories
+			WHERE content_hash = $1 AND memory_id::text <> $2 AND status <> 'proposed')`,
+		hashBytes, excludeMemoryID,
 	).Scan(&exists); err != nil {
-		return false, fmt.Errorf("find committed content hash: %w", err)
+		return false, fmt.Errorf("find duplicate content hash: %w", err)
 	}
 	return exists, nil
 }

--- a/internal/store/postgres_hash_test.go
+++ b/internal/store/postgres_hash_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPostgresFindByContentHashCommittedOnly(t *testing.T) {
+func TestPostgresFindByContentHashDedupPredicate(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	require.NoError(t, err)
 	t.Cleanup(mock.Close)
@@ -22,7 +22,8 @@ func TestPostgresFindByContentHashCommittedOnly(t *testing.T) {
 	hashBytes, err := hex.DecodeString(contentHash)
 	require.NoError(t, err)
 	query := regexp.QuoteMeta(
-		`SELECT EXISTS(SELECT 1 FROM memories WHERE content_hash = $1 AND status = 'committed')`,
+		`SELECT EXISTS(SELECT 1 FROM memories
+			WHERE content_hash = $1 AND memory_id::text <> $2 AND status <> 'proposed')`,
 	)
 
 	for _, test := range []struct {
@@ -30,15 +31,16 @@ func TestPostgresFindByContentHashCommittedOnly(t *testing.T) {
 		exists bool
 	}{
 		{name: "proposed candidate does not match itself", exists: false},
+		{name: "another proposed row does not block", exists: false},
 		{name: "committed memory matches", exists: true},
-		{name: "deprecated memory does not match", exists: false},
+		{name: "deprecated memory matches (sticky rejection)", exists: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			mock.ExpectQuery(query).
-				WithArgs(hashBytes).
+				WithArgs(hashBytes, "candidate-id").
 				WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(test.exists))
 
-			exists, findErr := store.FindByContentHash(context.Background(), contentHash)
+			exists, findErr := store.FindByContentHash(context.Background(), contentHash, "candidate-id")
 			require.NoError(t, findErr)
 			assert.Equal(t, test.exists, exists)
 		})
@@ -48,7 +50,7 @@ func TestPostgresFindByContentHashCommittedOnly(t *testing.T) {
 
 func TestPostgresFindByContentHashRejectsMalformedHash(t *testing.T) {
 	store := &PostgresStore{}
-	_, err := store.FindByContentHash(context.Background(), "not-hex")
+	_, err := store.FindByContentHash(context.Background(), "not-hex", "candidate-id")
 	require.ErrorContains(t, err, "decode content hash")
 }
 
@@ -82,16 +84,23 @@ func TestPostgresUpsertRefreshesContentHashLikeSQLite(t *testing.T) {
 
 // The dedup query is only cheap if an index covers it. voter.Run evaluates
 // FindByContentHash per pending memory on a 2s poll, against a table carrying
-// content TEXT plus a 768-dimension vector.
+// content TEXT plus a 768-dimension vector. The predicate is no longer
+// committed-only, so the migration must drop the legacy partial index and
+// install an unconditional one.
 func TestPostgresContentHashDedupIsIndexed(t *testing.T) {
-	var indexed bool
+	var droppedLegacy, indexedFull bool
 	for _, stmt := range postgresTaskAssignmentSchema {
-		if strings.Contains(stmt, "idx_memories_content_hash") {
-			indexed = true
-			require.Containsf(t, stmt, "status = 'committed'",
-				"the index must be partial on the same predicate FindByContentHash uses, got %q", stmt)
+		if strings.Contains(stmt, "DROP INDEX IF EXISTS idx_memories_content_hash") {
+			droppedLegacy = true
+		}
+		if strings.Contains(stmt, "idx_memories_content_hash_dedup") {
+			indexedFull = true
+			require.NotContainsf(t, stmt, "status =",
+				"the dedup index must not be partial on the status predicate it no longer matches, got %q", stmt)
 		}
 	}
-	require.True(t, indexed,
-		"existing Postgres databases need a content_hash index migration, not just deploy/init.sql")
+	require.True(t, droppedLegacy,
+		"existing Postgres databases carry the legacy committed-only partial index; the startup migration must drop it")
+	require.True(t, indexedFull,
+		"existing Postgres databases need an unconditional content_hash index, not just deploy/init.sql")
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -481,6 +481,10 @@ func (s *SQLiteStore) initSchema(ctx context.Context) error {
 		ON memories(domain_tag, status, memory_id)
 		WHERE status IN ('committed','challenged');
 	CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at);
+	-- Serves the voter's dedup lookup (FindByContentHash), evaluated once per
+	-- pending memory on a 2s poll. NOT partial: the predicate spans every
+	-- non-proposed status, so a committed-only partial index cannot serve it.
+	CREATE INDEX IF NOT EXISTS idx_memories_content_hash ON memories(content_hash);
 	-- Serves the CEREBRUM agent-as-lobe read: each agent's top memories by
 	-- confidence (WHERE submitting_agent = ? ORDER BY confidence_score DESC).
 	-- Composite so the per-agent seek is index-satisfiable (equality on the leading
@@ -1430,6 +1434,7 @@ func (s *SQLiteStore) migrateTaskSupport(ctx context.Context) {
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_provider ON memories(provider)`)
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_task_status ON memories(task_status) WHERE task_status != ''`)
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_submitting_agent ON memories(submitting_agent, confidence_score)`)
+	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_memories_content_hash ON memories(content_hash)`)
 	_, _ = s.writeExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_corroborations_memory_order ON corroborations(memory_id, created_at, agent_id, id)`)
 }
 
@@ -4970,25 +4975,34 @@ func (s *SQLiteStore) UpdateRedeployLog(ctx context.Context, id int64, status, e
 	return err
 }
 
-// FindByContentHash checks if a committed memory with this content hash exists.
-// The contentHash parameter is the hex-encoded SHA-256 hash of the content.
+// FindByContentHash reports whether a DIFFERENT memory that has left
+// status='proposed' already carries this content hash (hex-encoded SHA-256).
 //
-// The predicate MUST be committed-only. The voter's dedupCheck runs while the
-// candidate memory is itself sitting in this table with status='proposed', so the
-// previous predicate (status != 'deprecated') matched the candidate's OWN row —
-// every per-node vote became a self-inflicted "duplicate content" reject. On a
-// single-validator chain that reject was unanimous, so every memory was
-// deprecated on arrival (and on legacy multi-validator sets it wedged memories at
-// proposed). See RepairSelfDupRejected for the recovery path.
-func (s *SQLiteStore) FindByContentHash(ctx context.Context, contentHash string) (bool, error) {
+// Both halves of the predicate are load-bearing. The candidate's own row must
+// never match itself: the voter's dedupCheck runs while the candidate is itself
+// sitting in this table with status='proposed', and the pre-v10.1.0 predicate
+// matched that row, so every per-node vote became a self-inflicted "duplicate
+// content" reject — on a single-validator chain, unanimous, which deprecated
+// every memory on arrival (see RepairSelfDupRejected). And OTHER proposed rows
+// are not duplicates either: counting them would make two concurrent identical
+// submissions reject each other, leaving the content with no surviving row and
+// a rejected hash that blocks every later attempt to submit those bytes.
+//
+// Every post-proposal status counts. Committed/validated/challenged rows are
+// live copies; challenged and deprecated rows are the sticky half — identical
+// bytes must not re-enter through a fresh memory id after a rejection. A
+// genuine correction carries new content, hence a different hash, and stays
+// submittable.
+func (s *SQLiteStore) FindByContentHash(ctx context.Context, contentHash, excludeMemoryID string) (bool, error) {
 	hashBytes, err := hex.DecodeString(contentHash)
 	if err != nil {
 		return false, fmt.Errorf("decode content hash: %w", err)
 	}
 	var count int
 	err = s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM memories WHERE content_hash = ? AND status = 'committed'`,
-		hashBytes).Scan(&count)
+		`SELECT COUNT(*) FROM memories
+		  WHERE content_hash = ? AND memory_id != ? AND status != 'proposed'`,
+		hashBytes, excludeMemoryID).Scan(&count)
 	if err != nil {
 		return false, err
 	}
@@ -5001,11 +5015,16 @@ func (s *SQLiteStore) FindByContentHash(ctx context.Context, contentHash string)
 // chain that unanimous reject deprecated it on arrival.
 //
 // A memory qualifies ONLY when its recorded vote history is exactly one vote —
-// selfID rejecting with the dedupCheck rationale — and it was never challenged.
-// That fingerprint cannot match legitimately deprecated memories: quorum
-// rejections on real multi-validator sets carry multiple votes, challenge
-// deprecations carry a challenges row, and the legacy 4-archetype era always
-// recorded 4 votes per memory.
+// selfID rejecting with the dedupCheck rationale — it was never challenged, and
+// NO other row shares its content hash. That fingerprint cannot match
+// legitimately deprecated memories: quorum rejections on real multi-validator
+// sets carry multiple votes, challenge deprecations carry a challenges row, the
+// legacy 4-archetype era always recorded 4 votes per memory, and a genuine
+// duplicate rejection always has the twin row it was rejected against. That
+// last clause matters now that the dedup predicate is no longer committed-only:
+// without it, every restart would resurrect genuine duplicate rejections (their
+// fingerprint is otherwise identical) and the widened lookup would re-reject
+// them, churning deprecated ↔ proposed forever.
 //
 // For each candidate, flipChain (the caller's chain-state flip, e.g. badger
 // status + vote-key cleanup) runs FIRST; only on its success does the mirror row
@@ -5023,7 +5042,10 @@ func (s *SQLiteStore) RepairSelfDupRejected(ctx context.Context, selfID string, 
 		  AND NOT EXISTS (SELECT 1 FROM validation_votes v2
 		              WHERE v2.memory_id = m.memory_id AND NOT (v2.validator_id = ?
 		                AND v2.decision = 'reject' AND v2.rationale LIKE 'duplicate content%'))
-		  AND NOT EXISTS (SELECT 1 FROM challenges c WHERE c.memory_id = m.memory_id)`,
+		  AND NOT EXISTS (SELECT 1 FROM challenges c WHERE c.memory_id = m.memory_id)
+		  AND NOT EXISTS (SELECT 1 FROM memories m2
+		              WHERE m2.content_hash = m.content_hash
+		                AND m2.memory_id != m.memory_id)`,
 		selfID, selfID)
 	if err != nil {
 		return 0, fmt.Errorf("repair self-dup-rejected: scan candidates: %w", err)

--- a/internal/store/sqlite_repair_test.go
+++ b/internal/store/sqlite_repair_test.go
@@ -11,38 +11,103 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/l33tdawg/sage/internal/memory"
+	"github.com/l33tdawg/sage/internal/voter"
 )
 
-// TestFindByContentHash_CommittedOnly pins the dedup predicate to committed
-// memories ONLY. The voter's dedupCheck runs while the candidate memory is
-// itself in the table with status='proposed' — the old predicate
-// (status != 'deprecated') matched that row, so every memory was rejected as a
-// "duplicate" of itself and single-validator chains deprecated everything on
-// arrival.
-func TestFindByContentHash_CommittedOnly(t *testing.T) {
+// TestFindByContentHash_DedupPredicate pins the voter's dedup lookup: a
+// candidate never matches its own row, other still-proposed rows do not count,
+// and every post-proposal status (including deprecated) does. The own-row half
+// is the v10.1 self-match regression ("every memory deprecated on arrival");
+// the deprecated half is sticky rejection — identical bytes must not re-enter
+// through a fresh memory id.
+func TestFindByContentHash_DedupPredicate(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
+	const content = "a perfectly unique observation"
 
-	rec := testMemory("m1", "agent1", "a perfectly unique observation", "general")
+	rec := testMemory("m1", "agent1", content, "general")
 	require.NoError(t, s.InsertMemory(ctx, rec))
 	hash := hex.EncodeToString(rec.ContentHash)
 
-	// Proposed (the memory's own row) must NOT count as a duplicate.
-	exists, err := s.FindByContentHash(ctx, hash)
+	// The candidate's own proposed row must not match itself.
+	exists, err := s.FindByContentHash(ctx, hash, "m1")
 	require.NoError(t, err)
 	assert.False(t, exists, "a proposed memory must not be a duplicate of itself")
 
-	// Once committed, the same content IS a duplicate.
-	require.NoError(t, s.UpdateStatus(ctx, "m1", memory.StatusCommitted, time.Now().UTC()))
-	exists, err = s.FindByContentHash(ctx, hash)
+	// A concurrent identical proposal is not a duplicate either: counting other
+	// proposed rows would make two in-flight copies reject each other and leave
+	// the content permanently unsubmittable.
+	require.NoError(t, s.InsertMemory(ctx, testMemory("m2", "agent2", content, "general")))
+	exists, err = s.FindByContentHash(ctx, hash, "m1")
 	require.NoError(t, err)
-	assert.True(t, exists, "committed content must register as a duplicate")
+	assert.False(t, exists, "another proposed row must not block the candidate")
 
-	// Deprecated content is fair game to re-propose.
-	require.NoError(t, s.UpdateStatus(ctx, "m1", memory.StatusDeprecated, time.Now().UTC()))
-	exists, err = s.FindByContentHash(ctx, hash)
+	// Every post-proposal status registers as a duplicate for a DIFFERENT id...
+	for _, status := range []memory.MemoryStatus{memory.StatusValidated, memory.StatusCommitted, memory.StatusChallenged} {
+		require.NoError(t, s.UpdateStatus(ctx, "m1", status, time.Now().UTC()))
+		exists, err = s.FindByContentHash(ctx, hash, "m2")
+		require.NoError(t, err)
+		assert.Truef(t, exists, "status %s must register as a duplicate", status)
+	}
+
+	// ...while the candidate's own row is excluded whatever its status.
+	exists, err = s.FindByContentHash(ctx, hash, "m1")
 	require.NoError(t, err)
-	assert.False(t, exists, "deprecated content must not block a re-propose")
+	assert.False(t, exists, "the candidate's own row is excluded whatever its status")
+
+	// Deprecated (rejected) content is sticky: the same bytes cannot re-enter
+	// under a fresh memory id.
+	require.NoError(t, s.UpdateStatus(ctx, "m1", memory.StatusDeprecated, time.Now().UTC()))
+	exists, err = s.FindByContentHash(ctx, hash, "m2")
+	require.NoError(t, err)
+	assert.True(t, exists, "deprecated content must stay unsubmittable")
+
+	// An intended correction carries new content → a different hash → passes.
+	correction := testMemory("m3", "agent1", content+" — corrected", "general")
+	correctedHash := hex.EncodeToString(correction.ContentHash)
+	exists, err = s.FindByContentHash(ctx, correctedHash, "m3")
+	require.NoError(t, err)
+	assert.False(t, exists, "a correction with new content must stay submittable")
+}
+
+// TestDedupPredicate_ThroughVoterDecide runs the real SQLite lookup through the
+// real voter decision — the exact composition that shipped the v10.1 "every
+// memory deprecated on arrival" bug.
+func TestDedupPredicate_ThroughVoterDecide(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	const content = "this is a sufficiently long and substantive memory body"
+
+	rec := testMemory("live", "agent1", content, "general")
+	require.NoError(t, s.InsertMemory(ctx, rec))
+	hash := hex.EncodeToString(rec.ContentHash)
+	input := voter.MemoryInput{
+		MemoryID:    rec.MemoryID,
+		Content:     rec.Content,
+		ContentHash: hash,
+		Domain:      rec.DomainTag,
+		MemType:     string(rec.MemoryType),
+		Confidence:  rec.ConfidenceScore,
+	}
+
+	// A fresh proposal must vote accept, not "duplicate content".
+	decision, _ := voter.DecideVerbose(ctx, s, input)
+	require.True(t, decision.Accept, "fresh proposal rejected: %s", decision.Reason)
+
+	// After a rejection, identical bytes under a fresh id must vote reject.
+	require.NoError(t, s.UpdateStatus(ctx, "live", memory.StatusDeprecated, time.Now().UTC()))
+	input.MemoryID = "resubmit"
+	decision, _ = voter.DecideVerbose(ctx, s, input)
+	assert.False(t, decision.Accept, "rejected bytes must not re-enter")
+	assert.Contains(t, decision.Reason, "duplicate content")
+
+	// A correction with new content votes accept.
+	correction := testMemory("correction", "agent1", content+" corrected", "general")
+	input.MemoryID = correction.MemoryID
+	input.Content = correction.Content
+	input.ContentHash = hex.EncodeToString(correction.ContentHash)
+	decision, _ = voter.DecideVerbose(ctx, s, input)
+	assert.True(t, decision.Accept, "a correction must stay submittable: %s", decision.Reason)
 }
 
 // repairFixture inserts a deprecated memory with the given vote history.
@@ -88,6 +153,14 @@ func TestRepairSelfDupRejected(t *testing.T) {
 	require.NoError(t, s.InsertChallenge(ctx, &ChallengeEntry{
 		MemoryID: "challenged", ChallengerID: "agent2", Reason: "wrong", CreatedAt: time.Now().UTC(),
 	}))
+	// Genuine duplicate rejection: the same single-vote fingerprint, but the
+	// twin row it was rejected against still exists — the repair must not
+	// resurrect it (or every restart would churn it proposed ↔ deprecated).
+	repairFixture(t, s, "genuine-dup", "identical bytes submitted twice", []*ValidationVote{
+		{ValidatorID: selfID, Decision: "reject", Rationale: "duplicate content (hash: abc12345)"},
+	})
+	require.NoError(t, s.InsertMemory(ctx, testMemory("dup-original", "agent2", "identical bytes submitted twice", "general")))
+	require.NoError(t, s.UpdateStatus(ctx, "dup-original", memory.StatusCommitted, time.Now().UTC()))
 
 	var flipped []string
 	repaired, err := s.RepairSelfDupRejected(ctx, selfID, func(id string) error {
@@ -108,7 +181,7 @@ func TestRepairSelfDupRejected(t *testing.T) {
 	assert.Empty(t, votes)
 
 	// Everything else is untouched.
-	for _, id := range []string{"quality-reject", "legacy-era", "challenged"} {
+	for _, id := range []string{"quality-reject", "legacy-era", "challenged", "genuine-dup"} {
 		kept, keptErr := s.GetMemory(ctx, id)
 		require.NoError(t, keptErr)
 		assert.Equal(t, memory.StatusDeprecated, kept.Status, "memory %s must stay deprecated", id)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -404,8 +404,14 @@ type MemoryStore interface {
 	GetTagsBatch(ctx context.Context, memoryIDs []string) (map[string][]string, error)
 	ListAllTags(ctx context.Context) ([]TagCount, error)
 	ListMemoriesByTag(ctx context.Context, tag string, limit, offset int) ([]*memory.MemoryRecord, int, error)
-	// FindByContentHash checks if a committed memory with this content hash exists.
-	FindByContentHash(ctx context.Context, contentHash string) (bool, error)
+	// FindByContentHash reports whether a DIFFERENT memory (memory_id !=
+	// excludeMemoryID, which may be empty) that has left status='proposed'
+	// already carries this content hash. The candidate's own row never matches
+	// itself, and content that was already rejected or deprecated stays
+	// unsubmittable (sticky rejection). Other still-proposed rows are
+	// deliberately NOT duplicates: two concurrent identical submissions must
+	// not reject each other and leave the content with no surviving row.
+	FindByContentHash(ctx context.Context, contentHash, excludeMemoryID string) (bool, error)
 	// RepairSelfDupRejected resurrects memories wrongly deprecated by the voter
 	// dedup self-match bug: deprecated memories whose only recorded vote is selfID
 	// rejecting as "duplicate content" flip back to proposed (after flipChain

--- a/internal/store/sync_tables.go
+++ b/internal/store/sync_tables.go
@@ -1720,8 +1720,10 @@ func (s *SQLiteStore) ListSyncOriginIDs(ctx context.Context, originChainID, doma
 // idempotent duplicate (success); a match ONLY in different domains is the
 // cross-domain dup that gets rejected + surfaced, never silently moved.
 //
-// Domain-aware sibling of FindByContentHash (which is committed-only for the
-// same self-match reason documented there); content_hash is stored as raw
+// Domain-aware sibling of FindByContentHash. This one intentionally stays
+// committed-only — the sync gate compares committed state across chains — while
+// FindByContentHash answers the voter's local dedup question (any other row past
+// 'proposed', excluding the candidate itself). content_hash is stored as raw
 // bytes, so the hex parameter is decoded before comparison.
 func (s *SQLiteStore) FindCommittedByContentHashDomains(ctx context.Context, contentHash string) ([]CommittedHashMatch, error) {
 	hashBytes, err := hex.DecodeString(contentHash)

--- a/internal/voter/decision.go
+++ b/internal/voter/decision.go
@@ -35,6 +35,10 @@ type CheckResult struct {
 
 // MemoryInput is the minimal projection of a memory the decider needs.
 type MemoryInput struct {
+	// MemoryID is the candidate's own memory id, excluded from the dedup lookup
+	// so a proposed candidate is never a duplicate of itself. Empty for
+	// pre-submit advisory calls that have no candidate row yet.
+	MemoryID    string
 	Content     string
 	ContentHash string // hex-encoded
 	Domain      string
@@ -42,12 +46,15 @@ type MemoryInput struct {
 	Confidence  float64
 }
 
-// DupChecker abstracts the local content-hash lookup (store.FindByContentHash).
-// It is a node-local read producing this node's opinion — never consensus state —
-// so different nodes disagreeing is fine; the quorum tally resolves it
-// deterministically.
+// DupChecker abstracts the local content-hash dedup lookup
+// (store.FindByContentHash). It is a node-local read producing this node's
+// opinion — never consensus state — so different nodes disagreeing is fine; the
+// quorum tally resolves it deterministically.
 type DupChecker interface {
-	FindByContentHash(ctx context.Context, contentHash string) (bool, error)
+	// FindByContentHash reports whether a DIFFERENT memory that has left
+	// status='proposed' already carries this content hash. excludeMemoryID
+	// (may be empty) is the candidate's own row.
+	FindByContentHash(ctx context.Context, contentHash, excludeMemoryID string) (bool, error)
 }
 
 // noisePatterns are low-value observation fingerprints rejected by the quality
@@ -91,7 +98,7 @@ func dedupCheck(ctx context.Context, dup DupChecker, m MemoryInput) CheckResult 
 	// `err == nil && exists` reject condition. A node never blocks a memory on its
 	// own store hiccup; the quorum still decides.
 	if dup != nil {
-		if exists, err := dup.FindByContentHash(ctx, m.ContentHash); err == nil && exists {
+		if exists, err := dup.FindByContentHash(ctx, m.ContentHash, m.MemoryID); err == nil && exists {
 			short := m.ContentHash
 			if len(short) > 8 {
 				short = short[:8]

--- a/internal/voter/decision_test.go
+++ b/internal/voter/decision_test.go
@@ -7,8 +7,50 @@ import (
 
 type fakeDup struct{ dups map[string]bool }
 
-func (f fakeDup) FindByContentHash(_ context.Context, h string) (bool, error) {
+func (f fakeDup) FindByContentHash(_ context.Context, h, _ string) (bool, error) {
 	return f.dups[h], nil
+}
+
+type recordingDup struct {
+	gotHash    string
+	gotExclude string
+}
+
+func (r *recordingDup) FindByContentHash(_ context.Context, h, exclude string) (bool, error) {
+	r.gotHash, r.gotExclude = h, exclude
+	return false, nil
+}
+
+// TestDedupCheck_ExcludesCandidateOwnRow pins the voter half of the self-match
+// fix: dedupCheck must hand the candidate's own memory id to the store so a
+// proposed memory can never be a duplicate of itself. Pre-submit advisory calls
+// have no candidate row yet and pass an empty exclusion.
+func TestDedupCheck_ExcludesCandidateOwnRow(t *testing.T) {
+	ctx := context.Background()
+	const body = "this is a sufficiently long and substantive memory body"
+
+	rec := &recordingDup{}
+	decision := Decide(ctx, rec, MemoryInput{
+		MemoryID: "candidate-1", Content: body, ContentHash: "abc12345",
+		Domain: "d", MemType: "observation", Confidence: 0.8,
+	})
+	if !decision.Accept {
+		t.Fatalf("clean memory should accept, got reject: %s", decision.Reason)
+	}
+	if rec.gotExclude != "candidate-1" {
+		t.Fatalf("dedupCheck passed exclude=%q, want the candidate's own memory id", rec.gotExclude)
+	}
+	if rec.gotHash != "abc12345" {
+		t.Fatalf("dedupCheck passed hash=%q, want the candidate's content hash", rec.gotHash)
+	}
+
+	advisory := &recordingDup{}
+	Decide(ctx, advisory, MemoryInput{
+		Content: body, ContentHash: "abc12345", Domain: "d", MemType: "observation", Confidence: 0.8,
+	})
+	if advisory.gotExclude != "" {
+		t.Fatalf("pre-submit advisory passed exclude=%q, want empty (no candidate row exists yet)", advisory.gotExclude)
+	}
 }
 
 // TestDecide pins behavior parity with the legacy 4-archetype validators

--- a/internal/voter/voter.go
+++ b/internal/voter/voter.go
@@ -339,6 +339,7 @@ func voteOnPendingMemoriesResult(
 			}
 			contentHash := hex.EncodeToString(mem.ContentHash)
 			decision := Decide(ctx, store, MemoryInput{
+				MemoryID:    mem.MemoryID,
 				Content:     mem.Content,
 				ContentHash: contentHash,
 				Domain:      mem.DomainTag,

--- a/internal/voter/voter_test.go
+++ b/internal/voter/voter_test.go
@@ -84,7 +84,7 @@ func (f *fakeStore) GetPendingByDomainPage(_ context.Context, _ string, limit, o
 	end := min(len(f.pending), offset+limit)
 	return f.pending[offset:end], nil
 }
-func (f *fakeStore) FindByContentHash(_ context.Context, h string) (bool, error) {
+func (f *fakeStore) FindByContentHash(_ context.Context, h, _ string) (bool, error) {
 	return f.dups[h], nil
 }
 func (f *fakeStore) OldestProposedCreatedAt(_ context.Context) (time.Time, bool, error) {


### PR DESCRIPTION
## What

`FindByContentHash` was narrowed to `status='committed'` to fix the v10.1 self-match bug (a proposed candidate matched its own row, so a single-validator chain deprecated every memory on arrival). That narrowing also removed the only guard against re-admitting identical bytes after a rejection: a deprecated row was invisible to dedup, so the same content could be submitted again under a fresh memory id.

New predicate: `content_hash = ? AND memory_id != ? AND status != 'proposed'` — a DIFFERENT memory that has left `proposed` already carries the hash.

- Own row excluded, so a proposed memory never matches itself. The self-match regression stays fixed.
- Other `proposed` rows ignored, so two concurrent identical submissions cannot reject each other. This is a deliberate deviation from the literal review suggestion ("match any row with a different id"): with that rule A rejects against B's proposal, then B rejects against A's deprecation, and the hash is permanently poisoned for every later attempt.
- `validated` / `committed` / `challenged` / `deprecated` rows all match, so identical bytes cannot re-enter via dedup after a rejection (sticky rejection).
- A genuine correction carries new content, hence a new hash, and stays submittable.

## Surfaces

- `voter.Run` → `MemoryInput.MemoryID` → `dedupCheck` → `DupChecker.FindByContentHash(hash, excludeMemoryID)`. Pre-submit advisory calls pass an empty exclusion (no candidate row exists yet).
- SQLite and Postgres share the predicate. The Postgres startup migration drops the legacy committed-only partial index and installs an unconditional `idx_memories_content_hash_dedup`; `deploy/init.sql` matches. SQLite had no `content_hash` index at all and now has one — the lookup runs once per pending memory on the voter's 2s poll.
- `RepairSelfDupRejected` now also requires that no other row shares the content hash. Without that clause the widened predicate plus a repair pass would resurrect genuine duplicate rejections on every restart and churn them `deprecated ↔ proposed`.
- `docs/reference/concepts/voter-operations.md` documents the dedup semantics.

## Tests

- `TestFindByContentHash_DedupPredicate`: own-row exclusion, concurrent proposal tolerated, validated/committed/challenged count, sticky deprecated, correction submittable.
- `TestDedupPredicate_ThroughVoterDecide`: real SQLite store + real `voter.DecideVerbose` — the exact composition that shipped the v10.1 bug.
- `TestDedupCheck_ExcludesCandidateOwnRow`: candidate id threaded through; advisory passes empty.
- Repair fingerprint: a genuine duplicate rejection (same single-vote fingerprint, twin row present) is not resurrected.
- Postgres predicate + index-migration assertions.

## Verification

`go build ./...`; `go vet` on touched packages; full `go test ./...` green; explicit app-v20/app-v27 gate tests (`internal/abci`, `internal/statesync`) green.

## Note (follow-up, not touched here)

`SageApp.RepairSelfDupRejectedMemories` still has no production caller — only `internal/abci/reconcile_test.go`. Existing victims of the v10.1 self-match bug therefore need that repair wired or invoked deliberately; this PR only hardens what happens once the fixed voter re-votes them.
